### PR TITLE
Use Issue Types rather than Labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug Report
 description: File a bug report to help us improve the project.
 title: "[Bug]: "
-labels: ["bug"]
+type: 'Bug'
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/documentation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.yml
@@ -1,7 +1,7 @@
 name: 📝 Documentation Issue
 description: Report a problem with the project documentation, such as a typo, outdated information, or a broken link.
 title: "[Docs]: "
-labels: ["documentation"]
+type: 'Bug'
 
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: 🚀 Feature Request
 description: Propose a new feature for the project.
 title: "[Feat]: "
-labels: ["enhancement", "new feature"]
+type: 'Feature'
 
 body:
   - type: textarea


### PR DESCRIPTION
### Purpose of the change

Issue Templates should use GitHub Issue Types rather than Labels for improved searching, filtering, and reporting.

### Description

Issue Types are newer, but easier to use than labels.

### Fixes/Closes

Fixes #274 

### Type of change

- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual verification (list step-by-step instructions)

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

I will remove the labels once this PR merges as current issues require labels to exist.
