### PR TITLE
[GH-703] Semantic: Add ingestion trigger configuration.

### DIFF
--- a/src/memmachine/common/configuration/__init__.py
+++ b/src/memmachine/common/configuration/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, TypeGuard, cast
 
@@ -71,6 +72,15 @@ class SemanticMemoryConf(YamlSerializableMixin):
     embedding_model: str = Field(
         ...,
         description="The embedding model to use for semantic memory",
+    )
+
+    ingestion_trigger_messages: int = Field(
+        default=5,
+        description="The amount of uningested messages to trigger an ingestion.",
+    )
+    ingestion_trigger_age: timedelta = Field(
+        default=timedelta(minutes=5),
+        description="The amount of time a message is uningested before triggering an ingestion.",
     )
 
 

--- a/src/memmachine/common/configuration/mixin_confs.py
+++ b/src/memmachine/common/configuration/mixin_confs.py
@@ -1,5 +1,6 @@
 """Metrics configuration mixins."""
 
+from datetime import timedelta
 from enum import Enum
 from typing import ClassVar
 
@@ -65,6 +66,9 @@ class YamlSerializableMixin(BaseModel):
             # Unwrap enums like SimilarityMetric
             if isinstance(obj, Enum):
                 obj = obj.value
+
+            if isinstance(obj, timedelta):
+                obj = obj.total_seconds()
 
             # Dict — recurse & drop empty
             if isinstance(obj, dict):

--- a/src/memmachine/common/resource_manager/semantic_manager.py
+++ b/src/memmachine/common/resource_manager/semantic_manager.py
@@ -116,6 +116,8 @@ class SemanticResourceManager:
                 semantic_storage=semantic_storage,
                 episode_storage=episode_store,
                 resource_retriever=resource_retriever,
+                uningested_time_limit=self._conf.ingestion_trigger_age,
+                uningested_message_limit=self._conf.ingestion_trigger_messages,
             ),
         )
         return self._semantic_service

--- a/src/memmachine/semantic_memory/storage/alembic_pg/versions/62dff1150a46_add_created_at_to_history_add.py
+++ b/src/memmachine/semantic_memory/storage/alembic_pg/versions/62dff1150a46_add_created_at_to_history_add.py
@@ -1,0 +1,37 @@
+"""
+Add created at to history add.
+
+Revision ID: 62dff1150a46
+Revises: 79f00a9f2409
+Create Date: 2025-12-10 08:30:58.962290
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "62dff1150a46"
+down_revision: str | Sequence[str] | None = "79f00a9f2409"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "set_ingested_history",
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("set_ingested_history", "created_at")

--- a/src/memmachine/semantic_memory/storage/sqlalchemy_pgvector_semantic.py
+++ b/src/memmachine/semantic_memory/storage/sqlalchemy_pgvector_semantic.py
@@ -8,7 +8,7 @@ import numpy as np
 from alembic import command
 from alembic.config import Config
 from pgvector.sqlalchemy import Vector
-from pydantic import InstanceOf, TypeAdapter, ValidationError
+from pydantic import AwareDatetime, InstanceOf, TypeAdapter, ValidationError
 from sqlalchemy import (
     Boolean,
     Column,
@@ -156,6 +156,10 @@ class SetIngestedHistory(BaseSemanticStorage):
     history_id = mapped_column(
         String,
         primary_key=True,
+    )
+    created_at = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
     ingested = mapped_column(Boolean, default=False, nullable=False)
 
@@ -731,8 +735,11 @@ class SqlAlchemyPgVectorSemanticStorage(SemanticStorage):
         self,
         *,
         min_uningested_messages: int | None = None,
+        older_than: AwareDatetime | None = None,
     ) -> list[SetIdT]:
         stmt = select(SetIngestedHistory.set_id).distinct()
+
+        conditions = []
 
         if min_uningested_messages is not None and min_uningested_messages > 0:
             inner = aliased(SetIngestedHistory)
@@ -746,7 +753,20 @@ class SqlAlchemyPgVectorSemanticStorage(SemanticStorage):
                 .scalar_subquery()
             )
 
-            stmt = stmt.where(count_uningested >= min_uningested_messages)
+            conditions.append(count_uningested >= min_uningested_messages)
+
+        if older_than is not None:
+            conditions.append(
+                and_(
+                    SetIngestedHistory.created_at <= older_than,
+                    SetIngestedHistory.ingested.is_(False),
+                )
+            )
+
+        if len(conditions) == 1:
+            stmt = stmt.where(conditions[0])
+        elif len(conditions) > 1:
+            stmt = stmt.where(or_(*conditions))
 
         async with self._create_session() as session:
             result = await session.execute(stmt)

--- a/src/memmachine/semantic_memory/storage/storage_base.py
+++ b/src/memmachine/semantic_memory/storage/storage_base.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 import numpy as np
@@ -173,6 +174,7 @@ class SemanticStorage(ABC):
         self,
         *,
         min_uningested_messages: int | None = None,
+        older_than: datetime | None = None,
     ) -> list[SetIdT]:
         """Return all set id's that match the specified filters."""
         raise NotImplementedError

--- a/tests/memmachine/common/configuration/test_semantic_conf.py
+++ b/tests/memmachine/common/configuration/test_semantic_conf.py
@@ -1,0 +1,30 @@
+from datetime import timedelta
+
+from memmachine.common.configuration import SemanticMemoryConf
+
+
+def test_semantic_config_with_ingestion_triggers():
+    raw_conf = {
+        "database": "database",
+        "llm_model": "llm",
+        "embedding_model": "embedding",
+        "ingestion_trigger_messages": 24,
+        "ingestion_trigger_age": "PT2M",
+    }
+    conf = SemanticMemoryConf(**raw_conf)
+    assert conf.ingestion_trigger_messages == 24
+    assert conf.ingestion_trigger_age == timedelta(minutes=2)
+
+
+def test_semantic_config_timedelta_float():
+    raw_conf = {
+        "database": "database",
+        "llm_model": "llm",
+        "embedding_model": "embedding",
+        "ingestion_trigger_messages": 24,
+        "ingestion_trigger_age": 120.5,
+    }
+
+    conf = SemanticMemoryConf(**raw_conf)
+    assert conf.ingestion_trigger_messages == 24
+    assert conf.ingestion_trigger_age == timedelta(minutes=2, milliseconds=500)

--- a/tests/memmachine/semantic_memory/storage/test_semantic_storage.py
+++ b/tests/memmachine/semantic_memory/storage/test_semantic_storage.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+from datetime import UTC, datetime
+
 import numpy as np
 import pytest
 import pytest_asyncio
@@ -902,3 +905,98 @@ async def test_get_set_ids_with_min_uningested(
         min_uningested_messages=2,
     )
     assert set_ids == ["user_c"]
+
+
+@pytest.mark.asyncio
+async def test_get_set_ids_with_older_than(
+    semantic_storage: SemanticStorage,
+    episode_storage,
+):
+    early_history_id = await _add_episode(episode_storage, content="early")
+    await semantic_storage.add_history_to_set(
+        set_id="old_user",
+        history_id=early_history_id,
+    )
+
+    await asyncio.sleep(0.01)
+    cutoff = datetime.now(UTC)
+    await asyncio.sleep(0.01)
+
+    recent_history_id = await _add_episode(episode_storage, content="recent")
+    await semantic_storage.add_history_to_set(
+        set_id="recent_user",
+        history_id=recent_history_id,
+    )
+
+    set_ids = set(
+        await semantic_storage.get_history_set_ids(
+            older_than=cutoff,
+        )
+    )
+
+    assert set_ids == {"old_user"}
+
+    await semantic_storage.mark_messages_ingested(
+        set_id="old_user",
+        history_ids=[early_history_id],
+    )
+
+    set_ids_after_ingest = set(
+        await semantic_storage.get_history_set_ids(
+            older_than=cutoff,
+        )
+    )
+
+    assert set_ids_after_ingest == set()
+
+
+@pytest.mark.asyncio
+async def test_get_set_ids_with_older_than_and_min_uningested(
+    semantic_storage: SemanticStorage,
+    episode_storage,
+):
+    early_history_id = await _add_episode(episode_storage, content="early")
+    await semantic_storage.add_history_to_set(
+        set_id="old_user",
+        history_id=early_history_id,
+    )
+
+    await asyncio.sleep(0.01)
+    cutoff = datetime.now(UTC)
+    await asyncio.sleep(0.01)
+
+    busy_history_ids = [
+        await _add_episode(episode_storage, content=f"busy-{idx}") for idx in range(2)
+    ]
+    for history_id in busy_history_ids:
+        await semantic_storage.add_history_to_set(
+            set_id="busy_user",
+            history_id=history_id,
+        )
+
+    fresh_history_id = await _add_episode(episode_storage, content="fresh")
+    await semantic_storage.add_history_to_set(
+        set_id="fresh_user",
+        history_id=fresh_history_id,
+    )
+
+    set_ids = set(
+        await semantic_storage.get_history_set_ids(
+            min_uningested_messages=2,
+            older_than=cutoff,
+        )
+    )
+
+    assert set_ids == {"old_user", "busy_user"}
+
+    await semantic_storage.mark_messages_ingested(
+        set_id="old_user",
+        history_ids=[early_history_id],
+    )
+
+    set_ids = await semantic_storage.get_history_set_ids(
+        min_uningested_messages=2,
+        older_than=cutoff,
+    )
+
+    assert set_ids == ["busy_user"]

--- a/tests/memmachine/semantic_memory/test_semantic_memory.py
+++ b/tests/memmachine/semantic_memory/test_semantic_memory.py
@@ -116,7 +116,7 @@ async def semantic_service(
         episode_storage=episode_storage,
         resource_retriever=resource_retriever,
         feature_update_interval_sec=0.05,
-        feature_update_message_limit=10,
+        uningested_message_limit=10,
         feature_update_time_limit_sec=0.05,
     )
     service = SemanticService(params)

--- a/tests/memmachine/semantic_memory/test_semantic_memory_background.py
+++ b/tests/memmachine/semantic_memory/test_semantic_memory_background.py
@@ -87,7 +87,7 @@ async def semantic_service(
         episode_storage=episode_storage,
         resource_retriever=resource_retriever,
         feature_update_interval_sec=0.05,
-        feature_update_message_limit=2,
+        uningested_message_limit=2,
     )
     service = SemanticService(params)
     yield service
@@ -154,7 +154,7 @@ async def test_background_ingestion_processes_messages_on_message_limit(
         episode_storage=episode_storage,
         resource_retriever=resource_retriever,
         feature_update_interval_sec=0.05,
-        feature_update_message_limit=0,
+        uningested_message_limit=0,
     )
     service = SemanticService(params)
     await service.start()
@@ -311,7 +311,7 @@ async def test_multiple_sets_processed_independently(
         episode_storage=episode_storage,
         resource_retriever=resource_retriever,
         feature_update_interval_sec=0.05,
-        feature_update_message_limit=0,
+        uningested_message_limit=0,
     )
     service = SemanticService(params)
     await service.start()

--- a/tests/memmachine/semantic_memory/test_semantic_memory_integration.py
+++ b/tests/memmachine/semantic_memory/test_semantic_memory_integration.py
@@ -122,7 +122,7 @@ async def semantic_service(
             episode_storage=episode_storage,
             resource_retriever=resource_retriever,
             feature_update_interval_sec=0.05,
-            feature_update_message_limit=0,
+            uningested_message_limit=0,
             debug_fail_loudly=True,
         ),
     )

--- a/tests/memmachine/semantic_memory/test_semantic_session_manager.py
+++ b/tests/memmachine/semantic_memory/test_semantic_session_manager.py
@@ -126,7 +126,7 @@ async def semantic_service(
         episode_storage=episode_storage,
         resource_retriever=resource_retriever,
         feature_update_interval_sec=0.05,
-        feature_update_message_limit=10,
+        uningested_message_limit=10,
     )
     service = SemanticService(params)
     yield service


### PR DESCRIPTION
Adds in ingestion trigger parameters to Semantic Memory Config.

In addition adds time based age trigger.

The timedelta can be represented as an ISO string or a numeric representation in seconds.

```
    raw_conf = {
        "ingestion_trigger_age": "PT2M",
    }
    conf = SemanticMemoryConf(**raw_conf)
    assert conf.ingestion_trigger_age == timedelta(minutes=2)
# ---------------
    raw_conf = {
        "ingestion_trigger_age": 120.5,
    }
    conf = SemanticMemoryConf(**raw_conf)
    assert conf.ingestion_trigger_age == timedelta(minutes=2, milliseconds=500)
```

### Fixes/Closes

#703 
#753

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)
