### PR TITLE
Have profile memory only use dependency injection

### DIFF
--- a/tests/memmachine/server/test_app.py
+++ b/tests/memmachine/server/test_app.py
@@ -133,7 +133,7 @@ async def test_initialize_resource_success(
     assert embedder_builder_args["model_name"] == "text-embedding-ada-002"
 
     _, profile_kwargs = mock_dependencies["profile_memory"].call_args
-    db_config = profile_kwargs["db_config"]
+    db_config = profile_kwargs["profile_storage"]._config
     assert db_config["host"] == "localhost"
     assert db_config["port"] == 5432
     assert db_config["user"] == "postgres"


### PR DESCRIPTION
### Purpose of the change

Improve Profile memory code by only allowing the use of dependency injection into the main constructor and removing dictionary configs.

### Description

Remove the construction of the storage client from within Profile Memory.

### Type of change


- [x] Refactor (does not change functionality, e.g., code style improvements, linting)

### How Has This Been Tested?

- [x] End-to-end Test
- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

### Checklist

[Please delete options that are not relevant.]

- [ ] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
