### PR TITLE
Support delete multiple memories.

### DIFF
--- a/src/memmachine/rest_client/memory.py
+++ b/src/memmachine/rest_client/memory.py
@@ -527,7 +527,8 @@ class Memory:
 
     def delete_episodic(
         self,
-        episodic_id: str,
+        episodic_id: str = "",
+        episodic_ids: list[str] | None = None,
         timeout: int | None = None,
     ) -> bool:
         """
@@ -535,6 +536,7 @@ class Memory:
 
         Args:
             episodic_id: The unique identifier of the episodic memory to delete
+            episodic_ids: List of episodic memory IDs to delete (optional, can be used instead of episodic_id)
             timeout: Request timeout in seconds (uses client default if not provided)
 
         Returns:
@@ -558,6 +560,7 @@ class Memory:
             "org_id": self.__org_id,
             "project_id": self.__project_id,
             "episodic_id": episodic_id,
+            "episodic_ids": episodic_ids or [],
         }
 
         try:
@@ -577,7 +580,8 @@ class Memory:
 
     def delete_semantic(
         self,
-        semantic_id: str,
+        semantic_id: str = "",
+        semantic_ids: list[str] | None = None,
         timeout: int | None = None,
     ) -> bool:
         """
@@ -585,6 +589,7 @@ class Memory:
 
         Args:
             semantic_id: The unique identifier of the semantic memory to delete
+            semantic_ids: List of semantic memory IDs to delete
             timeout: Request timeout in seconds (uses client default if not provided)
 
         Returns:
@@ -608,6 +613,7 @@ class Memory:
             "org_id": self.__org_id,
             "project_id": self.__project_id,
             "semantic_id": semantic_id,
+            "semantic_ids": semantic_ids or [],
         }
 
         try:

--- a/src/memmachine/server/api_v2/doc.py
+++ b/src/memmachine/server/api_v2/doc.py
@@ -139,19 +139,28 @@ class SpecDoc:
     PAGE_SIZE = """
     The maximum number of memories to return per page. Use this for pagination.
     """
+
     PAGE_NUM = """
     The zero-based page number to retrieve. Use this for pagination.
     """
+
     MEMORY_TYPE_SINGLE = """
     The specific memory type to list (e.g., Episodic or Semantic).
     """
 
     EPISODIC_ID = """
-    The unique ID of the specific episodic memory to be deleted.
+    The unique ID of the specific episodic memory.
     """
+
+    EPISODIC_IDS = """
+    A list of unique IDs of episodic memories."""
+
     SEMANTIC_ID = """
-    The unique ID of the specific semantic memory to be deleted.
+    The unique ID of the specific semantic memory.
     """
+
+    SEMANTIC_IDS = """
+    A list of unique IDs of semantic memories."""
 
     STATUS = """
     The status code of the search operation. 0 typically indicates success.
@@ -186,7 +195,9 @@ class Examples:
     PAGE_SIZE: ClassVar[list[int]] = [50, 100]
     PAGE_NUM: ClassVar[list[int]] = [0, 1, 5, 10]
     EPISODIC_ID: ClassVar[list[str]] = ["123", "345"]
+    EPISODIC_IDS: ClassVar[list[list[str]]] = [["123", "345"], ["23"]]
     SEMANTIC_ID: ClassVar[list[str]] = ["12", "23"]
+    SEMANTIC_IDS: ClassVar[list[list[str]]] = [["123", "345"], ["23"]]
     SEARCH_RESULT_STATUS: ClassVar[list[int]] = [0]
 
 
@@ -313,19 +324,27 @@ class RouterDoc:
     """
 
     DELETE_EPISODIC_MEMORY = """
-    Delete a specific episodic memory from a project.
+    Delete episodic memories from a project.
 
-    Removes the episodic memory identified by `episodic_id` from the specified
-    project. This operation is permanent and cannot be undone.
-    If the episodic memory does not exist, a not-found error is returned.
+    This operation permanently removes one or more episodic memories from the
+    specified project. You may provide either `episodic_id` to delete a single
+    memory or `episodic_ids` to delete multiple memories in one request.
+    This action cannot be undone.
+
+    If any of the specified episodic memories do not exist, a not-found error
+    is returned for those entries.
     """
 
     DELETE_SEMANTIC_MEMORY = """
-    Delete a specific semantic memory from a project.
+    Delete semantic memories from a project.
 
-    Removes the semantic memory identified by `semantic_id` from the specified
-    project. This operation is permanent and cannot be undone.
-    If the semantic memory does not exist, a not-found error is returned.
+    This operation permanently removes one or more semantic memories from the
+    specified project. You may provide either `semantic_id` to delete a single
+    memory or `semantic_ids` to delete multiple memories in one request.
+    This action cannot be undone.
+
+    If any of the specified semantic memories do not exist, a not-found error
+    is returned for those entries.
     """
 
     METRICS_PROMETHEUS = """

--- a/src/memmachine/server/api_v2/router.py
+++ b/src/memmachine/server/api_v2/router.py
@@ -275,7 +275,7 @@ async def delete_episodic_memory(
                 org_id=spec.org_id,
                 project_id=spec.project_id,
             ),
-            episode_ids=[spec.episodic_id],
+            episode_ids=spec.get_ids(),
         )
     except ValueError as e:
         raise HTTPException(
@@ -301,7 +301,7 @@ async def delete_semantic_memory(
     """Delete semantic memories in a project."""
     try:
         await memmachine.delete_features(
-            feature_ids=[spec.semantic_id],
+            feature_ids=spec.get_ids(),
         )
     except ValueError as e:
         raise HTTPException(

--- a/src/memmachine/server/api_v2/spec.py
+++ b/src/memmachine/server/api_v2/spec.py
@@ -1,10 +1,10 @@
 """API v2 specification models for request and response structures."""
 
 from datetime import UTC, datetime
-from typing import Annotated, Any
+from typing import Annotated, Any, Self
 
 import regex
-from pydantic import AfterValidator, BaseModel, Field
+from pydantic import AfterValidator, BaseModel, Field, model_validator
 
 from memmachine.main.memmachine import MemoryType
 from memmachine.server.api_v2.doc import Examples, SpecDoc
@@ -393,10 +393,34 @@ class DeleteEpisodicMemorySpec(_WithOrgAndProj):
     episodic_id: Annotated[
         SafeId,
         Field(
+            default="",
             description=SpecDoc.EPISODIC_ID,
             examples=Examples.EPISODIC_ID,
         ),
     ]
+    episodic_ids: Annotated[
+        list[SafeId],
+        Field(
+            default=[],
+            description=SpecDoc.EPISODIC_IDS,
+            examples=Examples.EPISODIC_IDS,
+        ),
+    ]
+
+    def get_ids(self) -> list[str]:
+        """Get a list of episodic IDs to delete."""
+        id_set = set(self.episodic_ids)
+        if len(self.episodic_id) > 0:
+            id_set.add(self.episodic_id)
+        id_set = {i.strip() for i in id_set if i and i.strip()}
+        return sorted(id_set)
+
+    @model_validator(mode="after")
+    def validate_ids(self) -> Self:
+        """Ensure at least one ID is provided."""
+        if len(self.get_ids()) == 0:
+            raise ValueError("At least one episodic ID must be provided")
+        return self
 
 
 # ---
@@ -408,10 +432,34 @@ class DeleteSemanticMemorySpec(_WithOrgAndProj):
     semantic_id: Annotated[
         SafeId,
         Field(
+            default="",
             description=SpecDoc.SEMANTIC_ID,
             examples=Examples.SEMANTIC_ID,
         ),
     ]
+    semantic_ids: Annotated[
+        list[SafeId],
+        Field(
+            default=[],
+            description=SpecDoc.SEMANTIC_IDS,
+            examples=Examples.SEMANTIC_IDS,
+        ),
+    ]
+
+    def get_ids(self) -> list[str]:
+        """Get a list of semantic IDs to delete."""
+        id_set = set(self.semantic_ids)
+        if len(self.semantic_id) > 0:
+            id_set.add(self.semantic_id)
+        id_set = {i.strip() for i in id_set if len(i.strip()) > 0}
+        return sorted(id_set)
+
+    @model_validator(mode="after")
+    def validate_ids(self) -> Self:
+        """Ensure at least one ID is provided."""
+        if len(self.get_ids()) == 0:
+            raise ValueError("At least one semantic ID must be provided")
+        return self
 
 
 class SearchResult(BaseModel):

--- a/tests/memmachine/server/api_v2/test_spec.py
+++ b/tests/memmachine/server/api_v2/test_spec.py
@@ -193,9 +193,8 @@ def test_list_memories_spec():
 
 
 def test_delete_episodic_memory_spec():
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(ValidationError):
         DeleteEpisodicMemorySpec()
-    assert_pydantic_errors(exc_info, {"episodic_id": "missing"})
 
     spec = DeleteEpisodicMemorySpec(episodic_id="ep-123")
     assert spec.org_id == DEFAULT_ORG_AND_PROJECT_ID
@@ -204,14 +203,29 @@ def test_delete_episodic_memory_spec():
 
 
 def test_delete_semantic_memory_spec():
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(ValidationError):
         DeleteSemanticMemorySpec()
-    assert_pydantic_errors(exc_info, {"semantic_id": "missing"})
 
     spec = DeleteSemanticMemorySpec(semantic_id="sem-123")
     assert spec.org_id == DEFAULT_ORG_AND_PROJECT_ID
     assert spec.project_id == DEFAULT_ORG_AND_PROJECT_ID
     assert spec.semantic_id == "sem-123"
+
+
+def test_get_semantic_ids():
+    spec = DeleteSemanticMemorySpec(semantic_ids=["2", "1"])
+    assert spec.get_ids() == ["1", "2"]
+
+    spec = DeleteSemanticMemorySpec(semantic_id="1", semantic_ids=["2", "1"])
+    assert spec.get_ids() == ["1", "2"]
+
+
+def test_get_episodic_ids():
+    spec = DeleteEpisodicMemorySpec(episodic_ids=["2", "1"])
+    assert spec.get_ids() == ["1", "2"]
+
+    spec = DeleteEpisodicMemorySpec(episodic_id="1", episodic_ids=["2", "1"])
+    assert spec.get_ids() == ["1", "2"]
 
 
 def test_search_result_model():


### PR DESCRIPTION
### Purpose of the change

Add multi-delete support for episodic and semantic memories
* Added `episodic_ids` and `semantic_ids` to allow deleting multiple memories in a single request
* Updated deletion logic in handlers to process both single and batch deletion
* Updated API documentation and route descriptions to reflect support for multi-ID deletion

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

