### PR TITLE
Don't print database password when syncing profile database schema

### DIFF
--- a/src/memmachine/profile_memory/storage/syncschema.py
+++ b/src/memmachine/profile_memory/storage/syncschema.py
@@ -24,7 +24,17 @@ async def delete_data(
         "password": password,
         "database": database,
     }
-    print(f"Deleteing tables in {d}")
+    print(
+        f"Deleteing tables in {
+            {
+                'host': host,
+                'port': port,
+                'user': user,
+                'password': '****',
+                'database': database,
+            }
+        }"
+    )
     pool = await asyncpg.create_pool(init=register_vector, **d)
     table_records = await pool.fetch(
         """
@@ -49,7 +59,17 @@ async def sync_to(
         "password": password,
         "database": database,
     }
-    print(f"syncing to: {d}")
+    print(
+        f"Syncing schema to {
+            {
+                'host': host,
+                'port': port,
+                'user': user,
+                'password': '****',
+                'database': database,
+            }
+        }"
+    )
     connection = await asyncpg.connect(**d)
     await connection.execute(get_base())
     print("Re-initializing ...")


### PR DESCRIPTION
### Purpose of the change

It is bad to print passwords in clear-text.
https://github.com/MemMachine/MemMachine/security/code-scanning/2
https://github.com/MemMachine/MemMachine/security/code-scanning/3

### Description

Print stars instead of the password.

### Type of change

[Please delete options that are not relevant.]
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
-   [ ] Documentation update
-   [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
-   [x] Security (improves security without changing functionality)

### How Has This Been Tested?

Tested by running memmachine-sync-profile-schema with relevant arguments.

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have updated the change log.

### Maintainer Checklist

-   [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
-   [x] Made sure Checks passed
-   [x] Reviewed the code and verified the changes