### PR TITLE
Add count cache for EpisodeStorage

### DIFF
--- a/src/memmachine/common/configuration/__init__.py
+++ b/src/memmachine/common/configuration/__init__.py
@@ -45,6 +45,10 @@ class EpisodeStoreConf(BaseModel):
         default="",
         description="The database ID to use for episode storage",
     )
+    with_count_cache: bool = Field(
+        default=True,
+        description="Whether to use a in memory cache for counting messages per session.",
+    )
 
 
 class SemanticMemoryConf(BaseModel):

--- a/src/memmachine/common/episode_store/__init__.py
+++ b/src/memmachine/common/episode_store/__init__.py
@@ -1,5 +1,6 @@
 """Episode store package exports."""
 
+from .count_caching_episode_storage import CountCachingEpisodeStorage
 from .episode_model import (
     ContentType,
     Episode,
@@ -12,6 +13,7 @@ from .episode_storage import EpisodeStorage
 
 __all__ = [
     "ContentType",
+    "CountCachingEpisodeStorage",
     "Episode",
     "EpisodeEntry",
     "EpisodeIdT",

--- a/src/memmachine/common/episode_store/count_caching_episode_storage.py
+++ b/src/memmachine/common/episode_store/count_caching_episode_storage.py
@@ -1,0 +1,154 @@
+"""EpisodeStorage wrapper adding an in-memory count cache."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import cast
+
+from pydantic import AwareDatetime
+
+from memmachine.common.episode_store.episode_model import (
+    Episode,
+    EpisodeEntry,
+    EpisodeIdT,
+)
+from memmachine.common.episode_store.episode_storage import EpisodeStorage
+from memmachine.common.filter.filter_parser import Comparison, FilterExpr
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    count: int
+
+
+def _session_key_from_filter(filter_expr: FilterExpr | None) -> str | None:
+    """Return the session_key if the filter is exactly a session equality."""
+    if not isinstance(filter_expr, Comparison):
+        return None
+    if filter_expr.op != "=":
+        return None
+    if filter_expr.field not in {"session_key", "session"}:
+        return None
+    if not isinstance(filter_expr.value, str):
+        return None
+    return filter_expr.value
+
+
+class CountCachingEpisodeStorage(EpisodeStorage):
+    """
+    Incoherent count cache as an EpisodeStorage decorator.
+
+    As an incoherent cache, changes to the underlying store are not reflected in the cache.
+    Making this cache unsuited to concurrent deployment.
+    """
+
+    def __init__(self, wrapped: EpisodeStorage) -> None:
+        """Initialize the decorator with a wrapped EpisodeStorage."""
+        self._wrapped = wrapped
+        self._count_cache: dict[str, _CacheEntry] = {}
+        self._lock = asyncio.Lock()
+
+    async def startup(self) -> None:
+        await self._wrapped.startup()
+
+    async def add_episodes(
+        self,
+        session_key: str,
+        episodes: list[EpisodeEntry],
+    ) -> list[Episode]:
+        stored = await self._wrapped.add_episodes(session_key, episodes)
+
+        async with self._lock:
+            entry = self._count_cache.get(session_key)
+            if entry is not None:
+                self._count_cache[session_key] = _CacheEntry(
+                    count=entry.count + len(episodes),
+                )
+
+        return stored
+
+    async def get_episode(
+        self,
+        history_id: EpisodeIdT,
+    ) -> Episode | None:
+        return await self._wrapped.get_episode(history_id)
+
+    async def get_episode_messages(
+        self,
+        *,
+        page_size: int | None = None,
+        page_num: int | None = None,
+        filter_expr: FilterExpr | None = None,
+        start_time: AwareDatetime | None = None,
+        end_time: AwareDatetime | None = None,
+    ) -> list[Episode]:
+        return await self._wrapped.get_episode_messages(
+            page_size=page_size,
+            page_num=page_num,
+            filter_expr=filter_expr,
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+    async def get_episode_messages_count(
+        self,
+        *,
+        filter_expr: FilterExpr | None = None,
+        start_time: AwareDatetime | None = None,
+        end_time: AwareDatetime | None = None,
+    ) -> int:
+        session_key = _session_key_from_filter(filter_expr)
+
+        searching_only_session_key = (
+            session_key is not None and start_time is None and end_time is None
+        )
+
+        if searching_only_session_key:
+            session_key = cast(str, session_key)
+
+            async with self._lock:
+                entry = self._count_cache.get(session_key)
+                if entry is not None:
+                    return entry.count
+
+        count = await self._wrapped.get_episode_messages_count(
+            filter_expr=filter_expr,
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+        if searching_only_session_key:
+            session_key = cast(str, session_key)
+
+            async with self._lock:
+                self._count_cache[session_key] = _CacheEntry(
+                    count=count,
+                )
+
+        return count
+
+    async def delete_episodes(
+        self,
+        episode_ids: list[EpisodeIdT],
+    ) -> None:
+        await self._wrapped.delete_episodes(episode_ids)
+        await self._clear_cache()
+
+    async def delete_episode_messages(
+        self,
+        *,
+        filter_expr: FilterExpr | None = None,
+        start_time: AwareDatetime | None = None,
+        end_time: AwareDatetime | None = None,
+    ) -> None:
+        await self._wrapped.delete_episode_messages(
+            filter_expr=filter_expr,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        await self._clear_cache()
+
+    async def _clear_cache(self) -> None:
+        async with self._lock:
+            self._count_cache.clear()

--- a/src/memmachine/common/resource_manager/resource_manager.py
+++ b/src/memmachine/common/resource_manager/resource_manager.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from memmachine.common.configuration import Configuration
 from memmachine.common.configuration.metrics_conf import WithMetricsFactoryId
 from memmachine.common.embedder import Embedder
-from memmachine.common.episode_store import EpisodeStorage
+from memmachine.common.episode_store import CountCachingEpisodeStorage, EpisodeStorage
 from memmachine.common.episode_store.episode_sqlalchemy_store import (
     SqlAlchemyEpisodeStore,
 )
@@ -152,6 +152,9 @@ class ResourceManagerImpl:
 
         episode_storage = SqlAlchemyEpisodeStore(engine)
         await episode_storage.startup()
+
+        if episode_storage_conf.with_count_cache:
+            episode_storage = CountCachingEpisodeStorage(episode_storage)
 
         self._episode_storage = episode_storage
         return self._episode_storage

--- a/tests/memmachine/common/episode_store/test_count_caching_episode_storage.py
+++ b/tests/memmachine/common/episode_store/test_count_caching_episode_storage.py
@@ -1,0 +1,105 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from memmachine.common.episode_store import CountCachingEpisodeStorage, EpisodeStorage
+from memmachine.common.filter.filter_parser import Comparison
+
+
+@pytest.fixture
+def wrapped_store():
+    store = MagicMock(spec=EpisodeStorage)
+    store.startup = AsyncMock()
+    store.add_episodes = AsyncMock(return_value=[])
+    store.get_episode = AsyncMock()
+    store.get_episode_messages = AsyncMock()
+    store.get_episode_messages_count = AsyncMock()
+    store.delete_episodes = AsyncMock()
+    store.delete_episode_messages = AsyncMock()
+    return store
+
+
+@pytest.mark.asyncio
+async def test_caches_counts_per_key(wrapped_store):
+    wrapped_store.get_episode_messages_count = AsyncMock(side_effect=[2, 5])
+    storage = CountCachingEpisodeStorage(wrapped_store)
+
+    filter_a = Comparison(field="session_key", op="=", value="a")
+    filter_b = Comparison(field="session_key", op="=", value="b")
+
+    first_a = await storage.get_episode_messages_count(filter_expr=filter_a)
+    second_a = await storage.get_episode_messages_count(filter_expr=filter_a)
+    b_count = await storage.get_episode_messages_count(filter_expr=filter_b)
+
+    assert first_a == 2
+    assert second_a == 2
+    assert b_count == 5
+    assert wrapped_store.get_episode_messages_count.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_mutations_invalidate_cache(wrapped_store):
+    wrapped_store.get_episode_messages_count = AsyncMock(side_effect=[1, 3])
+    storage = CountCachingEpisodeStorage(wrapped_store)
+
+    session_filter = Comparison(field="session_key", op="=", value="abc")
+
+    first = await storage.get_episode_messages_count(filter_expr=session_filter)
+    second = await storage.get_episode_messages_count(filter_expr=session_filter)
+
+    assert first == 1
+    assert second == 1
+    assert wrapped_store.get_episode_messages_count.await_count == 1
+
+    await storage.add_episodes("abc", [{"msg": "x"}])
+
+    updated = await storage.get_episode_messages_count(filter_expr=session_filter)
+    assert updated == 2
+    assert wrapped_store.get_episode_messages_count.await_count == 1
+    wrapped_store.add_episodes.assert_awaited_once_with("abc", [{"msg": "x"}])
+
+
+@pytest.mark.asyncio
+async def test_deletes_clear_cached_counts(wrapped_store):
+    wrapped_store.get_episode_messages_count = AsyncMock(side_effect=[4, 6, 8])
+    storage = CountCachingEpisodeStorage(wrapped_store)
+
+    session_filter = Comparison(field="session_key", op="=", value="s")
+
+    initial = await storage.get_episode_messages_count(filter_expr=session_filter)
+    assert initial == 4
+
+    await storage.delete_episode_messages()
+    after_delete_messages = await storage.get_episode_messages_count(
+        filter_expr=session_filter
+    )
+
+    await storage.delete_episodes([1, 2])
+    after_delete_ids = await storage.get_episode_messages_count(
+        filter_expr=session_filter
+    )
+
+    assert after_delete_messages == 6
+    assert after_delete_ids == 8
+    assert wrapped_store.get_episode_messages_count.await_count == 3
+    wrapped_store.delete_episode_messages.assert_awaited_once_with(
+        filter_expr=None,
+        start_time=None,
+        end_time=None,
+    )
+    wrapped_store.delete_episodes.assert_awaited_once_with([1, 2])
+
+
+@pytest.mark.asyncio
+async def test_non_session_filters_bypass_cache(wrapped_store):
+    wrapped_store.get_episode_messages_count = AsyncMock(side_effect=[7, 9])
+    storage = CountCachingEpisodeStorage(wrapped_store)
+
+    topic_filter = Comparison(field="topic", op="=", value="alpha")
+
+    first = await storage.get_episode_messages_count(filter_expr=topic_filter)
+    second = await storage.get_episode_messages_count(filter_expr=topic_filter)
+
+    assert first == 7
+    assert second == 9
+    assert wrapped_store.get_episode_messages_count.await_count == 2


### PR DESCRIPTION
### Purpose of the change

Adds an in-memory incoherent cache for message count to optimize calls to episode count to be used by rate limiters.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)


### Checklist


- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


