### PR TITLE
Create non-existent projects when adding semantic memories

### DIFF
--- a/tests/memmachine/main/test_memmachine_mock.py
+++ b/tests/memmachine/main/test_memmachine_mock.py
@@ -393,6 +393,47 @@ async def test_add_episodes_dispatches_to_all_memories(
 
 
 @pytest.mark.asyncio
+async def test_add_semantic_memory_will_create_nonexistent_session(
+    minimal_conf, patched_resource_manager
+):
+    memmachine = MemMachine(minimal_conf, patched_resource_manager)
+    session = DummySessionData("new-session")
+
+    entries = [
+        EpisodeEntry(content="hello", producer_id="user", producer_role="assistant"),
+    ]
+
+    mock_session_manager = AsyncMock()
+    patched_resource_manager.get_session_data_manager = AsyncMock(
+        return_value=mock_session_manager
+    )
+    mock_session_manager.get_session_info.return_value = None
+
+    semantic_manager = MagicMock()
+    semantic_manager.add_message = AsyncMock()
+    patched_resource_manager.get_semantic_session_manager = AsyncMock(
+        return_value=semantic_manager
+    )
+
+    async def _create_session_side_effect(*args, **kwargs):
+        mock_session_manager.get_session_info.return_value = session
+
+    mock_session_manager.create_new_session = AsyncMock(
+        side_effect=_create_session_side_effect
+    )
+
+    await memmachine.add_episodes(
+        session, entries, target_memories=[MemoryType.Semantic]
+    )
+
+    mock_session_manager.create_new_session.assert_awaited_once()
+    call_args = mock_session_manager.create_new_session.await_args[1]
+    assert call_args["session_key"] == session.session_key
+
+    semantic_manager.add_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_add_episodes_skips_memories_not_requested(
     minimal_conf, patched_resource_manager
 ):


### PR DESCRIPTION
### Purpose of the change

Create non-existent projects when adding semantic memories. Currently we will only create non-existent projects when adding episodic memories. We should also create non-existent projects when adding semantic memories.

### Description

Create non-existent projects when adding semantic memories. Currently we will only create non-existent projects when adding episodic memories. We should also create non-existent projects when adding semantic memories.

### Fixes/Closes

Fixes #649

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?


- [x] Unit Test
- [x] Manual verification (list step-by-step instructions)

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

