### PR TITLE
Docs: Resolving Issue #766 - rename of `.mcp.json` to `claude_desktop_config.json`

### DIFF
--- a/docs/install_guide/integrate/claude_code_mcp.mdx
+++ b/docs/install_guide/integrate/claude_code_mcp.mdx
@@ -55,7 +55,7 @@ Choose the method that best fits your workflow.
 
 <Step title="Option A: Configure with Docker">
 
-If you're running MemMachine in Docker, create or edit the `.mcp.json` file in your project root:
+If you're running MemMachine in Docker, create or edit the `claude_desktop_config.json` file in your project root:
 
 ```json
 {
@@ -93,7 +93,7 @@ If you're running MemMachine in Docker, create or edit the `.mcp.json` file in y
 **Reference Implementation**: This method has not been fully tested with Claude Code. It follows the standard MCP stdio pattern and should work, but if you encounter issues, please use Option A (Docker) or report your findings.
 </Note>
 
-If you have MemMachine installed locally, create or edit the `.mcp.json` file in your project root:
+If you have MemMachine installed locally, create or edit the `claude_desktop_config.json` file in your project root:
 
 ```json
 {
@@ -140,7 +140,7 @@ Once configured, start Claude Code in your project directory:
 claude
 ```
 
-Claude Code will automatically detect the `.mcp.json` file and connect to MemMachine.
+Claude Code will automatically detect the `claude_desktop_config.json` file and connect to MemMachine.
 
 **Verify the connection** by checking /mcp or asking Claude to store something in memory:
 


### PR DESCRIPTION
### Purpose of the change

Our Claude Integration document incorrectly references the config file as `.mcp.json` when it should be `claude_desktop_config.json`.  This PR resolves this issue.

### Description

Edited `claude_code_mcp.mdx` such that any reference to `.mcp.json` is now replaced with `claude_desktop_config.json`.

### Fixes/Closes

Fixes #766 

### Type of change

[Please delete options that are not relevant.]

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


- [X] Manual verification (list step-by-step instructions)

Verified fix works in `mint dev` lab environment.

**Test Results:** 

First instance of switch:
<img width="1855" height="730" alt="Screenshot 2025-12-12 at 1 22 18 PM" src="https://github.com/user-attachments/assets/d5d4d4c0-d789-4299-8cd8-9767bad2a4ff" />

Second instance of switch:
<img width="1760" height="718" alt="Screenshot 2025-12-12 at 1 22 48 PM" src="https://github.com/user-attachments/assets/b5102aaa-1480-4f02-b824-328ead244618" />

Third instance of switch:
<img width="1803" height="720" alt="Screenshot 2025-12-12 at 1 23 24 PM" src="https://github.com/user-attachments/assets/519de078-a7e1-495d-b355-9d1bd7788440" />



### Checklist


- [X] I have signed the commit(s) within this pull request
- [X] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

Please see Test Result section.

### Further comments

None
