### PR TITLE
[GH-678] Semantic: Ignore invalid column names in filter

### DIFF
--- a/src/memmachine/semantic_memory/storage/sqlalchemy_pgvector_semantic.py
+++ b/src/memmachine/semantic_memory/storage/sqlalchemy_pgvector_semantic.py
@@ -1,5 +1,6 @@
 """SQLAlchemy-backed semantic storage implementation using pgvector."""
 
+import logging
 from pathlib import Path
 from typing import Any, overload
 
@@ -52,6 +53,8 @@ from memmachine.semantic_memory.storage.storage_base import (
     FeatureIdT,
     SemanticStorage,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class BaseSemanticStorage(DeclarativeBase):
@@ -610,11 +613,12 @@ class SqlAlchemyPgVectorSemanticStorage(SemanticStorage):
         self,
         expr: FilterComparison,
         table: type[Feature],
-    ) -> ColumnElement[bool]:
+    ) -> ColumnElement[bool] | None:
         column, is_metadata = self._resolve_feature_field(table, expr.field)
 
         if column is None:
-            raise ValueError(f"Unsupported feature filter field: {expr.field}")
+            logger.warning("Unsupported feature filter field: %s", expr.field)
+            return None
 
         if expr.op == "=":
             value = expr.value
@@ -646,7 +650,7 @@ class SqlAlchemyPgVectorSemanticStorage(SemanticStorage):
         self,
         expr: FilterExpr,
         table: type[Feature],
-    ) -> ColumnElement[bool]:
+    ) -> ColumnElement[bool] | None:
         if isinstance(expr, FilterComparison):
             return self._compile_feature_comparison_expr(expr, table)
 

--- a/tests/memmachine/semantic_memory/storage/in_memory_semantic_storage.py
+++ b/tests/memmachine/semantic_memory/storage/in_memory_semantic_storage.py
@@ -648,7 +648,7 @@ class InMemorySemanticStorage(SemanticStorage):
             metadata = entry.metadata or {}
             return metadata.get(key), True
 
-        raise ValueError(f"Unsupported feature filter field: {field}")
+        return None, False
 
     @staticmethod
     def _normalize_metadata_value(value: Any) -> str:

--- a/tests/memmachine/semantic_memory/storage/test_semantic_storage.py
+++ b/tests/memmachine/semantic_memory/storage/test_semantic_storage.py
@@ -672,9 +672,6 @@ async def test_filter_by_metadata_nullity(semantic_storage: SemanticStorage):
 async def test_get_feature_set_unknown_filter_column_errors(
     semantic_storage: SemanticStorage,
 ):
-    if getattr(semantic_storage, "backend_name", None) == "neo4j":
-        pytest.skip("Neo4j currently allows arbitrary property references")
-
     await semantic_storage.add_feature(
         set_id="user",
         category_name="default",
@@ -684,19 +681,16 @@ async def test_get_feature_set_unknown_filter_column_errors(
         embedding=np.array([1.0], dtype=float),
     )
 
-    with pytest.raises(ValueError, match="Unsupported feature filter field"):
-        await semantic_storage.get_feature_set(
-            filter_expr=_expr("missing_column IN (foo)"),
-        )
+    # No errors occurs
+    await semantic_storage.get_feature_set(
+        filter_expr=_expr("missing_column IN (foo)"),
+    )
 
 
 @pytest.mark.asyncio
 async def test_delete_feature_set_unknown_filter_column_errors(
     semantic_storage: SemanticStorage,
 ):
-    if getattr(semantic_storage, "backend_name", None) == "neo4j":
-        pytest.skip("Neo4j currently allows arbitrary property references")
-
     await semantic_storage.add_feature(
         set_id="user",
         category_name="default",
@@ -706,10 +700,10 @@ async def test_delete_feature_set_unknown_filter_column_errors(
         embedding=np.array([1.0], dtype=float),
     )
 
-    with pytest.raises(ValueError, match="Unsupported feature filter field"):
-        await semantic_storage.delete_feature_set(
-            filter_expr=_expr("missing_column IN (foo)"),
-        )
+    # No errors occurs
+    await semantic_storage.delete_feature_set(
+        filter_expr=_expr("missing_column IN (foo)"),
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Purpose of the change

Allows the use of non existent characteristics and features in the filter to semantic memory.

### Fixes/Closes

#678

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test

