### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/src/memmachine/profile_memory/storage/syncschema.py
+++ b/src/memmachine/profile_memory/storage/syncschema.py
@@ -49,7 +49,7 @@ async def sync_to(
         "password": password,
         "database": database,
     }
-    print(f"syncing to: {d}")
+    print(f"syncing to: {{'host': '{host}', 'port': '{port}', 'user': '{user}', 'database': '{database}', 'password': '****'}}")
     connection = await asyncpg.connect(**d)
     await connection.execute(get_base())
     print("Re-initializing ...")


### PR DESCRIPTION
Potential fix for [https://github.com/MemMachine/MemMachine/security/code-scanning/3](https://github.com/MemMachine/MemMachine/security/code-scanning/3)

The best fix is to ensure that any logging or print statements do not output sensitive information, specifically the database password. Rather than printing the full dictionary `d`, we should print only the non-sensitive parts (host, port, user, database), or alternatively mask the password (e.g., replace with '****'). The change should be made to the print statement on line 52. No new method needs to be defined; we can simply build and print a filtered dictionary or a string that omits or masks the sensitive value. No external dependencies are required. Review the delete_data function (similar print on line 27) as well, since it logs the full dictionary, but CodeQL only flags line 52 in this context.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
