### PR TITLE
Docs: Design document for semantic memory

### DIFF
--- a/docs/core_concepts/semantic_memory_design.mdx
+++ b/docs/core_concepts/semantic_memory_design.mdx
@@ -10,23 +10,19 @@ icon: "database"
 
 This document captures the design of the Semantic Memory subsystem that
 extracts, stores, and retrieves long-lived semantic features for agents.
+
 Knowledge is extracted using an LLM, where given a set of facts and a new piece of information,
 a LLM is used to extract new facts and modify existing facts.
-This is done through a series of `add`, `update`, and `delete` commands produced by the LLM.
+Each fact is represented as a `Feature` and is modified through a set of commands.
+Through a series of `add`, `update`, and `delete` commands produced by the LLM,
+the set of features is updated.
 
-## Problem Statement
-
-Agents build context by accumulating structured facts across sessions.
-These facts must be derived from unstructured interaction history,
-normalized into a consistent schema, stored with citations, and exposed
-through fast semantic search. The system needs to scale across many
-feature sets, minimize redundant information, and deliver low-latency
-responses while coordinating asynchronous ingestion.
 
 ## Goals
 
 - Automate feature extraction and consolidation from conversational
   history using LLM reasoning steps.
+- Allow for feature sets to be accessed by multiple users.
 - Provide CRUD and search APIs that surface curated semantic memories
   with caching for hot sets.
 - Run ingestion in the background without blocking the calling agent and
@@ -45,10 +41,39 @@ responses while coordinating asynchronous ingestion.
 3. Deduplicate overlapping memories when LLM-generated features exceed a
    configurable threshold.
 
+## User Experience
+
+Caller passes in a new message with a `SessionData` object.
+```python
+async def ingest_message(session_data: SessionData, message: str) -> None:
+```
+
+The `SessionData` object describes the different feature sets that will ingest the message.
+Some of these feature sets may be individual to the user, while others may be shared across
+users or sessions.
+
+Later the user can retrieve knowledge from either all feature sets or a specific feature type.
+```python
+async def search(
+    session_data: SessionData,
+    query: str,
+    feature_type: str | None = None
+) -> List[SemantidMemory]:
+```
+
+Example:
+```python
+# Performs a vector search over all feature sets.
+search(session, "Create an implementation of a chat agent in Python")
+
+# Performs a vector search over a specific feature type.
+search(session, "Create an implementation of a chat agent in Python", "coding_style")
+```
+
 # High-Level Architecture
 
 ```
-Agent -> SemanticProfileWrapper -> SemanticManager
+Agent -> SessionSemanticManager -> SemanticManager
                                          |         ↘
                                          |          -> SemanticStorageBase
                                          |         ↘
@@ -61,6 +86,19 @@ Agent -> SemanticProfileWrapper -> SemanticManager
                                   Background ingestion + consolidation loop
 ```
 
+## `SessionSemanticManager`
+
+`SessionSemanticManager` is the top level interface for the Semantic Memory subsystem.
+It acts as a facade for the `SemanticManager`, translating the application specific
+`SessionData` into a set of `set_id`s that will be used by the `SemanticManager`.
+
+This means that the `SessionSemanticManager` will be responsible for:
+- Allowing a single SessionData to be associated with multiple `set_id`s.
+    - Controlling data access to different feature sets.
+    - Having a single message be ingested by multiple semantic feature sets.
+
+
+## `SemanticManager`
 
 When a new message is received, the `SemanticManager` will store a reference
 in its internal storage. Then after certain triggers are met, the message
@@ -82,11 +120,6 @@ are applied to the feature set.
 `SemanticMemoryType`, the `LanguageModel` prompts, and the underlying
 `Embedder` and `LanguageModel` at a per-`set_id` level.
 
-Finally, we have a top level `SemanticProfileWrapper` whoese responsibility
-is to translate the application specific `SessionData` into a `set_id`
-that will be used by the `SemanticManager`.
-This includes the `persona_id` and the `session_id`, for both the profile based
-semantic memory and the session based semantic memory.
 
 ## Data Model
 


### PR DESCRIPTION
### Description

We are looking to refactor profile memory into a general knowladge and fact extractor.
Where given a set of specialized prompts, each prompt can extract a set of facts.

This can then be used both for extracting facts about a user persona as well as extracting facts on other topics.


### Type of change

- [x] Documentation update

