### PR TITLE
Update language models to use BaseModel params

### DIFF
--- a/src/memmachine/common/language_model/language_model.py
+++ b/src/memmachine/common/language_model/language_model.py
@@ -24,23 +24,23 @@ class LanguageModel(ABC):
         Generate a response based on the provided prompts and tools.
 
         Args:
-            system_prompt (str | None, optional):
+            system_prompt (str | None):
                 The system prompt to guide the model's behavior
                 (default: None).
-            user_prompt (str | None, optional):
+            user_prompt (str | None):
                 The user prompt containing the main input
                 (default: None).
-            tools (list[dict[str, Any]] | None, optional):
+            tools (list[dict[str, Any]] | None):
                 A list of tools that the model can use in its response, if supported
                 (default: None).
-            tool_choice (str | dict[str, str] | None, optional):
+            tool_choice (str | dict[str, str] | None):
                 Strategy for selecting tools, if supported.
                 Can be "auto" for automatic selection,
                 "required" for using at least one tool,
                 or a specific tool.
                 If None, implementation-defined default is used
                 (default: None).
-            max_attempts (int, optional):
+            max_attempts (int):
                 The maximum number of attempts to make before giving up
                 (default: 1).
 

--- a/tests/memmachine/common/language_model/test_openai_chat_completions_language_model.py
+++ b/tests/memmachine/common/language_model/test_openai_chat_completions_language_model.py
@@ -1,15 +1,17 @@
 """
-Unit tests for OpenAICompatibleLanguageModel.
+Unit tests for OpenAIChatCompletionsLanguageModel.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import openai
 import pytest
+from pydantic import ValidationError
 
 from memmachine.common.data_types import ExternalServiceAPIError
-from memmachine.common.language_model.openai_compatible_language_model import (
-    OpenAICompatibleLanguageModel,
+from memmachine.common.language_model.openai_chat_completions_language_model import (
+    OpenAIChatCompletionsLanguageModel,
+    OpenAIChatCompletionsLanguageModelParams,
 )
 from memmachine.common.metrics_factory.metrics_factory import MetricsFactory
 
@@ -57,124 +59,137 @@ def mock_tool_call_impl():
 
 
 @pytest.fixture
-def minimal_config():
+def mock_async_openai():
+    """Fixture for a mocked AsyncOpenAI client."""
+    with patch("openai.AsyncOpenAI", spec=openai.AsyncOpenAI) as mock_async_openai:
+        mock_client = mock_async_openai.return_value
+        mock_client.chat.completions.create = AsyncMock()
+        yield mock_async_openai
+
+
+@pytest.fixture
+def minimal_config(mock_async_openai):
     """Fixture for a minimal valid configuration."""
-    return {"api_key": "test_api_key", "model": "test-model"}
+    return OpenAIChatCompletionsLanguageModelParams(
+        client=openai.AsyncOpenAI(
+            api_key="test_api_key",
+        ),
+        model="test-model",
+    )
 
 
 @pytest.fixture
-def full_config(mock_metrics_factory):
+def full_config(mock_async_openai, mock_metrics_factory):
     """Fixture for a full valid configuration with metrics."""
-    return {
-        "api_key": "test_api_key",
-        "model": "test-model",
-        "base_url": "http://localhost:8080",
-        "max_retry_interval_seconds": 60,
-        "metrics_factory": mock_metrics_factory,
-        "user_metrics_labels": {"user": "test-user"},
-    }
+    return OpenAIChatCompletionsLanguageModelParams(
+        client=openai.AsyncOpenAI(
+            api_key="test_api_key",
+            base_url="http://localhost:8080",
+        ),
+        model="test-model",
+        max_retry_interval_seconds=60,
+        metrics_factory=mock_metrics_factory,
+        user_metrics_labels={"user": "test-user"},
+    )
 
 
 @pytest.fixture
-def max_retry_interval_seconds_config():
+def max_retry_interval_seconds_config(mock_async_openai):
     """Fixture for a valid configuration with small max_retry_interval_seconds."""
-    return {
-        "api_key": "test_api_key",
-        "model": "test-model",
-        "max_retry_interval_seconds": 4,
-    }
+    return OpenAIChatCompletionsLanguageModelParams(
+        client=openai.AsyncOpenAI(
+            api_key="test_api_key",
+        ),
+        model="test-model",
+        max_retry_interval_seconds=4,
+    )
 
 
-@patch(
-    "memmachine.common.language_model.openai_compatible_language_model.openai.AsyncOpenAI"
-)
 def test_init_success(mock_async_openai, minimal_config):
     """Test successful initialization."""
-    OpenAICompatibleLanguageModel(minimal_config)
-    mock_async_openai.assert_called_once_with(api_key="test_api_key", base_url=None)
+    OpenAIChatCompletionsLanguageModel(minimal_config)
 
 
-@patch(
-    "memmachine.common.language_model.openai_compatible_language_model.openai.AsyncOpenAI"
-)
 def test_init_with_full_config(mock_async_openai, full_config):
     """Test successful initialization with all optional parameters."""
-    _ = OpenAICompatibleLanguageModel(full_config)
+    _ = OpenAIChatCompletionsLanguageModel(full_config)
     mock_async_openai.assert_called_once_with(
         api_key="test_api_key", base_url="http://localhost:8080"
     )
 
 
+def test_init_missing_client():
+    """Test initialization fails if client is missing."""
+    with pytest.raises(ValidationError):
+        OpenAIChatCompletionsLanguageModel(
+            OpenAIChatCompletionsLanguageModelParams(
+                model="test-model",
+            )
+        )
+
+
 def test_init_missing_model():
     """Test initialization fails if model is missing."""
-    with pytest.raises(ValueError, match="The model name must be configured"):
-        OpenAICompatibleLanguageModel({"api_key": "key"})
-
-
-def test_init_missing_api_key():
-    """Test initialization fails if api_key is missing."""
-    with pytest.raises(ValueError, match="Language API key must be provided"):
-        OpenAICompatibleLanguageModel({"model": "test-model"})
-
-
-@pytest.mark.parametrize("bad_url", ["not_a_url", "http://", "localhost:8080"])
-def test_init_invalid_base_url(bad_url, minimal_config):
-    """Test initialization fails with an invalid base_url."""
-    config = {**minimal_config, "base_url": bad_url}
-    with pytest.raises(ValueError, match=f"Invalid base URL: {bad_url}"):
-        OpenAICompatibleLanguageModel(config)
+    with pytest.raises(ValidationError):
+        OpenAIChatCompletionsLanguageModel(
+            OpenAIChatCompletionsLanguageModelParams(
+                client=openai.AsyncOpenAI(
+                    api_key="test_api_key",
+                ),
+            )
+        )
 
 
 def test_init_invalid_max_retry_interval_seconds_type(minimal_config):
     """Test initialization fails with non-integer max_retry_interval_seconds."""
-    config = {**minimal_config, "max_retry_interval_seconds": "not-an-int"}
-    with pytest.raises(
-        TypeError, match="max_retry_interval_seconds must be an integer"
-    ):
-        OpenAICompatibleLanguageModel(config)
+    with pytest.raises(ValidationError):
+        OpenAIChatCompletionsLanguageModelParams(
+            **(
+                minimal_config.model_dump()
+                | {"max_retry_interval_seconds": "not-an-int"}
+            ),
+        )
 
 
 def test_init_invalid_max_retry_interval_seconds_value(minimal_config):
     """Test initialization fails with non-positive max_retry_interval_seconds."""
-    config = {**minimal_config, "max_retry_interval_seconds": 0}
-    with pytest.raises(
-        ValueError, match="max_retry_interval_seconds must be a positive integer"
-    ):
-        OpenAICompatibleLanguageModel(config)
+    with pytest.raises(ValidationError):
+        OpenAIChatCompletionsLanguageModelParams(
+            **(minimal_config.model_dump() | {"max_retry_interval_seconds": 0}),
+        )
 
 
 def test_init_invalid_metrics_factory_type(minimal_config):
     """Test initialization fails with invalid metrics_factory type."""
-    config = {**minimal_config, "metrics_factory": "not-a-factory"}
-    with pytest.raises(
-        TypeError, match="Metrics factory must be an instance of MetricsFactory"
-    ):
-        OpenAICompatibleLanguageModel(config)
+    with pytest.raises(ValidationError):
+        OpenAIChatCompletionsLanguageModelParams(
+            **(minimal_config.model_dump() | {"metrics_factory": "not-a-factory"}),
+        )
 
 
 def test_init_invalid_user_metrics_labels_type(minimal_config, mock_metrics_factory):
     """Test initialization fails with invalid user_metrics_labels type."""
-    config = {
-        **minimal_config,
-        "metrics_factory": mock_metrics_factory,
-        "user_metrics_labels": "not-a-dict",
-    }
-    with pytest.raises(TypeError, match="user_metrics_labels must be a dictionary"):
-        OpenAICompatibleLanguageModel(config)
+    with pytest.raises(ValidationError):
+        OpenAIChatCompletionsLanguageModelParams(
+            **(
+                minimal_config.model_dump()
+                | {
+                    "metrics_factory": mock_metrics_factory,
+                    "user_metrics_labels": "not-a-dict",
+                }
+            ),
+        )
 
 
 @pytest.mark.asyncio
 async def test_generate_response_invalid_max_attempts(minimal_config):
     """Test generate_response fails with non-positive max_attempts."""
-    lm = OpenAICompatibleLanguageModel(minimal_config)
+    lm = OpenAIChatCompletionsLanguageModel(minimal_config)
     with pytest.raises(ValueError, match="max_attempts must be a positive integer"):
         await lm.generate_response(max_attempts=0)
 
 
 @pytest.mark.asyncio
-@patch(
-    "memmachine.common.language_model.openai_compatible_language_model.openai.AsyncOpenAI"
-)
 async def test_generate_response_success(mock_async_openai, minimal_config):
     """Test a successful call to generate_response."""
     mock_response = MagicMock()
@@ -182,11 +197,10 @@ async def test_generate_response_success(mock_async_openai, minimal_config):
     mock_response.choices[0].message.tool_calls = None
     mock_response.usage = None
 
-    mock_client = AsyncMock()
+    mock_client = mock_async_openai.return_value
     mock_client.chat.completions.create.return_value = mock_response
-    mock_async_openai.return_value = mock_client
 
-    lm = OpenAICompatibleLanguageModel(minimal_config)
+    lm = OpenAIChatCompletionsLanguageModel(minimal_config)
     content, tool_calls = await lm.generate_response(
         system_prompt="System prompt", user_prompt="User prompt"
     )
@@ -203,9 +217,6 @@ async def test_generate_response_success(mock_async_openai, minimal_config):
 
 
 @pytest.mark.asyncio
-@patch(
-    "memmachine.common.language_model.openai_compatible_language_model.openai.AsyncOpenAI"
-)
 async def test_generate_response_with_tool_calls(
     mock_async_openai, minimal_config, mock_tool_call_impl
 ):
@@ -228,11 +239,10 @@ async def test_generate_response_with_tool_calls(
     ]
     mock_response.usage = None
 
-    mock_client = AsyncMock()
+    mock_client = mock_async_openai.return_value
     mock_client.chat.completions.create.return_value = mock_response
-    mock_async_openai.return_value = mock_client
 
-    lm = OpenAICompatibleLanguageModel(minimal_config)
+    lm = OpenAIChatCompletionsLanguageModel(minimal_config)
     content, tool_calls = await lm.generate_response()
 
     assert content == ""
@@ -248,9 +258,6 @@ async def test_generate_response_with_tool_calls(
 
 
 @pytest.mark.asyncio
-@patch(
-    "memmachine.common.language_model.openai_compatible_language_model.openai.AsyncOpenAI"
-)
 async def test_generate_response_tool_call_json_error(
     mock_async_openai, minimal_config, mock_tool_call_impl
 ):
@@ -264,22 +271,18 @@ async def test_generate_response_tool_call_json_error(
     mock_response.choices[0].message.tool_calls = [mock_tool_call]
     mock_response.usage = None
 
-    mock_client = AsyncMock()
+    mock_client = mock_async_openai.return_value
     mock_client.chat.completions.create.return_value = mock_response
-    mock_async_openai.return_value = mock_client
 
-    lm = OpenAICompatibleLanguageModel(minimal_config)
+    lm = OpenAIChatCompletionsLanguageModel(minimal_config)
     with pytest.raises(ValueError, match="JSON decode error"):
         await lm.generate_response()
 
 
 @pytest.mark.asyncio
 @patch("asyncio.sleep", new_callable=AsyncMock)
-@patch(
-    "memmachine.common.language_model.openai_compatible_language_model.openai.AsyncOpenAI"
-)
 async def test_generate_response_retry_on_rate_limit(
-    mock_async_openai, mock_sleep, minimal_config
+    mock_sleep, mock_async_openai, minimal_config
 ):
     """Test retry logic on RateLimitError."""
     mock_response = MagicMock()
@@ -287,14 +290,13 @@ async def test_generate_response_retry_on_rate_limit(
     mock_response.choices[0].message.tool_calls = None
     mock_response.usage = None
 
-    mock_client = AsyncMock()
+    mock_client = mock_async_openai.return_value
     mock_client.chat.completions.create.side_effect = [
         openai.RateLimitError("rate limited", response=MagicMock(), body=None),
         mock_response,
     ]
-    mock_async_openai.return_value = mock_client
 
-    lm = OpenAICompatibleLanguageModel(minimal_config)
+    lm = OpenAIChatCompletionsLanguageModel(minimal_config)
     content, _ = await lm.generate_response(max_attempts=2)
 
     assert content == "Success after retry"
@@ -304,11 +306,8 @@ async def test_generate_response_retry_on_rate_limit(
 
 @pytest.mark.asyncio
 @patch("asyncio.sleep", new_callable=AsyncMock)
-@patch(
-    "memmachine.common.language_model.openai_compatible_language_model.openai.AsyncOpenAI"
-)
 async def test_generate_response_retry_on_rate_limit_with_max_retry_interval_seconds(
-    mock_async_openai, mock_sleep, max_retry_interval_seconds_config
+    mock_sleep, mock_async_openai, max_retry_interval_seconds_config
 ):
     """Test retry logic on RateLimitError."""
     mock_response = MagicMock()
@@ -316,13 +315,12 @@ async def test_generate_response_retry_on_rate_limit_with_max_retry_interval_sec
     mock_response.choices[0].message.tool_calls = None
     mock_response.usage = None
 
-    mock_client = AsyncMock()
+    mock_client = mock_async_openai.return_value
     mock_client.chat.completions.create.side_effect = openai.RateLimitError(
         "rate limited", response=MagicMock(), body=None
     )
-    mock_async_openai.return_value = mock_client
 
-    lm = OpenAICompatibleLanguageModel(max_retry_interval_seconds_config)
+    lm = OpenAIChatCompletionsLanguageModel(max_retry_interval_seconds_config)
     with pytest.raises(ExternalServiceAPIError):
         await lm.generate_response(max_attempts=6)
 
@@ -340,18 +338,14 @@ async def test_generate_response_retry_on_rate_limit_with_max_retry_interval_sec
 
 @pytest.mark.asyncio
 @patch("asyncio.sleep", new_callable=AsyncMock)
-@patch(
-    "memmachine.common.language_model.openai_compatible_language_model.openai.AsyncOpenAI"
-)
 async def test_generate_response_fail_after_max_retries(
-    mock_async_openai, mock_sleep, minimal_config
+    mock_sleep, mock_async_openai, minimal_config
 ):
     """Test that an IOError is raised after max_attempts are exhausted."""
-    mock_client = AsyncMock()
+    mock_client = mock_async_openai.return_value
     mock_client.chat.completions.create.side_effect = openai.APITimeoutError(None)
-    mock_async_openai.return_value = mock_client
 
-    lm = OpenAICompatibleLanguageModel(minimal_config)
+    lm = OpenAIChatCompletionsLanguageModel(minimal_config)
     with pytest.raises(ExternalServiceAPIError, match=r"max attempts"):
         await lm.generate_response(max_attempts=3)
 
@@ -371,28 +365,21 @@ async def test_generate_response_fail_after_max_retries(
         (openai.OpenAIError("generic error")),
     ],
 )
-@patch(
-    "memmachine.common.language_model.openai_compatible_language_model.openai.AsyncOpenAI"
-)
 async def test_generate_response_runtime_exception_mapping(
     mock_async_openai, minimal_config, exception
 ):
     """Test that OpenAI exceptions are correctly mapped to generic
     exceptions.
     """
-    mock_client = AsyncMock()
+    mock_client = mock_async_openai.return_value
     mock_client.chat.completions.create.side_effect = exception
-    mock_async_openai.return_value = mock_client
 
-    lm = OpenAICompatibleLanguageModel(minimal_config)
+    lm = OpenAIChatCompletionsLanguageModel(minimal_config)
     with pytest.raises(ExternalServiceAPIError):
         await lm.generate_response()
 
 
 @pytest.mark.asyncio
-@patch(
-    "memmachine.common.language_model.openai_compatible_language_model.openai.AsyncOpenAI"
-)
 async def test_metrics_collection(mock_async_openai, full_config):
     """Test that metrics are collected on a successful call."""
     mock_usage = MagicMock()
@@ -405,15 +392,14 @@ async def test_metrics_collection(mock_async_openai, full_config):
     mock_response.choices[0].message.tool_calls = None
     mock_response.usage = mock_usage
 
-    mock_client = AsyncMock()
+    mock_client = mock_async_openai.return_value
     mock_client.chat.completions.create.return_value = mock_response
-    mock_async_openai.return_value = mock_client
 
-    lm = OpenAICompatibleLanguageModel(full_config)
+    lm = OpenAIChatCompletionsLanguageModel(full_config)
     await lm.generate_response()
 
-    metrics_factory = full_config["metrics_factory"]
-    labels = full_config["user_metrics_labels"]
+    metrics_factory = full_config.metrics_factory
+    labels = full_config.user_metrics_labels
 
     input_counter = metrics_factory.get_counter("test", "test")
     output_counter = metrics_factory.get_counter("test", "test")

--- a/tests/memmachine/profile_memory/test_profile_memory_integration.py
+++ b/tests/memmachine/profile_memory/test_profile_memory_integration.py
@@ -12,7 +12,10 @@ from memmachine.common.embedder.openai_embedder import (
     OpenAIEmbedder,
     OpenAIEmbedderParams,
 )
-from memmachine.common.language_model.openai_language_model import OpenAILanguageModel
+from memmachine.common.language_model.openai_responses_language_model import (
+    OpenAIResponsesLanguageModel,
+    OpenAIResponsesLanguageModelParams,
+)
 from memmachine.profile_memory.profile_memory import ProfileMemory
 from memmachine.profile_memory.prompt_provider import ProfilePrompt
 from memmachine.profile_memory.storage.asyncpg_profile import AsyncPgProfileStorage
@@ -44,8 +47,13 @@ def embedder(config):
 
 @pytest.fixture
 def llm_model(config):
-    return OpenAILanguageModel(
-        {"api_key": config["api_key"], "model": config["llm_model"]}
+    return OpenAIResponsesLanguageModel(
+        OpenAIResponsesLanguageModelParams(
+            client=openai.AsyncOpenAI(
+                api_key=config["api_key"],
+            ),
+            model=config["llm_model"],
+        )
     )
 
 
@@ -137,7 +145,7 @@ class TestLongMemEvalIngestion:
         user_id: str,
         profile_memory: ProfileMemory,
         question_str: str,
-        llm_model: OpenAILanguageModel,
+        llm_model: OpenAIResponsesLanguageModel,
     ):
         profile_search_resp = await profile_memory.semantic_search(
             question_str, user_id=user_id


### PR DESCRIPTION
### Purpose of the change

Part of refactoring to make MemMachine closer to a library and better support dependency injection.

### Description

All language models now take a BaseModel type for parameters.

Renamed OpenAILanguageModel --> OpenAIResponsesLanguageModel
Renamed OpenAICompatibleLanguageModel --> OpenAIChatCompletionsLanguageModel
Configuration file stays the same.

### Type of change

Breaking for consumers of lower-level resources.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

Unit tests pass.

- [x] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected