### PR TITLE
Fix: default header mixed with session data.

### DIFF
--- a/tests/memmachine/server/test_request_parameter.py
+++ b/tests/memmachine/server/test_request_parameter.py
@@ -66,3 +66,46 @@ def test_default_producer_with_empty_session():
     session = SessionData()
     episode = NewEpisode(session=session)
     assert episode.producer == "default"
+
+
+def test_merge_session_data_with_default():
+    session = SessionData(
+        user_id=["dave", "carol"],
+        group_id="group_a",
+        session_id="session_b",
+        agent_id=["my_agent", "another_agent"],
+    )
+    dft_session = SessionData()
+    session.merge(dft_session)
+    assert session.user_id == ["carol", "dave"]
+    assert session.group_id == "group_a"
+    assert session.session_id == "session_b"
+    assert session.agent_id == ["another_agent", "my_agent"]
+
+
+def test_no_default_agent_if_user_exists():
+    session = SessionData(
+        user_id=["dave", "carol"],
+        group_id="group_a",
+        session_id="session_b",
+    )
+    dft_session = SessionData()
+    session.merge(dft_session)
+    assert session.user_id == ["carol", "dave"]
+    assert session.group_id == "group_a"
+    assert session.session_id == "session_b"
+    assert session.agent_id == []
+
+
+def test_no_default_user_if_agent_exists():
+    session = SessionData(
+        group_id="group_a",
+        session_id="session_b",
+        agent_id=["my_agent", "another_agent"],
+    )
+    dft_session = SessionData()
+    session.merge(dft_session)
+    assert session.user_id == []
+    assert session.group_id == "group_a"
+    assert session.session_id == "session_b"
+    assert session.agent_id == ["another_agent", "my_agent"]

--- a/tests/memmachine/server/test_rest_memories.py
+++ b/tests/memmachine/server/test_rest_memories.py
@@ -144,10 +144,10 @@ def valid_session_headers():
 def alias_session_headers():
     """Provides valid headers using alias names for session fields."""
     return {
-        "group-id": "group-alias",
-        "session-id": "session-alias",
-        "agent-id": "agent5,agent6",
-        "user-id": "user5,user6",
+        "group_id": "group-alias",
+        "session_id": "session-alias",
+        "agent_id": "agent5,agent6",
+        "user_id": "user5,user6",
     }
 
 


### PR DESCRIPTION


### Purpose of the change

Fix bug #397, session data is polluted

### Description

If the session data is supplied in the request, the default value of the session will be mixed with the user input.

The fix is to update the merge function to remove the default or ignore the default value if user input is available.

Also fix the header alias.

### Fixes/Closes

Fixes #397

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

Test manually with curl.  Unit test are added to verify the change.

Here are the curl commands used for test:

```
curl -v -X POST http://localhost:8080/v1/memories -H "Content-Type: application/json" -d '{
  "session": {
    "group_id": "group-hello",
    "agent_id": ["agent_hello", "agent_bye"],
    "session_id": "session-hello"
  },
  "producer": "agent_hello",
  "produced_for": "agent_bye",
  "episode_content": "Test memory with string IDs",
  "episode_type": "test",
  "metadata": {}
}'
```

```
curl -v -X POST http://localhost:8080/v1/memories \
  -H "Content-Type: application/json" \
  -H "group_id: group-hello" \
  -H "user_id: user-hello,user-bye" \
  -H "session_id: session-user-hello-bye-header-under" \
  -d '{
    "producer": "user-hello",
    "produced_for": "user-bye",
    "episode_content": "Test memory with string IDs",
    "episode_type": "test",
    "metadata": {}
  }'
```

- [x] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [x] Manual verification (list step-by-step instructions)

**Test Results:**

For the first curl command.
```
< HTTP/1.1 200 OK
< date: Tue, 28 Oct 2025 22:37:12 GMT
< server: uvicorn
< content-length: 4
< content-type: application/json
< group-id: group-hello
< session-id: session-hello
< agent-id: agent_bye,agent_hello
```

For the second curl command

```
< HTTP/1.1 200 OK
< date: Tue, 28 Oct 2025 22:37:49 GMT
< server: uvicorn
< content-length: 4
< content-type: application/json
< group-id: group-hello
< session-id: session-user-hello-bye-header-under
< user-id: user-bye,user-hello
```


### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

