### PR TITLE
Treat `:` as valid character in id

### DIFF
--- a/src/memmachine/server/api_v2/doc.py
+++ b/src/memmachine/server/api_v2/doc.py
@@ -10,7 +10,7 @@ class SpecDoc:
     The unique identifier of the organization.
 
     - Must not contain slashes (`/`).
-    - Must contain only letters, numbers, underscores, hyphens, and Unicode
+    - Must contain only letters, numbers, underscores, hyphens, colon, and Unicode
       characters (e.g., Chinese/Japanese/Korean). No slashes or other symbols
       are allowed.
 
@@ -28,7 +28,7 @@ class SpecDoc:
 
     - Must be unique within the organization.
     - Must not contain slashes (`/`).
-    - Must contain only letters, numbers, underscores, hyphens, and Unicode
+    - Must contain only letters, numbers, underscores, hyphens, colon, and Unicode
       characters (e.g., Chinese/Japanese/Korean). No slashes or other symbols
       are allowed.
 
@@ -225,7 +225,7 @@ class RouterDoc:
     This endpoint creates a project under the specified organization using the
     provided identifiers and configuration. Both `org_id` and `project_id`
     follow the rules: no slashes; only letters, numbers, underscores,
-    hyphens, and Unicode characters.
+    hyphens, colon, and Unicode characters.
 
     Each project acts as an isolated memory namespace. All memories (episodes)
     inserted into a project belong exclusively to that project. Queries,
@@ -274,7 +274,7 @@ class RouterDoc:
     Returns a list of all projects accessible within the system. Each entry
     contains the project's organization ID and project ID. Identifiers follow
     the standard rules: no slashes; only letters, numbers, underscores,
-    hyphens, and Unicode characters.
+    hyphens, colon, and Unicode characters.
 
     Projects are isolated memory namespaces. Memories (episodes) belong
     exclusively to their project. All project operations, including queries and

--- a/src/memmachine/server/api_v2/spec.py
+++ b/src/memmachine/server/api_v2/spec.py
@@ -23,11 +23,10 @@ class InvalidNameError(ValueError):
 
 
 def _is_valid_name(v: str) -> str:
-    # Allow: Unicode letters, Unicode numbers, underscore, hyphen
-    if not regex.fullmatch(r"^[\p{L}\p{N}_-]+$", v):
+    if not regex.fullmatch(r"^[\p{L}\p{N}_:-]+$", v):
         raise InvalidNameError(
             "ID can only contain letters, numbers, underscore, hyphen, "
-            "or Unicode characters"
+            f"colon, or Unicode characters, found: '{v}'",
         )
     return v
 

--- a/tests/memmachine/server/api_v2/test_spec.py
+++ b/tests/memmachine/server/api_v2/test_spec.py
@@ -28,11 +28,11 @@ from memmachine.server.api_v2.spec import (
     [
         "abc",
         "abc123",
-        "ABC_xyz-123",
+        "ABC:xyz-123",
         "你好世界",
         "テスト123",
         "안녕-세상",
-        "名字_123",
+        "名字:123",
         "中文-english_混合",
     ],
 )
@@ -50,11 +50,14 @@ def test_validate_no_slash_valid(value):
         "name@123",  # symbol
         "value!",  # symbol
         "中文 test",  # space
+        "",  # empty
     ],
 )
 def test_validate_no_slash_invalid(value):
-    with pytest.raises(InvalidNameError):
+    with pytest.raises(InvalidNameError) as exe_info:
         _is_valid_name(value)
+    message = f"found: '{value}'"
+    assert message in str(exe_info.value)
 
 
 def assert_pydantic_errors(exc_info, expected_checks: dict[str, str]):


### PR DESCRIPTION
### Purpose of the change

The semantic id may contain `:` due to the implementation of neo4j. Add this character in the check for memory id.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [x] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

