### PR TITLE
Ask for api endpoint in memmachine-compose.sh

### DIFF
--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -503,6 +503,23 @@ check_config_file() {
     fi
 }
 
+select_openai_base_url() {
+    local base_url=""
+    local reply=""
+    
+    print_prompt
+    read -p "Would you like to configure a custom OpenAI Base URL? (Default: https://api.openai.com/v1) (y/N) " reply
+    if [[ $reply =~ ^[Yy]$ ]]; then
+        print_prompt
+        read -p "Enter your OpenAI Base URL: " base_url
+        if [ -n "$base_url" ]; then
+            safe_sed_inplace "/openai_model:/,/base_url:/ s|base_url: .*|base_url: \"$base_url\"|" configuration.yml
+            safe_sed_inplace "/openai_embedder:/,/base_url:/ s|base_url: .*|base_url: \"$base_url\"|" configuration.yml
+            print_success "Set OpenAI Base URL to $base_url"
+        fi
+    fi
+}
+
 # Prompt user if they would like to set their API keys based on provider; then set it in the .env file and configuration.yml file
 set_provider_api_keys() {
     local api_key=""
@@ -537,6 +554,8 @@ set_provider_api_keys() {
             else
                 print_success "OpenAI API key appears to be configured"
             fi
+            
+            select_openai_base_url
         fi
         
         # Configure Bedrock if selected

--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -52,6 +52,7 @@ resources:
       config:
         model: "text-embedding-3-small"
         api_key: <YOUR_API_KEY>
+        base_url: "https://api.openai.com/v1"
         dimensions: 1536
     aws_embedder_id:
       provider: 'amazon-bedrock'
@@ -74,6 +75,7 @@ resources:
       config:
         model: "gpt-4o-mini"
         api_key: <YOUR_API_KEY>
+        base_url: "https://api.openai.com/v1"
     aws_model:
       provider: "amazon-bedrock"
       config:

--- a/sample_configs/episodic_memory_config.gpu.sample
+++ b/sample_configs/episodic_memory_config.gpu.sample
@@ -52,6 +52,7 @@ resources:
       config:
         model: "text-embedding-3-small"
         api_key: <YOUR_API_KEY>
+        base_url: "https://api.openai.com/v1"
         dimensions: 1536
     aws_embedder_id:
       provider: 'amazon-bedrock'
@@ -74,6 +75,7 @@ resources:
       config:
         model: "gpt-4o-mini"
         api_key: <YOUR_API_KEY>
+        base_url: "https://api.openai.com/v1"
     aws_model:
       provider: "amazon-bedrock"
       config:


### PR DESCRIPTION
### Purpose of the change

The purpose of this change is to enable user to use models from providers other than openai. We have a base_url field in our configuration, but we didn't ask for it in memmachine-compose.sh. This change asks and sets the field to make deployments easier.

### Description

The purpose of this change is to enable user to use models from providers other than openai. We have a base_url field in our configuration, but we didn't ask for it in memmachine-compose.sh. This change asks and sets the field to make deployments easier.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

