### PR TITLE
Always pull the latest MemMachine Docker Image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
   # MemMachine application
   memmachine:
     image: ${MEMMACHINE_IMAGE:-memmachine/memmachine}
+    pull_policy: always
     container_name: memmachine-app
     restart: unless-stopped
     ports:


### PR DESCRIPTION
### Purpose of the change

I have applied the fix to ensure that MemMachine always pulls the latest image when starting.

### Description

Adding `pull_policy: always` to `Dockerfile` ensures we always get the latest release of MemMachine.

### Fixes/Closes

Fixes #826 

Depends on #886 to pull the correct image as specified in `.env`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

Ran `docker compose config` to validate the configuration. The output confirms that `pull_policy: always` is present and the configuration is valid.

MemMachine pulls the latest image and starts ok.

```
$ ./memmachine-compose.sh start
MemMachine Docker Startup Script
====================================

[SUCCESS] Docker and Docker Compose are available
[SUCCESS] .env file found
[SUCCESS] configuration.yml file found
[SUCCESS] OpenAI API key appears to be configured
[SUCCESS] OPENAI_API_KEY is configured
[SUCCESS] API key in configuration.yml appears to be configured
[SUCCESS] Database credentials in configuration.yml appear to be configured
[INFO] Pulling and starting MemMachine services...
[INFO] Pulling latest images...
[+] Pulling 3/3
 ✔ neo4j Pulled                                                                                                                                                                                                                                                                                                   0.5s 
 ✔ memmachine Pulled                                                                                                                                                                                                                                                                                              0.6s 
 ✔ postgres Pulled                                                                                                                                                                                                                                                                                                0.6s 
[INFO] Starting containers...
[+] Running 10/10
 ✔ memmachine Pulled                                                                                                                                                                                                                                                                                             90.1s 
   ✔ 02d7611c4eae Already exists                                                                                                                                                                                                                                                                                  0.0s 
   ✔ fe2d526e7d41 Already exists                                                                                                                                                                                                                                                                                  0.0s 
   ✔ 61a9f733534e Already exists                                                                                                                                                                                                                                                                                  0.0s 
   ✔ d7c2baa095fb Already exists                                                                                                                                                                                                                                                                                  0.0s 
   ✔ c58f95ee745f Pull complete                                                                                                                                                                                                                                                                                   0.5s 
   ✔ 34f3f0fb419d Pull complete                                                                                                                                                                                                                                                                                   0.9s 
   ✔ 9a446dfb3d5a Pull complete                                                                                                                                                                                                                                                                                   0.9s 
   ✔ 8b736364114d Pull complete                                                                                                                                                                                                                                                                                  86.2s 
   ✔ 184e696215b0 Pull complete                                                                                                                                                                                                                                                                                  89.1s 
[+] Running 0/1
[+] Running 4/4achine-network  Creating                                                                                                                                                                                                                                                                           0.0s 
 ✔ Network memmachine-network     Created                                                                                                                                                                                                                                                                         0.1s 
 ✔ Container memmachine-neo4j     Healthy                                                                                                                                                                                                                                                                        21.3s 
 ✔ Container memmachine-postgres  Healthy                                                                                                                                                                                                                                                                         5.8s 
 ✔ Container memmachine-app       Started                                                                                                                                                                                                                                                                        21.3s 
[SUCCESS] Services started successfully!
[INFO] Waiting for services to be healthy...
NAME                  IMAGE                    COMMAND                  SERVICE      CREATED          STATUS                                     PORTS
memmachine-app        memmachine/memmachine    "sh -c memmachine-se…"   memmachine   21 seconds ago   Up Less than a second (health: starting)   0.0.0.0:8080->8080/tcp, [::]:8080->8080/tcp
memmachine-neo4j      neo4j:5.23-community     "tini -g -- /startup…"   neo4j        21 seconds ago   Up 21 seconds (healthy)                    0.0.0.0:7473-7474->7473-7474/tcp, [::]:7473-7474->7473-7474/tcp, 0.0.0.0:7687->7687/tcp, [::]:7687->7687/tcp
memmachine-postgres   pgvector/pgvector:pg16   "docker-entrypoint.s…"   postgres     21 seconds ago   Up 21 seconds (healthy)                    0.0.0.0:5432->5432/tcp, [::]:5432->5432/tcp
[INFO] Checking service health...
[INFO] Waiting for PostgreSQL to be ready...
/var/run/postgresql:5432 - accepting connections
[SUCCESS] PostgreSQL is ready
[INFO] Waiting for Neo4j to be ready...
[SUCCESS] Neo4j is ready
[INFO] Waiting for MemMachine to be ready...
[SUCCESS] MemMachine is ready
[SUCCESS] 🎉 MemMachine is now running!

Service URLs:
  📊 MemMachine API Docs: http://localhost:8080/docs
  🗄️  Neo4j Browser: http://localhost:7474
  📈 Health Check: http://localhost:8080/api/v2/health
  📊 Metrics: http://localhost:8080/api/v2/metrics

Database Access:
  🐘 PostgreSQL: localhost:5432 (user: memmachine, db: memmachine)
  🔗 Neo4j Bolt: localhost:7687 (user: neo4j)

Useful Commands:
  📋 View logs: docker-compose logs -f
  🛑 Stop services: docker-compose down
  🔄 Restart: docker-compose restart
  🧹 Clean up: docker-compose down -v
```

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

As above

### Further comments

None
