### PR TITLE
CI Fix: Disable bedrock llm test in PR and bedrock llm fixes

### DIFF
--- a/src/memmachine/common/language_model/amazon_bedrock_language_model.py
+++ b/src/memmachine/common/language_model/amazon_bedrock_language_model.py
@@ -283,6 +283,8 @@ class AmazonBedrockLanguageModel(LanguageModel):
                 output_format=output_format,
             )
             if parsed is not None:
+                self._collect_metrics({}, start_time, time.monotonic())
+
                 return parsed
             raise
 

--- a/tests/memmachine/conftest.py
+++ b/tests/memmachine/conftest.py
@@ -175,6 +175,7 @@ def bedrock_integration_language_model_config(bedrock_integration_config):
 @pytest.fixture(scope="session")
 def boto3_bedrock_runtime_client(bedrock_integration_config):
     import boto3
+
     config = bedrock_integration_config
 
     return boto3.client(
@@ -189,6 +190,7 @@ def boto3_bedrock_runtime_client(bedrock_integration_config):
 @pytest.fixture(scope="session")
 def boto3_bedrock_agent_runtime_client(bedrock_integration_config):
     import boto3
+
     config = bedrock_integration_config
 
     return boto3.client(
@@ -201,7 +203,9 @@ def boto3_bedrock_agent_runtime_client(bedrock_integration_config):
 
 
 @pytest.fixture(scope="session")
-def bedrock_llm_model(boto3_bedrock_runtime_client, bedrock_integration_language_model_config):
+def bedrock_llm_model(
+    boto3_bedrock_runtime_client, bedrock_integration_language_model_config
+):
     config = bedrock_integration_language_model_config
     return AmazonBedrockLanguageModel(
         AmazonBedrockLanguageModelParams(

--- a/tests/memmachine/main/conftest.py
+++ b/tests/memmachine/main/conftest.py
@@ -120,12 +120,8 @@ def bedrock_language_model_config(
                         "provider": "amazon-bedrock",
                         "config": {
                             "model_id": config["model"],
-                            "aws_access_key_id": config[
-                                "aws_access_key_id"
-                            ],
-                            "aws_secret_access_key": config[
-                                "aws_secret_access_key"
-                            ],
+                            "aws_access_key_id": config["aws_access_key_id"],
+                            "aws_secret_access_key": config["aws_secret_access_key"],
                             "region": config["aws_region"],
                         },
                     }


### PR DESCRIPTION
Temporarily disable Bedrock LLM PR checks for now until results are more stable.