### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,6 @@
 name: Run Python unit test
+permissions:
+  contents: read
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/MemMachine/MemMachine/security/code-scanning/18](https://github.com/MemMachine/MemMachine/security/code-scanning/18)

To fix the problem, add an explicit `permissions` block to restrict GITHUB_TOKEN permissions for this workflow. Since the workflow is running Python unit tests and only needs to read repository content (not write or administer any data), set `permissions: contents: read` at the top level of the workflow. This ensures all jobs in the workflow use read-only permissions unless overridden, adhering to the principle of least privilege. Edit `.github/workflows/pytest.yml` and insert the following block immediately after the `name:` line (before the `on:` key) for clarity and best convention.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
