### PR TITLE
Convert profile prompt to dataclass

### DIFF
--- a/src/memmachine/profile_memory/prompt_provider.py
+++ b/src/memmachine/profile_memory/prompt_provider.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from types import ModuleType
+
+
+@dataclass
+class ProfilePrompt:
+    update_prompt: str
+    consolidation_prompt: str
+
+    @staticmethod
+    def load_from_module(prompt_module: ModuleType):
+        update_prompt = getattr(prompt_module, "UPDATE_PROMPT", "")
+        consolidation_prompt = getattr(prompt_module, "CONSOLIDATION_PROMPT", "")
+
+        return ProfilePrompt(
+            update_prompt=update_prompt,
+            consolidation_prompt=consolidation_prompt,
+        )


### PR DESCRIPTION
### Purpose of the change

Removes the use of modules as the definition of Profile Memory prompt in favor of a data class.

### Description

Removes the dependency on modules inside profile memory. This allows the use of profile memory without needing to define the prompt to be used in a module.
This allows bench-marking and tests to be easily done.

As well as easing the use of the profile memory interface
 
### Fixes/Closes

Fixes #275 

### Type of change

[Please delete options that are not relevant.]

- [x] Refactor (does not change functionality, e.g., code style improvements, linting)

### How Has This Been Tested?

Manually tested + ran all unit tests.

### Checklist


- [x] I have signed the commit(s) within this pull request
- [x] I have performed a self-review of my own code

