### PR TITLE
Docs: Updating REST Example to correctly represent V2 API Endpoints

### DIFF
--- a/docs/examples/rest.mdx
+++ b/docs/examples/rest.mdx
@@ -4,7 +4,6 @@ description: "Examples for using MemMachine's REST API"
 icon: "bed"
 ---
 
-# REST API Examples
 
 ## Hello World: A Guide to the MemMachine RESTful API v2
 
@@ -107,17 +106,31 @@ You should see a JSON response containing `episodic_memory` and `semantic_memory
 </Step>
 <Step title="Delete Memories">
 
-To clean up, you can use the `POST /api/v2/memories/delete` endpoint to remove memories matching a specific filter.
+To clean up, you can use the `POST /api/v2/memories/episodic/delete` endpoint to remove specific chronological events or message logs.
 
 **Command:**
-
 ```bash
-curl -X POST "http://127.0.0.1:8080/api/v2/memories/delete" \
+curl -X POST "[http://127.0.0.1:8080/api/v2/memories/episodic/delete](http://127.0.0.1:8080/api/v2/memories/episodic/delete)" \
 -H "Content-Type: application/json" \
 -d '{
   "org_id": "my-org",
   "project_id": "my-first-project",
-  "filter": {
+  "episodic_id": "specific-id-here",
+  "episodic_ids": []
+}'
+```
+
+You will also want to use the `POST /api/v2/memories/semantic/delete` endpoint to remove distilled facts, traits, or knowledge entries:
+```
+curl -X POST "[http://127.0.0.1:8080/api/v2/memories/semantic/delete](http://127.0.0.1:8080/api/v2/memories/semantic/delete)" \
+-H "Content-Type: application/json" \
+-d '{
+  "org_id": "my-org",
+  "project_id": "my-first-project",
+  "semantic_id": "specific-id-here",
+  "semantic_ids": []
+}'
+</Step> </Steps>
     "producer": "user-alice"
   }
 }'


### PR DESCRIPTION
### Purpose of the change

Within our Documentation, Examples Section, the REST API example asked users to use a single endpoint, "/memories/delete", that does not exist in the v2 structure.  

### Description
The single command was split into two: Episodic Memory Delete and Semantic Memory Delete.  The example needs to reflect this.   Within the same file, the old curl command example was replaced with an example and brief description of each of the two correct Memory Delete endpoints.  

### Fixes/Closes

Fixes #836 

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

### How Has This Been Tested?

- [X] Manual verification (list step-by-step instructions)

Within my lab system running a mintlify environment, I have confirmed no broken links:
```bash
(.venv) sarah ➜ ~/MemMachine/docs (main) $ mint broken-links
success no broken links found
```

I have also confirmed via visual inspection, as shown in the Test Results below.

**Test Results:** 

Screenshot of the new code, showing how the instructions have updated to reflect both commands:
<img width="1642" height="1215" alt="Screenshot 2025-12-30 at 3 01 21 PM" src="https://github.com/user-attachments/assets/5af3198d-e9ab-45b2-849c-bd4086e0dd99" />


### Checklist

- [X] I have signed the commit(s) within this pull request
- [X] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

See Test Results above.
### Further comments

None.
