### PR TITLE
fix: resolve MacBook M1 Docker issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       neo4j:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "--fail", "--silent", "http://localhost:8080/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/src/memmachine/common/reranker/cross_encoder_reranker.py
+++ b/src/memmachine/common/reranker/cross_encoder_reranker.py
@@ -4,8 +4,6 @@ Cross-encoder based reranker implementation.
 
 from typing import Any
 
-from sentence_transformers import CrossEncoder
-
 from .reranker import Reranker
 
 
@@ -15,7 +13,7 @@ class CrossEncoderReranker(Reranker):
     based on their relevance to the query.
     """
 
-    _cross_encoders: dict[str, CrossEncoder] = {}
+    _cross_encoders: dict[str, Any] = {}
 
     def __init__(self, config: dict[str, Any] = {}):
         """
@@ -35,6 +33,19 @@ class CrossEncoderReranker(Reranker):
 
         # TODO @edwinyyyu Remove: temporary fix for memory leak
         if model_name not in self._cross_encoders.keys():
+            # Import sentence_transformers only when needed
+            try:
+                from sentence_transformers import CrossEncoder
+            except ImportError as e:
+                raise ValueError(
+                    "sentence-transformers is required "
+                    "for CrossEncoderReranker. "
+                    "Please install it with "
+                    "`pip install sentence-transformers`, "
+                    "or by including GPU dependencies with "
+                    "`pip install memmachine[gpu]`."
+                ) from e
+            
             CrossEncoderReranker._cross_encoders[model_name] = CrossEncoder(model_name)
 
         self._cross_encoder = CrossEncoderReranker._cross_encoders[model_name]


### PR DESCRIPTION
- Fix ModuleNotFoundError for sentence_transformers by implementing lazy import
- Fix Docker health check failure by replacing curl with Python urllib
- Move sentence_transformers import inside conditional block for better performance
- Update health check to use Python built-in urllib instead of curl

Fixes #255
Fixes #256