### PR TITLE
Use relative Python imports in `spec.py` rather than absolute paths

### DIFF
--- a/src/memmachine/common/api/spec.py
+++ b/src/memmachine/common/api/spec.py
@@ -7,8 +7,8 @@ from typing import Annotated, Any, Self
 import regex
 from pydantic import AfterValidator, BaseModel, Field, field_validator, model_validator
 
-from memmachine.common.api import EpisodeType, MemoryType
-from memmachine.common.api.doc import Examples, SpecDoc
+from . import EpisodeType, MemoryType
+from .doc import Examples, SpecDoc
 
 DEFAULT_ORG_AND_PROJECT_ID = "universal"
 


### PR DESCRIPTION
### Purpose of the change

I changed the absolute imports in `memmachine.common.api` package to relative imports. This makes the package more robust when installed in Docker containers with multiple workspace members - meta, server, and client.

### Description

Using relative imports (`from . import ...`) ensures that Python searches for modules relative to the current file's package, reducing the risk of "shadowing" or "uninitialized package" issues when multiple packages share the same namespace. We have three packages - meta, server, and client (See `/packages`), which use symbolic links to `/src`.

### Fixes/Closes

Fixes #948 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

With the fix, MemMachine now runs as expected

```
$ ./memmachine-compose.sh start memmachine/memmachine:bugfix-948-cpu
MemMachine Docker Startup Script
====================================

[SUCCESS] Docker and Docker Compose are available
[SUCCESS] .env file found
[SUCCESS] configuration.yml file found
[SUCCESS] OpenAI API key appears to be configured
[SUCCESS] OPENAI_API_KEY is configured
[SUCCESS] API key in configuration.yml appears to be configured
[SUCCESS] Database credentials in configuration.yml appear to be configured
[INFO] Pulling and starting MemMachine services...
[INFO] Pulling latest images... (Target: memmachine/memmachine:bugfix-948-cpu)
[WARNING] Image 'memmachine/memmachine:bugfix-948-cpu' not found in Docker Hub registry (manifest unknown). Assuming local image.
[+] Running 4/4
 ✔ Network memmachine-network     Created                                                                                                                                                                                                                                                                         0.0s 
 ✔ Container memmachine-postgres  Healthy                                                                                                                                                                                                                                                                         5.7s 
 ✔ Container memmachine-neo4j     Healthy                                                                                                                                                                                                                                                                        34.7s 
 ✔ Container memmachine-app       Started                                                                                                                                                                                                                                                                        34.8s 
[SUCCESS] Services started successfully!
[INFO] Waiting for services to be healthy...
NAME                  IMAGE                                  COMMAND                  SERVICE      CREATED          STATUS                                     PORTS
memmachine-app        memmachine/memmachine:bugfix-948-cpu   "sh -c memmachine-se…"   memmachine   35 seconds ago   Up Less than a second (health: starting)   0.0.0.0:8080->8080/tcp, [::]:8080->8080/tcp
memmachine-neo4j      neo4j:5.23-community                   "tini -g -- /startup…"   neo4j        35 seconds ago   Up 34 seconds (healthy)                    0.0.0.0:7473-7474->7473-7474/tcp, [::]:7473-7474->7473-7474/tcp, 0.0.0.0:7687->7687/tcp, [::]:7687->7687/tcp
memmachine-postgres   pgvector/pgvector:pg16                 "docker-entrypoint.s…"   postgres     35 seconds ago   Up 34 seconds (healthy)                    0.0.0.0:5432->5432/tcp, [::]:5432->5432/tcp
[INFO] Checking service health...
[INFO] Waiting for PostgreSQL to be ready...
/var/run/postgresql:5432 - accepting connections
[SUCCESS] PostgreSQL is ready
[INFO] Waiting for Neo4j to be ready...
[SUCCESS] Neo4j is ready
[INFO] Waiting for MemMachine to be ready...
[SUCCESS] MemMachine is ready
[SUCCESS] 🎉 MemMachine is now running!

Service URLs:
  📊 MemMachine API Docs: http://localhost:8080/docs
  🗄️  Neo4j Browser: http://localhost:7474
  📈 Health Check: http://localhost:8080/api/v2/health
  📊 Metrics: http://localhost:8080/api/v2/metrics

Database Access:
  🐘 PostgreSQL: localhost:5432 (user: memmachine, db: memmachine)
  🔗 Neo4j Bolt: localhost:7687 (user: neo4j)

Useful Commands:
  📋 View logs: docker-compose logs -f
  🛑 Stop services: docker-compose down
  🔄 Restart: docker-compose restart
  🧹 Clean up: docker-compose down -v
```

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

[If applicable, add screenshots or GIFs that show the changes in action. This is especially helpful for API responses. Otherwise, delete this section or type "N/A".]

### Further comments

[Add any other relevant information here, such as potential side effects, future considerations, or any specific questions for the reviewer. Otherwise, type "None".]
