### PR TITLE
Deduplicate derivatives' source episodes

### DIFF
--- a/src/memmachine/episodic_memory/declarative_memory/declarative_memory.py
+++ b/src/memmachine/episodic_memory/declarative_memory/declarative_memory.py
@@ -331,13 +331,14 @@ class DeclarativeMemory:
             for matched_derivative_node in matched_derivative_nodes
         ]
 
-        source_episode_nodes = [
+        # Use a dict instead of a set to preserve order.
+        source_episode_nodes = dict.fromkeys(
             episode_node
             for episode_nodes in await asyncio.gather(
                 *search_derivatives_source_episode_nodes_tasks,
             )
             for episode_node in episode_nodes
-        ]
+        )
 
         # Use source episodes as nuclei for contextualization.
         nuclear_episodes = [
@@ -436,7 +437,7 @@ class DeclarativeMemory:
         query: str,
         episode_contexts: Iterable[Iterable[Episode]],
     ) -> list[float]:
-        """Score episode node contexts based on their relevance to the query."""
+        """Score episode contexts based on their relevance to the query."""
         context_strings = []
         for episode_context in episode_contexts:
             context_string = DeclarativeMemory.string_from_episode_context(


### PR DESCRIPTION
### Purpose of the change

Reduce unnecessary database accesses and reranker calls.

### Description

When multiple derivatives point to the same episode and are retrieved, that episode will be contextualized multiple times and the episode context will be reranked multiple times. This is a waste of resources.

Use a Python dict as an ordered set to deduplicate the episodes.

Appears to reduce average memory retrieval time by ~0.4s when retrieval limit is 50 episodes.

Increased total number of episodes retrieved for 500 longmemeval_s_cleaned.json questions by 2 when retrieval limit is 50 episodes for each question.

### Type of change

[Please delete options that are not relevant.]

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

WIP.

- [ ] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [x] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected