### PR TITLE
Adding new OpenAI Agent Example to Examples Section

### DIFF
--- a/docs/examples/agents.mdx
+++ b/docs/examples/agents.mdx
@@ -51,12 +51,10 @@ Ready to see MemMachine in action? Click any link below to got directly to the [
 >
     AI-powered Writing assistant
   </Card>
-  <Card title="OpenAI GPTStore" icon="openai" href="https://github.com/MemMachine/MemMachine/blob/main/examples/openai_agent/README.md">
+  <Card title="OpenAI Agent" icon="openai" href="https://github.com/MemMachine/MemMachine/blob/main/examples/openai_agent/README.md">
     **Memory for Custom GPTs.** Set up MemMachine as a Custom Action for reliable history.
   </Card>
 </Columns>
-
-<Warning>Advice recieved from using these examples comes from AI generation, and should not be considered the same as advice recieved from an expert in any given field.</Warning>
 
 
 These agents are designed to showcase how to integrate with MemMachine's memory services. Follow these simple steps to get an agent up and running in no time.


### PR DESCRIPTION
### Purpose of the change

Adding the new OpenAI Agent to our Documentation Examples section.

### Description

Created new card that matched the existing style of the other cards with links to the appropriate Example README.md files.  Removed  a warning that is no longer necessary, and ensured language was correct.

### Fixes/Closes

Fixes #947 

### Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [X] Manual verification (list step-by-step instructions)

Generation of the edited page on a lab system running a Mintlify environment.  Please See Test Results:

**Test Results:** [Attach logs, screenshots, or relevant output]

No Broken Links:
(.venv) sarah ➜ ~/MemMachine/docs (openai) $ mint broken-links
success no broken links found

Image showing the new card, which links to the README.md file, like all other agents:
<img width="1687" height="1006" alt="Screenshot 2026-01-27 at 2 00 16 PM" src="https://github.com/user-attachments/assets/8a392ce1-6f42-4750-b4c9-2f46035acd30" />


### Checklist


- [X] I have signed the commit(s) within this pull request
- [X] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

Please see Test Results Section

### Further comments

None.
