### PR TITLE
Install 'curl' in the MemMachine Docker Image to allow Docker Compose health checks to work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@
 FROM python:3.12-slim-trixie AS builder
 
 # Update OS and Python/PIP Packages
+# Install curl
 RUN apt-get update && \
     apt-get upgrade -y && \
+    apt-get install -y curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -48,8 +50,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 FROM python:3.12-slim-trixie AS final
 
 # Update OS and Python/PIP Packages
+# Install curl
 RUN apt-get update && \
     apt-get upgrade -y && \
+    apt-get install -y curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Purpose of the change

Install the missing `curl` binary to allow internal health checks to work, as defined in `docker-compose.yml`

### Description

Fixes #144

In `docker-compose.yml`, the `memmachine` container performs tests against the `/health` endpoint; however, the `curl` binary is missing within the MemMachine Docker image, so these tests fail and the container remains in an `unhealthy` state.

### Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Verified the Docker image builds correctly.
- Verified the Docker Compose now shows the memmachine container is 'healthy'

-   [x] End-to-end Test

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

-   [ ] closes #144 
-   [ ] Made sure Checks passed
-   [ ] Reviewed the code and verified the changes

### Screenshots/Gifs

N/A

### Further comments

None