### PR TITLE
Do not exit if user does not install neo4j

### DIFF
--- a/src/memmachine/installation/memmachine_configure.py
+++ b/src/memmachine/installation/memmachine_configure.py
@@ -78,17 +78,14 @@ class Installer(ABC):
         if not self.check_neo4j_running():
             choice = (
                 input(
-                    "Neo4j is not running. Do you want to install and start Neo4j? (y/n): "
+                    "Cannot find Neo4j locally. Do you want to install and start Neo4j? (y/n): "
                 )
                 .strip()
                 .lower()
             )
-            if choice != "y":
-                raise RuntimeError(
-                    "Neo4j installation is required to proceed. Exiting installation."
-                )
-            self.install_and_start_neo4j()
-            neo4j_started_by_installer = True
+            if choice == "y":
+                self.install_and_start_neo4j()
+                neo4j_started_by_installer = True
         else:
             logger.info("Neo4j is already running.")
 
@@ -339,6 +336,7 @@ class WindowsEnvironment:
                     "Neo4j service is installed but not running. "
                     "Please start the service before running MemMachine."
                 )
+                return False
             return True
 
 

--- a/tests/memmachine/installation/test_memmachine_configure.py
+++ b/tests/memmachine/installation/test_memmachine_configure.py
@@ -132,17 +132,12 @@ def test_install_in_windows_default_dir(mock_input, monkeypatch, mock_wizard):
 
 
 @patch("builtins.input")
-def test_cancel_install_in_windows(mock_input, mock_wizard):
+def test_use_custom_neo4j(mock_input, mock_wizard):
     mock_input.side_effect = [
-        "n",  # Cancel installation
+        "n",  # do not install neo4j
     ]
     installer = WindowsInstaller(MockWindowsEnvironment())
-    with pytest.raises(RuntimeError) as excinfo:
-        installer.install()
-    assert (
-        str(excinfo.value)
-        == "Neo4j installation is required to proceed. Exiting installation."
-    )
+    installer.install()
     assert not installer.environment.neo4j_installed
 
 


### PR DESCRIPTION
### Purpose of the change

If user does not install neo4j and system cannot detect a local neo4j at localhost:7474, continue with the wizard and asks the user for the uri and credentials for the existing neo4j.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [x] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
