### PR TITLE
Validate OpenAI-compatible embedder dimensions

### DIFF
--- a/src/memmachine/common/embedder/openai_embedder.py
+++ b/src/memmachine/common/embedder/openai_embedder.py
@@ -38,17 +38,9 @@ class OpenAIEmbedder(Embedder):
                   Name of the OpenAI embedding model to use
                   (default: "text-embedding-3-small").
                 - dimensions (int | None, optional):
-                  Dimensionality of the embedding vectors.
-                  Required if model is not recognized
+                  Dimensionality of the embedding vectors,
+                  if different from the model's default
                   (default: None).
-                - use_dimensions_parameter (bool, optional):
-                  Whether to use the dimensions parameter
-                  in the OpenAI embedding API call.
-                  The model must support configurable dimensions
-                  if this is set to True.
-                  This must be set to True for configured dimensions
-                  to take effect.
-                  (default: False).
                 - base_url (str, optional):
                   Base URL of the OpenAI embedding model to use.
                 - metrics_factory (MetricsFactory, optional):
@@ -77,53 +69,45 @@ class OpenAIEmbedder(Embedder):
 
         self._model = model
 
+        temp_client = openai.OpenAI(api_key=api_key, base_url=config.get("base_url"))
+
         # https://platform.openai.com/docs/guides/embeddings#embedding-models
         dimensions = config.get("dimensions")
         if dimensions is None:
-            match self._model:
-                case "text-embedding-3-small":
-                    dimensions = 1536
-                case "text-embedding-3-large":
-                    dimensions = 3072
-                case "text-embedding-ada-002":
-                    dimensions = 1536
-                case _:
-                    raise ValueError(
-                        f"Unknown dimensions for model {model}."
-                        "Please specify dimensions in the configuration."
-                    )
+            # Get dimensions by embedding a dummy string.
+            response = temp_client.embeddings.create(
+                input="\n",
+                model=self._model,
+            )
+            dimensions = len(response.data[0].embedding)
+            self._use_dimensions_parameter = False
+        else:
+            if not isinstance(dimensions, int):
+                raise TypeError("Dimensions must be an integer")
+            if dimensions <= 0:
+                raise ValueError("Dimensions must be positive")
 
-        if not isinstance(dimensions, int):
-            raise TypeError("Dimensions must be an integer")
+            # Validate dimensions by embedding a dummy string.
+            try:
+                response = temp_client.embeddings.create(
+                    input="\n",
+                    model=self._model,
+                    dimensions=dimensions,
+                )
+                self._use_dimensions_parameter = True
+            except openai.OpenAIError:
+                response = temp_client.embeddings.create(
+                    input="\n",
+                    model=self._model,
+                )
+                self._use_dimensions_parameter = False
 
-        if dimensions <= 0:
-            raise ValueError("Dimensions must be positive")
-
-        match self._model:
-            case "text-embedding-3-small":
-                if dimensions > 1536:
-                    raise ValueError(
-                        "Dimensions for text-embedding-3-small "
-                        "cannot be greater than 1536"
-                    )
-            case "text-embedding-3-large":
-                if dimensions > 3072:
-                    raise ValueError(
-                        "Dimensions for text-embedding-3-large "
-                        "cannot be greater than 3072"
-                    )
-            case "text-embedding-ada-002":
-                if dimensions != 1536:
-                    raise ValueError(
-                        "Dimensions for text-embedding-ada-002 must be exactly 1536"
-                    )
+            if len(response.data[0].embedding) != dimensions:
+                raise ValueError(
+                    f"Invalid dimensions {dimensions} for model {self._model}"
+                )
 
         self._dimensions = dimensions
-        use_dimensions_parameter = config.get("use_dimensions_parameter", True)
-        if not isinstance(use_dimensions_parameter, bool):
-            raise TypeError("use_dimensions_parameter must be a boolean")
-
-        self._use_dimensions_parameter = use_dimensions_parameter
 
         self._client = openai.AsyncOpenAI(
             api_key=api_key, base_url=config.get("base_url")


### PR DESCRIPTION
### Purpose of the change

Non-recognized OpenAI-compatible embedding models were assumed to support the dimensions parameter. This is a wrong assumption, so the OpenAIEmbedder has been updated to validate the user-provided dimensions by making a dummy embedding.

### Description

Validate dimensions by embedding a dummy string.

### Fixes/Closes

Fixes #304

### Type of change

Breaks any configurations where a custom dimensions was already specified.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

Not tested.

- [ ] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected