### PR TITLE
fix: update MemMachine API URL to /docs endpoint

### DIFF
--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -751,7 +751,7 @@ show_service_info() {
     print_success "🎉 MemMachine is now running!"
     echo ""
     echo "Service URLs:"
-    echo "  📊 MemMachine API: http://localhost:${MEMORY_SERVER_PORT:-8080}"
+    echo "  📊 MemMachine API Docs: http://localhost:${MEMORY_SERVER_PORT:-8080}/docs"
     echo "  🗄️  Neo4j Browser: http://localhost:${NEO4J_HTTP_PORT:-7474}"
     echo "  📈 Health Check: http://localhost:${MEMORY_SERVER_PORT:-8080}/api/v2/health"
     echo "  📊 Metrics: http://localhost:${MEMORY_SERVER_PORT:-8080}/api/v2/metrics"


### PR DESCRIPTION
### Purpose of the change

Fix incorrect MemMachine API URL in startup script output.

### Description

The script was displaying `http://localhost:8080` as the MemMachine API URL, but the root path `/` returns 404 as no route is defined. Updated the URL to point to `/docs` which serves the Swagger UI documentation page.

**Changes:**
- Updated MemMachine API URL from root path to `/docs` (Swagger UI documentation)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested the endpoint after starting services:
- ✅ `http://localhost:8080/docs` - Returns Swagger UI documentation
- ✅ Verified root path `http://localhost:8080` correctly returns 404