### PR TITLE
Wrap startup DB failures as ConfigurationError

### DIFF
--- a/tests/memmachine/common/episode_store/test_sqlalchemy_episode_store_startup.py
+++ b/tests/memmachine/common/episode_store/test_sqlalchemy_episode_store_startup.py
@@ -1,0 +1,50 @@
+import socket
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from memmachine.common.episode_store.episode_sqlalchemy_store import (
+    SqlAlchemyEpisodeStore,
+)
+from memmachine.common.errors import ConfigurationError
+
+
+class _FailingBeginContext:
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    async def __aenter__(self):
+        raise self._exc
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeAsyncEngine:
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    def begin(self):
+        return _FailingBeginContext(self._exc)
+
+
+@pytest.mark.asyncio
+async def test_startup_wraps_operational_error():
+    engine = _FakeAsyncEngine(OperationalError("select 1", {}, Exception("db down")))
+    store = SqlAlchemyEpisodeStore(engine)  # type: ignore[arg-type]
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        await store.startup()
+
+    assert isinstance(exc_info.value.__cause__, OperationalError)
+
+
+@pytest.mark.asyncio
+async def test_startup_wraps_socket_gaierror():
+    engine = _FakeAsyncEngine(socket.gaierror(8, "dns lookup failed"))
+    store = SqlAlchemyEpisodeStore(engine)  # type: ignore[arg-type]
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        await store.startup()
+
+    assert isinstance(exc_info.value.__cause__, socket.gaierror)


### PR DESCRIPTION
### Purpose of the change

Provide a more user-friendly error message when the user configure the postgresql db wrong.

### Description

Wrap startup DB failures as ConfigurationError. The original error message is very long and hard to read.

### Fixes/Closes

Fixes #666

### Type of change

- [x] Refactor (does not change functionality, e.g., code style improvements, linting)

### How Has This Been Tested?

- [x] Unit Test
- [x] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
