### PR TITLE
Don't return 500 when deleting memories in non-existent projects.

### DIFF
--- a/src/memmachine/main/memmachine.py
+++ b/src/memmachine/main/memmachine.py
@@ -462,10 +462,7 @@ class MemMachine:
         episode_storage = await self._resources.get_episode_storage()
         semantic_service = await self._resources.get_semantic_service()
 
-        tasks: list[Coroutine[Any, Any, Any]] = [
-            episode_storage.delete_episodes(episode_ids),
-            semantic_service.delete_history(episode_ids),
-        ]
+        tasks: list[Coroutine[Any, Any, Any]] = []
 
         if session_data is not None:
             episodic_memory_manager = (
@@ -477,6 +474,8 @@ class MemMachine:
                 t = episodic_session.delete_episodes(episode_ids)
                 tasks.append(t)
 
+        tasks.append(episode_storage.delete_episodes(episode_ids))
+        tasks.append(semantic_service.delete_history(episode_ids))
         await asyncio.gather(*tasks)
 
     async def delete_features(

--- a/src/memmachine/server/api_v2/router.py
+++ b/src/memmachine/server/api_v2/router.py
@@ -347,6 +347,8 @@ async def delete_episodic_memory(
         raise RestError(code=422, message="invalid argument", ex=e) from e
     except ResourceNotFoundError as e:
         raise RestError(code=404, message=str(e), ex=e) from e
+    except SessionNotFoundError as e:
+        raise RestError(code=404, message=str(e), ex=e) from e
     except Exception as e:
         raise RestError(
             code=500, message="Unable to delete episodic memory", ex=e

--- a/tests/memmachine/server/api_v2/test_router.py
+++ b/tests/memmachine/server/api_v2/test_router.py
@@ -400,6 +400,18 @@ def test_delete_episodic_memory(client, mock_memmachine):
     assert response.status_code == 404
     assert response.json()["detail"]["message"] == "Not found"
 
+    # Session does not exist
+    mock_memmachine.delete_episodes.reset_mock()
+    mock_memmachine.delete_episodes.side_effect = SessionNotFoundError(
+        "test_org/test_proj"
+    )
+    response = client.post("/api/v2/memories/episodic/delete", json=payload)
+    assert response.status_code == 404
+    assert (
+        response.json()["detail"]["message"]
+        == "Session 'test_org/test_proj' does not exist."
+    )
+
     # Error
     mock_memmachine.delete_episodes.reset_mock()
     mock_memmachine.delete_episodes.side_effect = Exception("Error")


### PR DESCRIPTION
### Purpose of the change

Don't return 500 when deleting memories in non-existent projects.

### Description

Don't return 500 when deleting memories in non-existent projects.

### Fixes/Closes

Fixes #(issue number)

### Type of change

[Please delete options that are not relevant.]

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Unit Test
- [x] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

