### PR TITLE
Fix error message "group_id or user_id cannot be empty"

### DIFF
--- a/src/memmachine/server/app.py
+++ b/src/memmachine/server/app.py
@@ -79,8 +79,8 @@ class SessionData(BaseModel):
         self.user_id = merge_lists(self.user_id, other.user_id)
 
     def is_valid(self) -> bool:
-        """Return True if the session data is invalid (both group_id and
-        session_id are empty), False otherwise.
+        """Return False if the session data is invalid (both group_id and
+        session_id are empty), True otherwise.
         """
         return self.group_id != "" or self.session_id != ""
 
@@ -145,7 +145,7 @@ class RequestWithSession(BaseModel):
                 [
                     {
                         "loc": ["header", "session"],
-                        "msg": "group_id or user_id cannot be empty",
+                        "msg": "group_id or session_id cannot be empty",
                         "type": "value_error.missing",
                     }
                 ]


### PR DESCRIPTION
### Purpose of the change

Fix error message when neither `group_id` nor `session_id` is provided. 

### Description

The error message mentions `user_id` which is wrong.

### Fixes/Closes

Fixes #311

### Type of change

[Please delete options that are not relevant.]

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Manual verification (list step-by-step instructions)

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request

### Maintainer Checklist

- [x] Confirmed all checks passed
- [x] Contributor has signed the commit(s)
- [x] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A.

### Further comments

None.
