### PR TITLE
Potential fix for code scanning alert no. 17: Information exposure through an exception

### DIFF
--- a/examples/writing_assistant/writing_assistant_server.py
+++ b/examples/writing_assistant/writing_assistant_server.py
@@ -462,7 +462,7 @@ async def get_user_writing_styles(user_id: str):
 
     except Exception as e:
         logging.exception("Error occurred in get_user_writing_styles")
-        return {"status": "error", "message": f"Internal error: {str(e)}"}
+        return {"status": "error", "message": "Internal server error"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Potential fix for [https://github.com/MemMachine/MemMachine/security/code-scanning/17](https://github.com/MemMachine/MemMachine/security/code-scanning/17)

To fix this problem, we should avoid exposing the actual exception message (`str(e)`) to the user. Instead, return a generic error string such as `"Internal server error"` or a similarly generic message. The full error, including stack trace and message, should be logged internally (as is already happening with `logging.exception()`). 

You need to:
- On line 465 (the error return value in the `except` block) change the returned message so it does NOT include any exception information, but just a generic error to the client.
- Leave server-side logging (`logging.exception`) unchanged, so developers can still diagnose the issue.

No new imports or helper methods are needed, as `logging` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
