### PR TITLE
Fix MCP search_memory filter to use metadata.user_id (BUG #696)

### DIFF
--- a/src/memmachine/server/api_v2/mcp.py
+++ b/src/memmachine/server/api_v2/mcp.py
@@ -209,7 +209,7 @@ class Params(BaseModel):
             project_id=self.proj_id,
             query=query,
             top_k=top_k,
-            filter=f"user_id='{self.user_id}'",
+            filter=f"metadata.user_id='{self.user_id}'",
             types=ALL_MEMORY_TYPES,
         )
 

--- a/tests/memmachine/server/api_v2/test_mcp.py
+++ b/tests/memmachine/server/api_v2/test_mcp.py
@@ -105,7 +105,7 @@ def test_search_memory_param_get_search_query(params):
     assert spec.project_id == "proj"
     assert spec.top_k == 7
     assert spec.query == "hello"
-    assert spec.filter == "user_id='usr'"
+    assert spec.filter == "metadata.user_id='usr'"
     assert spec.types == ALL_MEMORY_TYPES
 
 


### PR DESCRIPTION
### Purpose of the change

Fix MCP `search_memory` tool filter field format to use `metadata.user_id` instead of `user_id` to match semantic memory storage requirements.

### Description

The filter field in `to_search_memories_spec` method was using `user_id` directly, but the semantic memory storage system requires metadata fields to have `metadata.` prefix. Changed `filter=f"user_id='{self.user_id}'"` to `filter=f"metadata.user_id='{self.user_id}'"` at line 212 in `src/memmachine/server/api_v2/mcp.py`.

### Fixes/Closes

Fixes #696

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

**Manual verification:**
- Tested MCP `search_memory` tool in Claude Desktop before and after fix
- Before: Error 422 "Unsupported feature filter field: user_id"
- After: Successfully returns memories (status 0)



**Test Results:** Screenshots attached showing before/after comparison.
### Screenshots/Gifs

Screenshots showing error before fix and successful retrieval after fix.

<img width="847" height="752" alt="image" src="https://github.com/user-attachments/assets/f6bccd50-5144-40aa-a1fd-45a2373718a0" />
<img width="798" height="751" alt="image" src="https://github.com/user-attachments/assets/822ca337-b580-4f2f-83b8-eea507b8389f" />


### Further comments

None