### PR TITLE
Update rerankers to use BaseModel params

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
 [tool.mypy]
 follow_untyped_imports = true
 exclude = ["venv/", ".venv/"]
+plugins = ['pydantic.mypy']
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]

--- a/src/memmachine/common/reranker/bm25_reranker.py
+++ b/src/memmachine/common/reranker/bm25_reranker.py
@@ -2,14 +2,36 @@
 BM25-based reranker implementation.
 """
 
-import re
-from typing import Any
+import asyncio
+from collections.abc import Callable
 
-from nltk import word_tokenize
-from nltk.corpus import stopwords
+from pydantic import BaseModel, Field
 from rank_bm25 import BM25Okapi
 
 from .reranker import Reranker
+
+
+class BM25RerankerParams(BaseModel):
+    """
+    Parameters for BM25Reranker.
+
+    Attributes:
+        k1 (float):
+            BM25 k1 parameter (default: 1.5).
+        b (float):
+            BM25 b parameter (default: 0.75).
+        epsilon (float):
+            BM25 epsilon parameter (default: 0.25).
+        tokenize (Callable[[str], list[str]]):
+            Tokenizer function to split text into tokens.
+    """
+
+    k1: float = Field(1.5, description="BM25 k1 parameter")
+    b: float = Field(0.75, description="BM25 b parameter")
+    epsilon: float = Field(0.25, description="BM25 epsilon parameter")
+    tokenize: Callable[[str], list[str]] = Field(
+        ..., description="Tokenizer function to split text into tokens"
+    )
 
 
 class BM25Reranker(Reranker):
@@ -18,59 +40,46 @@ class BM25Reranker(Reranker):
     based on their relevance to the query.
     """
 
-    def __init__(self, config: dict[str, Any] = {}):
+    def __init__(self, params: BM25RerankerParams):
         """
-        Initialize a BM25Reranker with the provided configuration.
+        Initialize a BM25Reranker with the provided parameters.
 
         Args:
-            config (dict[str, Any], optional):
-                Configuration dictionary containing:
-                - languages (str | list[str], optional):
-                  Language(s) for stop words (default: "english").
-                  Languages must be supported by NLTK stopwords corpus.
+            params (BM25RerankerParams):
+                Parameters for the BM25Reranker.
         """
         super().__init__()
 
-        languages = config.get("languages", "english")
-        try:
-            self._stop_words = stopwords.words(languages)
-        except Exception as e:
-            raise ValueError(f"Unsupported language(s) provided: {languages}") from e
+        self._k1 = params.k1
+        self._b = params.b
+        self._epsilon = params.epsilon
+
+        self._tokenize = params.tokenize
 
     async def score(self, query: str, candidates: list[str]) -> list[float]:
-        candidates_tokens = [
-            self._preprocess_text(candidate) for candidate in candidates
-        ]
+        tokenized_query_future = asyncio.to_thread(self._tokenize, query)
+        tokenized_candidates_future = asyncio.to_thread(
+            self._tokenize_multiple, candidates
+        )
 
-        if not any(candidates_tokens):
+        tokenized_query = await tokenized_query_future
+        tokenized_candidates = await tokenized_candidates_future
+
+        if not any(tokenized_candidates):
             # There are no tokens in the corpus.
             return [0.0 for _ in candidates]
 
         # There is at least one token in the corpus.
-        bm25 = BM25Okapi(candidates_tokens)
+        bm25 = BM25Okapi(
+            tokenized_candidates,
+            k1=self._k1,
+            b=self._b,
+            epsilon=self._epsilon,
+        )
 
-        scores = [
-            float(score) for score in bm25.get_scores(self._preprocess_text(query))
-        ]
+        scores = [float(score) for score in bm25.get_scores(tokenized_query)]
 
         return scores
 
-    def _preprocess_text(self, text: str) -> list[str]:
-        """
-        Preprocess the input text
-        by removing non-alphanumeric characters,
-        converting to lowercase,
-        word-tokenizing,
-        and removing stop words.
-
-        Args:
-            text (str): The input text to preprocess.
-
-        Returns:
-            list[str]: A list of tokens for use in BM25 scoring.
-        """
-        alphanumeric_text = re.sub(r"\W+", " ", text)
-        lower_text = alphanumeric_text.lower()
-        words = word_tokenize(lower_text)
-        tokens = [word for word in words if word and word not in self._stop_words]
-        return tokens
+    def _tokenize_multiple(self, corpus: list[str]) -> list[list[str]]:
+        return [self._tokenize(document) for document in corpus]

--- a/src/memmachine/common/reranker/embedder_reranker.py
+++ b/src/memmachine/common/reranker/embedder_reranker.py
@@ -2,45 +2,45 @@
 Embedder-based reranker implementation.
 """
 
-from typing import Any
-
 import numpy as np
+from pydantic import BaseModel, Field, InstanceOf
 
-from memmachine.common.embedder import Embedder
+from memmachine.common.embedder import Embedder, SimilarityMetric
 
 from .reranker import Reranker
 
 
+class EmbedderRerankerParams(BaseModel):
+    """
+    Parameters for EmbedderReranker.
+
+    Attributes:
+        embedder (Embedder):
+            Embedder instance.
+    """
+
+    embedder: InstanceOf[Embedder] = Field(
+        ..., description="An instance of an Embedder to use for generating embeddings"
+    )
+
+
 class EmbedderReranker(Reranker):
     """
-    Reranker that uses an embedder and cosine similarity
+    Reranker that uses an embedder
     to score relevance of candidates to a query.
     """
 
-    def __init__(self, config: dict[str, Any]):
+    def __init__(self, params: EmbedderRerankerParams):
         """
         Initialize an EmbedderReranker with the provided configuration.
 
         Args:
-            config (dict[str, Any]):
-                Configuration dictionary containing:
-                - embedder (Embedder):
-                    An instance of an Embedder
-                    to use for generating embeddings.
-
-        Raises:
-            ValueError: If embedder is not provided.
-            TypeError: If embedder is not an instance of Embedder.
+            params (EmbedderRerankerParams):
+                Parameters for the EmbedderReranker.
         """
         super().__init__()
 
-        embedder = config.get("embedder")
-        if embedder is None:
-            raise ValueError("Embedder must be provided")
-        if not isinstance(embedder, Embedder):
-            raise TypeError("Embedder must be an instance of Embedder")
-
-        self._embedder = embedder
+        self._embedder = params.embedder
 
     async def score(self, query: str, candidates: list[str]) -> list[float]:
         if len(candidates) == 0:
@@ -49,10 +49,35 @@ class EmbedderReranker(Reranker):
         query_embedding = np.array(await self._embedder.search_embed([query])).flatten()
         candidate_embeddings = np.array(await self._embedder.ingest_embed(candidates))
 
-        magnitude_products = np.linalg.norm(
-            candidate_embeddings, axis=-1
-        ) * np.linalg.norm(query_embedding)
+        match self._embedder.similarity_metric:
+            case SimilarityMetric.COSINE:
+                magnitude_products = np.linalg.norm(
+                    candidate_embeddings, axis=-1
+                ) * np.linalg.norm(query_embedding)
+                magnitude_products[magnitude_products == 0] = float("inf")
 
-        magnitude_products[magnitude_products == 0] = float("inf")
-        scores = np.dot(candidate_embeddings, query_embedding) / magnitude_products
+                scores = (
+                    np.dot(candidate_embeddings, query_embedding) / magnitude_products
+                )
+            case SimilarityMetric.DOT:
+                scores = np.dot(candidate_embeddings, query_embedding)
+            case SimilarityMetric.EUCLIDEAN:
+                scores = -np.linalg.norm(
+                    candidate_embeddings - query_embedding, axis=-1
+                )
+            case SimilarityMetric.MANHATTAN:
+                scores = -np.sum(
+                    np.abs(candidate_embeddings - query_embedding), axis=-1
+                )
+            case _:
+                # Default to cosine similarity.
+                magnitude_products = np.linalg.norm(
+                    candidate_embeddings, axis=-1
+                ) * np.linalg.norm(query_embedding)
+                magnitude_products[magnitude_products == 0] = float("inf")
+
+                scores = (
+                    np.dot(candidate_embeddings, query_embedding) / magnitude_products
+                )
+
         return scores.astype(float).tolist()

--- a/src/memmachine/common/reranker/reranker.py
+++ b/src/memmachine/common/reranker/reranker.py
@@ -13,9 +13,7 @@ class Reranker(ABC):
     Abstract base class for a reranker.
     """
 
-    async def rerank(
-        self, query: str, candidates: list[str]
-    ) -> list[tuple[float, str]]:
+    async def rerank(self, query: str, candidates: list[str]) -> list[str]:
         """
         Rerank the candidates based on their relevance to the query.
 
@@ -26,15 +24,16 @@ class Reranker(ABC):
                 A list of candidate strings to be reranked.
 
         Returns:
-            list[tuple[float, str]]:
-            A list of tuples where each tuple contains
-            a score and the corresponding candidate string,
-            sorted by score in descending order.
+            list[str]:
+                The reranked list of candidates,
+                sorted by score in descending order.
         """
         scores = await self.score(query, candidates)
+        score_map = dict(zip(candidates, scores))
+
         return sorted(
-            zip(scores, candidates),
-            key=lambda pair: pair[0],
+            candidates,
+            key=lambda candidate: score_map[candidate],
             reverse=True,
         )
 

--- a/src/memmachine/common/reranker/reranker_builder.py
+++ b/src/memmachine/common/reranker/reranker_builder.py
@@ -14,6 +14,8 @@ class RerankerBuilder(Builder):
     Builder for Reranker instances.
     """
 
+    _rerankers: dict[str, Any] = {}
+
     @staticmethod
     def get_dependency_ids(name: str, config: dict[str, Any]) -> set[str]:
         dependency_ids = set()
@@ -34,19 +36,74 @@ class RerankerBuilder(Builder):
     ) -> Reranker:
         match name:
             case "amazon-bedrock":
+                import boto3
+
                 from .amazon_bedrock_reranker import (
                     AmazonBedrockReranker,
-                    AmazonBedrockRerankerConfig,
+                    AmazonBedrockRerankerParams,
                 )
 
-                return AmazonBedrockReranker(AmazonBedrockRerankerConfig(**config))
-            case "bm25":
-                from .bm25_reranker import BM25Reranker
+                region = config.get("region", "us-west-2")
 
-                return BM25Reranker(config)
+                client = boto3.client(
+                    "bedrock-agent-runtime",
+                    region_name=region,
+                    aws_access_key_id=config["aws_access_key_id"],
+                    aws_secret_access_key=config["aws_secret_access_key"],
+                )
+
+                return AmazonBedrockReranker(
+                    AmazonBedrockRerankerParams(
+                        client=client,
+                        region=region,
+                        model_id=config["model_id"],
+                        additional_model_request_fields=config.get(
+                            "additional_model_request_fields", {}
+                        ),
+                    )
+                )
+            case "bm25":
+                import re
+
+                from nltk.corpus import stopwords
+                from nltk.tokenize import word_tokenize
+
+                from .bm25_reranker import BM25Reranker, BM25RerankerParams
+
+                language = config.get("language", "english")
+                stop_words = stopwords.words(language)
+
+                def default_tokenize(text: str) -> list[str]:
+                    """
+                    Preprocess the input text
+                    by removing non-alphanumeric characters,
+                    converting to lowercase,
+                    word-tokenizing,
+                    and removing stop words.
+
+                    Args:
+                        text (str): The input text to preprocess.
+
+                    Returns:
+                        list[str]: A list of tokens for use in BM25 scoring.
+                    """
+                    alphanumeric_text = re.sub(r"\W+", " ", text)
+                    lower_text = alphanumeric_text.lower()
+                    words = word_tokenize(lower_text, language)
+                    tokens = [word for word in words if word and word not in stop_words]
+                    return tokens
+
+                return BM25Reranker(
+                    BM25RerankerParams(
+                        tokenize=default_tokenize,
+                    )
+                )
             case "cross-encoder":
                 try:
-                    from .cross_encoder_reranker import CrossEncoderReranker
+                    from .cross_encoder_reranker import (
+                        CrossEncoderReranker,
+                        CrossEncoderRerankerParams,
+                    )
                 except ImportError as e:
                     raise ValueError(
                         "sentence-transformers is required "
@@ -57,30 +114,53 @@ class RerankerBuilder(Builder):
                         "`pip install memmachine[gpu]`."
                     ) from e
 
-                return CrossEncoderReranker(config)
-            case "embedder":
-                from .embedder_reranker import EmbedderReranker
+                from sentence_transformers import CrossEncoder
 
+                model_name = config.get("model_name")
+                if model_name is None:
+                    raise ValueError(
+                        "model_name must be provided for CrossEncoderReranker"
+                    )
+                if not isinstance(model_name, str):
+                    raise ValueError("model_name must be a string")
+
+                if model_name not in RerankerBuilder._rerankers:
+                    RerankerBuilder._rerankers[model_name] = CrossEncoder(model_name)
+
+                reranker = RerankerBuilder._rerankers[model_name]
+
+                return CrossEncoderReranker(
+                    CrossEncoderRerankerParams(cross_encoder=reranker)
+                )
+            case "embedder":
+                from .embedder_reranker import EmbedderReranker, EmbedderRerankerParams
+
+                embedder = injections[config["embedder_id"]]
                 return EmbedderReranker(
-                    {
-                        "embedder": injections[config["embedder_id"]],
-                    }
+                    EmbedderRerankerParams(
+                        embedder=embedder,
+                    )
                 )
             case "identity":
                 from .identity_reranker import IdentityReranker
 
                 return IdentityReranker()
             case "rrf-hybrid":
-                from .rrf_hybrid_reranker import RRFHybridReranker
+                from .rrf_hybrid_reranker import (
+                    RRFHybridReranker,
+                    RRFHybridRerankerParams,
+                )
+
+                rerankers = [
+                    injections[reranker_id] for reranker_id in config["reranker_ids"]
+                ]
+                k = config.get("k", 60)
 
                 return RRFHybridReranker(
-                    {
-                        "rerankers": [
-                            injections[reranker_id]
-                            for reranker_id in config["reranker_ids"]
-                        ],
-                        "k": config.get("k", 60),
-                    }
+                    RRFHybridRerankerParams(
+                        rerankers=rerankers,
+                        k=k,
+                    )
                 )
             case _:
                 raise ValueError(f"Unknown Reranker name: {name}")

--- a/tests/memmachine/common/reranker/test_bm25_reranker.py
+++ b/tests/memmachine/common/reranker/test_bm25_reranker.py
@@ -1,13 +1,19 @@
+import re
+
 import pytest
 
 from memmachine import setup_nltk
-from memmachine.common.reranker.bm25_reranker import BM25Reranker
+from memmachine.common.reranker.bm25_reranker import BM25Reranker, BM25RerankerParams
 
 
 @pytest.fixture
 def reranker():
     setup_nltk()
-    return BM25Reranker()
+    return BM25Reranker(
+        BM25RerankerParams(
+            tokenize=lambda text: re.sub(r"\W+", " ", text).lower().split()
+        )
+    )
 
 
 @pytest.fixture(params=["Are tomatoes fruits?", ""])
@@ -39,7 +45,7 @@ async def test_score(reranker, query, candidates):
 async def test_score_values(reranker):
     query = "What is the capital of France?"
     candidates = [
-        "The Eiffel Tower is in Paris.",
+        "Hello, world!",
         "Berlin is the capital of Germany.",
         "Paris is the capital of France.",
     ]
@@ -48,11 +54,3 @@ async def test_score_values(reranker):
 
     assert scores == sorted(scores)
     assert scores != reversed(scores)
-
-
-def test_invalid_languages():
-    with pytest.raises(ValueError):
-        BM25Reranker(config={"languages": "invalid_language"})
-
-    with pytest.raises(ValueError):
-        BM25Reranker(config={"languages": ["english", "invalid_language"]})

--- a/tests/memmachine/common/reranker/test_cross_encoder_reranker.py
+++ b/tests/memmachine/common/reranker/test_cross_encoder_reranker.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock
+
+import pytest
+from sentence_transformers import CrossEncoder
+
+from memmachine.common.reranker.cross_encoder_reranker import (
+    CrossEncoderReranker,
+    CrossEncoderRerankerParams,
+)
+
+
+@pytest.fixture
+def cross_encoder():
+    mock_cross_encoder = MagicMock(spec=CrossEncoder)
+    return mock_cross_encoder
+
+
+@pytest.fixture
+def reranker(cross_encoder):
+    return CrossEncoderReranker(
+        CrossEncoderRerankerParams(
+            cross_encoder=cross_encoder,
+        )
+    )
+
+
+@pytest.fixture(params=["Are tomatoes fruits?", ""])
+def query(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        ["Apples are fruits.", "Tomatoes are red."],
+        ["Apples are fruits.", "Tomatoes are red.", ""],
+        [""],
+        [],
+    ]
+)
+def candidates(request):
+    return request.param
+
+
+@pytest.mark.asyncio
+async def test_shape(reranker, cross_encoder, query, candidates):
+    mock_scores = [0.0] * len(candidates)
+    cross_encoder.predict.return_value = mock_scores
+
+    scores = await reranker.score(query, candidates)
+    assert isinstance(scores, list)
+    assert len(scores) == len(candidates)
+    assert all(isinstance(score, float) for score in scores)
+
+
+@pytest.mark.asyncio
+async def test_score(reranker, cross_encoder):
+    mock_scores = [0.9, 0.1, 0.5]
+    cross_encoder.predict.return_value = mock_scores
+
+    query = "query"
+    candidates = ["candidate1", "candidate2", "candidate3"]
+    scores = await reranker.score(query, candidates)
+
+    assert scores == mock_scores

--- a/tests/memmachine/common/reranker/test_rrf_hybrid_reranker.py
+++ b/tests/memmachine/common/reranker/test_rrf_hybrid_reranker.py
@@ -1,0 +1,71 @@
+import pytest
+
+from memmachine.common.reranker import Reranker
+from memmachine.common.reranker.rrf_hybrid_reranker import (
+    RRFHybridReranker,
+    RRFHybridRerankerParams,
+)
+
+
+class FakeReranker(Reranker):
+    def __init__(self, scores: list[float]):
+        super().__init__()
+        self._scores = scores
+
+    async def score(self, query: str, candidates: list[str]) -> list[float]:
+        return self._scores
+
+
+@pytest.fixture
+def reranker():
+    return RRFHybridReranker(
+        RRFHybridRerankerParams(
+            rerankers=[
+                FakeReranker([1.0, 2.0, 4.0]),
+                FakeReranker([2.0, 1.0, 4.0]),
+            ]
+        )
+    )
+
+
+@pytest.fixture(params=["Are tomatoes fruits?", ""])
+def query(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        ["Apples are fruits.", "Tomatoes are red."],
+        ["Apples are fruits.", "Tomatoes are red.", ""],
+        [""],
+        [],
+    ]
+)
+def candidates(request):
+    return request.param
+
+
+@pytest.mark.asyncio
+async def test_shape(query, candidates):
+    reranker = RRFHybridReranker(
+        RRFHybridRerankerParams(
+            rerankers=[
+                FakeReranker([-1.0] * len(candidates)),
+                FakeReranker([1.0] * len(candidates)),
+            ]
+        )
+    )
+
+    scores = await reranker.score(query, candidates)
+    assert isinstance(scores, list)
+    assert len(scores) == len(candidates)
+    assert all(isinstance(score, float) for score in scores)
+
+
+@pytest.mark.asyncio
+async def test_score(reranker):
+    query = "query"
+    candidates = ["candidate1", "candidate2", "candidate3"]
+    scores = await reranker.score(query, candidates)
+
+    assert scores[0] == scores[1] < scores[2]


### PR DESCRIPTION
### Purpose of the change

Part of refactoring to make MemMachine closer to a library and better support dependency injection.

### Description

All rerankers now take a BaseModel type for parameters.

### Type of change

Breaking for consumers of lower-level resources. Should not break data. May break currently unused parts of configuration.

Updated some reranker logic.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

Added tests for a couple of rerankers.
Unit tests pass.
For non-tested AmazonBedrockReranker and RerankerBuilder, ran LoCoMo evaluation scripts with all types of rerankers used in RRF (however, embedder initialization is hard-coded so we cannot use multiple embedders right now).

- [x] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [x] Manual verification (list step-by-step instructions)

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected