### PR TITLE
Ensure docker build fails if NLTK download fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,9 @@ COPY --from=builder /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Download NLTK data and models
-RUN python -c "import nltk; nltk.download('punkt_tab'); nltk.download('stopwords')"
+RUN python -c "import nltk, sys; \
+       passed = nltk.download('punkt_tab') and nltk.download('stopwords'); \
+       sys.exit(0 if passed else 1)"
 
 # Set host to 0.0.0.0 to allow external access
 ENV HOST=0.0.0.0


### PR DESCRIPTION
### Purpose of the change

Ensure docker build fails if NLTK download fails

### Description

Ensure docker build fails if NLTK download fails

### Fixes/Closes

Fixes #593

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)

### How Has This Been Tested?

- [x] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

