### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/signed-commits.yml
+++ b/.github/workflows/signed-commits.yml
@@ -2,6 +2,8 @@
 # This ensures a verifiable chain of custody for all code contributions.
 
 name: Enforce Signed Commits
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/MemMachine/MemMachine/security/code-scanning/1](https://github.com/MemMachine/MemMachine/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks commit signatures and does not interact with the GitHub API, the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job needs different permissions.  
Edit `.github/workflows/signed-commits.yml` and add the following block after the `name:` field and before the `on:` field:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
