### PR TITLE
Unifying docker-compose and docker compose

### DIFF
--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -15,6 +15,13 @@ NC='\033[0m' # No Color
 
 is_first_run=false
 
+# Use docker-compose or docker compose based on what's available
+if command -v docker-compose &> /dev/null; then
+    COMPOSE_CMD="docker-compose"
+else
+    COMPOSE_CMD="docker compose"
+fi
+
 ## Function to run a command with a timeout
 timeout() {
     local duration=$1
@@ -687,13 +694,6 @@ start_services() {
 
     print_info "Pulling and starting MemMachine services..."
     
-    # Use docker-compose or docker compose based on what's available
-    if command -v docker-compose &> /dev/null; then
-        COMPOSE_CMD="docker-compose"
-    else
-        COMPOSE_CMD="docker compose"
-    fi
-
     # Unset the memmachine image temporarily; without this, 'docker compose pull' will attempt
     # to pull ${MEMMACHINE_IMAGE} if it is set, which may not be a remote image.
     ENV_MEMMACHINE_IMAGE=""
@@ -712,13 +712,6 @@ start_services() {
 # Wait for services to be healthy
 wait_for_health() {
     print_info "Waiting for services to be healthy..."
-    
-    # Use docker-compose or docker compose based on what's available
-    if command -v docker-compose &> /dev/null; then
-        COMPOSE_CMD="docker-compose"
-    else
-        COMPOSE_CMD="docker compose"
-    fi
     
     # Wait for services to be healthy
     $COMPOSE_CMD ps
@@ -864,29 +857,17 @@ main() {
 case "${1:-}" in
     "stop")
         print_info "Stopping MemMachine services..."
-        if command -v docker-compose &> /dev/null; then
-            docker-compose down
-        else
-            docker compose down
-        fi
+        $COMPOSE_CMD down
         print_success "Services stopped"
         ;;
     "restart")
         print_info "Restarting MemMachine services..."
-        if command -v docker-compose &> /dev/null; then
-            docker-compose restart
-        else
-            docker compose restart
-        fi
+        $COMPOSE_CMD restart
         print_success "Services restarted"
         ;;
     "logs")
         print_info "Showing MemMachine logs..."
-        if command -v docker-compose &> /dev/null; then
-            docker-compose logs -f
-        else
-            docker compose logs -f
-        fi
+        $COMPOSE_CMD logs -f
         ;;
     "clean")
         print_warning "This will remove all data and volumes!"
@@ -895,11 +876,7 @@ case "${1:-}" in
         echo
         if [[ $REPLY =~ ^[Yy]$ ]]; then
             print_info "Cleaning up MemMachine services and data..."
-            if command -v docker-compose &> /dev/null; then
-                docker-compose down -v
-            else
-                docker compose down -v
-            fi
+            $COMPOSE_CMD down -v
             print_success "Cleanup completed"
         else
             print_info "Cleanup cancelled"


### PR DESCRIPTION
### Purpose of the change

Refactoring.

### Description

In `memmachine-compose.sh`, there are many places that use either `docker-compose` or `docker compose` but they are repeated multiple times.

This patch simply unifying those logics into a single place for simplicity.

### Type of change

[Please delete options that are not relevant.]

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

Running `memmachine-compose.sh` was fine.

**Test Results:** [Attach logs, screenshots, or relevant output]

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected