### PR TITLE
Add limit on number of episodes returned by DeclarativeMemory

### DIFF
--- a/src/memmachine/episodic_memory/long_term_memory/long_term_memory.py
+++ b/src/memmachine/episodic_memory/long_term_memory/long_term_memory.py
@@ -242,7 +242,7 @@ class LongTermMemory:
     ):
         declarative_memory_episodes = await self._declarative_memory.search(
             query,
-            num_episodes_request=num_episodes_limit,
+            num_episodes_limit=num_episodes_limit,
             isolation_properties=id_filter,
         )
         return [
@@ -275,7 +275,7 @@ class LongTermMemory:
                 user_metadata=declarative_memory_episode.user_metadata,
             )
             for declarative_memory_episode in declarative_memory_episodes
-        ][-num_episodes_limit:]
+        ]
 
     async def clear(self):
         self._declarative_memory.forget_all()


### PR DESCRIPTION
### Purpose of the change

This change replaces request for number of episodes to a strict limit on number of episodes returned `DeclarativeMemory`.

Previously, when a caller searches the `DeclarativeMemory`, the caller is required to do any strict limiting themself. Because the episodes are returned in a list sorted by timestamp, the caller is not aware of the ranking of the episodes with respect to the relevance to the query. Thus, any limiting heuristic could unfortunately discard highly relevant search results.

By implementing a limit at a lower level, callers need not be aware of the internals of how the relevant search results are obtained.

### Description

This change adds a `num_episodes_limit` argument to `DeclarativeMemory.search()`, so that callers will not need to do limiting themselves.

`num_episodes_limit` replaces `num_episodes_request`. The `num_episodes_request` parameter is removed to simplify the interface.

`LongTermMemory` is updated accordingly to use the new argument rather than a keep-most-recent heuristic.

### Type of change

[Please delete options that are not relevant.]
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Ran LoCoMo benchmark on episodic memory, resulting in improved score by LLM judge.

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [ ] I have updated the change log.

### Maintainer Checklist

-   [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Made sure Checks passed
-   [ ] Reviewed the code and verified the changes