### PR TITLE
docker-compose.yml: Fixed the memmachine service healthcheck command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       neo4j:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health", "||", "exit", "1"]
+      test: ["CMD", "curl", "--fail", "--silent", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
### Purpose of the change

Changed the healthcheck test command for the memmachine docker compose service so it works correctly.

### Description

Fixes #144

Resolved an incorrect test command to verify the memmachine API server is running.

### Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

-   [x] End-to-end Test

With the change, all three services (Neo4j, Postgres, and MemMachine-app) start successfully and are in a 'healthy' state

```
$ docker compose up -d --force-recreate
[+] Running 3/3
 ✔ Container memmachine-neo4j     Healthy                                                                                                                                                          37.2s 
 ✔ Container memmachine-postgres  Healthy                                                                                                                                                          21.2s 
 ✔ Container memmachine-app       Started                                                                                                                                                          31.9s 
```

```
$ docker ps
CONTAINER ID   IMAGE                    COMMAND                  CREATED          STATUS                    PORTS                                                                                                          NAMES
1fcaf1c80655   memmachine/memmachine    "sh -c 'memmachine-s…"   38 seconds ago   Up 6 seconds (healthy)    0.0.0.0:8080->8080/tcp, [::]:8080->8080/tcp                                                                    memmachine-app
548e4012de17   neo4j:5.23-community     "tini -g -- /startup…"   43 seconds ago   Up 27 seconds (healthy)   0.0.0.0:7473-7474->7473-7474/tcp, [::]:7473-7474->7473-7474/tcp, 0.0.0.0:7687->7687/tcp, [::]:7687->7687/tcp   memmachine-neo4j
8fff364bd65b   pgvector/pgvector:pg16   "docker-entrypoint.s…"   43 seconds ago   Up 27 seconds (healthy)   0.0.0.0:5432->5432/tcp, [::]:5432->5432/tcp                                                                    memmachine-postgres
```

The `.State.Health` for the `memmachine-app` service shows everything is okay.

```
$ docker inspect --format='{{json .State.Health}}' memmachine-app
{"Status":"healthy","FailingStreak":0,"Log":[{"Start":"2025-09-25T16:33:38.829346222Z","End":"2025-09-25T16:33:38.877810239Z","ExitCode":0,"Output":"{\"status\":\"healthy\",\"service\":\"memmachine\",\"version\":\"1.0.0\",\"memory_managers\":{\"profile_memory\":true,\"episodic_memory\":true}}"}]}
```

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] New and existing unit tests pass locally with my changes
-   [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

-   [x] closes #144 
-   [ ] Made sure Checks passed
-   [ ] Reviewed the code and verified the changes

### Screenshots/Gifs

See above

### Further comments

None