### PR TITLE
Feature/add mcp stdio mode

### DIFF
--- a/src/memmachine/server/app.py
+++ b/src/memmachine/server/app.py
@@ -10,11 +10,11 @@ It includes:
   connections and memory managers.
 """
 
+import argparse
 import asyncio
 import copy
 import logging
 import os
-import sys
 from contextlib import asynccontextmanager
 from importlib import import_module
 from typing import Any, Self, cast
@@ -1114,17 +1114,30 @@ def main():
     # Load environment variables from .env file
     load_dotenv()
 
-    # Check if running in MCP stdio mode
-    if len(sys.argv) > 1 and sys.argv[1] == "--mcp":
-        # MCP stdio mode for Claude Desktop
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="MemMachine server")
+    parser.add_argument(
+        "--stdio",
+        action="store_true",
+        help="Run in MCP stdio mode",
+    )
+    args = parser.parse_args()
+
+    if args.stdio:
+        # MCP stdio mode
         config_file = os.getenv("MEMORY_CONFIG", "configuration.yml")
 
         async def run_mcp_server():
             """Initialize resources and run MCP server in the same event loop."""
             global episodic_memory, profile_memory
-            episodic_memory, profile_memory = await initialize_resource(config_file)
-            await profile_memory.startup()
-            await mcp.run_stdio_async()
+            try:
+                episodic_memory, profile_memory = await initialize_resource(config_file)
+                await profile_memory.startup()
+                await mcp.run_stdio_async()
+            finally:
+                # Clean up resources when server stops
+                if profile_memory:
+                    await profile_memory.cleanup()
 
         asyncio.run(run_mcp_server())
     else:


### PR DESCRIPTION
## Purpose
This PR adds MCP stdio mode support to enable Claude Desktop integration with our memory system.

## Problem
- Claude Desktop requires stdio transport protocol, but our server only supported HTTP mode
- Port conflicts when HTTP server binds to 8080 while MCP clients expect stdio communication
- Claude Desktop couldn't connect to our MCP server

## Solution
- Add `--mcp` argument detection to switch between HTTP and stdio modes
- Implement MCP stdio mode with proper resource initialization in single event loop
- Maintain backward compatibility for existing HTTP API users

## Changes
- Add `--mcp` argument handling in `main()` function
- Create `run_mcp_server()` async function for stdio mode
- Use `mcp.run_stdio_async()` for Claude Desktop communication
- Keep existing HTTP mode unchanged

## Configuration Required
To use this with Claude Desktop, users need to add this configuration to their `claude_desktop_config.json`:

```json
{
  "mcpServers": {
    "memmachine": {
      "command": "/Users/xudecheng/Memverge/MemMachine/.venv/bin/python",
      "args": [
        "-m",
        "memmachine.server.app",
        "--stdio"
      ],
      "cwd": "/Users/xudecheng/Memverge/MemMachine",
      "env": {
        "PYTHONPATH": "/Users/xudecheng/Memverge/MemMachine/src",
        "MEMORY_CONFIG": "/Users/xudecheng/Memverge/MemMachine/configuration.yml"
      },
      "timeout": 30000
    }
  }
}
```

**Why this configuration is needed:**
- `"--mcp"` argument triggers stdio mode in our server
- `PYTHONPATH` ensures the `memmachine` module can be imported
- `MEMORY_CONFIG` points to the configuration file
- `timeout` prevents connection timeouts during startup

## Testing
- ✅ Claude Desktop can now connect to MCP server
- ✅ HTTP API continues to work for existing users
- ✅ No breaking changes to existing functionality

<img width="797" height="1198" alt="Image" src="https://github.com/user-attachments/assets/771f7172-b59b-401c-b850-e8a09f958e55" />

<img width="2177" height="859" alt="Image" src="https://github.com/user-attachments/assets/4e3d9952-db0f-400b-ac0e-dba0bb2df577" />

<img width="2197" height="930" alt="Image" src="https://github.com/user-attachments/assets/f61139e1-51a7-49c3-bf4e-4db2149b253f" />


## Usage
- **HTTP mode**: `python -m memmachine.server.app` (existing behavior)
- **MCP mode**: `python -m memmachine.server.app --mcp` (new for Claude Desktop)

