### PR TITLE
correct the env name for mcp param override

### DIFF
--- a/src/memmachine/server/api_v2/mcp.py
+++ b/src/memmachine/server/api_v2/mcp.py
@@ -147,10 +147,10 @@ class Params(BaseModel):
         Override proj_id if MM_PROJ_ID is set or user_id is set.
         Override org_id if MM_ORG_ID is set.
         """
-        env_org_id = os.getenv("MC_ORG_ID")
+        env_org_id = os.getenv("MM_ORG_ID")
         if env_org_id:
             self.org_id = env_org_id
-        env_proj_id = os.getenv("MC_PROJ_ID")
+        env_proj_id = os.getenv("MM_PROJ_ID")
         if env_proj_id:
             self.proj_id = env_proj_id
         env_user_id = os.environ.get("MM_USER_ID")

--- a/tests/memmachine/server/api_v2/test_mcp.py
+++ b/tests/memmachine/server/api_v2/test_mcp.py
@@ -17,13 +17,23 @@ pytestmark = pytest.mark.asyncio
 
 @pytest.fixture(autouse=True)
 def clear_env():
-    """Automatically clear MM_USER_ID env var before and after each test."""
-    old_env = os.environ.pop("MM_USER_ID", None)
+    """Automatically clear env vars before and after each test."""
+    old_org_id = os.getenv("MM_ORG_ID")
+    old_proj_id = os.getenv("MM_PROJ_ID")
+    old_user_id = os.getenv("MM_USER_ID")
     yield
-    if old_env:
-        os.environ["MM_USER_ID"] = old_env
+    if old_user_id:
+        os.environ["MM_USER_ID"] = old_user_id
     else:
         os.environ.pop("MM_USER_ID", None)
+    if old_org_id:
+        os.environ["MM_ORG_ID"] = old_org_id
+    else:
+        os.environ.pop("MM_ORG_ID", None)
+    if old_proj_id:
+        os.environ["MM_PROJ_ID"] = old_proj_id
+    else:
+        os.environ.pop("MM_PROJ_ID", None)
 
 
 def test_user_id_without_env():
@@ -37,6 +47,20 @@ def test_user_id_with_env_override(monkeypatch):
     monkeypatch.setenv("MM_USER_ID", "env_user")
     model = Params(user_id="original_user")
     assert model.user_id == "env_user"
+
+
+def test_org_id_with_env_override(monkeypatch):
+    """Should override org_id when MM_ORG_ID is set in environment."""
+    monkeypatch.setenv("MM_ORG_ID", "env_org")
+    model = Params(org_id="original_org", user_id="user")
+    assert model.org_id == "env_org"
+
+
+def test_proj_id_with_env_override(monkeypatch):
+    """Should override proj_id when MM_PROJ_ID is set in environment."""
+    monkeypatch.setenv("MM_PROJ_ID", "env_proj")
+    model = Params(proj_id="original_proj", user_id="user")
+    assert model.proj_id == "env_proj"
 
 
 def test_user_id_with_empty_env(monkeypatch):


### PR DESCRIPTION
### Purpose of the change

The env variable name that overrides the parameters in mcp is not correct.  Fix them to use the correct env variable names.

Add unittest to check that.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [x] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
