### PR TITLE
Fix MCP stdio output to keep stdout JSON-only #

### DIFF
--- a/src/memmachine/common/configuration/log_conf.py
+++ b/src/memmachine/common/configuration/log_conf.py
@@ -106,7 +106,7 @@ class LogConf(BaseModel):
             self.path,
         )
 
-        handlers: list[logging.Handler] = [logging.StreamHandler(sys.stdout)]
+        handlers: list[logging.Handler] = [logging.StreamHandler(sys.stderr)]
         if self.path:
             file_handler = logging.FileHandler(self.path)
             file_handler.setFormatter(logging.Formatter(self.format))


### PR DESCRIPTION
Fix JSON parse errors in Claude Desktop MCP connection by ensuring stdout contains only JSON-RPC messages.

Fixes https://github.com/MemMachine/MemMachine/issues/691