### PR TITLE
Introduce async profile ingestion

### DIFF
--- a/src/memmachine/profile_memory/storage/baseschema.sql
+++ b/src/memmachine/profile_memory/storage/baseschema.sql
@@ -15,14 +15,25 @@ CREATE TABLE IF NOT EXISTS prof (
     isolations JSONB NOT NULL DEFAULT '{}'
 );
 
+CREATE INDEX IF NOT EXISTS prof_user_idx ON prof (user_id);
+
 CREATE TABLE IF NOT EXISTS history (
     id SERIAL PRIMARY KEY,
     user_id TEXT NOT NULL,
+    ingested BOOLEAN NOT NULL DEFAULT FALSE,
     content TEXT NOT NULL,
     create_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     metadata JSONB NOT NULL DEFAULT '{}',
     isolations JSONB NOT NULL DEFAULT '{}'
 );
+
+CREATE INDEX IF NOT EXISTS history_user_idx ON
+    history (user_id);
+CREATE INDEX IF NOT EXISTS history_user_ingested_idx ON
+    history (user_id, ingested);
+CREATE INDEX IF NOT EXISTS history_user_ingested_ts_desc ON
+    history (user_id, ingested, create_at DESC);
+
 
 CREATE TABLE IF NOT EXISTS citations (
     profile_id INTEGER REFERENCES prof(id) ON DELETE CASCADE,

--- a/src/memmachine/profile_memory/storage/storage_base.py
+++ b/src/memmachine/profile_memory/storage/storage_base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Mapping
 
 import numpy as np
 
@@ -11,7 +11,35 @@ class ProfileStorageBase(ABC):
     """
 
     @abstractmethod
-    async def get_profile(self, user_id: str) -> dict[str, Any]:
+    async def startup(self):
+        """
+        initializations for the profile storage,
+        such as creating connection to the database
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def cleanup(self):
+        """
+        cleanup for the profile storage
+        such as closing connection to the database
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def delete_all(self):
+        """
+        delete all profiles in the storage
+        such as truncating the database table
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_profile(
+        self,
+        user_id: str,
+        isolations: dict[str, bool | int | float | str] | None = None,
+    ) -> dict[str, Any]:
         """
         Get profile by id
         Return: A list of KV for eatch feature and value.
@@ -20,7 +48,11 @@ class ProfileStorageBase(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def delete_profile(self, user_id: str):
+    async def delete_profile(
+        self,
+        user_id: str,
+        isolations: dict[str, bool | int | float | str] | None = None,
+    ):
         """
         Delete all the profile by id
         """
@@ -34,6 +66,9 @@ class ProfileStorageBase(ABC):
         value: str,
         tag: str,
         embedding: np.ndarray,
+        metadata: dict[str, Any] | None = None,
+        isolations: dict[str, bool | int | float | str] | None = None,
+        citations: list[int] | None = None,
     ):
         """
         Add a new feature to the profile.
@@ -41,7 +76,36 @@ class ProfileStorageBase(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def delete_profile_feature(self, user_id: str, feature: str):
+    async def semantic_search(
+        self,
+        user_id: str,
+        qemb: np.ndarray,
+        k: int,
+        min_cos: float,
+        isolations: dict[str, bool | int | float | str] | None = None,
+        include_citations: bool = False,
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def delete_profile_feature_by_id(self, pid: int):
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_all_citations_for_ids(
+        self, pids: list[int]
+    ) -> list[tuple[int, dict[str, bool | int | float | str]]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def delete_profile_feature(
+        self,
+        user_id: str,
+        feature: str,
+        tag: str,
+        value: str | None = None,
+        isolations: dict[str, bool | int | float | str] | None = None,
+    ):
         """
         Delete a feature from the profile with the key from the given user
         """
@@ -49,8 +113,11 @@ class ProfileStorageBase(ABC):
 
     @abstractmethod
     async def get_large_profile_sections(
-        self, user_id: str, thresh: int
-    ) -> list[dict[str, Any]]:
+        self,
+        user_id: str,
+        thresh: int,
+        isolations: dict[str, bool | int | float | str] | None = None,
+    ) -> list[list[dict[str, Any]]]:
         """
         get sections of profile with at least thresh entries
         """
@@ -59,51 +126,65 @@ class ProfileStorageBase(ABC):
     @abstractmethod
     async def add_history(
         self,
-        group_id: str = "NA",
-        user_id: str = "NA",
-        session_id: str = "NA",
-        messages: str = "NA",
-    ):
+        user_id: str,
+        content: str,
+        metadata: dict[str, str] | None = None,
+        isolations: dict[str, bool | int | float | str] | None = None,
+    ) -> Mapping[str, Any]:
         raise NotImplementedError
 
     @abstractmethod
     async def delete_history(
         self,
-        group_id: str = "NA",
-        user_id: str = "NA",
-        session_id: str = "NA",
-        start_time=0,
-        end_time=0,
+        user_id: str,
+        start_time: int = 0,
+        end_time: int = 0,
+        isolations: dict[str, bool | int | float | str] | None = None,
     ):
         raise NotImplementedError
 
     @abstractmethod
-    async def get_last_history_messages(
+    async def get_history_messages_by_ingestion_status(
         self,
-        group_id: str = "NA",
-        user_id: str = "NA",
-        session_id: str = "NA",
-        message_num=0,
-    ) -> list[tuple[int, str]]:
+        user_id: str,
+        k: int = 0,
+        is_ingested: bool = False,
+    ) -> list[Mapping[str, Any]]:
+        """
+        retrieve the list of the history messages for the user
+        with the ingestion status, up to k messages if k > 0
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_uningested_history_messages_count(self) -> int:
+        """
+        retrieve the count of the uningested history messages
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def mark_messages_ingested(self, ids: list[int]) -> None:
+        """
+        mark the messages with the id as ingested
+        """
         raise NotImplementedError
 
     @abstractmethod
     async def get_history_message(
         self,
-        group_id: str = "NA",
-        user_id: str = "NA",
-        session_id: str = "NA",
-        start_time=0,
-        end_time=0,
+        user_id: str,
+        start_time: int = 0,
+        end_time: int = 0,
+        isolations: dict[str, bool | int | float | str] | None = None,
     ) -> list[str]:
         raise NotImplementedError
 
     @abstractmethod
     async def purge_history(
         self,
-        group_id: str = "NA",
-        user_id: str = "NA",
-        session_id: str = "NA",
-        start_time=0,
+        user_id: str,
+        start_time: int = 0,
+        isolations: dict[str, bool | int | float | str] | None = None,
     ):
         raise NotImplementedError

--- a/tests/memmachine/profile_memory/test_profile_memory.py
+++ b/tests/memmachine/profile_memory/test_profile_memory.py
@@ -1,0 +1,74 @@
+"""Unit tests for the profile_memory module."""
+
+import time
+
+import pytest
+
+from memmachine.profile_memory.profile_memory import (
+    ProfileUpdateTracker,
+    ProfileUpdateTrackerManager,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def profile_tracker():
+    return ProfileUpdateTracker("a", message_limit=2, time_limit_sec=0.1)
+
+
+def test_profile_tracker_expires(profile_tracker):
+    assert not profile_tracker.should_update()
+    profile_tracker.mark_update()
+    assert not profile_tracker.should_update()
+    time.sleep(0.15)
+    assert profile_tracker.should_update()
+
+
+def test_profile_tracker_message_limit(profile_tracker):
+    assert not profile_tracker.should_update()
+    profile_tracker.mark_update()
+    assert not profile_tracker.should_update()
+    profile_tracker.mark_update()
+    assert profile_tracker.should_update()
+    profile_tracker.reset()
+    assert not profile_tracker.should_update()
+
+
+@pytest.fixture
+def profile_update_tracker_manager():
+    return ProfileUpdateTrackerManager(message_limit=2, time_limit_sec=0.1)
+
+
+async def test_profile_update_tracker_manager_with_message_limit(
+    profile_update_tracker_manager,
+):
+    users = await profile_update_tracker_manager.get_users_to_update()
+    assert users == []
+
+    for user in ["a", "b", "a", "a"]:
+        await profile_update_tracker_manager.mark_update(user)
+
+    users = await profile_update_tracker_manager.get_users_to_update()
+    assert set(users) == {"a"}
+
+    for user in ["b", "a"]:
+        await profile_update_tracker_manager.mark_update(user)
+    users = await profile_update_tracker_manager.get_users_to_update()
+    assert set(users) == {"b"}
+
+
+async def test_profile_update_tracker_manager_with_time_limit(
+    profile_update_tracker_manager,
+):
+    users = await profile_update_tracker_manager.get_users_to_update()
+    assert users == []
+
+    await profile_update_tracker_manager.mark_update("a")
+    await profile_update_tracker_manager.mark_update("b")
+    users = await profile_update_tracker_manager.get_users_to_update()
+    assert users == []
+
+    time.sleep(0.15)
+    users = await profile_update_tracker_manager.get_users_to_update()
+    assert set(users) == {"a", "b"}


### PR DESCRIPTION
### Purpose of the change

Instead of processing ingestion in real time. Set the framework to have ingestion for profile memory to be done in the background.

### Description

Adds a new column to the raw data store of Profile memory to indicate if a message has been igested or not.

Then a background task loads these uningested messages and processes them.

This way adding messages to profile memory never block due to the LLM call.

Next steps:
- Batch calls to the LLM. In which multiple messages of the same user get sent in a single prompt to the LLM.

### Fixes/Closes

Fixes #(issue number)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Breaking change:
Requires updating the profile store database.

### How Has This Been Tested?

- [ ] Unit Test
- [x] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

Unit test for this will be part of #182 

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
