### PR TITLE
Fix 'Terminated' errors of memmachine-compose.sh

### DIFF
--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -25,17 +25,18 @@ timeout() {
     # Start a background sleep that will kill the command
     (
         sleep "$duration"
-        kill -0 "$cmd_pid" 2>/dev/null && kill -TERM "$cmd_pid"
+        kill -0 "$cmd_pid" 2>/dev/null && kill -TERM "$cmd_pid" 2>/dev/null
     ) &
 
     local watchdog_pid=$!
 
-    # Wait for the command to finish
-    wait "$cmd_pid"
+    # Wait for the command to finish and suppress termination messages
+    wait "$cmd_pid" 2>/dev/null
     local status=$?
 
-    # Clean up watchdog if command finished early
-    kill -TERM "$watchdog_pid" 2>/dev/null
+    # Clean up watchdog if command finished early - suppress termination message
+    kill -TERM "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
 
     return $status
 }


### PR DESCRIPTION
### Purpose of the change

Handles the 'Terminated: 15' messages when running `memmachine-compose.sh` on macos

### Description

Suppresses all termination messages from commands in `memmachine-compose.sh`

### Fixes/Closes

Fixes #321 

### Type of change

[Please delete options that are not relevant.]

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)

### How Has This Been Tested?

Tested locally on Macos

[Please delete options that are not relevant.]

- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

```
jinggong@Jings-MBP MemMachine % ./memmachine-compose.sh start
MemMachine Docker Startup Script
====================================

[SUCCESS] Docker and Docker Compose are available
[SUCCESS] .env file found
[SUCCESS] configuration.yml file found
[SUCCESS] OPENAI_API_KEY is configured
[SUCCESS] API key in configuration.yml appears to be configured
[SUCCESS] Database credentials in configuration.yml appear to be configured
[INFO] Pulling and starting MemMachine services...
[INFO] Pulling latest images...
[+] Pulling 3/3
 ✔ memmachine Pulled                                                                                                                                    0.9s
 ✔ postgres Pulled                                                                                                                                      0.9s
 ✔ neo4j Pulled                                                                                                                                         0.8s
[INFO] Starting containers...
[+] Running 4/4
 ✔ Network memmachine-network     Created                                                                                                               0.0s
 ✔ Container memmachine-neo4j     Healthy                                                                                                              20.3s
 ✔ Container memmachine-postgres  Healthy                                                                                                               5.8s
 ✔ Container memmachine-app       Started                                                                                                              20.4s
[SUCCESS] Services started successfully!
[INFO] Waiting for services to be healthy...
NAME                  IMAGE                    COMMAND                  SERVICE      CREATED          STATUS                                     PORTS
memmachine-app        memmachine/memmachine    "sh -c 'memmachine-s…"   memmachine   20 seconds ago   Up Less than a second (health: starting)   0.0.0.0:8080->8080/tcp
memmachine-neo4j      neo4j:5.23-community     "tini -g -- /startup…"   neo4j        20 seconds ago   Up 20 seconds (healthy)                    0.0.0.0:7473-7474->7473-7474/tcp, 0.0.0.0:7687->7687/tcp
memmachine-postgres   pgvector/pgvector:pg16   "docker-entrypoint.s…"   postgres     20 seconds ago   Up 20 seconds (healthy)                    0.0.0.0:5432->5432/tcp
[INFO] Checking service health...
[INFO] Waiting for PostgreSQL to be ready...
/var/run/postgresql:5432 - accepting connections
[SUCCESS] PostgreSQL is ready
[INFO] Waiting for Neo4j to be ready...
[SUCCESS] Neo4j is ready
[INFO] Waiting for MemMachine to be ready...
[SUCCESS] MemMachine is ready
[SUCCESS] 🎉 MemMachine is now running!

Service URLs:
  📊 MemMachine API: http://localhost:8080
  🗄️  Neo4j Browser: http://localhost:7474
  📈 Health Check: http://localhost:8080/health
  📊 Metrics: http://localhost:8080/metrics

Database Access:
  🐘 PostgreSQL: localhost:5432 (user: memmachine, db: memmachine)
  🔗 Neo4j Bolt: localhost:7687 (user: neo4j)

Useful Commands:
  📋 View logs: docker-compose logs -f
  🛑 Stop services: docker-compose down
  🔄 Restart: docker-compose restart
  🧹 Clean up: docker-compose down -v
```

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [x] Confirmed all checks passed
- [x] Contributor has signed the commit(s)
- [x] Reviewed the code
- [x] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

[If applicable, add screenshots or GIFs that show the changes in action. This is especially helpful for API responses. Otherwise, delete this section or type "N/A".]

### Further comments

[Add any other relevant information here, such as potential side effects, future considerations, or any specific questions for the reviewer. Otherwise, type "None".]
