### PR TITLE
Rename root project to 'memmachine-dev' to avoid namespace conflict with the 'memmachine' package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,14 @@ requires = ["uv_build"]
 build-backend = "uv_build"
 
 [tool.uv.workspace]
-members = ["packages/client", "packages/server"]
+members = ["packages/client", "packages/server", "packages/meta"]
 
 [tool.uv.sources]
 memmachine-server = { workspace = true }
 memmachine-client = { workspace = true }
 
 [project]
-name = "memmachine"
+name = "memmachine-dev"
 version = "0.1.0"
 dependencies = [
     "alembic>=1.17.1",


### PR DESCRIPTION
### Purpose of the change

When we released v0.2.0, the metapackage failed to publish using the automation tools.

The top-level 'memmachine' package was missing from the `uv build` list. It has been added.
Had to rename the main project from `memmachine` to `memmachine-dev` to resolve a naming conflict with the new meta package. 

### Description

This change allows us to build and publish a meta package called "memmachine" to pypi.org to replace https://pypi.org/project/memmachine/, which was the server package. By running `pip install memmachine` you now get both `memmachine-client` and `memmachine-server` installed in one command. Users are still able to install the packages individually if they so choose. This design decision was to avoid breaking existing user functionality.

### Fixes/Closes

N/A

### Type of change

- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

This command (from `.github/workflows/build-python.yml` builds all three packages:

```
uv build --project packages/client && uv build --project packages/server && uv build --project packages/meta
```

The result is shown in the output `/dist` directory:

```
$ ls -lh dist/
total 476K
-rw-rw-r-- 1 steve steve 1.3K Dec 10 01:33 memmachine-0.1.0-py3-none-any.whl
-rw-rw-r-- 1 steve steve 1.2K Dec 10 01:33 memmachine-0.1.0.tar.gz
-rw-rw-r-- 1 steve steve  30K Dec 10 01:33 memmachine_client-0.1.0-py3-none-any.whl
-rw-rw-r-- 1 steve steve  28K Dec 10 01:33 memmachine_client-0.1.0.tar.gz
-rw-rw-r-- 1 steve steve 232K Dec 10 01:33 memmachine_server-0.1.0-py3-none-any.whl
-rw-rw-r-- 1 steve steve 176K Dec 10 01:33 memmachine_server-0.1.0.tar.gz
```

`.github/workflows/pypi-publish.yml` will publish all packages found in `/dist` to pypi.org

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

This will only work when we do the next release as pypi won't allow us to overwrite existing packages.