### PR TITLE
Fix mistakes in syncschema.py argument usage help text

### DIFF
--- a/src/memmachine/profile_memory/storage/syncschema.py
+++ b/src/memmachine/profile_memory/storage/syncschema.py
@@ -105,12 +105,12 @@ def main():
     parser.add_argument(
         "--password",
         default=os.getenv("POSTGRES_PASSWORD"),
-        help="the defualt password is read from the environement variable POSTGRES_PASS",
+        help="the default password is read from the environement variable POSTGRES_PASSWORD",
     )
     parser.add_argument(
         "--delete",
         action="store_true",
-        help="delete and recreate the database with new schema. Use the migration system if you care about data inside the old database.",
+        help="delete and recreate the database with new schema.",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
### Purpose of the change

The usage help text is wrong.

### Description

Fix typo defualt --> default
The correct environment variable is POSTGRES_PASSWORD.
There is no migration system.

### Type of change

[Please delete options that are not relevant.]
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
-   [ ] Documentation update
-   [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
-   [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

Not tested.

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [ ] I have updated the change log.

### Maintainer Checklist

-   [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Made sure Checks passed
-   [ ] Reviewed the code and verified the changes