### PR TITLE
memmachine-compose.sh: add sed support for Linux and macOS, and add prompt for OpenAI key

### DIFF
--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -21,10 +21,10 @@ Model:
 storage:
   my_storage_id:
     vendor_name: neo4j
-    host: localhost
+    host: neo4j
     port: 7687
     user: neo4j
-    password: <YOUR_PASSWORD_HERE>
+    password: neo4j_password
 
 sessionMemory:
   model_name: testmodel

--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -21,10 +21,10 @@ Model:
 storage:
   my_storage_id:
     vendor_name: neo4j
-    host: neo4j
+    host: localhost
     port: 7687
     user: neo4j
-    password: neo4j_password
+    password: <YOUR_PASSWORD_HERE>
 
 sessionMemory:
   model_name: testmodel


### PR DESCRIPTION
### Purpose of the change

To fix issues with `sed` across platforms and make the experience of running ./memmachine-compose.sh for the first time smoother.

### Description

`sed` and `timeout` have different behaviors across Linux/MacOS; account for that.

Also, add a `read -p` call that automatically places the OpenAI key in `.env` and `configuration.yml`.

Also, unify the default neo4j hostname/password in the config files so that users don't have to manually unify the placeholders when doing first-time setup.

### Fixes/Closes

Fixes #173 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Manual verification (list step-by-step instructions)

Manually verified on Linux and MacOS by:

1. Running `./memmachine-compose.sh` three times in order to generate `configuration.yml`, `.env`, and to test both the y/N options of the OpenAI API key prompt.
2. Manually verifying that the API key appears as needed in `configuration.yml` and `.env`.

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [x] Confirmed all checks passed
- [x] Contributor has signed the commit(s)
- [x] Reviewed the code
- [x] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None
