### PR TITLE
Docs: Updating Memory Tables and Nomenclature from "Profile" to "Semantic"

### DIFF
--- a/docs/open_source/memory_types.mdx
+++ b/docs/open_source/memory_types.mdx
@@ -84,7 +84,7 @@ Here are the fields you'll find in this table:
 | isolations | A JSONB field for storing isolation parameters, which can be used to restrict access to certain knowledge entries based on specific criteria. |
 
 <Danger>
-**Vector Demension Mismatch** 
+**Vector Dimension Mismatch** 
 
 Vector dimension in a memory table must never change.
 


### PR DESCRIPTION
### Purpose of the change

To update `memory_types.mdx` so it reflects existing code.



### Description

Two primary reasons for this change:
   1. Update nomenclature from "profile" memory to "semantic" memory.  This is done to prepare users for more changes as they are made.
   2. Update the semantic memory, history table, and citations table information due to changes made since product launch.

No Dependencies.
### Fixes/Closes

Fixes #(issue number)

### Type of change

- [X] Documentation update


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

[Please delete options that are not relevant.]

- [ ] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [X] Manual verification (list step-by-step instructions)
   `mint dev` and `mint broken-links` in mint test environment/server.  

**Test Results:**
Top of page showing changes from Profile to Semantic:
<img width="1733" height="873" alt="Screenshot 2025-11-13 at 3 40 13 PM" src="https://github.com/user-attachments/assets/12675a30-1b5d-4e8c-8743-7d4763c556c6" />

Middle of Page:
<img width="1711" height="863" alt="Screenshot 2025-11-13 at 3 40 53 PM" src="https://github.com/user-attachments/assets/81cc0898-2cd1-4d0d-9f96-36d4e0d39632" />

Bottom of Page, showing Table Accordion:
<img width="1516" height="872" alt="Screenshot 2025-11-13 at 3 42 20 PM" src="https://github.com/user-attachments/assets/e30298c0-70de-496f-b88c-9e8351aa2561" />

Semantic Table Accordion (Top):
<img width="1499" height="865" alt="Screenshot 2025-11-13 at 3 42 55 PM" src="https://github.com/user-attachments/assets/d1718148-c5c4-4b64-b625-b65830926ddb" />

Semantic Table Accordion (Middle):
<img width="1528" height="855" alt="Screenshot 2025-11-13 at 3 43 55 PM" src="https://github.com/user-attachments/assets/18e8ae06-d079-4962-bbe1-258ce40fddd9" />

Semantic Table Accordion (Bottom, shows Callouts):
<img width="1467" height="866" alt="Screenshot 2025-11-13 at 3 44 26 PM" src="https://github.com/user-attachments/assets/0e81e7d0-51e7-4631-a992-70ce3d092f83" />

History Table Accordion (Top):
<img width="1518" height="853" alt="Screenshot 2025-11-13 at 3 45 06 PM" src="https://github.com/user-attachments/assets/31667733-d2e9-4ae9-be66-db128b4eab29" />

History Table Accordion (Bottom):
<img width="1493" height="864" alt="Screenshot 2025-11-13 at 3 45 33 PM" src="https://github.com/user-attachments/assets/d6713260-e002-4811-98bb-4a42a26c3e21" />

Citations Table Accordion (entirety):
<img width="1513" height="869" alt="Screenshot 2025-11-13 at 3 47 37 PM" src="https://github.com/user-attachments/assets/400e6585-fa3e-4e12-97d2-119e41cc4496" />





### Checklist

[Please delete options that are not relevant.]

- [X] I have signed the commit(s) within this pull request
- [X] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

See Testing Area for all screen shots.

### Further comments

Added new "Danger" callout to grab attention for our Semantic Table and potential "Vector Dimension Mismatch"
