### PR TITLE
Improve profile robustness against poorly generated responses

### DIFF
--- a/src/memmachine/profile_memory/profile_memory.py
+++ b/src/memmachine/profile_memory/profile_memory.py
@@ -428,15 +428,16 @@ class ProfileMemory:
                 str(e),
             )
             profile_update_commands = {}
-
-        logger.info(
-            "PROFILE MEMORY INGESTOR",
-            extra={
-                "queries_to_ingest": memory_content,
-                "thoughts": thinking,
-                "outputs": profile_update_commands,
-            },
-        )
+            return
+        finally:
+            logger.info(
+                "PROFILE MEMORY INGESTOR",
+                extra={
+                    "queries_to_ingest": memory_content,
+                    "thoughts": thinking,
+                    "outputs": profile_update_commands,
+                },
+            )
 
         # This should probably just be a list of commands
         # instead of a dictionary mapping
@@ -449,7 +450,7 @@ class ProfileMemory:
                 type(profile_update_commands).__name__,
                 profile_update_commands,
             )
-            profile_update_commands = {}
+            return
 
         commands = profile_update_commands.values()
 
@@ -570,15 +571,16 @@ class ProfileMemory:
                 str(e),
             )
             updated_profile_entries = {}
-
-        logger.info(
-            "PROFILE MEMORY CONSOLIDATOR",
-            extra={
-                "receives": memories,
-                "thoughts": thinking,
-                "outputs": updated_profile_entries,
-            },
-        )
+            return
+        finally:
+            logger.info(
+                "PROFILE MEMORY CONSOLIDATOR",
+                extra={
+                    "receives": memories,
+                    "thoughts": thinking,
+                    "outputs": updated_profile_entries,
+                },
+            )
 
         if not isinstance(updated_profile_entries, dict):
             logger.warning(
@@ -586,7 +588,7 @@ class ProfileMemory:
                 type(updated_profile_entries).__name__,
                 updated_profile_entries,
             )
-            updated_profile_entries = {}
+            return
 
         if "consolidate_memories" not in updated_profile_entries:
             logger.warning(
@@ -596,6 +598,8 @@ class ProfileMemory:
             )
             updated_profile_entries["consolidate_memories"] = []
 
+        keep_all_memories = False
+
         if "keep_memories" not in updated_profile_entries:
             logger.warning(
                 "AI response format incorrect: "
@@ -603,11 +607,10 @@ class ProfileMemory:
                 updated_profile_entries,
             )
             updated_profile_entries["keep_memories"] = []
+            keep_all_memories = True
 
         consolidate_memories = updated_profile_entries["consolidate_memories"]
         keep_memories = updated_profile_entries["keep_memories"]
-
-        keep_all_memories = False
 
         if not isinstance(consolidate_memories, list):
             logger.warning(


### PR DESCRIPTION
### Purpose of the change

Prevent the profile from raising exceptions when language model-generated response is formatted wrong.

### Description

Add many checks on types.
Make response parsing readable.

### Type of change

[Please delete options that are not relevant.]
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
-   [ ] Documentation update
-   [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
-   [ ] Security (improves security without changing functionality)

### How Has This Been Tested?
Ran the following script with the default prompt and modified versions of the default prompt to break the output schema.
When the LLM output is correct, the ingestion works as expected.
Error cases are not fully tested.

```
import os
import yaml
from dataclasses import dataclass
from memmachine.profile_memory.profile_memory import ProfileMemory

from dotenv import load_dotenv
load_dotenv()

config_file = os.getenv("MEMORY_CONFIG", "cfg.yml")
try:
    yaml_config = yaml.safe_load(open(config_file, encoding="utf-8"))
except Exception as e:
    raise e

@dataclass
class DBConfig:
    """Database configuration model."""

    host: str | None
    port: str | None
    user: str | None
    password: str | None
    database: str | None


def get_db_config(yaml_config) -> DBConfig:
    """Helper function to retrieve database configuration."""
    db_host = os.getenv("POSTGRES_HOST")
    db_port = os.getenv("POSTGRES_PORT")
    db_user = os.getenv("POSTGRES_USER")
    db_pass = os.getenv("POSTGRES_PASS")
    db_name = os.getenv("POSTGRES_DB")
    # get DB config from configuration file is available
    profile_config = yaml_config.get("profile_memory", {})
    db_config_name = profile_config.get("database")
    if db_config_name is not None:
        db_config = yaml_config.get("storage", {})
        db_config = db_config.get(db_config_name)
        if db_config is not None:
            db_host = db_config.get("host", db_host)
            db_port = db_config.get("port", db_port)
            db_user = db_config.get("user", db_user)
            db_pass = db_config.get("password", db_pass)
            db_name = db_config.get("database", db_name)
    return DBConfig(db_host, db_port, db_user, db_pass, db_name)

from memmachine.common.embedder.openai_embedder import OpenAIEmbedder
from memmachine.common.language_model.openai_language_model import (
    OpenAILanguageModel,
)
api_key = os.getenv("OPENAI_API_KEY")
model = "gpt-4.1-mini"
llm_model = OpenAILanguageModel({"api_key": api_key, "model": model})
embeddings = OpenAIEmbedder({"api_key": api_key})

from importlib import import_module

prompt_file = yaml_config.get("prompt", {}).get(
    "profile", "profile_prompt"
)

db_config = get_db_config(yaml_config)
profile_memory = ProfileMemory(
    model=llm_model,
    embeddings=embeddings,
    db_config={
        "host": db_config.host,
        "port": db_config.port,
        "user": db_config.user,
        "password": db_config.password,
        "database": db_config.database,
    },
    prompt_module=import_module(f".prompt.{prompt_file}", "memmachine.profile_memory"),
)

async def start():
    await profile_memory.startup()

    await profile_memory.add_persona_message("I like apples.")
    await profile_memory.add_persona_message("I also like oranges.")

    await profile_memory.cleanup()

if __name__ == "__main__":
    import asyncio
    asyncio.run(start())
```

-   [ ] Unit Test
-   [x] Integration Test
-   [ ] End-to-end Test
-   [x] Test Script (please provide)

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [ ] I have updated the change log.

### Maintainer Checklist

-   [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Made sure Checks passed
-   [ ] Reviewed the code and verified the changes