### PR TITLE
Removed pre-commit steps

### DIFF
--- a/CONTRIBUTING-CORE.md
+++ b/CONTRIBUTING-CORE.md
@@ -43,23 +43,10 @@ Follow these steps to set up your local development environment:
     pip install -r requirements.txt
     ```
 
-4. **Install Pre-Commit Hooks:**
-
-    ```bash
-    pip install pre-commit
-    pre-commit install
-    ```
-
-    This will install the hooks that automatically check your Python code for
-    formatting and style issues on every commit.
-
 ## 3. Code Style and Quality
 
 The project enforces a strict code style using **Black** for formatting and
-**Ruff** for linting. The pre-commit hooks you installed will automatically run
-these checks on every commit.
-
-- To run all checks manually, use: `pre-commit run --all-files`
+**Ruff** for linting.
 
 ## 4. Testing
 


### PR DESCRIPTION
### Purpose of the change

Removed the Pre-Commit steps from the Contributing guide.

### Description

It was decided not to use pre-commit hooks as they:

- requires installing dependencies locally
- slows down local commits
- can be overridden—need GitHub actions to check anyway

### Type of change

[Please delete options that are not relevant.]
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
-   [ ] Documentation update
-   [X] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
-   [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

I verified the changes to Markdown using VSCode Preview and `markdownlint`

### Checklist:

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [X] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have updated the change log.

### Maintainer Checklist

-   [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Made sure Checks passed
-   [ ] Reviewed the code and verified the changes

### Screenshots/Gifs

N/A

### Further comments

N/A