### PR TITLE
Add Neo4j max_connection_pool_size and connection_acquisition_timeout in sample_config files

### DIFF
--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -44,6 +44,8 @@ resources:
         uri: 'bolt://localhost:7687'
         username: neo4j
         password: <YOUR_PASSWORD_HERE>
+        max_connection_pool_size: 100
+        connection_acquisition_timeout: 60.0
         range_index_creation_threshold: 10000
         vector_index_creation_threshold: 10000
     sqlite_test:

--- a/sample_configs/episodic_memory_config.gpu.sample
+++ b/sample_configs/episodic_memory_config.gpu.sample
@@ -44,6 +44,8 @@ resources:
         uri: 'bolt://localhost:7687'
         username: neo4j
         password: <YOUR_PASSWORD_HERE>
+        max_connection_pool_size: 100
+        connection_acquisition_timeout: 60.0
         range_index_creation_threshold: 10000
         vector_index_creation_threshold: 10000
     sqlite_test:

--- a/src/memmachine/common/configuration/database_conf.py
+++ b/src/memmachine/common/configuration/database_conf.py
@@ -46,6 +46,20 @@ class Neo4jConf(YamlSerializableMixin, PasswordMixin):
             "required before Neo4j automatically creates a vector index."
         ),
     )
+    max_connection_pool_size: int | None = Field(
+        default=None,
+        description=(
+            "Maximum number of connections to maintain in the connection pool. "
+            "Internal default is 100."
+        ),
+    )
+    connection_acquisition_timeout: float | None = Field(
+        default=None,
+        description=(
+            "Maximum time in seconds to wait for a connection from the pool. "
+            "Internal default is 60.0."
+        ),
+    )
 
     def get_uri(self) -> str:
         if self.uri:


### PR DESCRIPTION
### Purpose of the change

This is part of the ongoing performance improvements. This PR exposes Neo4j `max_connection_pool_size` and `connection_acquisition_timeout` by adding them to the database_manager and sample config files. Users can tune the Neo4j connection pool size and timeout as we did for Postgres.

### Description

- `max_connection_pool_size` controls how many simultaneous connections the driver can keep open to a single Neo4j server (or per cluster member, depending on the driver). It should be increased when you see connection-acquisition timeouts under high concurrent load, and your Neo4j server and network have capacity for more connections, and decreased when the database is over-subscribed, or you want to limit its resource usage.

- `connection_acquisition_timeout` controls how long a query waits for a free connection from the pool before failing with a client-side timeout error, and it only applies when the pool is already at its configured maximum size. It should be increased if you see sporadic timeouts during brief load spikes but do not want to grow the pool further, decreased (or set to fail fast) when you prefer immediate errors over waiting, or set to unlimited if you want the client to block until a connection is free.

### Fixes/Closes

Relates to #940 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual verification (list step-by-step instructions)

Using this client connection script, and executing it in the project root, where the `configuration.yml` is:

```bash
uv run python -c "
import asyncio
from memmachine.common.configuration import Configuration
from memmachine.common.resource_manager.database_manager import DatabaseManager

async def verify():
    config = Configuration.load_yml_file('./configuration.yml')
    manager = DatabaseManager(config.resources.databases)
    
    name = 'my_storage_id'
    driver = await manager.async_get_neo4j_driver(name)
    
    # max_connection_pool_size is in pool_config
    pool_size = driver._pool.pool_config.max_connection_pool_size
    
    # connection_acquisition_timeout is in workspace_config
    acq_timeout = driver._pool.workspace_config.connection_acquisition_timeout
    
    print(f'\n--- Neo4j Driver Configuration for [{name}] ---')
    print(f'Max Connection Pool Size: {pool_size}')
    print(f'Connection Acquisition Timeout: {acq_timeout}s')
    
    await driver.close()

asyncio.run(verify())
"
```

With no properties in `configuration.yml`, I get

```bash
--- Neo4j Driver Configuration for [my_storage_id] ---
Max Connection Pool Size: 100
Connection Acquisition Timeout: 30.0s
```

When I add the properties and set them to non-default values, then re-run the script above, I get the expected output

```
    my_storage_id:
      provider: neo4j
      config:
        uri: "bolt://neo4j:7687"
        username: neo4j
        password: neo4j_password
        max_connection_pool_size: 200
        connection_acquisition_timeout: 120.0
        range_index_creation_threshold: 10
        vector_index_creation_threshold: 10
```

```bash
--- Neo4j Driver Configuration for [my_storage_id] ---
Max Connection Pool Size: 200
Connection Acquisition Timeout: 120.0s
```

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

We will test and validate this PR using load-test scripts before merging to confirm that the issue reported in #940 is resolved.