### PR TITLE
Add deprecated check with ruff

### DIFF
--- a/examples/crm/query_constructor.py
+++ b/examples/crm/query_constructor.py
@@ -8,7 +8,6 @@ import logging
 import os
 import sys
 from datetime import datetime
-from typing import Optional
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from base_query_constructor import BaseQueryConstructor
@@ -434,9 +433,7 @@ class CRMQueryConstructor(BaseQueryConstructor):
     def __init__(self):
         self.prompt_template = _build_unified_query_template()
 
-    def create_query(
-        self, profile: Optional[str], context: Optional[str], query: str
-    ) -> str:
+    def create_query(self, profile: str | None, context: str | None, query: str) -> str:
         """Create a CRM query using the prompt template"""
         if not query or not query.strip():
             raise ValueError("Query cannot be empty")

--- a/examples/crm/slack_service.py
+++ b/examples/crm/slack_service.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, Dict, Optional
+from typing import Any
 
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
@@ -13,7 +13,7 @@ class SlackService:
     Thin async wrapper around Slack Web API for the operations we need.
     """
 
-    def __init__(self, token: Optional[str] = None):
+    def __init__(self, token: str | None = None):
         self.token = token or os.getenv("SLACK_BOT_TOKEN")
         if not self.token:
             logger.warning("SLACK_BOT_TOKEN is not set; Slack operations will fail")
@@ -26,8 +26,8 @@ class SlackService:
         """
         try:
             resp = await self.client.users_info(user=user_id)
-            user: Dict[str, Any] = resp.get("user") or {}
-            profile: Dict[str, Any] = user.get("profile") or {}
+            user: dict[str, Any] = resp.get("user") or {}
+            profile: dict[str, Any] = user.get("profile") or {}
             display = (profile.get("display_name") or "").strip()
             real = (profile.get("real_name") or "").strip()
             return display or real or user_id
@@ -41,8 +41,8 @@ class SlackService:
             return user_id
 
     async def post_message(
-        self, channel: str, text: str, thread_ts: Optional[str] = None
-    ) -> Optional[str]:
+        self, channel: str, text: str, thread_ts: str | None = None
+    ) -> str | None:
         """
         Post a message to a channel (optionally in a thread). Returns ts if successful.
         """
@@ -62,7 +62,7 @@ class SlackService:
 
     async def get_channel_history(
         self, channel: str, limit: int = 1000
-    ) -> list[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Fetch historical messages from a Slack channel.
         Returns list of message objects with metadata.
@@ -106,7 +106,7 @@ class SlackService:
             logger.exception("[SLACK] conversations.history unexpected error")
             return []
 
-    async def get_all_channels(self) -> list[Dict[str, Any]]:
+    async def get_all_channels(self) -> list[dict[str, Any]]:
         """
         Get list of all channels the bot has access to.
         """

--- a/examples/default_query_constructor.py
+++ b/examples/default_query_constructor.py
@@ -2,7 +2,6 @@ import logging
 import os
 import sys
 from datetime import datetime
-from typing import Optional
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from base_query_constructor import BaseQueryConstructor
@@ -53,9 +52,7 @@ Response Format:
 </USER_QUERY>
 """
 
-    def create_query(
-        self, profile: Optional[str], context: Optional[str], query: str
-    ) -> str:
+    def create_query(self, profile: str | None, context: str | None, query: str) -> str:
         """Create a general chatbot query using the prompt template"""
         if not query or not query.strip():
             raise ValueError("Query cannot be empty")

--- a/examples/financial_analyst/query_constructor.py
+++ b/examples/financial_analyst/query_constructor.py
@@ -2,7 +2,6 @@ import logging
 import os
 import sys
 from datetime import datetime
-from typing import Optional
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from base_query_constructor import BaseQueryConstructor
@@ -57,9 +56,7 @@ Response Format:
 </USER_QUERY>
 """
 
-    def create_query(
-        self, profile: Optional[str], context: Optional[str], query: str
-    ) -> str:
+    def create_query(self, profile: str | None, context: str | None, query: str) -> str:
         """Create a financial analyst query using the prompt template"""
         if not query or not query.strip():
             raise ValueError("Query cannot be empty")

--- a/examples/health_assistant/query_constructor.py
+++ b/examples/health_assistant/query_constructor.py
@@ -2,7 +2,6 @@ import logging
 import os
 import sys
 from datetime import datetime
-from typing import Optional
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from base_query_constructor import BaseQueryConstructor
@@ -59,9 +58,7 @@ Response Format:
 </USER_QUERY>
 """
 
-    def create_query(
-        self, profile: Optional[str], context: Optional[str], query: str
-    ) -> str:
+    def create_query(self, profile: str | None, context: str | None, query: str) -> str:
         """Create a health assistant query using the prompt template"""
         if not query or not query.strip():
             raise ValueError("Query cannot be empty")

--- a/examples/writing_assistant/query_constructor.py
+++ b/examples/writing_assistant/query_constructor.py
@@ -2,7 +2,6 @@ import logging
 import os
 import sys
 from datetime import datetime
-from typing import Optional
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from base_query_constructor import BaseQueryConstructor
@@ -137,9 +136,7 @@ Use the "/submit" command followed by the content type and your writing sample:
                 "original_query": query,
             }
 
-    def create_query(
-        self, profile: Optional[str], context: Optional[str], query: str
-    ) -> str:
+    def create_query(self, profile: str | None, context: str | None, query: str) -> str:
         """Create a writing assistant query using the prompt template"""
         if not query or not query.strip():
             raise ValueError("Query cannot be empty")
@@ -169,7 +166,7 @@ Use the "/submit" command followed by the content type and your writing sample:
                 return f"{profile_str}\n\n{context_block}{query}"
 
     def create_submission_query(
-        self, profile: Optional[str], context: Optional[str], submit_info: dict
+        self, profile: str | None, context: str | None, submit_info: dict
     ) -> str:
         """Create a specialized query for writing sample submissions"""
         content_type = submit_info["content_type"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,12 +64,13 @@ dev = [
 
 [tool.mypy]
 follow_untyped_imports = true
+enable_error_code = ["deprecated"]
 exclude = ["venv/", ".venv/"]
 plugins = ['pydantic.mypy']
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W"]
-ignore = ["E501"]
+select = ["E", "F", "I", "W", "UP"]
+ignore = ["E501", "UP015"]
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "session"

--- a/src/memmachine/profile_memory/profile_memory.py
+++ b/src/memmachine/profile_memory/profile_memory.py
@@ -700,16 +700,13 @@ class ProfileMemory:
         user_prompt = (
             "The old profile is provided below:\n"
             "<OLD_PROFILE>\n"
-            "{profile}\n"
+            f"{str(profile)}\n"
             "</OLD_PROFILE>\n"
             "\n"
             "The history is provided below:\n"
             "<HISTORY>\n"
-            "{memory_content}\n"
+            f"{memory_content}\n"
             "</HISTORY>\n"
-        ).format(
-            profile=str(profile),
-            memory_content=memory_content,
         )
         # Use chain-of-thought to get entity profile update commands.
         logger.debug(

--- a/src/memmachine/profile_memory/storage/asyncpg_profile.py
+++ b/src/memmachine/profile_memory/storage/asyncpg_profile.py
@@ -1,8 +1,8 @@
 import functools
 import json
 import logging
-from collections.abc import Mapping
-from typing import Any, Iterator
+from collections.abc import Iterator, Mapping
+from typing import Any
 
 import asyncpg
 import numpy as np

--- a/src/memmachine/profile_memory/storage/storage_base.py
+++ b/src/memmachine/profile_memory/storage/storage_base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 import numpy as np
 

--- a/src/memmachine/rest_client/client.py
+++ b/src/memmachine/rest_client/client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 from weakref import WeakSet
 
 import requests
@@ -46,8 +46,8 @@ class MemMachineClient:
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
-        base_url: Optional[str] = None,
+        api_key: str | None = None,
+        base_url: str | None = None,
         timeout: int = 30,
         max_retries: int = 3,
         **kwargs,
@@ -104,10 +104,10 @@ class MemMachineClient:
 
     def memory(
         self,
-        group_id: Optional[str] = None,
-        agent_id: Optional[Union[str, List[str]]] = None,
-        user_id: Optional[Union[str, List[str]]] = None,
-        session_id: Optional[str] = None,
+        group_id: str | None = None,
+        agent_id: str | list[str] | None = None,
+        user_id: str | list[str] | None = None,
+        session_id: str | None = None,
         **kwargs,
     ) -> Memory:
         """
@@ -135,7 +135,7 @@ class MemMachineClient:
         self._memory_objects.add(memory)
         return memory
 
-    def health_check(self) -> Dict[str, Any]:
+    def health_check(self) -> dict[str, Any]:
         """
         Check the health status of the MemMachine server.
 

--- a/src/memmachine/rest_client/memory.py
+++ b/src/memmachine/rest_client/memory.py
@@ -6,7 +6,7 @@ operations for a specific context.
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 from uuid import uuid4
 
 import requests
@@ -44,10 +44,10 @@ class Memory:
     def __init__(
         self,
         client,
-        group_id: Optional[str] = None,
-        agent_id: Optional[Union[str, List[str]]] = None,
-        user_id: Optional[Union[str, List[str]]] = None,
-        session_id: Optional[str] = None,
+        group_id: str | None = None,
+        agent_id: str | list[str] | None = None,
+        user_id: str | list[str] | None = None,
+        session_id: str | None = None,
         **kwargs,
     ):
         """
@@ -97,7 +97,7 @@ class Memory:
             self.__group_id = self.__user_id[0]
 
     @property
-    def user_id(self) -> Optional[List[str]]:
+    def user_id(self) -> list[str] | None:
         """
         Get the user_id list (read-only).
 
@@ -107,7 +107,7 @@ class Memory:
         return self.__user_id
 
     @property
-    def agent_id(self) -> Optional[List[str]]:
+    def agent_id(self) -> list[str] | None:
         """
         Get the agent_id list (read-only).
 
@@ -117,7 +117,7 @@ class Memory:
         return self.__agent_id
 
     @property
-    def group_id(self) -> Optional[str]:
+    def group_id(self) -> str | None:
         """
         Get the group_id (read-only).
 
@@ -139,10 +139,10 @@ class Memory:
     def add(
         self,
         content: str,
-        producer: Optional[str] = None,
-        produced_for: Optional[str] = None,
+        producer: str | None = None,
+        produced_for: str | None = None,
         episode_type: str = "text",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> bool:
         """
         Add a memory episode.
@@ -251,9 +251,9 @@ class Memory:
     def search(
         self,
         query: str,
-        limit: Optional[int] = None,
-        filter_dict: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+        limit: int | None = None,
+        filter_dict: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         """
         Search for memories.
 
@@ -300,7 +300,7 @@ class Memory:
             logger.error(f"Failed to search memories: {e}")
             raise
 
-    def get_context(self) -> Dict[str, Any]:
+    def get_context(self) -> dict[str, Any]:
         """
         Get the current memory context.
 


### PR DESCRIPTION
Adds ruff linter check to find the use of deprecated features and functions and fixes the issues it reports.

This linter also enforces the use of newer Python styles, like union types instead of `Optional`.