### PR TITLE
handles config for vector_graph_store

### DIFF
--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -402,13 +402,30 @@ set_config_defaults() {
         -v pg_db="${POSTGRES_DB:-memmachine}" \
         -v neo4j_user="${NEO4J_USER:-neo4j}" \
         -v neo4j_pass="${NEO4J_PASSWORD:-neo4j_password}" '
+/^storage:/ || /^vector_graph_store:/ {
+  vendor = ""
+}
+/^[a-zA-Z][^:]*:/ && !/^storage:/ && !/^vector_graph_store:/ {
+  vendor = ""
+}
+
 /vendor_name:/ {
   vendor = $2
+  gsub(/^[ \t]+|[ \t]+$/, "", vendor)  # trim whitespace
+}
+
+/provider:/ && /neo4j/ {
+  vendor = "neo4j"
+}
+/provider:/ && /postgres/ {
+  vendor = "postgres"
 }
 
 vendor == "neo4j" && /host:/ { sub(/localhost/, "neo4j") }
+vendor == "neo4j" && /uri:/ { sub(/localhost/, "neo4j") }
 vendor == "neo4j" && /password:/ { sub(/<YOUR_PASSWORD_HERE>/, neo4j_pass) }
 
+# Handle postgres configurations
 vendor == "postgres" && /host:/ { sub(/localhost/, "postgres") }
 vendor == "postgres" && /user:/ { sub(/postgres/, pg_user) }
 vendor == "postgres" && /db_name:/ { sub(/postgres/, pg_db) }


### PR DESCRIPTION
### Purpose of the change

the vector_graph_store config is not created correctly, this PR fixes the vector_graph_store config

### Description

Please include a summary of the change and the issue it addresses. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Fixes/Closes

Fixes #514 

### Type of change

[Please delete options that are not relevant.]

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

[Please delete options that are not relevant.]

- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

After fix, the vector_graph_store config in configuration.yml is
```
vector_graph_store:
  my_storage_id:
    provider: neo4j
    config:
      uri: 'bolt://neo4j:7687'
      username: neo4j
      password: neo4j_password
```

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

[If applicable, add screenshots or GIFs that show the changes in action. This is especially helpful for API responses. Otherwise, delete this section or type "N/A".]

### Further comments

[Add any other relevant information here, such as potential side effects, future considerations, or any specific questions for the reviewer. Otherwise, type "None".]
