### PR TITLE
Improve low-limit search results

### DIFF
--- a/src/memmachine/episodic_memory/declarative_memory/declarative_memory.py
+++ b/src/memmachine/episodic_memory/declarative_memory/declarative_memory.py
@@ -98,6 +98,8 @@ class DeclarativeMemory:
 
         self._derived_from_relation = f"DERIVED_FROM_{session_id}"
 
+        self._score_single_episodes_threshold = 10
+
     async def add_episodes(
         self,
         episodes: Iterable[Episode],
@@ -355,29 +357,39 @@ class DeclarativeMemory:
 
         episode_contexts = await asyncio.gather(*contextualize_episode_tasks)
 
+        if max_num_episodes <= self._score_single_episodes_threshold:
+            nuclear_episodes = [
+                episode
+                for episode_context in episode_contexts
+                for episode in episode_context
+            ]
+            episode_contexts = [
+                [nuclear_episode] for nuclear_episode in nuclear_episodes
+            ]
+
         # Rerank episode contexts.
         episode_context_scores = await self._score_episode_contexts(
             query,
             episode_contexts,
         )
 
-        reranked_episode_contexts = [
-            episode_context
-            for _, episode_context in sorted(
+        reranked_anchored_episode_contexts = [
+            (nuclear_episode, episode_context)
+            for _, nuclear_episode, episode_context in sorted(
                 zip(
                     episode_context_scores,
+                    nuclear_episodes,
                     episode_contexts,
                     strict=True,
                 ),
-                key=lambda pair: pair[0],
+                key=lambda triple: triple[0],
                 reverse=True,
             )
         ]
 
         # Unify episode contexts.
-        unified_episode_context = await self._unify_episode_contexts(
-            query,
-            reranked_episode_contexts,
+        unified_episode_context = DeclarativeMemory._unify_anchored_episode_contexts(
+            reranked_anchored_episode_contexts,
             max_num_episodes=max_num_episodes,
         )
         return unified_episode_context
@@ -552,50 +564,41 @@ class DeclarativeMemory:
 
         await asyncio.gather(*delete_nodes_tasks)
 
-    async def _unify_episode_contexts(
-        self,
-        query: str,
-        episode_contexts: Iterable[Iterable[Episode]],
+    @staticmethod
+    def _unify_anchored_episode_contexts(
+        anchored_episode_contexts: Iterable[tuple[Episode, Iterable[Episode]]],
         max_num_episodes: int,
     ) -> list[Episode]:
-        """Unify episode contexts into a single list within the limit."""
+        """Unify anchored episode contexts into a single list within the limit."""
         episode_set: set[Episode] = set()
 
-        for episode_context in episode_contexts:
-            episode_context = list(episode_context)
+        for nuclear_episode, context in anchored_episode_contexts:
+            context = list(context)
 
             if len(episode_set) >= max_num_episodes:
                 break
-            if (len(episode_set) + len(episode_context)) <= max_num_episodes:
+            if (len(episode_set) + len(context)) <= max_num_episodes:
                 # It is impossible that the context exceeds the limit.
-                episode_set.update(episode_context)
+                episode_set.update(context)
             else:
                 # It is possible that the context exceeds the limit.
-                # Rank the episodes in the context.
-                episode_scores = await self._reranker.score(
-                    query,
-                    [
-                        DeclarativeMemory.string_from_episode_context([episode])
-                        for episode in episode_context
-                    ],
-                )
+                # Prioritize episodes near the nuclear episode.
 
-                ranked_episode_context = [
-                    episode
-                    for _, episode in sorted(
-                        zip(
-                            episode_scores,
-                            episode_context,
-                            strict=True,
-                        ),
-                        key=lambda pair: pair[0],
-                        reverse=True,
-                    )
-                ]
+                # Sort chronological episodes by weighted index-proximity to the nuclear episode.
+                nuclear_index = context.index(nuclear_episode)
+
+                nuclear_context = sorted(
+                    context,
+                    key=lambda episode: DeclarativeMemory._weighted_index_proximity(
+                        episode=episode,
+                        context=context,
+                        nuclear_index=nuclear_index,
+                    ),
+                )
 
                 # Add episodes to unified context until limit is reached,
                 # or until the context is exhausted.
-                for episode in ranked_episode_context:
+                for episode in nuclear_context:
                     if len(episode_set) >= max_num_episodes:
                         break
                     episode_set.add(episode)
@@ -609,6 +612,18 @@ class DeclarativeMemory:
         )
 
         return unified_episode_context
+
+    @staticmethod
+    def _weighted_index_proximity(
+        episode: Episode,
+        context: list[Episode],
+        nuclear_index: int,
+    ) -> float:
+        proximity = context.index(episode) - nuclear_index
+        if proximity >= 0:
+            # Forward recall is better than backward recall.
+            return (proximity - 0.5) / 2
+        return -proximity
 
     @staticmethod
     def _episode_from_episode_node(episode_node: Node) -> Episode:

--- a/tests/memmachine/episodic_memory/declarative_memory/test_declarative_memory.py
+++ b/tests/memmachine/episodic_memory/declarative_memory/test_declarative_memory.py
@@ -297,9 +297,6 @@ async def test_search(declarative_memory):
     # Most relevant.
     assert "episode1" in [result.uid for result in results]
 
-    # The bunch of filler episodes should separate episode1 and episode2.
-    assert "episode2" not in [result.uid for result in results]
-
     results = await declarative_memory.search(
         query="Who wrote the test?",
         max_num_episodes=4,

--- a/tests/memmachine/episodic_memory/long_term_memory/test_long_term_memory.py
+++ b/tests/memmachine/episodic_memory/long_term_memory/test_long_term_memory.py
@@ -309,9 +309,6 @@ async def test_search(long_term_memory):
     # Most relevant.
     assert "episode1" in [result.uid for result in results]
 
-    # The bunch of filler episodes should separate episode1 and episode2.
-    assert "episode2" not in [result.uid for result in results]
-
     results = await long_term_memory.search(
         query="Who wrote the test?",
         num_episodes_limit=4,


### PR DESCRIPTION
### Purpose of the change

When search limit is very low e.g. 1-3, and/or episodes are very small e.g. on the order of 0-50 characters, returned results are likely to be terrible because the episode budget is filled based on weighted index proximity instead of relevance.

### Description

The current implementation fills up the return limit budget by taking the episodes closest to the nuclear episode first. When a good episode happens to be part of the context of a bad nuclear episode, it is possible that the reranker gives a high score to the context belonging to the bad nuclear episode, so that the good episode is not included.

This is an easy issue to hit especially in contrived scenarios where consecutive episodes are likely to be unrelated.

Discovered by #771 failing integration tests. 
Just rank individual episodes when the search limit is low.

### Type of change

[Please delete options that are not relevant.]

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [ ] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [x] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected