### PR TITLE
Support host.docker.internal in Linux for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,8 @@ services:
       start_period: 60s
     networks:
       - memmachine-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
 volumes:
   postgres_data:


### PR DESCRIPTION
### Purpose of the change

This PR is to fix `memmachine-compose.sh` for ollama in Linux environment.

### Description

Since "host.docker.internal" is only available in docker desktop, it needs to be explicitly added to docker-compose.yml for Linux users.

### Fixes/Closes

Fixes #918

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I have tested it by running `memmachine-compose.sh` with ollama environment in Linux.
- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

MemMachine is ready as follows.
```
$ ./memmachine-compose.sh
MemMachine Docker Startup Script
====================================

[SUCCESS] Docker and Docker Compose are available
[WARNING] .env file not found. Creating from template...
[SUCCESS] Created .env file from sample_configs/env.dockercompose
[WARNING] configuration.yml file not found. Creating from template...
[PROMPT] Which configuration would you like to use for the Docker Image? (CPU/GPU) [CPU]:
[INFO] CPU configuration selected.
[PROMPT] Which provider would you like to use? (OpenAI/Bedrock/Ollama/OpenAI-compatible) [OpenAI]: Ollama
[INFO] Selected provider: OLLAMA
[SUCCESS] Set MEMMACHINE_IMAGE to memmachine/memmachine:latest-cpu in .env file
[PROMPT] Which Ollama LLM model would you like to use? [llama3]:
[SUCCESS] Selected Ollama LLM model: llama3
[PROMPT] Which Ollama embedding model would you like to use? [nomic-embed-text]:
[SUCCESS] Selected Ollama embedding model: nomic-embed-text
[INFO] Generating configuration file for OLLAMA provider...
[SUCCESS] Generated configuration file with OLLAMA provider settings
[PROMPT] Ollama base URL [http://host.docker.internal:11434/v1]:
[SUCCESS] Set Ollama base URL: http://host.docker.internal:11434/v1
[SUCCESS] Ollama configuration detected with default base URL
[SUCCESS] API key in configuration.yml appears to be configured
[SUCCESS] Database credentials in configuration.yml appear to be configured
[INFO] Pulling and starting MemMachine services...
[INFO] Pulling latest images... (Target: memmachine/memmachine:latest-cpu)
    ...
[INFO] Waiting for MemMachine to be ready...
[SUCCESS] MemMachine is ready
[SUCCESS] 🎉 MemMachine is now running!

Service URLs:
  📊 MemMachine API Docs: http://localhost:8080/docs
  🗄️   Neo4j Browser: http://localhost:7474
  📈 Health Check: http://localhost:8080/api/v2/health
  📊 Metrics: http://localhost:8080/api/v2/metrics

Database Access:
  🐘 PostgreSQL: localhost:5432 (user: memmachine, db: memmachine)
  🔗 Neo4j Bolt: localhost:7687 (user: neo4j)

Useful Commands:
  📋 View logs: docker-compose logs -f
  🛑 Stop services: docker-compose down
  🔄 Restart: docker-compose restart
  🧹 Clean up: docker-compose down -v
```

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected