### PR TITLE
Add SELinux permission to configuration.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
     volumes:
-      - ./configuration.yml:/app/configuration.yml:ro
+      - ./configuration.yml:/app/configuration.yml:ro,Z
       - memmachine_logs:/tmp/memory_logs
     depends_on:
       postgres:


### PR DESCRIPTION
### Purpose of the change

Allow MemMachine docker compose container to access `configuration.yml` on SELinux systems.


### Description

When running on a system with SELinux and `configuration.yml` belonging to the non root user. 
MemMachine reports `PermissionError: [Errno 13] Permission denied: 'configuration.yml'`.

This is due to the SELinux label for `configuration.yml` not allowing the container to access the file.


### Type of change


-   [x] Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

Ran manually on local system.
On an SELinux system ran `./memmachine-compose.sh`.

Without fix MemMachine fails with 
```
  File "/app/.venv/lib/python3.12/site-packages/memmachine/server/app.py", line 160, in http_app_lifespan
    open(config_file, encoding="utf-8")
PermissionError: [Errno 13] Permission denied: 'configuration.yml'
```

-   [ ] Unit Test
-   [ ] Integration Test
-   [ ] End-to-end Test
-   [ ] Test Script (please provide)

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have updated the change log.

### Maintainer Checklist

-   [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
-   [x] Made sure Checks passed
-   [x] Reviewed the code and verified the changes

