### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,4 +1,6 @@
 name: Ruff
+permissions:
+  contents: read
 on: [ push, pull_request ]
 jobs:
   ruff:


### PR DESCRIPTION
Potential fix for [https://github.com/MemMachine/MemMachine/security/code-scanning/4](https://github.com/MemMachine/MemMachine/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root of the workflow file or inside the job definition (for finer-grained control). The job shown only checks out code and runs a linter (ruff-action); neither action needs write access to the repository or other resources. Therefore, setting `contents: read` suffices, limiting the GITHUB_TOKEN to minimal permissions. You should add the following under the workflow's metadata (after `name:` and before `on:` or after `on:` but before `jobs:`), unless you want job-level granularity. In this specific case, adding at the root is more concise and will cover any future jobs added to the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
