### PR TITLE
Add episodic_type to add memory api

### DIFF
--- a/src/memmachine/common/api/__init__.py
+++ b/src/memmachine/common/api/__init__.py
@@ -10,4 +10,10 @@ class MemoryType(Enum):
     Episodic = "episodic"
 
 
-__all__ = ["MemoryType"]
+class EpisodeType(Enum):
+    """Episode type."""
+
+    MESSAGE = "message"
+
+
+__all__ = ["EpisodeType", "MemoryType"]

--- a/src/memmachine/common/api/doc.py
+++ b/src/memmachine/common/api/doc.py
@@ -106,6 +106,10 @@ class SpecDoc:
     Use 'metadata.{key}' to filter based on specific metadata keys.
     """
 
+    MEMORY_EPISODIC_TYPE = """
+    The type of an episode (e.g., 'message').
+    """
+
     MEMORY_MESSAGES = """
     A list of messages to be added (batch input).
     Must contain at least one message.

--- a/src/memmachine/common/api/spec.py
+++ b/src/memmachine/common/api/spec.py
@@ -20,7 +20,7 @@ except ModuleNotFoundError:
             self.detail = detail
 
 
-from memmachine.common.api import MemoryType
+from memmachine.common.api import EpisodeType, MemoryType
 from memmachine.common.api.doc import Examples, SpecDoc
 
 DEFAULT_ORG_AND_PROJECT_ID = "universal"
@@ -289,6 +289,13 @@ class MemoryMessage(BaseModel):
         Field(
             default_factory=dict,
             description=SpecDoc.MEMORY_METADATA,
+        ),
+    ]
+    episode_type: Annotated[
+        EpisodeType | None,
+        Field(
+            default=None,
+            description=SpecDoc.MEMORY_EPISODIC_TYPE,
         ),
     ]
 

--- a/src/memmachine/common/episode_store/episode_model.py
+++ b/src/memmachine/common/episode_store/episode_model.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 from pydantic import AwareDatetime, BaseModel, JsonValue
 
+from memmachine.common.api import EpisodeType
 from memmachine.common.data_types import FilterablePropertyValue
 
 EpisodeIdT = str
@@ -14,13 +15,6 @@ class ContentType(Enum):
 
     STRING = "string"
     # Other content types like 'vector', 'image' could be added here.
-
-
-class EpisodeType(Enum):
-    """Enumeration for the type of an Episode."""
-
-    MESSAGE = "message"
-    # Other episode types like 'thought', 'action' could be added here.
 
 
 class EpisodeEntry(BaseModel):

--- a/src/memmachine/server/api_v2/mcp.py
+++ b/src/memmachine/server/api_v2/mcp.py
@@ -200,6 +200,7 @@ class Params(BaseModel):
                     metadata={
                         "user_id": self.user_id,
                     },
+                    episode_type=None,
                 )
             ],
         )

--- a/src/memmachine/server/api_v2/service.py
+++ b/src/memmachine/server/api_v2/service.py
@@ -56,6 +56,7 @@ async def _add_messages_to(
             producer_role=message.role,
             created_at=message.timestamp,
             metadata=message.metadata,
+            episode_type=message.episode_type,
         )
         for message in spec.messages
     ]

--- a/tests/memmachine/rest_client/test_memory.py
+++ b/tests/memmachine/rest_client/test_memory.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 import pytest
 import requests
 
+from memmachine.common.episode_store.episode_model import EpisodeType
 from memmachine.rest_client.client import MemMachineClient
 from memmachine.rest_client.memory import Memory
 
@@ -217,11 +218,14 @@ class TestMemory:
             user_id="user1",
         )
 
-        memory.add("Content", episode_type="text")
+        memory.add("Content", episode_type=EpisodeType.MESSAGE)
 
         call_args = mock_client.request.call_args
         json_data = call_args[1]["json"]
-        assert json_data["messages"][0]["metadata"]["episode_type"] == "text"
+        assert (
+            json_data["messages"][0]["metadata"]["episode_type"]
+            == EpisodeType.MESSAGE.value
+        )
 
     def test_add_request_exception(self, mock_client):
         """Test add raises exception on request failure."""

--- a/tests/memmachine/server/api_v2/test_spec.py
+++ b/tests/memmachine/server/api_v2/test_spec.py
@@ -20,6 +20,7 @@ from memmachine.common.api.spec import (
     SearchResult,
     _is_valid_name,
 )
+from memmachine.common.episode_store.episode_model import EpisodeType
 from memmachine.main.memmachine import MemoryType
 
 
@@ -134,6 +135,16 @@ def test_memory_message_required_fields():
     assert message.timestamp
     assert message.role == ""
     assert message.metadata == {}
+    assert message.episode_type is None
+
+
+def test_memory_message_episode_type_validation():
+    message = MemoryMessage(content="hello", episode_type="message")
+    assert message.episode_type == EpisodeType.MESSAGE
+
+    with pytest.raises(ValidationError) as exc_info:
+        MemoryMessage(content="hello", episode_type="not-a-real-type")
+    assert any(e["loc"][-1] == "episode_type" for e in exc_info.value.errors())
 
 
 def test_add_memory_spec():


### PR DESCRIPTION
### Purpose of the change

Add episodic_type to add memory api. We want to return proper error when user sets it to an unsupported value instead of fallback silently.

### Description

Add episodic_type to add memory api. We want to return proper error when user sets it to an unsupported value instead of fallback silently. For now "message" is the only supported value. The default value of this field is None.

### Fixes/Closes

Fixes #675

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- [x] Unit Test
- [x] Manual verification (list step-by-step instructions)

### Checklist


- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

