### PR TITLE
build with gpu using `memmachine-compose.sh build`

### DIFF
--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -764,7 +764,7 @@ show_service_info() {
 build_image() {
     local name=""
     local force="false"
-    local gpu="false"
+    local gpu="false" # default to false
     local reply=""
     local key=""
     local value=""
@@ -814,17 +814,19 @@ build_image() {
 
     if [[ "$force" == "false" ]]; then
         print_prompt
-        read -p "Building $name with '--build-arg GPU=$gpu' (y/N): " -r reply
+        read -p "Building $name with '--build-arg GPU=[true|false]' (default: false): " reply
+        gpu=$(echo "${reply:-false}" | tr '[:upper:]' '[:lower:]')
+        if [[ "$gpu" != "true" && "$gpu" != "false" ]]; then
+            print_error "Invalid value for GPU: $gpu"
+            exit 1
+        fi
     else
         print_info "Building $name with '--build-arg GPU=$gpu'"
     fi
 
-    if [[ $reply =~ ^[Yy]$ || $force == "true" ]]; then
-        docker build --build-arg GPU=$gpu -t "$name" .
-    else
-        print_info "Build cancelled"
-        exit 0
-    fi
+    # Proceed with build after validation passes
+    print_info "Building $name with '--build-arg GPU=$gpu'"
+    docker build --build-arg GPU=$gpu -t "$name" .
 }
 
 # Main execution


### PR DESCRIPTION
### Purpose of the change

Update memmachine-compose.sh script to allow building with gpu.

### Description

Please include a summary of the change and the issue it addresses. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Fixes/Closes

Fixes #636

### Type of change

[Please delete options that are not relevant.]

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

[Please delete options that are not relevant.]

- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

1. build with default, gpu=false
```
jinggong@Jings-MBP MemMachine % ./memmachine-compose.sh build
[INFO] No name specified.
[INFO] Using default name: memmachine/memmachine:latest
[PROMPT] Building memmachine/memmachine:latest with '--build-arg GPU=[true|false]' (default: false):
[INFO] Building memmachine/memmachine:latest with '--build-arg GPU=false'
[+] Building 0.9s (24/24) FINISHED                                                           docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                         0.0s

```
2. build with gpu=true
```
jinggong@Jings-MBP MemMachine % ./memmachine-compose.sh build
[INFO] No name specified.
[INFO] Using default name: memmachine/memmachine:latest
[PROMPT] Building memmachine/memmachine:latest with '--build-arg GPU=[true|false]' (default: false): true
[INFO] Building memmachine/memmachine:latest with '--build-arg GPU=true'
[+] Building 6.6s (15/21)                                                                    docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                         0.0s
...
 => [builder 10/12] RUN --mount=type=cache,target=/root/.cache/uv     if [ "true" = "true" ]; then          21.6s
 => [builder 11/12] COPY . /app                                                                              0.8s
 => [builder 12/12] RUN --mount=type=cache,target=/root/.cache/uv     if [ "true" = "true" ]; then           1.4s
 => CACHED [final 4/6] WORKDIR /app                                                                          0.0s
 => [final 5/6] COPY --from=builder /app/.venv /app/.venv                                                    5.9s
 => [final 6/6] RUN python -c "import nltk; nltk.download('punkt_tab'); nltk.download('stopwords')"          4.9s
 => exporting to image                                                                                      31.4s
 => => exporting layers                                                                                     25.6s
 => => exporting manifest sha256:e28cfeb5ce4d6aba66866620d20057b3738737a0a53628831451a0403cbafb51            0.0s
 => => exporting config sha256:8f81d054a1cc049e32fbbcdf2abefe34aa497974727f7e4a7c5ab8c36913025d              0.0s
 => => exporting attestation manifest sha256:e3f1b9c520cdd173e9dddd07b61d75ce260c78fd9a6f17c5e76165f0baf581  0.0s
 => => exporting manifest list sha256:4ac8b2dab4c386c4547eb992c4096a24e08c8b6d78c3843f0d5522e32a95ba3e       0.0s
 => => naming to docker.io/memmachine/memmachine:latest                                                      0.0s
 => => unpacking to docker.io/memmachine/memmachine:latest                                                   5.6s
```


### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

[If applicable, add screenshots or GIFs that show the changes in action. This is especially helpful for API responses. Otherwise, delete this section or type "N/A".]

### Further comments

[Add any other relevant information here, such as potential side effects, future considerations, or any specific questions for the reviewer. Otherwise, type "None".]
