### PR TITLE
Create pypi-publish.yml

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,66 @@
+# This workflow will upload a Python Package to PyPI when a release is created
+# For more information, see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+name: Publish Python Package to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Patch version in pyproject.toml
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          echo "Updating pyproject.toml version to $VERSION"
+          sed -i -E "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
+
+      - name: Install dependencies and uv
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade build
+          pip install uv
+
+      - name: Build the package with uv
+        run: |
+          uv build
+          ls -lh dist/
+
+      - name: Upload built distributions as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-dist
+          path: dist/*
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/project/memmachine/
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-dist
+          path: dist/
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
### Purpose of the change

Add automation for building and publishing Python packages to PyPI using GitHub Actions.  
This workflow updates the `pyproject.toml` version from a GitHub release tag, builds the package with `uv`, and publishes it securely using OIDC trusted publishing.  

### Description

This change introduces a new GitHub Actions workflow (`.github/workflows/publish.yml`) that:  
- Triggers on GitHub Release published events  
- Updates the package version in `pyproject.toml` to match the release tag  
- Builds the package using `uv build`  
- Publishes the built `.whl` and `.tar.gz` distributions to PyPI using GitHub Actions OIDC without storing tokens  

Includes documentation and workflow configuration necessary for setting up trusted publishing on PyPI.  
No new runtime dependencies or code changes in the library itself.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)  
- [x] Project Maintenance (build scripts and CI improvements)  
- [ ] Documentation update  
- [ ] Security (improves security without changing functionality)  

### How Has This Been Tested?

- [x] Manually built the PyPi package and published the test package to TestPyPI and the production PyPi site

### Checklist:

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] My changes generate no new warnings  

### Maintainer Checklist

- [ ] closes # (replace with issue number)  
- [ ] Made sure GitHub Actions checks passed (build & publish)  
- [ ] Reviewed code and verified changes  

### Screenshots/Gifs

N/A

### Further comments

This workflow requires configuring PyPI trusted publishing by linking the GitHub repo and workflow environment with your PyPI project to enable tokenless publishing via OIDC.
