### PR TITLE
Fix query_memory in locomo_search.py

### DIFF
--- a/evaluation/locomo_search.py
+++ b/evaluation/locomo_search.py
@@ -99,7 +99,12 @@ async def process_question(
         ),
     )
 
-    episodes, summaries = await memory.query_memory(query=question, limit=20)
+    (
+        short_term_episodes,
+        long_term_episodes,
+        summaries,
+    ) = await memory.query_memory(query=question, limit=30)
+    episodes = long_term_episodes + short_term_episodes
     summary = summaries[0] if summaries else ""
     memory_end = time.time()
 


### PR DESCRIPTION
### Purpose of the change

API for `query_memory()` changed. The evaluation code broke.

### Description

Short-term and long-term episodes have been separated.
`query_memory()` now returns a 3-tuple, and the caller now expects that.
Also set limit to 30, which improves LLM judge scores on LoCoMo.

### Type of change

[Please delete options that are not relevant.]
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
-   [ ] Documentation update
-   [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
-   [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

Ran locomo_search.py on pre-ingested data.

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [ ] I have updated the change log.

### Maintainer Checklist

-   [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Made sure Checks passed
-   [ ] Reviewed the code and verified the changes