### PR TITLE
Can not get semantic memory with MCP

### DIFF
--- a/src/memmachine/server/api_v2/mcp.py
+++ b/src/memmachine/server/api_v2/mcp.py
@@ -212,7 +212,7 @@ class Params(BaseModel):
             project_id=self.proj_id,
             query=query,
             top_k=top_k,
-            filter=f"metadata.user_id='{self.user_id}'",
+            filter="",
             types=ALL_MEMORY_TYPES,
         )
 
@@ -305,6 +305,7 @@ def load_configuration() -> Configuration:
     if config_file is None or not Path(config_file).exists():
         raise FileNotFoundError(f"Configuration file '{config_file}' not found.")
     ret = Configuration.load_yml_file(config_file)
+    ret.logging.apply()
     logger.info("Configuration file '%s' loaded.", config_file)
     return ret
 

--- a/tests/memmachine/server/api_v2/test_mcp.py
+++ b/tests/memmachine/server/api_v2/test_mcp.py
@@ -127,7 +127,7 @@ def test_search_memory_param_get_search_query(params):
     assert spec.project_id == "proj"
     assert spec.top_k == 7
     assert spec.query == "hello"
-    assert spec.filter == "metadata.user_id='usr'"
+    assert spec.filter == ""
     assert spec.types == ALL_MEMORY_TYPES
 
 


### PR DESCRIPTION
### Purpose of the change

fix the issue that the semantic memory returned in mcp search memory response is always empty.

### Description

The root cause is that semantic memory does not support metadata filter. In order for semantic memory to work, just query the information in the whole project in mcp.  The good part is that in mcp, the project is used by only one user.  So the solution should work for now.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [x] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [x] Manual verification (list step-by-step instructions)

### Checklist

- [ ] I have signed the commit(s) within this pull request
- [ ] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

