### PR TITLE
Docs: Adding "memmachine-server" and "memmachine-client" packages where appropriate in pip install commands.

### DIFF
--- a/docs/api_reference/python/client.mdx
+++ b/docs/api_reference/python/client.mdx
@@ -70,7 +70,7 @@ sequenceDiagram
 Install the client package via pip:
 
 ```bash
-pip install memmachine
+pip install memmachine-client
 ```
 
 ## Hello World Example

--- a/docs/examples/python.mdx
+++ b/docs/examples/python.mdx
@@ -18,7 +18,7 @@ import uuid
 Install the MemMachine package using pip:
 
 ```bash
-pip install memmachine
+pip install memmachine-server
 ```
 
 ## Hello World Example


### PR DESCRIPTION
### Purpose of the change

V0.2 introduces two sub-packages, "Memmachine-server" and "Memmachine-client" that are directly under a meta package consisting of both, "Memmachine".  This PR changes references to "pip install memmachine" for the PythonSDK Client and Server pages such that they point to the sub-packages instead of the meta package.

### Description

Updated client.mdx to refer to "memmachine-client".
Updated server.mdx to refer to "memmachine-server".

### Fixes/Closes

### Type of change

- [X] Documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

Rendering on lab system running mintlify.  Text changes, no image changes.

- [X] Manual verification (list step-by-step instructions)

**Test Results:**
As no new images or really markdown code was touched, only text inside a codeblock, verified that all is correctly spelled.

### Checklist

[Please delete options that are not relevant.]

- [X] I have signed the commit(s) within this pull request
- [X] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs
N/A
### Further comments

Screenshots can be created upon request, but given how small this change is, it didn't feel appropriate.
