### PR TITLE
Install neo4j with zip files in macos instead of brew.

### DIFF
--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
         python-version: ["3.12"]
 
     steps:
@@ -114,13 +114,13 @@ jobs:
       # ─────────────────────────────────────
       #
       - name: macOS - Install Ollama
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel'
         run: |
           brew install ollama
           brew services start ollama
 
       - name: macOS - Test installation
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel'
         shell: bash
         run: |
           set -eo pipefail

--- a/src/memmachine/installation/utilities.py
+++ b/src/memmachine/installation/utilities.py
@@ -12,6 +12,16 @@ WINDOWS_NEO4J_ZIP_NAME = f"{NEO4J_DIR_NAME}-windows.zip"
 WINDOWS_NEO4J_URL = f"https://dist.neo4j.org/{WINDOWS_NEO4J_ZIP_NAME}"
 LINUX_NEO4J_TAR_NAME = f"{NEO4J_DIR_NAME}-unix.tar.gz"
 LINUX_NEO4J_URL = f"https://dist.neo4j.org/{LINUX_NEO4J_TAR_NAME}"
+
+MACOS_JDK_TAR_NAME_X64 = "jdk-21_macos-x64_bin.tar.gz"
+MACOS_JDK_URL_X64 = (
+    f"https://download.oracle.com/java/21/latest/{MACOS_JDK_TAR_NAME_X64}"
+)
+MACOS_JDK_TAR_NAME_ARM64 = "jdk-21_macos-aarch64_bin.tar.gz"
+MACOS_JDK_URL_ARM64 = (
+    f"https://download.oracle.com/java/21/latest/{MACOS_JDK_TAR_NAME_ARM64}"
+)
+
 JDK_DIR_NAME = "jdk-21.0.9"
 NEO4J_WINDOWS_SERVICE_NAME = "neo4j"
 


### PR DESCRIPTION
### Purpose of the change

Support configuration script in older macos systems. Avoid installing xcode

### Description

In older macos systems like macos-12, homebrew doesn't provide pre-compiled jdk and jdk has to be compiled locally when installing neo4j. This makes the installation of neo4j depends on Xcode, which is very large.
So we would like to switch to download the pre-built java binary and neo4j binary directly and extract them. Like we do in linux and windows.

### Fixes/Closes

Fixes #758

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)

### How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test
- [ ] Manual verification (list step-by-step instructions)

### Checklist


- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
