### PR TITLE
Pass user/group/session ID to `language_model`, to enable per-user metrics tracking

### DIFF
--- a/src/memmachine/common/data_types.py
+++ b/src/memmachine/common/data_types.py
@@ -2,6 +2,9 @@
 Common data types for MemMachine.
 """
 
+from dataclasses import dataclass
+from typing import Iterable
+
 
 class ExternalServiceAPIError(Exception):
     """
@@ -9,3 +12,24 @@ class ExternalServiceAPIError(Exception):
     """
 
     pass
+
+
+@dataclass
+class SessionData:
+    """Class for session data."""
+
+    group_id: str
+    user_id: list[str]
+    session_id: str
+    agent_id: list[str]
+
+    def generate_all_combinations(self) -> Iterable[dict[str, str]]:
+        """Generate all combinations of user_id, agent_id, group_id, and session_id."""
+        for user_id in self.user_id:
+            for agent_id in self.agent_id:
+                yield {
+                    "group_id": self.group_id,
+                    "session_id": self.session_id,
+                    "user_id": user_id,
+                    "agent_id": agent_id,
+                }

--- a/src/memmachine/common/language_model/language_model.py
+++ b/src/memmachine/common/language_model/language_model.py
@@ -3,13 +3,27 @@ Abstract base class for a language model.
 """
 
 from abc import ABC, abstractmethod
+from dataclasses import fields
 from typing import Any
+
+from memmachine.common.data_types import SessionData
 
 
 class LanguageModel(ABC):
     """
     Abstract base class for a language model.
     """
+
+    def __init__(self):
+        """Initialize the language model with an empty metrics labels dict."""
+        # Instance variable for metrics labels, managed by base class
+        self._user_metrics_labels: dict[str, str] = {}
+
+    def _set_session_metrics_labels(self):
+        """Append the SessionData field names to the user metrics labels."""
+        self._user_metrics_labels.update(
+            {session_data_field.name: "" for session_data_field in fields(SessionData)}
+        )
 
     @abstractmethod
     async def generate_response(
@@ -19,6 +33,7 @@ class LanguageModel(ABC):
         tools: list[dict[str, Any]] | None = None,
         tool_choice: str | dict[str, str] | None = None,
         max_attempts: int = 1,
+        session_data: SessionData | None = None,
     ) -> tuple[str, Any]:
         """
         Generate a response based on the provided prompts and tools.

--- a/src/memmachine/common/utils.py
+++ b/src/memmachine/common/utils.py
@@ -4,9 +4,14 @@ Common utility functions.
 
 import asyncio
 import functools
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Mapping
 from contextlib import AbstractAsyncContextManager
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from memmachine.common.data_types import SessionData
+
+if TYPE_CHECKING:
+    from memmachine.episodic_memory.data_types import MemoryContext
 
 
 async def async_with(
@@ -43,3 +48,42 @@ def async_locked(func):
             return await func(*args, **kwargs)
 
     return wrapper
+
+
+def isolations_to_session_data(
+    isolations: Mapping[str, bool | int | float | str] | None = None,
+    default_user_id: str = "",
+) -> SessionData:
+    """Convert isolations to session data."""
+    if isolations is None:
+        return SessionData(
+            group_id="",
+            user_id=[default_user_id],
+            session_id="",
+            agent_id=[""],
+        )
+
+    return SessionData(
+        group_id=str(isolations.get("group_id", "")),
+        user_id=[str(isolations.get("producer", default_user_id))],
+        session_id=str(isolations.get("session_id", "")),
+        agent_id=[str(isolations.get("agent_id", ""))],
+    )
+
+
+def memory_context_to_session_data(
+    memory_context: "MemoryContext",
+) -> SessionData:
+    """Convert memory context to session data."""
+    from memmachine.episodic_memory.data_types import MemoryContext
+
+    # Type check to ensure the parameter is a MemoryContext
+    if not isinstance(memory_context, MemoryContext):
+        raise TypeError(f"Expected MemoryContext, got {type(memory_context)}")
+
+    return SessionData(
+        group_id=memory_context.group_id,
+        user_id=list(memory_context.user_id),
+        session_id=memory_context.session_id,
+        agent_id=list(memory_context.agent_id),
+    )

--- a/src/memmachine/episodic_memory/declarative_memory/derivative_mutator/third_person_rewrite_derivative_mutator.py
+++ b/src/memmachine/episodic_memory/declarative_memory/derivative_mutator/third_person_rewrite_derivative_mutator.py
@@ -1,0 +1,144 @@
+"""
+A derivative mutator implementation that rewrites derivatives
+in the third person using a language model.
+
+This can be used to standardize the perspective of derivatives
+for improved consistency and searchability.
+"""
+
+from typing import Any
+from uuid import uuid4
+
+from memmachine.common.language_model.language_model import LanguageModel
+from memmachine.common.utils import isolations_to_session_data
+
+from ..data_types import ContentType, Derivative, EpisodeCluster
+from .derivative_mutator import DerivativeMutator
+
+
+class ThirdPersonRewriteDerivativeMutator(DerivativeMutator):
+    """
+    Derivative mutator that rewrites derivatives
+    in the third person using a language model.
+    """
+
+    def __init__(self, config: dict[str, Any]):
+        """
+        Initialize a ThirdPersonRewriteDerivativeMutator
+        with the provided configuration.
+
+        Args:
+            config (dict[str, Any]):
+                Configuration dictionary containing:
+                - language_model (LanguageModel):
+                  An instance of a LanguageModel
+                  to use for rewriting derivatives.
+
+        Raises:
+            ValueError:
+                If configuration argument values are missing or invalid.
+            TypeError:
+                If configuration argument values are of incorrect type.
+        """
+        super().__init__()
+
+        language_model = config.get("language_model")
+        if language_model is None:
+            raise ValueError("Language model must be provided")
+        if not isinstance(language_model, LanguageModel):
+            raise TypeError("Language model must be an instance of LanguageModel")
+
+        self._language_model = language_model
+
+    async def mutate(
+        self,
+        derivative: Derivative,
+        source_episode_cluster: EpisodeCluster,
+    ) -> list[Derivative]:
+        (
+            _,
+            function_calls_arguments,
+        ) = await self._language_model.generate_response(
+            system_prompt=THIRD_PERSON_REWRITE_SYSTEM_PROMPT,
+            user_prompt=THIRD_PERSON_REWRITE_USER_PROMPT.format(
+                context="\n".join(
+                    episode.content for episode in source_episode_cluster.episodes
+                ),
+                derivative=derivative.content,
+            ),
+            tools=THIRD_PERSON_REWRITE_TOOLS,
+            tool_choice={
+                "type": "function",
+                "name": "submit_rewritten_derivative_content",
+            },
+            session_data=isolations_to_session_data(
+                isolations=source_episode_cluster.filterable_properties,
+                default_user_id="",
+            ),
+        )
+
+        rewritten_derivative_content = [
+            function_call_arguments["rewritten_derivative_content"]
+            for function_call_arguments in function_calls_arguments
+            if "rewritten_derivative_content" in function_call_arguments
+        ]
+
+        derivatives = [
+            Derivative(
+                uuid=uuid4(),
+                derivative_type=derivative.derivative_type,
+                content_type=ContentType.STRING,
+                content=mutated_content,
+                timestamp=derivative.timestamp,
+                filterable_properties=(source_episode_cluster.filterable_properties),
+                user_metadata=derivative.user_metadata,
+            )
+            for mutated_content in rewritten_derivative_content
+        ]
+        return derivatives
+
+
+THIRD_PERSON_REWRITE_SYSTEM_PROMPT = """
+You are an expert in linguistics.
+"""
+
+THIRD_PERSON_REWRITE_USER_PROMPT = """
+You are given DERIVATIVE content derived from the CONTEXT text:
+
+<CONTEXT>
+{context}
+</CONTEXT>
+
+<DERIVATIVE>
+{derivative}
+</DERIVATIVE>
+
+Your task is to rewrite the DERIVATIVE content as an objective observer in the third person.
+
+Guidelines:
+- Attribute propositional attitudes to the source of the DERIVATIVE content. Do not represent propositional attitudes as facts.
+- Resolve anaphoric references using the CONTEXT text when rewriting the DERIVATIVE content.
+- Do not include anaphora. Use names for subjects and objects instead of pronouns.
+- Retain as much of the original language as possible to capture all nuance. Do not alter sentence structure or order unless necessary.
+- Exclude all phatic expressions, except when the DERIVATIVE content is purely phatic.
+- If an expression in the DERIVATIVE content requires a response from another participant in an interaction, then the expression is not phatic.
+- If an expression in the DERIVATIVE content expresses a propositional attitude, then it is not phatic.
+"""
+
+THIRD_PERSON_REWRITE_TOOLS = [
+    {
+        "type": "function",
+        "name": "submit_rewritten_derivative_content",
+        "description": "Submit the rewritten derivative content.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "rewritten_derivative_content": {
+                    "type": "string",
+                    "description": "The rewritten derivative content.",
+                },
+            },
+            "required": ["rewritten_derivative_content"],
+        },
+    },
+]

--- a/src/memmachine/episodic_memory/short_term_memory/session_memory.py
+++ b/src/memmachine/episodic_memory/short_term_memory/session_memory.py
@@ -14,6 +14,7 @@ import logging
 from collections import deque
 
 from memmachine.common.data_types import ExternalServiceAPIError
+from memmachine.common.utils import memory_context_to_session_data
 
 from ..data_types import Episode, MemoryContext
 
@@ -183,8 +184,11 @@ class SessionMemory:
             msg = self._summary_user_prompt.format(
                 episodes=episode_content, summary=self._summary
             )
+            # Generate the summary
             result = await self._model.generate_response(
-                system_prompt=self._summary_system_prompt, user_prompt=msg
+                system_prompt=self._summary_system_prompt,
+                user_prompt=msg,
+                session_data=memory_context_to_session_data(self._memory_context),
             )
             self._summary = result[0]
             logger.debug("Summary: %s\n", self._summary)

--- a/tests/memmachine/common/language_model/test_openai_language_model.py
+++ b/tests/memmachine/common/language_model/test_openai_language_model.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import openai
 import pytest
 
-from memmachine.common.data_types import ExternalServiceAPIError
+from memmachine.common.data_types import ExternalServiceAPIError, SessionData
 from memmachine.common.language_model.openai_language_model import (
     OpenAILanguageModel,
 )
@@ -366,11 +366,20 @@ async def test_metrics_collection(mock_async_openai, full_config):
     mock_client.responses.create.return_value = mock_response
     mock_async_openai.return_value = mock_client
 
+    mock_session_data = SessionData(
+        group_id="test-group",
+        user_id=["test-user"],
+        session_id="test-session",
+        agent_id=["test-agent"],
+    )
+
     lm = OpenAILanguageModel(full_config)
-    await lm.generate_response()
+    await lm.generate_response(session_data=mock_session_data)
 
     metrics_factory = full_config["metrics_factory"]
     labels = full_config["user_metrics_labels"]
+    for combination in mock_session_data.generate_all_combinations():
+        labels = labels | combination
 
     input_counter = metrics_factory.get_counter("test", "test")
     output_counter = metrics_factory.get_counter("test", "test")


### PR DESCRIPTION
### Purpose of the change

Expose per-user token/openAI latency data in the existing `<host>:<port>/metrics` endpoint.

### Description

All of the instrumentation necessary for this already existed in `openai_language_model.py` and its sibling files. The only missing piece was passing the user/group/session IDs, which exist at the top-level `app.py`, down to the `<counter/gauge>.increment()` calls in the language_model files. To accomplish this, added some default fields in `self._user_metrics_labels` that are manually updated before each call to `generate_response()`.

### Fixes/Closes

N/A

### Type of change

- [X] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- [X] Manual verification (list step-by-step instructions)

**Test Results:**

Full set of metrics produced after a few sample POSTs to `http://127.0.0.1:8080/v1/memories`:

https://gist.github.com/svetly-todorov/e598d86d1d46c48adf6ef759e9c42bdb

Screenshot showing the input token counts for two different users:

<img width="1680" height="762" alt="Screenshot 2025-10-21 at 1 20 51 PM" src="https://github.com/user-attachments/assets/1938496d-c5f0-4d32-97b0-fd5707254107" />

### Checklist

- [X] I have signed the commit(s) within this pull request
- [X] I have performed a self-review of my own code
- [X] I have commented my code
- [X] I have made corresponding changes to the documentation

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Further comments

Putting this PR up partly to request comments. From recent discussions it seems that the user/group/agent/session ID paradigm may not persist in the core layer of `memmachine`, in which case, this will need to change significantly. Is this worth pursuing?