### PR TITLE
List both episodic and semantic memory if type is not specified

### DIFF
--- a/src/memmachine/common/api/spec.py
+++ b/src/memmachine/common/api/spec.py
@@ -430,9 +430,9 @@ class ListMemoriesSpec(_WithOrgAndProj):
         ),
     ]
     type: Annotated[
-        MemoryType,
+        MemoryType | None,
         Field(
-            default=MemoryType.Episodic,
+            default=None,
             description=SpecDoc.MEMORY_TYPE_SINGLE,
             examples=Examples.MEMORY_TYPE_SINGLE,
         ),

--- a/src/memmachine/server/api_v2/router.py
+++ b/src/memmachine/server/api_v2/router.py
@@ -308,12 +308,13 @@ async def _list_target_memories(
     spec: ListMemoriesSpec,
     memmachine: MemMachine,
 ) -> SearchResult:
+    target_memories = [spec.type] if spec.type is not None else ALL_MEMORY_TYPES
     results = await memmachine.list_search(
         session_data=_SessionData(
             org_id=spec.org_id,
             project_id=spec.project_id,
         ),
-        target_memories=[spec.type],
+        target_memories=target_memories,
         search_filter=spec.filter,
         page_size=spec.page_size,
         page_num=spec.page_num,

--- a/tests/memmachine/server/api_v2/test_spec.py
+++ b/tests/memmachine/server/api_v2/test_spec.py
@@ -23,7 +23,6 @@ from memmachine.common.api.spec import (
     _is_valid_name,
 )
 from memmachine.common.episode_store.episode_model import EpisodeType
-from memmachine.main.memmachine import MemoryType
 from memmachine.server.api_v2.router import RestError
 
 
@@ -208,7 +207,7 @@ def test_list_memories_spec():
     assert spec.page_size == 100
     assert spec.page_num == 0
     assert spec.filter == ""
-    assert spec.type == MemoryType.Episodic
+    assert spec.type is None
 
 
 def test_delete_episodic_memory_spec():


### PR DESCRIPTION
### Purpose of the change

Keep the behavior of search and list consistent. We should return both episodic and semantic memory if type is not specified.

### Description

List both episodic and semantic memory if type is not specified.

### Fixes/Closes

Fixes #702

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Unit Test
- [x] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

