### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/src/memmachine/profile_memory/storage/syncschema.py
+++ b/src/memmachine/profile_memory/storage/syncschema.py
@@ -24,7 +24,10 @@ async def delete_data(
         "password": password,
         "database": database,
     }
-    print(f"Deleteing tables in {d}")
+    print(
+        f"Deleteing tables in "
+        f"{{'host': d['host'], 'port': d['port'], 'user': d['user'], 'database': d['database']}}"
+    )
     pool = await asyncpg.create_pool(init=register_vector, **d)
     table_records = await pool.fetch(
         """


### PR DESCRIPTION
Potential fix for [https://github.com/MemMachine/MemMachine/security/code-scanning/2](https://github.com/MemMachine/MemMachine/security/code-scanning/2)

To fix the problem, we should stop printing or logging sensitive information such as passwords. Specifically, the print statement at line 27 should be changed so it does not include the full `d` dictionary, which contains the password. Instead, print only non-sensitive details (such as host, port, user, and database).  
Change line 27 to print a dictionary or message that omits the password field. This can be achieved by creating a filtered version of `d` without its password (or explicitly building a dictionary with only the safe-to-log fields).

No additional imports or method definitions are necessary; only the print statement at line 27 needs to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
