### PR TITLE
Fix cartesian product performance notifications caused by the comma-separated MATCH pattern in Cypher queries

### DIFF
--- a/src/memmachine/common/vector_graph_store/neo4j_vector_graph_store.py
+++ b/src/memmachine/common/vector_graph_store/neo4j_vector_graph_store.py
@@ -557,9 +557,8 @@ class Neo4jVectorGraphStore(VectorGraphStore):
         )
         await self._driver.execute_query(
             "UNWIND $edges AS edge\n"
-            "MATCH"
-            f"    (source:{sanitized_source_collection} {{uid: edge.source_uid}}),"
-            f"    (target:{sanitized_target_collection} {{uid: edge.target_uid}})\n"
+            f"MATCH (source:{sanitized_source_collection} {{uid: edge.source_uid}})\n"
+            f"MATCH (target:{sanitized_target_collection} {{uid: edge.target_uid}})\n"
             "CREATE (source)"
             f"    -[r:{sanitized_relation} {{uid: edge.uid}}]->"
             "    (target)\n"


### PR DESCRIPTION
### Purpose of the change

This fix resolves a performance issue identified by Neo4j.

### Description

As above.

### Fixes/Closes

Fixes #912

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Performance Test Script (See `locustfile.py` script in #837)
- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

Without the fix, we see the following in the container logs frequently when inserting data

```bash
memmachine-app       | 2026-01-07 01:45:52,140 [INFO] neo4j.notifications - Received notification from DBMS server: <GqlStatusObject gql_status='03N90', status_description='info: cartesian product. The disconnected patterns `(source:SANITIZED_Derivative_u5f_benchmark_u5f_org_u2f_benchmark_u5f_project_u5f_03b5fccd {uid: edge.source_uid}), (target:SANITIZED_Episode_u5f_benchmark_u5f_org_u2f_benchmark_u5f_project_u5f_03b5fccd {uid: edge.target_uid})` build a cartesian product. A cartesian product may produce a large amount of data and slow down query processing.', position=<SummaryInputPosition line=2, column=1, offset=22>, raw_classification='PERFORMANCE', classification=<NotificationClassification.PERFORMANCE: 'PERFORMANCE'>, raw_severity='INFORMATION', severity=<NotificationSeverity.INFORMATION: 'INFORMATION'>, diagnostic_record={'_classification': 'PERFORMANCE', '_status_parameters': {'pat': '(source:SANITIZED_Derivative_u5f_benchmark_u5f_org_u2f_benchmark_u5f_project_u5f_03b5fccd {uid: edge.source_uid}), (target:SANITIZED_Episode_u5f_benchmark_u5f_org_u2f_benchmark_u5f_project_u5f_03b5fccd {uid: edge.target_uid})'}, '_severity': 'INFORMATION', '_position': {'offset': 22, 'line': 2, 'column': 1}, 'OPERATION': '', 'OPERATION_CODE': '0', 'CURRENT_SCHEMA': '/'}> for query: 'UNWIND $edges AS edge\nMATCH    (source:SANITIZED_Derivative_u5f_benchmark_u5f_org_u2f_benchmark_u5f_project_u5f_03b5fccd {uid: edge.source_uid}),    (target:SANITIZED_Episode_u5f_benchmark_u5f_org_u2f_benchmark_u5f_project_u5f_03b5fccd {uid: edge.target_uid})\nCREATE (source)    -[r:SANITIZED_DERIVED_u5f_FROM_u5f_benchmark_u5f_org_u2f_benchmark_u5f_project_u5f_03b5fccd {uid: edge.uid}]->    (target)\nSET r += edge.properties'
```

With the fix, I no longer see the warnings.

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

See above

### Further comments

None
