### PR TITLE
Fixes #886 - memmachine-compose.sh ignores MEMMACHINE_IMAGE in .env

### DIFF
--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -759,13 +759,18 @@ start_services() {
     # to pull ${MEMMACHINE_IMAGE} if it is set, which may not be a remote image.
     ENV_MEMMACHINE_IMAGE=""
     # Pull the latest images to ensure we are running the latest version
-    print_info "Pulling latest images..."
+    local target_image="${memmachine_image_tmp:-${MEMMACHINE_IMAGE:-memmachine/memmachine:latest}}"
+    print_info "Pulling latest images... (Target: $target_image)"
     $COMPOSE_CMD pull
     ENV_MEMMACHINE_IMAGE="${memmachine_image_tmp:-}"
 
     # Start services (override the image if specified in memmachine-compose.sh start <image>:<tag>)
     print_info "Starting containers..."
-    MEMMACHINE_IMAGE="${ENV_MEMMACHINE_IMAGE:-}" $COMPOSE_CMD up -d
+    if [ -n "${ENV_MEMMACHINE_IMAGE:-}" ]; then
+        MEMMACHINE_IMAGE="${ENV_MEMMACHINE_IMAGE}" $COMPOSE_CMD up -d
+    else
+        $COMPOSE_CMD up -d
+    fi
     
     print_success "Services started successfully!"
 }


### PR DESCRIPTION
### Purpose of the change

`memmachine-compose.sh` now pulls the image specified in the users `.env` file, if it exists. Otherwise, defaults to `latest`. Previously, it always ignored the `.env` value.

### Description

When running `memmachine-compose.sh`, the script starts the `memmachine/memmachine:latest` image even if the user has configured `MEMMACHINE_IMAGE=memmachine/memmachine:latest-cpu` or a specific tag in their `.env` file.

This happens because `start_services` unconditionally overrides `MEMMACHINE_IMAGE` with `ENV_MEMMACHINE_IMAGE` during `docker compose up`. Since `ENV_MEMMACHINE_IMAGE` defaults to an empty string when not specifying an image argument, it forces `docker compose `to ignore the `.env` value and fall back to the default `memmachine/memmachine` defined in `docker-compose.yml`.

We now see the image name and tag in the `[INFO]` message. This helps confirm the correct image is being pulled.

```
[INFO] Pulling latest images... (Target: memmachine/memmachine:latest-cpu)
```

### Fixes/Closes

Fixes #886 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x ] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

Before the change, we pulled both `latest` and `latest-cpu`. Now, we only pull whatever the user specifies in their `.env file`, in this example `latest-cpu`.

```
$ docker image ls
REPOSITORY              TAG              IMAGE ID       CREATED          SIZE
memmachine/memmachine   latest-cpu       647e38d0ebf1   53 minutes ago   459MB
pgvector/pgvector       pg16             68f823d56bc9   6 weeks ago      507MB
neo4j                   5.23-community   d6c2c1adfcb5   16 months ago    506MB
moby/buildkit           v0.12.0          869c7038a926   2 years ago      172MB
```

Users can always override this using `./memmachine-compose.sh start <image:tag>`

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None