### PR TITLE
fix scm_version when `memmachine-compose.sh build`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY README.md README.md
 
 # Determine whether to include GPU dependencies
 ARG GPU="false"
-ARG SCM_VERSION
+ARG SCM_VERSION="0.0.0"
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SCM_VERSION}
 
 # Install dependencies into a virtual environment, but NOT the project itself


### PR DESCRIPTION
### Purpose of the change

### Description

This fix changes `sed` command to `sed -E`, so that the git version string can be converted into PEP 440 compliant version on macos.

### Fixes/Closes

Fixes #952

### Type of change

[Please delete options that are not relevant.]

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

[Please delete options that are not relevant.]

- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]
Run `memmachine-compose.sh build` on macos completes successfully
```
(memmachine) jinggong@Jings-MBP MemMachine % ./memmachine-compose.sh build
[INFO] No name specified.
[INFO] Using default name: memmachine/memmachine:latest
[PROMPT] Building memmachine/memmachine:latest with '--build-arg GPU=[true|false]' (default: false): 
[INFO] Building memmachine/memmachine:latest with GPU=false (SCM_VERSION: 0.2.3.dev13+ge6f831d)
[+] Building 17.3s (24/24) FINISHED                                                          docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                         0.0s
 => => transferring dockerfile: 2.16kB                                                                       0.0s
 => [internal] load metadata for docker.io/library/python:3.12-slim-trixie                                   1.2s
 => [internal] load metadata for ghcr.io/astral-sh/uv:latest                                                 1.2s
 => [auth] library/python:pull token for registry-1.docker.io                                                0.0s
 => [auth] astral-sh/uv:pull token for ghcr.io                                                               0.0s
 => [internal] load .dockerignore                                                                            0.0s
 => => transferring context: 1.33kB                                                                          0.0s
 => FROM ghcr.io/astral-sh/uv:latest@sha256:9a23023be68b2ed09750ae636228e903a54a05ea56ed03a934d00fe9fbeded4  0.0s
 => => resolve ghcr.io/astral-sh/uv:latest@sha256:9a23023be68b2ed09750ae636228e903a54a05ea56ed03a934d00fe9f  0.0s
 => [builder  1/12] FROM docker.io/library/python:3.12-slim-trixie@sha256:d75c4b6cdd039ae966a34cd3ccab9e0e5  0.0s
 => => resolve docker.io/library/python:3.12-slim-trixie@sha256:d75c4b6cdd039ae966a34cd3ccab9e0e5f7299280ad  0.0s
 => [internal] load build context                                                                            0.0s
 => => transferring context: 98.03kB                                                                         0.0s
 => CACHED [builder  2/12] RUN apt-get update &&     apt-get upgrade -y &&     apt-get install -y curl &&    0.0s
 => CACHED [builder  3/12] RUN python -m pip install --upgrade pip                                           0.0s
 => CACHED [builder  4/12] COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/                  0.0s
 => CACHED [builder  5/12] WORKDIR /app                                                                      0.0s
 => CACHED [builder  6/12] COPY pyproject.toml uv.lock ./                                                    0.0s
 => CACHED [builder  7/12] COPY packages/ packages/                                                          0.0s
 => CACHED [builder  8/12] COPY src/ src/                                                                    0.0s
 => CACHED [builder  9/12] COPY README.md README.md                                                          0.0s
 => [builder 10/12] RUN --mount=type=cache,target=/root/.cache/uv     if [ "false" = "true" ]; then     uv   3.1s
 => [builder 11/12] COPY . /app                                                                              0.3s 
 => [builder 12/12] RUN --mount=type=cache,target=/root/.cache/uv     if [ "false" = "true" ]; then     uv   0.9s 
 => CACHED [final 4/6] WORKDIR /app                                                                          0.0s 
 => [final 5/6] COPY --from=builder /app/.venv /app/.venv                                                    1.4s 
 => [final 6/6] RUN python -c "import nltk, sys;     passed = nltk.download('punkt_tab') and nltk.download(  1.5s 
 => exporting to image                                                                                       7.9s 
 => => exporting layers                                                                                      6.1s 
 => => exporting manifest sha256:5329c2a28cdf7047f731ccbb3d7afbb8320e2f00e30993ca71eaaaacd76d31e2            0.0s
 => => exporting config sha256:cb3faca2ff433460a42173d576ab57e857eea85ff18b93b4bfc806d650411055              0.0s
 => => exporting attestation manifest sha256:9119ce2ee518545cb5a92950e4740f6eafe9b4ad55bbbaf33a91091d239ad8  0.0s
 => => exporting manifest list sha256:e0b80c479e063018ed71fd2bdedbed41ccc9127fdb8a9f69c70e115bd281aa7f       0.0s
 => => naming to docker.io/memmachine/memmachine:latest                                                      0.0s
 => => unpacking to docker.io/memmachine/memmachine:latest                                                   1.7s
(memmachine) jinggong@Jings-MBP MemMachine % 
```


### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

[If applicable, add screenshots or GIFs that show the changes in action. This is especially helpful for API responses. Otherwise, delete this section or type "N/A".]

### Further comments

[Add any other relevant information here, such as potential side effects, future considerations, or any specific questions for the reviewer. Otherwise, type "None".]
