### PR TITLE
Always ensure that the latest version of the Docker image is pulled before starting services.

### DIFF
--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -217,7 +217,12 @@ start_services() {
         COMPOSE_CMD="docker compose"
     fi
     
-    # Pull and start services (override the image if specified in memmachine-compose.sh start <image>:<tag>)
+    # Pull the latest images to ensure we are running the latest version
+    print_info "Pulling latest images..."
+    $COMPOSE_CMD pull
+
+    # Start services (override the image if specified in memmachine-compose.sh start <image>:<tag>)
+    print_info "Starting containers..."
     MEMMACHINE_IMAGE="${ENV_MEMMACHINE_IMAGE:-}" $COMPOSE_CMD up -d
     
     print_success "Services started successfully!"


### PR DESCRIPTION
### Purpose of the change

If a new MemMachine Docker image is published on Docker Hub, `memmachine-compose.sh` currently has no knowledge of it and continues to use the existing local images previously downloaded.

### Description

`memmachine-compose.sh` has been updated to run `docker compose pull`, which retrieves the latest image for MemMachine, Neo4j, and Postgres each time it is executed. This resolves several reported issues of not being able to see bug fixes.

### Fixes/Closes

Fixes #267 

### Type of change

[Please delete options that are not relevant.]

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I ran `memmachine-compose.sh` with the new change and observed it pulling the updated images. `[INFO] Pulling latest images...`

- [x] Manual verification (list step-by-step instructions)

**Test Results:** 

```
$ ./memmachine-compose.sh 
MemMachine Docker Startup Script
====================================

[SUCCESS] Docker and Docker Compose are available
[SUCCESS] .env file found
[SUCCESS] configuration.yml file found
OPENAI_API_KEY is not set or is using placeholder value. Would you like to set your OpenAI API key? (y/N) y
Enter your OpenAI API key: setting .env
setting configuration.yml
[SUCCESS] Set OPENAI_API_KEY in .env and configuration.yml
[SUCCESS] OPENAI_API_KEY is configured
[SUCCESS] API key in configuration.yml appears to be configured
[SUCCESS] Database credentials in configuration.yml appear to be configured
[INFO] Pulling and starting MemMachine services...
[INFO] Pulling latest images...
[+] Pulling 12/12
 ✔ neo4j Pulled                                                                                                                                                                                                        0.6s 
 ✔ memmachine Pulled                                                                                                                                                                                                   5.6s 
   ✔ 8c7716127147 Already exists                                                                                                                                                                                       0.0s 
   ✔ 3c43e65991bd Already exists                                                                                                                                                                                       0.0s 
   ✔ c8cc3e95286c Already exists                                                                                                                                                                                       0.0s 
   ✔ 9a7c3b4d36fc Already exists                                                                                                                                                                                       0.0s 
   ✔ 8e18f9f06954 Pull complete                                                                                                                                                                                        1.3s 
   ✔ 735a63a16e8c Pull complete                                                                                                                                                                                        1.7s 
   ✔ 8d10eaeaef96 Pull complete                                                                                                                                                                                        1.7s 
   ✔ b40e8c286051 Pull complete                                                                                                                                                                                        4.5s 
   ✔ 0e3ba8db766b Pull complete                                                                                                                                                                                        4.6s 
 ✔ postgres Pulled                                                                                                                                                                                                     0.6s 
[INFO] Starting containers...
WARN[0000] Found orphan containers ([memmachine-alloy]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up. 
[+] Running 9/9
 ✔ Volume "memmachine_postgres_data"    Created                                                                                                                                                                        0.0s 
 ✔ Volume "memmachine_neo4j_data"       Created                                                                                                                                                                        0.0s 
 ✔ Volume "memmachine_neo4j_logs"       Created                                                                                                                                                                        0.0s 
 ✔ Volume "memmachine_neo4j_import"     Created                                                                                                                                                                        0.0s 
 ✔ Volume "memmachine_neo4j_plugins"    Created                                                                                                                                                                        0.0s 
 ✔ Volume "memmachine_memmachine_logs"  Created                                                                                                                                                                        0.0s 
 ✔ Container memmachine-postgres        Healthy                                                                                                                                                                        5.9s 
 ✔ Container memmachine-neo4j           Healthy                                                                                                                                                                       21.4s 
 ✔ Container memmachine-app             Started                                                                                                                                                                       21.4s 
[SUCCESS] Services started successfully!
[INFO] Waiting for services to be healthy...
NAME                  IMAGE                    COMMAND                  SERVICE      CREATED          STATUS                                     PORTS
memmachine-app        memmachine/memmachine    "sh -c 'memmachine-s…"   memmachine   22 seconds ago   Up Less than a second (health: starting)   0.0.0.0:8080->8080/tcp, [::]:8080->8080/tcp
memmachine-neo4j      neo4j:5.23-community     "tini -g -- /startup…"   neo4j        22 seconds ago   Up 21 seconds (healthy)                    0.0.0.0:7473-7474->7473-7474/tcp, [::]:7473-7474->7473-7474/tcp, 0.0.0.0:7687->7687/tcp, [::]:7687->7687/tcp
memmachine-postgres   pgvector/pgvector:pg16   "docker-entrypoint.s…"   postgres     22 seconds ago   Up 21 seconds (healthy)                    0.0.0.0:5432->5432/tcp, [::]:5432->5432/tcp
[INFO] Checking service health...
[INFO] Waiting for PostgreSQL to be ready...
/var/run/postgresql:5432 - accepting connections
[SUCCESS] PostgreSQL is ready
[INFO] Waiting for Neo4j to be ready...
[SUCCESS] Neo4j is ready
[INFO] Waiting for MemMachine to be ready...
[SUCCESS] MemMachine is ready
[SUCCESS] 🎉 MemMachine is now running!

Service URLs:
  📊 MemMachine API: http://localhost:8080
  🗄️  Neo4j Browser: http://localhost:7474
  📈 Health Check: http://localhost:8080/health
  📊 Metrics: http://localhost:8080/metrics

Database Access:
  🐘 PostgreSQL: localhost:5432 (user: memmachine, db: memmachine)
  🔗 Neo4j Bolt: localhost:7687 (user: neo4j)

Useful Commands:
  📋 View logs: docker-compose logs -f
  🛑 Stop services: docker-compose down
  🔄 Restart: docker-compose restart
  🧹 Clean up: docker-compose down -v
```

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

We may want to consider end-to-end testing, as we don't currently use a fixed version Docker image for Neo4j or Postgres, so upstream changes to these externally maintained database images could break MemMachine in the future.