### PR TITLE
Return prometheus metrics factory by default

### DIFF
--- a/src/memmachine/common/configuration/metrics_conf.py
+++ b/src/memmachine/common/configuration/metrics_conf.py
@@ -10,6 +10,10 @@ from memmachine.common.metrics_factory.prometheus_metrics_factory import (
 )
 
 
+class UnknownMetricsFactoryError(ValueError):
+    """Raised when the metrics factory name is invalid."""
+
+
 class WithMetricsFactoryId(BaseModel):
     """Mixin for configurations that include a metrics factory ID."""
 
@@ -28,17 +32,14 @@ class WithMetricsFactoryId(BaseModel):
         """Return the configured metrics factory instance, if any."""
         factory_id = self.metrics_factory_id
         if factory_id is None:
-            return None
+            factory_id = "prometheus"
         if factory_id not in self._factories:
             match factory_id:
                 case "prometheus":
                     factory = PrometheusMetricsFactory()
                     self._factories[factory_id] = factory
                 case _:
-                    raise ValueError(f"Unknown MetricsFactory name: {factory_id}")
-        ret = self._factories[factory_id]
-        if not isinstance(ret, MetricsFactory):
-            raise TypeError(
-                f"Injected dependency with id {factory_id} is not a MetricsFactory",
-            )
-        return ret
+                    raise UnknownMetricsFactoryError(
+                        f"Unknown MetricsFactory name: {factory_id}"
+                    )
+        return self._factories[factory_id]

--- a/tests/memmachine/common/configuration/test_metrics_conf.py
+++ b/tests/memmachine/common/configuration/test_metrics_conf.py
@@ -1,0 +1,48 @@
+import pytest
+
+from memmachine.common.configuration.metrics_conf import (
+    UnknownMetricsFactoryError,
+    WithMetricsFactoryId,
+)
+from memmachine.common.metrics_factory import PrometheusMetricsFactory
+
+
+@pytest.fixture(autouse=True)
+def reset_factories(monkeypatch):
+    """Clear global factories before each test."""
+    monkeypatch.setattr(WithMetricsFactoryId, "_factories", {})
+
+
+def test_default_factory_is_prometheus():
+    cfg = WithMetricsFactoryId()
+    factory = cfg.get_metrics_factory()
+
+    assert isinstance(factory, PrometheusMetricsFactory)
+    assert "prometheus" in cfg._factories
+    assert cfg._factories["prometheus"] is factory  # same instance
+
+
+def test_explicit_prometheus_id():
+    cfg = WithMetricsFactoryId(metrics_factory_id="prometheus")
+    factory = cfg.get_metrics_factory()
+
+    assert isinstance(factory, PrometheusMetricsFactory)
+    assert "prometheus" in cfg._factories
+
+
+def test_memoized_factory_is_reused():
+    cfg = WithMetricsFactoryId()
+
+    factory1 = cfg.get_metrics_factory()
+    factory2 = cfg.get_metrics_factory()
+
+    assert factory1 is factory2  # cached
+
+
+def test_unknown_factory_id_raises():
+    cfg = WithMetricsFactoryId(metrics_factory_id="invalid_factory")
+
+    with pytest.raises(UnknownMetricsFactoryError) as exc:
+        cfg.get_metrics_factory()
+
+    assert "Unknown MetricsFactory name" in str(exc.value)


### PR DESCRIPTION
### Purpose of the change

As title.  If metrics factory name is not specified, use the prometheus metrics factory by default.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [x] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
