### PR TITLE
Fix URLs when generating openapi.json

### DIFF
--- a/docs/tools/generate_openapi.py
+++ b/docs/tools/generate_openapi.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from memmachine.server.api_v2.router import load_v2_api_router
 
 def generate_openapi():
-    app = FastAPI(servers=[{"url": "http://localhost:8080"}])
+    app = FastAPI(servers=[{"url": "https://localhost:8080"}])
     load_v2_api_router(app)
     
     openapi_schema = app.openapi()


### PR DESCRIPTION
### Purpose of the change

URLs were being generated with `v1` and `v2`, which is incorrect. eg: `https://localhost:8080/v1/api/v2/projects/get`

### Description

This PR updates `docs/tools/generate_openapi.py` to resolve the issue.

### Fixes/Closes

Fixes #797 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

Validated the script produces valid URLs for `openapi.json` 

- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

Here is the *before*, showing the incorrect URL

```
curl --request POST \
  --url https://localhost:8080/v1/api/v2/projects/get \
  --header 'Content-Type: application/json' \
  --data '
{
  "org_id": "<string>",
  "project_id": "<string>"
}
'
```

Here is the `curl` command for GET Projects with the correct URL.

```
curl --request POST \
  --url http://localhost:8080/api/v2/projects/get \
  --header 'Content-Type: application/json' \
  --data '
{
  "org_id": "MemVerge",
  "project_id": "memmachine"
}
'
```

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

See above

### Further comments

None.
