### PR TITLE
Fix CodeQL 'Information exposure through an exception' issues

### DIFF
--- a/examples/v1/writing_assistant/writing_assistant_server.py
+++ b/examples/v1/writing_assistant/writing_assistant_server.py
@@ -21,7 +21,23 @@ writing_assistant_constructor = WritingAssistantQueryConstructor()
 
 
 def format_error_response(e: Exception, context: str):
-    """Format a user-friendly error message based on the exception type."""
+    """
+    Format a user-friendly error message based on the exception type.
+
+    Parameters
+    ----------
+    e : Exception
+        The exception that was raised, typically a `requests` exception.
+    context : str
+        A short description of the operation being performed when the error occurred.
+
+    Returns
+    -------
+    dict
+        A dictionary with the keys:
+        - ``status`` (str): Always set to ``"error"``.
+        - ``message`` (str): A human-readable error message tailored to the exception type and context.
+    """
     if isinstance(e, requests.exceptions.Timeout):
         return {
             "status": "error",


### PR DESCRIPTION
### Purpose of the change

This addresses the 5 CodeQL "Information exposure through an exception" issues.

### Description

GitHub CodeQL highlighted some potential security issues relating to the  examples/v1/writing_assistant/writing_assistant_server.py file:

<img width="1297" height="395" alt="Screenshot 2026-01-08 at 1 21 55 PM" src="https://github.com/user-attachments/assets/9a022565-51f3-4d33-b656-e43e8279cb3a" />

<img width="921" height="517" alt="Screenshot 2026-01-08 at 1 31 01 PM" src="https://github.com/user-attachments/assets/5fea5d73-03a8-4fda-b4e5-d5d8b0a503a4" />

The resolution is to remove all occurrences of `{e!s}` and replace it with a more human-friendly message. Rather than generic messages, we can still include useful information from the exception without displaying the full data or stack by introducing a new `format_error_response()` function to process the exception and return relevant information only.

### Fixes/Closes

Fixes CodeQL issues 39, 40, 41, 42, & 43. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security (improves security without changing functionality)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

See above

### Further comments

None
