### PR TITLE
QuickStart Guide - resolving Issue #94 - hello worlds point to wrong port number

### DIFF
--- a/docs/getting_started/quickstart.mdx
+++ b/docs/getting_started/quickstart.mdx
@@ -71,7 +71,7 @@ uvicorn app:app --reload
 The simplest way to start is by checking for existing sessions. This `GET` request doesn't require any data. You will likely see an empty list since no sessions have been created yet.
 
 ```
-curl http://127.0.0.1:8000/v1/sessions
+curl http://127.0.0.1:8080/v1/sessions
 ```
 </Step>
 <Step title="Add a New Memory">
@@ -81,7 +81,7 @@ This is where you'll create your first memory episode. The `POST /v1/memories` e
 **Command:**
 
 ```
-curl -X POST "http://127.0.0.1:8000/v1/memories" \
+curl -X POST "http://127.0.0.1:8080/v1/memories" \
 -H "Content-Type: application/json" \
 -d '{
   "session": {
@@ -109,7 +109,7 @@ Now that a memory has been added, let's try to find it. The `POST /v1/memories/s
 **Command:**
 
 ```
-curl -X POST "http://127.0.0.1:8000/v1/memories/search" \
+curl -X POST "http://127.0.0.1:8080/v1/memories/search" \
 -H "Content-Type: application/json" \
 -d '{
   "session": {
@@ -135,7 +135,7 @@ To clean up after your test, you can use the `DELETE /v1/memories` endpoint. Thi
 **Command:**
 
 ```
-curl -X DELETE "http://127.0.0.1:8000/v1/memories" \
+curl -X DELETE "http://127.0.0.1:8080/v1/memories" \
 -H "Content-Type: application/json" \
 -d '{
   "session": {
@@ -169,7 +169,7 @@ The simplest way to start is by checking for existing sessions. This is an MCP *
 **Command:**
 
 ```
-curl http://127.0.0.1:8000/mcp/sessions
+curl http://127.0.0.1:8080/mcp/sessions
 ```
 
 **Expected Output:**
@@ -183,7 +183,7 @@ This is where you'll use an MCP **tool** to create your first memory episode. Th
 **Command:**
 
 ```
-curl -X POST "http://127.0.0.1:8000/mcp/add_session_memory" \
+curl -X POST "http://127.0.0.1:8080/mcp/add_session_memory" \
 -H "Content-Type: application/json" \
 -d '{
   "session": {
@@ -218,7 +218,7 @@ Now that a memory has been added, let's use another MCP **tool** to find it. The
 **Command:**
 
 ```
-curl -X POST "http://127.0.0.1:8000/mcp/search_session_memory" \
+curl -X POST "http://127.0.0.1:8080/mcp/search_session_memory" \
 -H "Content-Type: application/json" \
 -d '{
   "session": {
@@ -244,7 +244,7 @@ To clean up after your test, use the `mcp_delete_session_data` **tool**. This is
 **Command:**
 
 ```
-curl -X POST "http://127.0.0.1:8000/mcp/delete_session_data" \
+curl -X POST "http://127.0.0.1:8080/mcp/delete_session_data" \
 -H "Content-Type: application/json" \
 -d '{
   "session": {


### PR DESCRIPTION
### Purpose of the change

Issue #94 points out that our Hello World curl examples within the Quickstart.mdx page point to port 8000, when elsewhere in the site we refer to port 8080.  The purpose of this change is to resolve so that the curl commands point to port 8080

### Description

Edited the eight curl commands that held port 8000 in quickstart.mdx such that it now holds port 8080.

Fixes # (issue)

### Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [X] Documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

-   [X] Doc Test - sight test for confirmation on lab system running `mint dev`


### Checklist:

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [X] I have made corresponding changes to the documentation
-   [X] My changes generate no new warnings
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [X] I have checked my code and corrected any misspellings
-   [ ] I have updated the change log.

### Maintainer Checklist

-   [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
-   [ ] Made sure Checks passed
-   [ ] Reviewed the code and verified the changes

### Screenshots/Gifs

NA

### Further comments