### PR TITLE
Add runtime configuration API, graceful startup, and client SDK

### DIFF
--- a/src/memmachine/common/api/config_spec.py
+++ b/src/memmachine/common/api/config_spec.py
@@ -1,0 +1,413 @@
+"""Configuration API specification models for request and response structures."""
+
+from enum import Enum
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field
+
+from memmachine.common.api.doc import SpecDoc
+
+
+class ResourceStatus(str, Enum):
+    """Status of a resource."""
+
+    READY = "ready"
+    FAILED = "failed"
+    PENDING = "pending"
+
+
+class ResourceInfo(BaseModel):
+    """Information about a configured resource."""
+
+    name: Annotated[
+        str,
+        Field(..., description=SpecDoc.RESOURCE_NAME),
+    ]
+    provider: Annotated[
+        str,
+        Field(..., description=SpecDoc.RESOURCE_PROVIDER),
+    ]
+    status: Annotated[
+        ResourceStatus,
+        Field(..., description=SpecDoc.RESOURCE_STATUS),
+    ]
+    error: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.RESOURCE_ERROR_MSG),
+    ]
+
+
+class ResourcesStatus(BaseModel):
+    """Status of all configured resources."""
+
+    embedders: Annotated[
+        list[ResourceInfo],
+        Field(default_factory=list, description=SpecDoc.EMBEDDERS_STATUS),
+    ]
+    language_models: Annotated[
+        list[ResourceInfo],
+        Field(default_factory=list, description=SpecDoc.LANGUAGE_MODELS_STATUS),
+    ]
+    rerankers: Annotated[
+        list[ResourceInfo],
+        Field(default_factory=list, description=SpecDoc.RERANKERS_STATUS),
+    ]
+    databases: Annotated[
+        list[ResourceInfo],
+        Field(default_factory=list, description=SpecDoc.DATABASES_STATUS),
+    ]
+
+
+class GetConfigResponse(BaseModel):
+    """Response model for configuration retrieval."""
+
+    resources: Annotated[
+        ResourcesStatus,
+        Field(..., description=SpecDoc.RESOURCES_STATUS),
+    ]
+
+
+# --- Add Embedder Models ---
+
+
+class AddOpenAIEmbedderConfig(BaseModel):
+    """Configuration for adding an OpenAI embedder."""
+
+    api_key: Annotated[
+        str,
+        Field(..., description=SpecDoc.API_KEY_OPENAI),
+    ]
+    model: Annotated[
+        str,
+        Field(default="text-embedding-3-small", description=SpecDoc.MODEL_NAME),
+    ]
+    dimensions: Annotated[
+        int | None,
+        Field(default=1536, description=SpecDoc.EMBEDDING_DIMENSIONS),
+    ]
+    base_url: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.API_BASE_URL),
+    ]
+    max_input_length: Annotated[
+        int | None,
+        Field(default=None, description=SpecDoc.MAX_INPUT_LENGTH),
+    ]
+    max_retry_interval_seconds: Annotated[
+        int,
+        Field(default=120, description=SpecDoc.MAX_RETRY_INTERVAL),
+    ]
+
+
+class AddAmazonBedrockEmbedderConfig(BaseModel):
+    """Configuration for adding an Amazon Bedrock embedder."""
+
+    region: Annotated[
+        str,
+        Field(..., description=SpecDoc.AWS_REGION),
+    ]
+    model_id: Annotated[
+        str,
+        Field(
+            default="amazon.titan-embed-text-v2:0",
+            description=SpecDoc.MODEL_ID_BEDROCK,
+        ),
+    ]
+    aws_access_key_id: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.AWS_ACCESS_KEY_ID),
+    ]
+    aws_secret_access_key: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.AWS_SECRET_ACCESS_KEY),
+    ]
+    aws_session_token: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.AWS_SESSION_TOKEN),
+    ]
+    max_input_length: Annotated[
+        int | None,
+        Field(default=None, description=SpecDoc.MAX_INPUT_LENGTH),
+    ]
+    max_retry_interval_seconds: Annotated[
+        int,
+        Field(default=120, description=SpecDoc.MAX_RETRY_INTERVAL),
+    ]
+
+
+class AddSentenceTransformerEmbedderConfig(BaseModel):
+    """Configuration for adding a SentenceTransformer embedder."""
+
+    model: Annotated[
+        str,
+        Field(..., description=SpecDoc.SENTENCE_TRANSFORMER_MODEL),
+    ]
+    max_input_length: Annotated[
+        int | None,
+        Field(default=None, description=SpecDoc.MAX_INPUT_LENGTH),
+    ]
+
+
+class AddEmbedderSpec(BaseModel):
+    """Specification for adding a new embedder."""
+
+    name: Annotated[
+        str,
+        Field(..., description=SpecDoc.EMBEDDER_NAME),
+    ]
+    provider: Annotated[
+        Literal["openai", "amazon-bedrock", "sentence-transformer"],
+        Field(..., description=SpecDoc.EMBEDDER_PROVIDER_TYPE),
+    ]
+    config: Annotated[
+        dict[str, Any],
+        Field(..., description=SpecDoc.PROVIDER_CONFIG),
+    ]
+
+
+# --- Add Language Model Models ---
+
+
+class AddOpenAIResponsesLanguageModelConfig(BaseModel):
+    """Configuration for adding an OpenAI Responses language model."""
+
+    api_key: Annotated[
+        str,
+        Field(..., description=SpecDoc.API_KEY_OPENAI),
+    ]
+    model: Annotated[
+        str,
+        Field(default="gpt-4o", description=SpecDoc.MODEL_NAME),
+    ]
+    base_url: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.API_BASE_URL),
+    ]
+    max_retry_interval_seconds: Annotated[
+        int,
+        Field(default=120, description=SpecDoc.MAX_RETRY_INTERVAL),
+    ]
+
+
+class AddOpenAIChatCompletionsLanguageModelConfig(BaseModel):
+    """Configuration for adding an OpenAI Chat Completions language model."""
+
+    api_key: Annotated[
+        str,
+        Field(..., description=SpecDoc.API_KEY_OPENAI),
+    ]
+    model: Annotated[
+        str,
+        Field(default="gpt-4o", description=SpecDoc.MODEL_NAME),
+    ]
+    base_url: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.API_BASE_URL),
+    ]
+    max_retry_interval_seconds: Annotated[
+        int,
+        Field(default=120, description=SpecDoc.MAX_RETRY_INTERVAL),
+    ]
+
+
+class AddAmazonBedrockLanguageModelConfig(BaseModel):
+    """Configuration for adding an Amazon Bedrock language model."""
+
+    region: Annotated[
+        str,
+        Field(..., description=SpecDoc.AWS_REGION),
+    ]
+    model_id: Annotated[
+        str,
+        Field(..., description=SpecDoc.MODEL_ID_BEDROCK),
+    ]
+    aws_access_key_id: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.AWS_ACCESS_KEY_ID),
+    ]
+    aws_secret_access_key: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.AWS_SECRET_ACCESS_KEY),
+    ]
+    aws_session_token: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.AWS_SESSION_TOKEN),
+    ]
+    max_retry_interval_seconds: Annotated[
+        int,
+        Field(default=120, description=SpecDoc.MAX_RETRY_INTERVAL),
+    ]
+    inference_config: Annotated[
+        dict[str, Any] | None,
+        Field(default=None, description=SpecDoc.INFERENCE_CONFIG),
+    ]
+    additional_model_request_fields: Annotated[
+        dict[str, Any] | None,
+        Field(default=None, description=SpecDoc.ADDITIONAL_MODEL_FIELDS),
+    ]
+
+
+class AddLanguageModelSpec(BaseModel):
+    """Specification for adding a new language model."""
+
+    name: Annotated[
+        str,
+        Field(..., description=SpecDoc.LM_NAME),
+    ]
+    provider: Annotated[
+        Literal["openai-responses", "openai-chat-completions", "amazon-bedrock"],
+        Field(..., description=SpecDoc.LM_PROVIDER_TYPE),
+    ]
+    config: Annotated[
+        dict[str, Any],
+        Field(..., description=SpecDoc.PROVIDER_CONFIG),
+    ]
+
+
+# --- Response Models ---
+
+
+# --- Update Memory Configuration Models ---
+
+
+class UpdateLongTermMemorySpec(BaseModel):
+    """Partial update for long-term memory configuration."""
+
+    embedder: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.LTM_EMBEDDER),
+    ]
+    reranker: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.LTM_RERANKER),
+    ]
+    vector_graph_store: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.LTM_VECTOR_GRAPH_STORE),
+    ]
+
+
+class UpdateShortTermMemorySpec(BaseModel):
+    """Partial update for short-term memory configuration."""
+
+    llm_model: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.STM_LLM_MODEL),
+    ]
+    message_capacity: Annotated[
+        int | None,
+        Field(default=None, gt=0, description=SpecDoc.STM_MESSAGE_CAPACITY),
+    ]
+
+
+class UpdateEpisodicMemorySpec(BaseModel):
+    """Partial update for episodic memory configuration."""
+
+    long_term_memory: Annotated[
+        UpdateLongTermMemorySpec | None,
+        Field(default=None, description=SpecDoc.EPISODIC_LTM_UPDATE),
+    ]
+    short_term_memory: Annotated[
+        UpdateShortTermMemorySpec | None,
+        Field(default=None, description=SpecDoc.EPISODIC_STM_UPDATE),
+    ]
+    long_term_memory_enabled: Annotated[
+        bool | None,
+        Field(default=None, description=SpecDoc.EPISODIC_LTM_ENABLED),
+    ]
+    short_term_memory_enabled: Annotated[
+        bool | None,
+        Field(default=None, description=SpecDoc.EPISODIC_STM_ENABLED),
+    ]
+    enabled: Annotated[
+        bool | None,
+        Field(default=None, description=SpecDoc.EPISODIC_ENABLED),
+    ]
+
+
+class UpdateSemanticMemorySpec(BaseModel):
+    """Partial update for semantic memory configuration."""
+
+    enabled: Annotated[
+        bool | None,
+        Field(default=None, description=SpecDoc.SEMANTIC_ENABLED),
+    ]
+    database: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.SEMANTIC_DATABASE),
+    ]
+    llm_model: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.SEMANTIC_LLM_MODEL),
+    ]
+    embedding_model: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.SEMANTIC_EMBEDDING_MODEL),
+    ]
+    ingestion_trigger_messages: Annotated[
+        int | None,
+        Field(default=None, gt=0, description=SpecDoc.SEMANTIC_INGESTION_MESSAGES),
+    ]
+    ingestion_trigger_age_seconds: Annotated[
+        int | None,
+        Field(default=None, gt=0, description=SpecDoc.SEMANTIC_INGESTION_AGE),
+    ]
+
+
+class UpdateMemoryConfigSpec(BaseModel):
+    """Specification for updating memory configuration."""
+
+    episodic_memory: Annotated[
+        UpdateEpisodicMemorySpec | None,
+        Field(default=None, description=SpecDoc.UPDATE_EPISODIC_MEMORY),
+    ]
+    semantic_memory: Annotated[
+        UpdateSemanticMemorySpec | None,
+        Field(default=None, description=SpecDoc.UPDATE_SEMANTIC_MEMORY),
+    ]
+
+
+class UpdateMemoryConfigResponse(BaseModel):
+    """Response model for memory configuration update."""
+
+    success: Annotated[
+        bool,
+        Field(..., description=SpecDoc.OPERATION_SUCCESS),
+    ]
+    message: Annotated[
+        str,
+        Field(..., description=SpecDoc.STATUS_MESSAGE),
+    ]
+
+
+# --- Response Models ---
+
+
+class UpdateResourceResponse(BaseModel):
+    """Response model for resource update operations."""
+
+    success: Annotated[
+        bool,
+        Field(..., description=SpecDoc.OPERATION_SUCCESS),
+    ]
+    status: Annotated[
+        ResourceStatus,
+        Field(..., description=SpecDoc.RESOURCE_STATUS_AFTER_OP),
+    ]
+    error: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.OPERATION_ERROR),
+    ]
+
+
+class DeleteResourceResponse(BaseModel):
+    """Response model for resource deletion operations."""
+
+    success: Annotated[
+        bool,
+        Field(..., description=SpecDoc.DELETION_SUCCESS),
+    ]
+    message: Annotated[
+        str,
+        Field(..., description=SpecDoc.STATUS_MESSAGE),
+    ]

--- a/src/memmachine/common/api/doc.py
+++ b/src/memmachine/common/api/doc.py
@@ -274,6 +274,178 @@ class SpecDoc:
     CLIENT_VERSION = """
     The version of the MemMachine client."""
 
+    RESOURCE_NAME = """
+    The unique name/identifier of the resource."""
+
+    RESOURCE_PROVIDER = """
+    The provider type of the resource (e.g., 'openai', 'amazon-bedrock"""
+
+    RESOURCE_STATUS = """
+    The current status of the resource."""
+
+    RESOURCES_STATUS = """
+    The status of all configured resources."""
+
+    RESOURCE_ERROR_MSG = """
+    The error message if the resource operation failed."""
+
+    EMBEDDERS_STATUS = """
+    The status of all configured embedders."""
+
+    LANGUAGE_MODELS_STATUS = """
+    The status of all configured language models."""
+
+    RERANKERS_STATUS = """
+    The status of all configured rerankers."""
+
+    DATABASES_STATUS = """
+    The status of all configured databases."""
+
+    # --- Configuration API Fields ---
+
+    API_KEY_OPENAI = """
+    OpenAI API key for authentication."""
+
+    MODEL_NAME = """
+    The model name to use."""
+
+    EMBEDDING_DIMENSIONS = """
+    The number of dimensions for embedding vectors."""
+
+    API_BASE_URL = """
+    Custom base URL for the API endpoint."""
+
+    MAX_INPUT_LENGTH = """
+    Maximum input length in Unicode code points."""
+
+    MAX_RETRY_INTERVAL = """
+    Maximum retry interval in seconds for failed requests."""
+
+    AWS_REGION = """
+    AWS region where the service is hosted."""
+
+    MODEL_ID_BEDROCK = """
+    Amazon Bedrock model ID."""
+
+    AWS_ACCESS_KEY_ID = """
+    AWS access key ID for authentication."""
+
+    AWS_SECRET_ACCESS_KEY = """
+    AWS secret access key for authentication."""
+
+    AWS_SESSION_TOKEN = """
+    AWS session token for temporary credentials."""
+
+    SENTENCE_TRANSFORMER_MODEL = """
+    The name of the sentence transformer model to use."""
+
+    EMBEDDER_NAME = """
+    Unique name/identifier for the embedder."""
+
+    EMBEDDER_PROVIDER_TYPE = """
+    The embedder provider type (e.g., 'openai', 'amazon-bedrock', 'sentence-transformer')."""
+
+    PROVIDER_CONFIG = """
+    Provider-specific configuration settings."""
+
+    LM_NAME = """
+    Unique name/identifier for the language model."""
+
+    LM_PROVIDER_TYPE = """
+    The language model provider type (e.g., 'openai-responses', 'openai-chat-completions', 'amazon-bedrock')."""
+
+    INFERENCE_CONFIG = """
+    Inference configuration for the model."""
+
+    ADDITIONAL_MODEL_FIELDS = """
+    Additional model request fields."""
+
+    OPERATION_SUCCESS = """
+    Whether the operation succeeded."""
+
+    RESOURCE_STATUS_AFTER_OP = """
+    Current status of the resource after the operation."""
+
+    OPERATION_ERROR = """
+    Error message if the operation failed."""
+
+    DELETION_SUCCESS = """
+    Whether the deletion succeeded."""
+
+    STATUS_MESSAGE = """
+    Status message describing the result of the operation."""
+
+    # --- Memory Configuration Update Fields ---
+
+    LTM_EMBEDDER = """
+    The ID of the embedder resource to use for long-term memory.
+    Must reference an embedder configured in the resources section."""
+
+    LTM_RERANKER = """
+    The ID of the reranker resource to use for long-term memory search.
+    Must reference a reranker configured in the resources section."""
+
+    LTM_VECTOR_GRAPH_STORE = """
+    The ID of the vector graph store (database) for storing long-term memories.
+    Must reference a database configured in the resources section."""
+
+    STM_LLM_MODEL = """
+    The ID of the language model to use for short-term memory summarization.
+    Must reference a language model configured in the resources section."""
+
+    STM_MESSAGE_CAPACITY = """
+    The maximum message capacity for short-term memory, in characters.
+    When exceeded, older messages are summarized."""
+
+    EPISODIC_LTM_UPDATE = """
+    Partial update for long-term memory settings. Only supplied fields
+    are updated; omitted fields remain unchanged."""
+
+    EPISODIC_STM_UPDATE = """
+    Partial update for short-term memory settings. Only supplied fields
+    are updated; omitted fields remain unchanged."""
+
+    EPISODIC_LTM_ENABLED = """
+    Whether long-term episodic memory is enabled."""
+
+    EPISODIC_STM_ENABLED = """
+    Whether short-term episodic memory is enabled."""
+
+    EPISODIC_ENABLED = """
+    Whether episodic memory as a whole is enabled."""
+
+    SEMANTIC_ENABLED = """
+    Whether semantic memory is enabled. When set to true, the required
+    fields (database, llm_model, embedding_model) must also be configured.
+    Set to false to disable semantic memory entirely."""
+
+    SEMANTIC_DATABASE = """
+    The ID of the database to use for semantic memory storage.
+    Must reference a database configured in the resources section."""
+
+    SEMANTIC_LLM_MODEL = """
+    The ID of the language model to use for semantic memory extraction.
+    Must reference a language model configured in the resources section."""
+
+    SEMANTIC_EMBEDDING_MODEL = """
+    The ID of the embedder to use for semantic memory vector search.
+    Must reference an embedder configured in the resources section."""
+
+    SEMANTIC_INGESTION_MESSAGES = """
+    The number of uningested messages that triggers an ingestion cycle."""
+
+    SEMANTIC_INGESTION_AGE = """
+    The maximum age (in seconds) of uningested messages before
+    triggering an ingestion cycle."""
+
+    UPDATE_EPISODIC_MEMORY = """
+    Partial update for episodic memory configuration. Only supplied
+    fields are updated; omitted fields remain unchanged."""
+
+    UPDATE_SEMANTIC_MEMORY = """
+    Partial update for semantic memory configuration. Only supplied
+    fields are updated; omitted fields remain unchanged."""
+
 
 class Examples:
     """Common examples for API fields."""
@@ -456,3 +628,235 @@ class RouterDoc:
 
     HEALTH_CHECK = """
     Health check endpoint to verify server is running."""
+
+    # --- Configuration API Router Docs ---
+
+    CONFIG_SECURITY_WARNING = """
+    **Security Warning**: Configuration changes made via the API are persisted
+    to the configuration file in plain text, including API keys and credentials.
+    Only use the configuration API in protected environments where the
+    configuration file is secured.
+
+    To avoid storing secrets in plain text, you can use environment variable
+    references in your API requests (e.g., `"api_key": "$OPENAI_API_KEY"`).
+    The server will resolve these at runtime while preserving the reference
+    in the configuration file.
+    """
+
+    GET_CONFIG = """
+    Get current configuration and resource status.
+
+    Returns a comprehensive view of all configured resources in the system,
+    including embedders, language models, rerankers, and databases. Each
+    resource includes its current status (ready, failed, or pending) and
+    any error messages if initialization failed.
+
+    This endpoint is useful for:
+    - Monitoring the health of configured resources
+    - Diagnosing startup failures when resources are unavailable
+    - Verifying that runtime configuration changes have been applied
+
+    Resources may be in one of three states:
+    - `ready`: The resource is initialized and available for use
+    - `failed`: The resource failed to initialize (error details included)
+    - `pending`: The resource is configured but not yet initialized
+    """
+
+    GET_RESOURCES = """
+    Get status of all configured resources.
+
+    Returns the status of all embedders, language models, rerankers, and
+    databases configured in the system. This is a subset of the full
+    configuration response, focused specifically on resource health.
+
+    Each resource entry includes:
+    - `name`: The unique identifier for the resource
+    - `provider`: The type of provider (e.g., 'openai', 'amazon-bedrock')
+    - `status`: Current state ('ready', 'failed', or 'pending')
+    - `error`: Error message if the resource failed to initialize
+
+    Use this endpoint to quickly check which resources are available before
+    making API calls that depend on specific embedders or models.
+    """
+
+    ADD_EMBEDDER = """
+    Add a new embedder configuration at runtime.
+
+    Creates a new embedder with the specified configuration and attempts to
+    initialize it immediately. This allows adding embedders without restarting
+    the server. The configuration is persisted to the configuration file.
+
+    **Security Warning**: API keys and credentials are stored in plain text in
+    the configuration file. Only use this API in protected environments. To
+    avoid storing secrets in plain text, use environment variable references
+    (e.g., `"api_key": "$OPENAI_API_KEY"`) which will be resolved at runtime.
+
+    Supported providers:
+    - `openai`: OpenAI embedding models (requires api_key, model)
+    - `amazon-bedrock`: AWS Bedrock embedding models (requires region, model_id)
+    - `sentence-transformer`: Local sentence transformer models (requires model)
+
+    The response indicates whether the embedder was successfully initialized:
+    - `success: true, status: ready`: Embedder is available for use
+    - `success: false, status: failed`: Initialization failed (check error field)
+
+    If initialization fails, the embedder configuration is still stored and can
+    be retried later using the retry endpoint when the underlying service
+    becomes available.
+
+    Returns 422 if the provider type or configuration is invalid.
+    """
+
+    ADD_LANGUAGE_MODEL = """
+    Add a new language model configuration at runtime.
+
+    Creates a new language model with the specified configuration and attempts
+    to initialize it immediately. This allows adding models without restarting
+    the server. The configuration is persisted to the configuration file.
+
+    **Security Warning**: API keys and credentials are stored in plain text in
+    the configuration file. Only use this API in protected environments. To
+    avoid storing secrets in plain text, use environment variable references
+    (e.g., `"api_key": "$OPENAI_API_KEY"`) which will be resolved at runtime.
+
+    Supported providers:
+    - `openai-responses`: OpenAI models using the Responses API (requires api_key, model)
+    - `openai-chat-completions`: OpenAI models using Chat Completions API (requires api_key, model)
+    - `amazon-bedrock`: AWS Bedrock models (requires region, model_id)
+
+    The response indicates whether the model was successfully initialized:
+    - `success: true, status: ready`: Model is available for use
+    - `success: false, status: failed`: Initialization failed (check error field)
+
+    If initialization fails, the model configuration is still stored and can
+    be retried later using the retry endpoint when the underlying service
+    becomes available.
+
+    Returns 422 if the provider type or configuration is invalid.
+    """
+
+    DELETE_EMBEDDER = """
+    Remove an embedder configuration.
+
+    Permanently removes the specified embedder from the system. This removes
+    both the cached instance and the configuration, so the embedder cannot
+    be used until it is added again. The change is persisted to the
+    configuration file.
+
+    This operation is useful for:
+    - Removing embedders that are no longer needed
+    - Clearing failed embedders before adding a corrected configuration
+    - Freeing resources used by unused embedders
+
+    Returns 404 if the embedder does not exist.
+    """
+
+    DELETE_LANGUAGE_MODEL = """
+    Remove a language model configuration.
+
+    Permanently removes the specified language model from the system. This
+    removes both the cached instance and the configuration, so the model
+    cannot be used until it is added again. The change is persisted to the
+    configuration file.
+
+    This operation is useful for:
+    - Removing models that are no longer needed
+    - Clearing failed models before adding a corrected configuration
+    - Freeing resources used by unused models
+
+    Returns 404 if the language model does not exist.
+    """
+
+    RETRY_EMBEDDER = """
+    Retry building a failed embedder.
+
+    Attempts to reinitialize an embedder that previously failed to build.
+    This is useful when the underlying service (e.g., OpenAI API, AWS Bedrock)
+    was temporarily unavailable during initial startup or configuration.
+
+    The retry clears any previous error state and attempts a fresh build.
+    If successful, the embedder becomes available for use immediately.
+
+    The response indicates the result:
+    - `success: true, status: ready`: Embedder is now available
+    - `success: false, status: failed`: Still failing (check error field)
+
+    Returns 404 if the embedder is not configured.
+    """
+
+    RETRY_LANGUAGE_MODEL = """
+    Retry building a failed language model.
+
+    Attempts to reinitialize a language model that previously failed to build.
+    This is useful when the underlying service (e.g., OpenAI API, AWS Bedrock)
+    was temporarily unavailable during initial startup or configuration.
+
+    The retry clears any previous error state and attempts a fresh build.
+    If successful, the model becomes available for use immediately.
+
+    The response indicates the result:
+    - `success: true, status: ready`: Model is now available
+    - `success: false, status: failed`: Still failing (check error field)
+
+    Returns 404 if the language model is not configured.
+    """
+
+    UPDATE_MEMORY_CONFIG = """
+    Update the episodic and/or semantic memory configuration.
+
+    This endpoint allows updating the memory configuration at runtime after
+    resources (embedders, language models, rerankers) have been added or
+    changed. Without calling this endpoint, newly added resources will not
+    be used by the memory systems.
+
+    Both `episodic_memory` and `semantic_memory` are optional. Supply one
+    or both depending on which sections need updating. Within each section,
+    only the fields you supply are modified; omitted fields retain their
+    current values.
+
+    **Typical workflow:**
+    1. Add a new resource via `POST /config/resources/embedders` or
+       `POST /config/resources/language_models`
+    2. Call this endpoint to point the memory configuration at the new resource
+    3. The configuration is persisted to the configuration file
+
+    **Example - update episodic long-term memory to use a new embedder:**
+    ```json
+    {
+      "episodic_memory": {
+        "long_term_memory": {
+          "embedder": "my-new-embedder"
+        }
+      }
+    }
+    ```
+
+    **Example - update semantic memory to use a new LLM and embedder:**
+    ```json
+    {
+      "semantic_memory": {
+        "llm_model": "my-new-model",
+        "embedding_model": "my-new-embedder"
+      }
+    }
+    ```
+
+    Returns 400 if no updates are supplied (both sections are null or empty).
+    """
+
+    RETRY_RERANKER = """
+    Retry building a failed reranker.
+
+    Attempts to reinitialize a reranker that previously failed to build.
+    This is useful when the underlying service or dependencies were
+    temporarily unavailable during initial startup.
+
+    The retry clears any previous error state and attempts a fresh build.
+    If successful, the reranker becomes available for use immediately.
+
+    The response indicates the result:
+    - `success: true, status: ready`: Reranker is now available
+    - `success: false, status: failed`: Still failing (check error field)
+
+    Returns 404 if the reranker is not configured.
+    """

--- a/src/memmachine/common/errors.py
+++ b/src/memmachine/common/errors.py
@@ -118,6 +118,20 @@ class InvalidRerankerError(MemMachineError):
     """Exception raised for invalid reranker."""
 
 
+class ResourceNotReadyError(MemMachineError):
+    """
+    Raised when an operation requires a resource that is not ready.
+
+    This typically occurs when a resource (embedder, language model, reranker)
+    failed to initialize during startup but is required for an API operation.
+    """
+
+    def __init__(self, message: str, resource_name: str | None = None) -> None:
+        """Initialize with message and optional resource name."""
+        self.resource_name = resource_name
+        super().__init__(message)
+
+
 class EpisodicMemoryManagerClosedError(MemMachineError):
     """Exception raised when operating on a closed EpisodicMemory instance."""
 

--- a/src/memmachine/common/resource_manager/base_manager.py
+++ b/src/memmachine/common/resource_manager/base_manager.py
@@ -1,0 +1,183 @@
+"""Base class for resource managers with common status tracking functionality."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from asyncio import Lock
+from typing import TypeVar
+
+from memmachine.common.api.config_spec import ResourceStatus
+
+logger = logging.getLogger(__name__)
+
+# Type variable for the resource type (Embedder, LanguageModel, Reranker, etc.)
+ResourceT = TypeVar("ResourceT")
+
+
+class BaseResourceManager[ResourceT](ABC):
+    """
+    Base class providing common resource status tracking and retry functionality.
+
+    Subclasses must implement:
+    - `_is_configured(name)`: Check if a resource is configured
+    - `_get_resource(name, validate)`: Build/retrieve a resource
+    - `_get_not_found_error(name)`: Return the appropriate error for unknown resources
+    - `get_all_names()`: Return all configured resource names
+    """
+
+    def __init__(self) -> None:
+        """Initialize the base manager with error tracking."""
+        self._build_errors: dict[str, Exception] = {}
+        self._resources: dict[str, ResourceT] = {}
+        self._lock = Lock()
+        self._resource_locks: dict[str, Lock] = {}
+
+    @abstractmethod
+    def _is_configured(self, name: str) -> bool:
+        """Check if a resource with the given name is configured."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def _build_resource(self, name: str, validate: bool = False) -> ResourceT:
+        """Build a resource by name. Called within the locking context."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _get_not_found_error(self, name: str) -> Exception:
+        """Return the appropriate 'not found' error for the resource type."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_all_names(self) -> set[str]:
+        """Return all configured resource names."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def _resource_type_name(self) -> str:
+        """Return the human-readable name of the resource type (e.g., 'embedder')."""
+        raise NotImplementedError
+
+    def get_resource_status(self, name: str) -> ResourceStatus:
+        """Return the status of a named resource."""
+        if name in self._resources:
+            return ResourceStatus.READY
+        if name in self._build_errors:
+            return ResourceStatus.FAILED
+        if self._is_configured(name):
+            return ResourceStatus.PENDING
+        raise self._get_not_found_error(name)
+
+    def get_resource_error(self, name: str) -> Exception | None:
+        """Return the build error for a failed resource, or None if not failed."""
+        return self._build_errors.get(name)
+
+    async def _try_build_with_error_tracking(self, name: str) -> None:
+        """Attempt to build a resource, tracking failures in _build_errors."""
+        try:
+            await self._get_resource_with_locking(name)
+        except Exception as e:
+            logger.warning(
+                "Failed to build %s '%s': %s", self._resource_type_name, name, e
+            )
+            self._build_errors[name] = e
+
+    async def _get_resource_with_locking(
+        self, name: str, validate: bool = False
+    ) -> ResourceT:
+        """
+        Get a resource with proper locking and error checking.
+
+        This implements the common pattern of:
+        1. Check cache
+        2. Check for previous build errors
+        3. Acquire lock
+        4. Double-check cache and errors
+        5. Build resource
+        """
+        from memmachine.common.errors import ResourceNotReadyError
+
+        # Return cached if already built
+        if name in self._resources:
+            return self._resources[name]
+
+        # Check if this resource previously failed to build
+        if name in self._build_errors:
+            raise ResourceNotReadyError(
+                f"{self._resource_type_name.capitalize()} '{name}' is not ready: "
+                f"{self._build_errors[name]}"
+            )
+
+        # Ensure a lock exists for this resource
+        if name not in self._resource_locks:
+            async with self._lock:
+                self._resource_locks.setdefault(name, Lock())
+
+        async with self._resource_locks[name]:
+            # Double-checked locking
+            if name in self._resources:
+                return self._resources[name]
+
+            # Check again after acquiring lock
+            if name in self._build_errors:
+                raise ResourceNotReadyError(
+                    f"{self._resource_type_name.capitalize()} '{name}' is not ready: "
+                    f"{self._build_errors[name]}"
+                )
+
+            # Build the resource
+            resource = await self._build_resource(name, validate=validate)
+            self._resources[name] = resource
+            return resource
+
+    async def retry_build(self, name: str, validate: bool = False) -> ResourceT:
+        """
+        Retry building a failed resource.
+
+        Clears the previous error and attempts to build again.
+        """
+        if (
+            name not in self._build_errors
+            and name not in self._resources
+            and not self._is_configured(name)
+        ):
+            raise self._get_not_found_error(name)
+        # Clear error to allow retry
+        self._build_errors.pop(name, None)
+        return await self._get_resource_with_locking(name, validate=validate)
+
+    async def build_all_with_error_tracking(
+        self, names: set[str] | list[str]
+    ) -> dict[str, ResourceT]:
+        """
+        Build all resources, catching and logging failures.
+
+        Failures are tracked in _build_errors, allowing startup to continue
+        even if some resources fail to initialize.
+        """
+        await asyncio.gather(
+            *[self._try_build_with_error_tracking(name) for name in names]
+        )
+        return self._resources
+
+    def _remove_from_cache(self, name: str) -> bool:
+        """
+        Remove a resource from cache and error tracking.
+
+        Returns True if anything was removed, False otherwise.
+        Subclasses should call this and also handle config removal.
+        """
+        removed = False
+        if name in self._resources:
+            del self._resources[name]
+            removed = True
+        if name in self._build_errors:
+            del self._build_errors[name]
+            removed = True
+        return removed
+
+    def clear_build_error(self, name: str) -> None:
+        """Clear any build error for a resource, allowing it to be retried."""
+        self._build_errors.pop(name, None)

--- a/src/memmachine/common/resource_manager/resource_manager.py
+++ b/src/memmachine/common/resource_manager/resource_manager.py
@@ -211,3 +211,37 @@ class ResourceManagerImpl:
         if ret is None:
             raise ValueError(f"MetricsFactory '{name}' could not be created.")
         return ret
+
+    @property
+    def embedder_manager(self) -> EmbedderManager:
+        """Return the embedder manager."""
+        return self._embedder_manager
+
+    @property
+    def language_model_manager(self) -> LanguageModelManager:
+        """Return the language model manager."""
+        return self._model_manager
+
+    @property
+    def reranker_manager(self) -> RerankerManager:
+        """Return the reranker manager."""
+        return self._reranker_manager
+
+    @property
+    def database_manager(self) -> DatabaseManager:
+        """Return the database manager."""
+        return self._database_manager
+
+    def save_config(self, path: str | None = None) -> None:
+        """
+        Save the current configuration to file.
+
+        This persists any runtime changes made to resources (embedders,
+        language models, etc.) back to the configuration file.
+
+        Args:
+            path: Optional path to save to. If None, saves to the original
+                  configuration file path.
+
+        """
+        self._conf.save(path)

--- a/src/memmachine/rest_client/__init__.py
+++ b/src/memmachine/rest_client/__init__.py
@@ -6,7 +6,8 @@ episodic and profile memory systems.
 """
 
 from .client import MemMachineClient
+from .config import Config
 from .memory import Memory
 from .project import Project
 
-__all__ = ["MemMachineClient", "Memory", "Project"]
+__all__ = ["Config", "MemMachineClient", "Memory", "Project"]

--- a/src/memmachine/rest_client/client.py
+++ b/src/memmachine/rest_client/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from types import TracebackType
-from typing import Any, NoReturn, TypedDict
+from typing import TYPE_CHECKING, Any, NoReturn, TypedDict
 
 # Python 3.11+ has Self in typing, Python 3.10 uses typing_extensions
 try:
@@ -27,6 +27,9 @@ from memmachine.common.api.spec import (
 )
 
 from .project import Project
+
+if TYPE_CHECKING:
+    from .config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -540,6 +543,18 @@ class MemMachineClient:
             raise
         else:
             return response.text
+
+    def config(self) -> Config:
+        """
+        Return a Config instance for managing server configuration.
+
+        Returns:
+            Config instance bound to this client
+
+        """
+        from .config import Config
+
+        return Config(client=self)
 
     def close(self) -> None:
         """Close the client and clean up resources."""

--- a/src/memmachine/rest_client/config.py
+++ b/src/memmachine/rest_client/config.py
@@ -1,0 +1,413 @@
+"""Configuration management interface for MemMachine."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Literal
+
+import requests
+
+from memmachine.common.api.config_spec import (
+    AddEmbedderSpec,
+    AddLanguageModelSpec,
+    DeleteResourceResponse,
+    GetConfigResponse,
+    ResourcesStatus,
+    UpdateEpisodicMemorySpec,
+    UpdateMemoryConfigResponse,
+    UpdateMemoryConfigSpec,
+    UpdateResourceResponse,
+    UpdateSemanticMemorySpec,
+)
+
+if TYPE_CHECKING:
+    from .client import MemMachineClient
+
+logger = logging.getLogger(__name__)
+
+
+class Config:
+    """
+    Configuration interface for managing MemMachine server settings.
+
+    Provides methods for reading and updating server configuration including
+    resources (embedders, language models, rerankers) and memory settings.
+
+    Example:
+        ```python
+        from memmachine import MemMachineClient
+
+        client = MemMachineClient(base_url="http://localhost:8080")
+        config = client.config()
+
+        # Get full configuration
+        cfg = config.get_config()
+
+        # Add an embedder
+        config.add_embedder(
+            name="my-embedder",
+            provider="openai",
+            config={"api_key": "sk-...", "model": "text-embedding-3-small"},
+        )
+        ```
+
+    """
+
+    def __init__(self, client: MemMachineClient) -> None:
+        """
+        Initialize Config instance.
+
+        Args:
+            client: MemMachineClient instance
+
+        """
+        self.client = client
+
+    def _check_closed(self) -> None:
+        if self.client.closed:
+            raise RuntimeError("Cannot use config: client has been closed")
+
+    def get_config(self, timeout: int | None = None) -> GetConfigResponse:
+        """
+        Get the full server configuration.
+
+        Args:
+            timeout: Request timeout in seconds (uses client default if not provided)
+
+        Returns:
+            GetConfigResponse containing resources status
+
+        Raises:
+            requests.RequestException: If the request fails
+            RuntimeError: If the client has been closed
+
+        """
+        self._check_closed()
+        try:
+            response = self.client.request(
+                "GET",
+                f"{self.client.base_url}/api/v2/config",
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return GetConfigResponse(**response.json())
+        except requests.RequestException:
+            logger.exception("Failed to get config")
+            raise
+
+    def get_resources(self, timeout: int | None = None) -> ResourcesStatus:
+        """
+        Get the status of all configured resources.
+
+        Args:
+            timeout: Request timeout in seconds (uses client default if not provided)
+
+        Returns:
+            ResourcesStatus containing status of all resources
+
+        Raises:
+            requests.RequestException: If the request fails
+            RuntimeError: If the client has been closed
+
+        """
+        self._check_closed()
+        try:
+            response = self.client.request(
+                "GET",
+                f"{self.client.base_url}/api/v2/config/resources",
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return ResourcesStatus(**response.json())
+        except requests.RequestException:
+            logger.exception("Failed to get resources")
+            raise
+
+    def update_memory_config(
+        self,
+        episodic_memory: UpdateEpisodicMemorySpec | None = None,
+        semantic_memory: UpdateSemanticMemorySpec | None = None,
+        timeout: int | None = None,
+    ) -> UpdateMemoryConfigResponse:
+        """
+        Update memory configuration settings.
+
+        Args:
+            episodic_memory: Episodic memory configuration updates
+            semantic_memory: Semantic memory configuration updates
+            timeout: Request timeout in seconds (uses client default if not provided)
+
+        Returns:
+            UpdateMemoryConfigResponse indicating success
+
+        Raises:
+            requests.RequestException: If the request fails
+            RuntimeError: If the client has been closed
+
+        """
+        self._check_closed()
+        spec = UpdateMemoryConfigSpec(
+            episodic_memory=episodic_memory,
+            semantic_memory=semantic_memory,
+        )
+        try:
+            response = self.client.request(
+                "PUT",
+                f"{self.client.base_url}/api/v2/config/memory",
+                json=spec.model_dump(exclude_none=True),
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return UpdateMemoryConfigResponse(**response.json())
+        except requests.RequestException:
+            logger.exception("Failed to update memory config")
+            raise
+
+    def add_embedder(
+        self,
+        name: str,
+        provider: Literal["openai", "amazon-bedrock", "sentence-transformer"],
+        config: dict[str, Any],
+        timeout: int | None = None,
+    ) -> UpdateResourceResponse:
+        """
+        Add a new embedder resource.
+
+        Args:
+            name: Name for the embedder
+            provider: Provider type
+            config: Provider-specific configuration
+            timeout: Request timeout in seconds (uses client default if not provided)
+
+        Returns:
+            UpdateResourceResponse with status of the added resource
+
+        Raises:
+            requests.RequestException: If the request fails
+            RuntimeError: If the client has been closed
+
+        """
+        self._check_closed()
+        spec = AddEmbedderSpec(name=name, provider=provider, config=config)
+        try:
+            response = self.client.request(
+                "POST",
+                f"{self.client.base_url}/api/v2/config/resources/embedders",
+                json=spec.model_dump(),
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return UpdateResourceResponse(**response.json())
+        except requests.RequestException:
+            logger.exception("Failed to add embedder '%s'", name)
+            raise
+
+    def add_language_model(
+        self,
+        name: str,
+        provider: Literal[
+            "openai-responses", "openai-chat-completions", "amazon-bedrock"
+        ],
+        config: dict[str, Any],
+        timeout: int | None = None,
+    ) -> UpdateResourceResponse:
+        """
+        Add a new language model resource.
+
+        Args:
+            name: Name for the language model
+            provider: Provider type
+            config: Provider-specific configuration
+            timeout: Request timeout in seconds (uses client default if not provided)
+
+        Returns:
+            UpdateResourceResponse with status of the added resource
+
+        Raises:
+            requests.RequestException: If the request fails
+            RuntimeError: If the client has been closed
+
+        """
+        self._check_closed()
+        spec = AddLanguageModelSpec(name=name, provider=provider, config=config)
+        try:
+            response = self.client.request(
+                "POST",
+                f"{self.client.base_url}/api/v2/config/resources/language_models",
+                json=spec.model_dump(),
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return UpdateResourceResponse(**response.json())
+        except requests.RequestException:
+            logger.exception("Failed to add language model '%s'", name)
+            raise
+
+    def delete_embedder(
+        self,
+        name: str,
+        timeout: int | None = None,
+    ) -> DeleteResourceResponse:
+        """
+        Delete an embedder resource.
+
+        Args:
+            name: Name of the embedder to delete
+            timeout: Request timeout in seconds (uses client default if not provided)
+
+        Returns:
+            DeleteResourceResponse indicating success
+
+        Raises:
+            requests.RequestException: If the request fails
+            RuntimeError: If the client has been closed
+
+        """
+        self._check_closed()
+        try:
+            response = self.client.request(
+                "DELETE",
+                f"{self.client.base_url}/api/v2/config/resources/embedders/{name}",
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return DeleteResourceResponse(**response.json())
+        except requests.RequestException:
+            logger.exception("Failed to delete embedder '%s'", name)
+            raise
+
+    def delete_language_model(
+        self,
+        name: str,
+        timeout: int | None = None,
+    ) -> DeleteResourceResponse:
+        """
+        Delete a language model resource.
+
+        Args:
+            name: Name of the language model to delete
+            timeout: Request timeout in seconds (uses client default if not provided)
+
+        Returns:
+            DeleteResourceResponse indicating success
+
+        Raises:
+            requests.RequestException: If the request fails
+            RuntimeError: If the client has been closed
+
+        """
+        self._check_closed()
+        try:
+            response = self.client.request(
+                "DELETE",
+                f"{self.client.base_url}/api/v2/config/resources/language_models/{name}",
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return DeleteResourceResponse(**response.json())
+        except requests.RequestException:
+            logger.exception("Failed to delete language model '%s'", name)
+            raise
+
+    def retry_embedder(
+        self,
+        name: str,
+        timeout: int | None = None,
+    ) -> UpdateResourceResponse:
+        """
+        Retry initialization of a failed embedder resource.
+
+        Args:
+            name: Name of the embedder to retry
+            timeout: Request timeout in seconds (uses client default if not provided)
+
+        Returns:
+            UpdateResourceResponse with updated status
+
+        Raises:
+            requests.RequestException: If the request fails
+            RuntimeError: If the client has been closed
+
+        """
+        self._check_closed()
+        try:
+            response = self.client.request(
+                "POST",
+                f"{self.client.base_url}/api/v2/config/resources/embedders/{name}/retry",
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return UpdateResourceResponse(**response.json())
+        except requests.RequestException:
+            logger.exception("Failed to retry embedder '%s'", name)
+            raise
+
+    def retry_language_model(
+        self,
+        name: str,
+        timeout: int | None = None,
+    ) -> UpdateResourceResponse:
+        """
+        Retry initialization of a failed language model resource.
+
+        Args:
+            name: Name of the language model to retry
+            timeout: Request timeout in seconds (uses client default if not provided)
+
+        Returns:
+            UpdateResourceResponse with updated status
+
+        Raises:
+            requests.RequestException: If the request fails
+            RuntimeError: If the client has been closed
+
+        """
+        self._check_closed()
+        try:
+            response = self.client.request(
+                "POST",
+                f"{self.client.base_url}/api/v2/config/resources/language_models/{name}/retry",
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return UpdateResourceResponse(**response.json())
+        except requests.RequestException:
+            logger.exception("Failed to retry language model '%s'", name)
+            raise
+
+    def retry_reranker(
+        self,
+        name: str,
+        timeout: int | None = None,
+    ) -> UpdateResourceResponse:
+        """
+        Retry initialization of a failed reranker resource.
+
+        Args:
+            name: Name of the reranker to retry
+            timeout: Request timeout in seconds (uses client default if not provided)
+
+        Returns:
+            UpdateResourceResponse with updated status
+
+        Raises:
+            requests.RequestException: If the request fails
+            RuntimeError: If the client has been closed
+
+        """
+        self._check_closed()
+        try:
+            response = self.client.request(
+                "POST",
+                f"{self.client.base_url}/api/v2/config/resources/rerankers/{name}/retry",
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return UpdateResourceResponse(**response.json())
+        except requests.RequestException:
+            logger.exception("Failed to retry reranker '%s'", name)
+            raise
+
+    def __repr__(self) -> str:
+        """Return a developer-friendly string representation."""
+        return f"Config(client={self.client!r})"

--- a/src/memmachine/server/api_v2/config_router.py
+++ b/src/memmachine/server/api_v2/config_router.py
@@ -1,0 +1,242 @@
+"""API v2 router for configuration management endpoints."""
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request
+
+from memmachine.common.api.config_spec import (
+    AddEmbedderSpec,
+    AddLanguageModelSpec,
+    DeleteResourceResponse,
+    GetConfigResponse,
+    ResourcesStatus,
+    ResourceStatus,
+    UpdateMemoryConfigResponse,
+    UpdateMemoryConfigSpec,
+    UpdateResourceResponse,
+)
+from memmachine.common.api.doc import RouterDoc
+from memmachine.common.errors import (
+    InvalidEmbedderError,
+    InvalidLanguageModelError,
+    InvalidRerankerError,
+)
+from memmachine.server.api_v2.config_service import ConfigService
+from memmachine.server.api_v2.exceptions import RestError
+
+logger = logging.getLogger(__name__)
+
+
+async def get_config_service(request: Request) -> ConfigService:
+    """Get config service from application state."""
+    resource_manager = request.app.state.mem_machine.resource_manager
+    return ConfigService(resource_manager)
+
+
+config_router = APIRouter(prefix="/config", tags=["Configuration"])
+
+
+@config_router.get("", description=RouterDoc.GET_CONFIG)
+async def get_config(
+    service: Annotated[ConfigService, Depends(get_config_service)],
+) -> GetConfigResponse:
+    """Get current configuration with resource status."""
+    resources = service.get_resources_status()
+    return GetConfigResponse(resources=resources)
+
+
+@config_router.get("/resources", description=RouterDoc.GET_RESOURCES)
+async def get_resources(
+    service: Annotated[ConfigService, Depends(get_config_service)],
+) -> ResourcesStatus:
+    """Get status of all configured resources."""
+    return service.get_resources_status()
+
+
+@config_router.put(
+    "/memory",
+    description=RouterDoc.UPDATE_MEMORY_CONFIG,
+)
+async def update_memory_config_endpoint(
+    spec: UpdateMemoryConfigSpec,
+    service: Annotated[ConfigService, Depends(get_config_service)],
+) -> UpdateMemoryConfigResponse:
+    """Update episodic and/or semantic memory configuration."""
+    if spec.episodic_memory is None and spec.semantic_memory is None:
+        raise RestError(
+            code=400,
+            message="At least one of 'episodic_memory' or 'semantic_memory' must be provided.",
+        )
+    try:
+        message = service.update_memory_config(
+            spec.episodic_memory, spec.semantic_memory
+        )
+        return UpdateMemoryConfigResponse(success=True, message=message)
+    except Exception as e:
+        raise RestError(
+            code=500, message="Failed to update memory configuration", ex=e
+        ) from e
+
+
+@config_router.post(
+    "/resources/embedders",
+    status_code=201,
+    description=RouterDoc.ADD_EMBEDDER,
+)
+async def add_embedder_endpoint(
+    spec: AddEmbedderSpec,
+    service: Annotated[ConfigService, Depends(get_config_service)],
+) -> UpdateResourceResponse:
+    """Add a new embedder configuration."""
+    try:
+        status = await service.add_embedder(spec.name, spec.provider, spec.config)
+        error_msg = None
+        if status == ResourceStatus.FAILED:
+            error_msg = service.get_embedder_error(spec.name) or "Unknown error"
+        return UpdateResourceResponse(
+            success=(status == ResourceStatus.READY),
+            status=status,
+            error=error_msg,
+        )
+    except ValueError as e:
+        raise RestError(code=422, message=str(e), ex=e) from e
+    except Exception as e:
+        raise RestError(code=500, message="Failed to add embedder", ex=e) from e
+
+
+@config_router.post(
+    "/resources/language_models",
+    status_code=201,
+    description=RouterDoc.ADD_LANGUAGE_MODEL,
+)
+async def add_language_model_endpoint(
+    spec: AddLanguageModelSpec,
+    service: Annotated[ConfigService, Depends(get_config_service)],
+) -> UpdateResourceResponse:
+    """Add a new language model configuration."""
+    try:
+        status = await service.add_language_model(spec.name, spec.provider, spec.config)
+        error_msg = None
+        if status == ResourceStatus.FAILED:
+            error_msg = service.get_language_model_error(spec.name) or "Unknown error"
+        return UpdateResourceResponse(
+            success=(status == ResourceStatus.READY),
+            status=status,
+            error=error_msg,
+        )
+    except ValueError as e:
+        raise RestError(code=422, message=str(e), ex=e) from e
+    except Exception as e:
+        raise RestError(code=500, message="Failed to add language model", ex=e) from e
+
+
+@config_router.delete(
+    "/resources/embedders/{name}",
+    description=RouterDoc.DELETE_EMBEDDER,
+)
+async def delete_embedder_endpoint(
+    name: str,
+    service: Annotated[ConfigService, Depends(get_config_service)],
+) -> DeleteResourceResponse:
+    """Remove an embedder configuration."""
+    removed = service.remove_embedder(name)
+    if removed:
+        return DeleteResourceResponse(
+            success=True,
+            message=f"Embedder '{name}' removed successfully.",
+        )
+    raise RestError(code=404, message=f"Embedder '{name}' not found.")
+
+
+@config_router.delete(
+    "/resources/language_models/{name}",
+    description=RouterDoc.DELETE_LANGUAGE_MODEL,
+)
+async def delete_language_model_endpoint(
+    name: str,
+    service: Annotated[ConfigService, Depends(get_config_service)],
+) -> DeleteResourceResponse:
+    """Remove a language model configuration."""
+    removed = service.remove_language_model(name)
+    if removed:
+        return DeleteResourceResponse(
+            success=True,
+            message=f"Language model '{name}' removed successfully.",
+        )
+    raise RestError(code=404, message=f"Language model '{name}' not found.")
+
+
+@config_router.post(
+    "/resources/embedders/{name}/retry",
+    description=RouterDoc.RETRY_EMBEDDER,
+)
+async def retry_embedder_endpoint(
+    name: str,
+    service: Annotated[ConfigService, Depends(get_config_service)],
+) -> UpdateResourceResponse:
+    """Retry building a failed embedder."""
+    try:
+        status = await service.retry_embedder(name)
+        error_msg = None
+        if status == ResourceStatus.FAILED:
+            error_msg = service.get_embedder_error(name) or "Unknown error"
+        return UpdateResourceResponse(
+            success=(status == ResourceStatus.READY),
+            status=status,
+            error=error_msg,
+        )
+    except InvalidEmbedderError as e:
+        raise RestError(code=404, message=str(e), ex=e) from e
+    except Exception as e:
+        raise RestError(code=500, message="Failed to retry embedder", ex=e) from e
+
+
+@config_router.post(
+    "/resources/language_models/{name}/retry",
+    description=RouterDoc.RETRY_LANGUAGE_MODEL,
+)
+async def retry_language_model_endpoint(
+    name: str,
+    service: Annotated[ConfigService, Depends(get_config_service)],
+) -> UpdateResourceResponse:
+    """Retry building a failed language model."""
+    try:
+        status = await service.retry_language_model(name)
+        error_msg = None
+        if status == ResourceStatus.FAILED:
+            error_msg = service.get_language_model_error(name) or "Unknown error"
+        return UpdateResourceResponse(
+            success=(status == ResourceStatus.READY),
+            status=status,
+            error=error_msg,
+        )
+    except InvalidLanguageModelError as e:
+        raise RestError(code=404, message=str(e), ex=e) from e
+    except Exception as e:
+        raise RestError(code=500, message="Failed to retry language model", ex=e) from e
+
+
+@config_router.post(
+    "/resources/rerankers/{name}/retry",
+    description=RouterDoc.RETRY_RERANKER,
+)
+async def retry_reranker_endpoint(
+    name: str,
+    service: Annotated[ConfigService, Depends(get_config_service)],
+) -> UpdateResourceResponse:
+    """Retry building a failed reranker."""
+    try:
+        status = await service.retry_reranker(name)
+        error_msg = None
+        if status == ResourceStatus.FAILED:
+            error_msg = service.get_reranker_error(name) or "Unknown error"
+        return UpdateResourceResponse(
+            success=(status == ResourceStatus.READY),
+            status=status,
+            error=error_msg,
+        )
+    except InvalidRerankerError as e:
+        raise RestError(code=404, message=str(e), ex=e) from e
+    except Exception as e:
+        raise RestError(code=500, message="Failed to retry reranker", ex=e) from e

--- a/src/memmachine/server/api_v2/config_service.py
+++ b/src/memmachine/server/api_v2/config_service.py
@@ -1,0 +1,508 @@
+"""Configuration service for managing runtime resources."""
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+from pydantic import SecretStr
+
+from memmachine.common.api.config_spec import (
+    ResourceInfo,
+    ResourcesStatus,
+    ResourceStatus,
+    UpdateEpisodicMemorySpec,
+    UpdateLongTermMemorySpec,
+    UpdateSemanticMemorySpec,
+    UpdateShortTermMemorySpec,
+)
+from memmachine.common.configuration import SemanticMemoryConf
+from memmachine.common.configuration.embedder_conf import (
+    AmazonBedrockEmbedderConf,
+    EmbeddersConf,
+    OpenAIEmbedderConf,
+    SentenceTransformerEmbedderConf,
+)
+from memmachine.common.configuration.episodic_config import EpisodicMemoryConfPartial
+from memmachine.common.configuration.language_model_conf import (
+    AmazonBedrockLanguageModelConf,
+    LanguageModelsConf,
+    OpenAIChatCompletionsLanguageModelConf,
+    OpenAIResponsesLanguageModelConf,
+)
+from memmachine.common.configuration.reranker_conf import RerankersConf
+from memmachine.common.resource_manager.resource_manager import ResourceManagerImpl
+
+logger = logging.getLogger(__name__)
+
+
+def _get_embedder_provider(manager_conf: EmbeddersConf, name: str) -> str:
+    """Determine the provider type for an embedder."""
+    if name in manager_conf.openai:
+        return "openai"
+    if name in manager_conf.amazon_bedrock:
+        return "amazon-bedrock"
+    if name in manager_conf.sentence_transformer:
+        return "sentence-transformer"
+    return "unknown"
+
+
+def _get_language_model_provider(manager_conf: LanguageModelsConf, name: str) -> str:
+    """Determine the provider type for a language model."""
+    if name in manager_conf.openai_responses_language_model_confs:
+        return "openai-responses"
+    if name in manager_conf.openai_chat_completions_language_model_confs:
+        return "openai-chat-completions"
+    if name in manager_conf.amazon_bedrock_language_model_confs:
+        return "amazon-bedrock"
+    return "unknown"
+
+
+def _get_reranker_provider(manager_conf: RerankersConf, name: str) -> str:
+    """Determine the provider type for a reranker."""
+    if name in manager_conf.bm25:
+        return "bm25"
+    if name in manager_conf.cohere:
+        return "cohere"
+    if name in manager_conf.cross_encoder:
+        return "cross-encoder"
+    if name in manager_conf.amazon_bedrock:
+        return "amazon-bedrock"
+    if name in manager_conf.embedder:
+        return "embedder"
+    if name in manager_conf.identity:
+        return "identity"
+    if name in manager_conf.rrf_hybrid:
+        return "rrf-hybrid"
+    return "unknown"
+
+
+def _create_embedder_config(
+    provider: str, config: dict[str, Any]
+) -> AmazonBedrockEmbedderConf | OpenAIEmbedderConf | SentenceTransformerEmbedderConf:
+    """Create an embedder configuration object from provider and config dict."""
+    if provider == "openai":
+        # Convert api_key to SecretStr
+        if "api_key" in config:
+            config["api_key"] = SecretStr(config["api_key"])
+        return OpenAIEmbedderConf(**config)
+    if provider == "amazon-bedrock":
+        # Convert AWS secrets to SecretStr
+        for key in ["aws_access_key_id", "aws_secret_access_key", "aws_session_token"]:
+            if key in config and config[key] is not None:
+                config[key] = SecretStr(config[key])
+        return AmazonBedrockEmbedderConf(**config)
+    if provider == "sentence-transformer":
+        return SentenceTransformerEmbedderConf(**config)
+    raise ValueError(f"Unknown embedder provider: {provider}")
+
+
+def _create_language_model_config(
+    provider: str, config: dict[str, Any]
+) -> (
+    OpenAIResponsesLanguageModelConf
+    | OpenAIChatCompletionsLanguageModelConf
+    | AmazonBedrockLanguageModelConf
+):
+    """Create a language model configuration object from provider and config dict."""
+    if provider == "openai-responses":
+        # Convert api_key to SecretStr
+        if "api_key" in config:
+            config["api_key"] = SecretStr(config["api_key"])
+        return OpenAIResponsesLanguageModelConf(**config)
+    if provider == "openai-chat-completions":
+        # Convert api_key to SecretStr
+        if "api_key" in config:
+            config["api_key"] = SecretStr(config["api_key"])
+        return OpenAIChatCompletionsLanguageModelConf(**config)
+    if provider == "amazon-bedrock":
+        # Convert AWS secrets to SecretStr
+        for key in ["aws_access_key_id", "aws_secret_access_key", "aws_session_token"]:
+            if key in config and config[key] is not None:
+                config[key] = SecretStr(config[key])
+        return AmazonBedrockLanguageModelConf(**config)
+    raise ValueError(f"Unknown language model provider: {provider}")
+
+
+def _apply_ltm_updates(
+    em: EpisodicMemoryConfPartial,
+    spec_ltm: UpdateLongTermMemorySpec,
+) -> list[str]:
+    """Apply long-term memory updates and return change descriptions."""
+    from memmachine.common.configuration.episodic_config import (
+        LongTermMemoryConfPartial,
+    )
+
+    ltm = em.long_term_memory
+    if ltm is None:
+        ltm = LongTermMemoryConfPartial()
+        em.long_term_memory = ltm
+
+    changes: list[str] = []
+    if spec_ltm.embedder is not None:
+        ltm.embedder = spec_ltm.embedder
+        changes.append(f"episodic_memory.long_term_memory.embedder={spec_ltm.embedder}")
+    if spec_ltm.reranker is not None:
+        ltm.reranker = spec_ltm.reranker
+        changes.append(f"episodic_memory.long_term_memory.reranker={spec_ltm.reranker}")
+    if spec_ltm.vector_graph_store is not None:
+        ltm.vector_graph_store = spec_ltm.vector_graph_store
+        changes.append(
+            f"episodic_memory.long_term_memory.vector_graph_store={spec_ltm.vector_graph_store}"
+        )
+    return changes
+
+
+def _apply_stm_updates(
+    em: EpisodicMemoryConfPartial,
+    spec_stm: UpdateShortTermMemorySpec,
+) -> list[str]:
+    """Apply short-term memory updates and return change descriptions."""
+    from memmachine.common.configuration.episodic_config import (
+        ShortTermMemoryConfPartial,
+    )
+
+    stm = em.short_term_memory
+    if stm is None:
+        stm = ShortTermMemoryConfPartial()
+        em.short_term_memory = stm
+
+    changes: list[str] = []
+    if spec_stm.llm_model is not None:
+        stm.llm_model = spec_stm.llm_model
+        changes.append(
+            f"episodic_memory.short_term_memory.llm_model={spec_stm.llm_model}"
+        )
+    if spec_stm.message_capacity is not None:
+        stm.message_capacity = spec_stm.message_capacity
+        changes.append(
+            f"episodic_memory.short_term_memory.message_capacity={spec_stm.message_capacity}"
+        )
+    return changes
+
+
+def _apply_episodic_memory_updates(
+    em: EpisodicMemoryConfPartial,
+    spec: UpdateEpisodicMemorySpec,
+) -> list[str]:
+    """Apply episodic memory updates and return list of change descriptions."""
+    changes: list[str] = []
+
+    if spec.long_term_memory is not None:
+        changes.extend(_apply_ltm_updates(em, spec.long_term_memory))
+    if spec.short_term_memory is not None:
+        changes.extend(_apply_stm_updates(em, spec.short_term_memory))
+
+    if spec.long_term_memory_enabled is not None:
+        em.long_term_memory_enabled = spec.long_term_memory_enabled
+        changes.append(
+            f"episodic_memory.long_term_memory_enabled={spec.long_term_memory_enabled}"
+        )
+    if spec.short_term_memory_enabled is not None:
+        em.short_term_memory_enabled = spec.short_term_memory_enabled
+        changes.append(
+            f"episodic_memory.short_term_memory_enabled={spec.short_term_memory_enabled}"
+        )
+    if spec.enabled is not None:
+        em.enabled = spec.enabled
+        changes.append(f"episodic_memory.enabled={spec.enabled}")
+
+    return changes
+
+
+def _apply_semantic_memory_updates(
+    sm: SemanticMemoryConf,
+    spec: UpdateSemanticMemorySpec,
+) -> list[str]:
+    """Apply semantic memory updates and return list of change descriptions."""
+    changes: list[str] = []
+
+    if spec.enabled is not None:
+        sm.enabled = spec.enabled
+        changes.append(f"semantic_memory.enabled={spec.enabled}")
+    if spec.database is not None:
+        sm.database = spec.database
+        changes.append(f"semantic_memory.database={spec.database}")
+    if spec.llm_model is not None:
+        sm.llm_model = spec.llm_model
+        changes.append(f"semantic_memory.llm_model={spec.llm_model}")
+    if spec.embedding_model is not None:
+        sm.embedding_model = spec.embedding_model
+        changes.append(f"semantic_memory.embedding_model={spec.embedding_model}")
+    if spec.ingestion_trigger_messages is not None:
+        sm.ingestion_trigger_messages = spec.ingestion_trigger_messages
+        changes.append(
+            f"semantic_memory.ingestion_trigger_messages={spec.ingestion_trigger_messages}"
+        )
+    if spec.ingestion_trigger_age_seconds is not None:
+        sm.ingestion_trigger_age = timedelta(seconds=spec.ingestion_trigger_age_seconds)
+        changes.append(
+            f"semantic_memory.ingestion_trigger_age={spec.ingestion_trigger_age_seconds}s"
+        )
+
+    return changes
+
+
+class ConfigService:
+    """Service for managing runtime configuration resources."""
+
+    def __init__(self, resource_manager: ResourceManagerImpl) -> None:
+        """Initialize the config service with a resource manager."""
+        self._resource_manager = resource_manager
+
+    def _persist_config(self) -> None:
+        """Persist configuration changes to file if a config file path is set."""
+        try:
+            if self._resource_manager.config.config_file_path:
+                self._resource_manager.save_config()
+        except Exception as e:
+            logger.warning("Failed to persist configuration to file: %s", e)
+
+    def get_resources_status(self) -> ResourcesStatus:
+        """Get the status of all configured resources."""
+        resource_manager = self._resource_manager
+        embedders: list[ResourceInfo] = []
+        language_models: list[ResourceInfo] = []
+        rerankers: list[ResourceInfo] = []
+        databases: list[ResourceInfo] = []
+
+        # Get embedder status
+        embedder_manager = resource_manager.embedder_manager
+        for name in embedder_manager.get_all_names():
+            status = embedder_manager.get_resource_status(name)
+            error = embedder_manager.get_resource_error(name)
+            provider = _get_embedder_provider(embedder_manager.conf, name)
+            embedders.append(
+                ResourceInfo(
+                    name=name,
+                    provider=provider,
+                    status=ResourceStatus(status.value),
+                    error=str(error) if error else None,
+                )
+            )
+
+        # Get language model status
+        lm_manager = resource_manager.language_model_manager
+        for name in lm_manager.get_all_names():
+            status = lm_manager.get_resource_status(name)
+            error = lm_manager.get_resource_error(name)
+            provider = _get_language_model_provider(lm_manager.conf, name)
+            language_models.append(
+                ResourceInfo(
+                    name=name,
+                    provider=provider,
+                    status=ResourceStatus(status.value),
+                    error=str(error) if error else None,
+                )
+            )
+
+        # Get reranker status
+        reranker_manager = resource_manager.reranker_manager
+        for name in reranker_manager.get_all_names():
+            status = reranker_manager.get_resource_status(name)
+            error = reranker_manager.get_resource_error(name)
+            provider = _get_reranker_provider(reranker_manager.conf, name)
+            rerankers.append(
+                ResourceInfo(
+                    name=name,
+                    provider=provider,
+                    status=ResourceStatus(status.value),
+                    error=str(error) if error else None,
+                )
+            )
+
+        # Get database status - databases are always ready if they exist
+        # (they fail hard at startup if unavailable)
+        db_manager = resource_manager.database_manager
+        databases.extend(
+            ResourceInfo(
+                name=name,
+                provider="neo4j",
+                status=ResourceStatus.READY,
+                error=None,
+            )
+            for name in db_manager.conf.neo4j_confs
+        )
+        databases.extend(
+            ResourceInfo(
+                name=name,
+                provider="sqlite" if conf.dialect == "sqlite" else "postgres",
+                status=ResourceStatus.READY,
+                error=None,
+            )
+            for name, conf in db_manager.conf.relational_db_confs.items()
+        )
+
+        return ResourcesStatus(
+            embedders=embedders,
+            language_models=language_models,
+            rerankers=rerankers,
+            databases=databases,
+        )
+
+    async def add_embedder(
+        self,
+        name: str,
+        provider: str,
+        config: dict[str, Any],
+    ) -> ResourceStatus:
+        """Add a new embedder configuration and build it."""
+        embedder_config = _create_embedder_config(provider, config)
+        self._resource_manager.embedder_manager.add_embedder_config(
+            name, provider, embedder_config
+        )
+
+        # Persist configuration to file
+        self._persist_config()
+
+        # Attempt to build it immediately
+        try:
+            await self._resource_manager.embedder_manager.get_embedder(name)
+        except Exception as e:
+            logger.warning("Failed to build new embedder '%s': %s", name, e)
+            return ResourceStatus.FAILED
+        else:
+            return ResourceStatus.READY
+
+    async def add_language_model(
+        self,
+        name: str,
+        provider: str,
+        config: dict[str, Any],
+    ) -> ResourceStatus:
+        """Add a new language model configuration and build it."""
+        lm_config = _create_language_model_config(provider, config)
+        self._resource_manager.language_model_manager.add_language_model_config(
+            name, provider, lm_config
+        )
+
+        # Persist configuration to file
+        self._persist_config()
+
+        # Attempt to build it immediately
+        try:
+            await self._resource_manager.language_model_manager.get_language_model(name)
+        except Exception as e:
+            logger.warning("Failed to build new language model '%s': %s", name, e)
+            return ResourceStatus.FAILED
+        else:
+            return ResourceStatus.READY
+
+    def remove_embedder(self, name: str) -> bool:
+        """Remove an embedder from the manager."""
+        removed = self._resource_manager.embedder_manager.remove_embedder(name)
+        if removed:
+            self._persist_config()
+        return removed
+
+    def remove_language_model(self, name: str) -> bool:
+        """Remove a language model from the manager."""
+        removed = self._resource_manager.language_model_manager.remove_language_model(
+            name
+        )
+        if removed:
+            self._persist_config()
+        return removed
+
+    async def retry_embedder(self, name: str) -> ResourceStatus:
+        """
+        Retry building a failed embedder.
+
+        Raises:
+            InvalidEmbedderError: If the embedder is not configured.
+
+        """
+        from memmachine.common.errors import InvalidEmbedderError
+
+        try:
+            await self._resource_manager.embedder_manager.retry_build(name)
+        except InvalidEmbedderError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to retry building embedder '%s': %s", name, e)
+            return ResourceStatus.FAILED
+        else:
+            return ResourceStatus.READY
+
+    async def retry_language_model(self, name: str) -> ResourceStatus:
+        """
+        Retry building a failed language model.
+
+        Raises:
+            InvalidLanguageModelError: If the language model is not configured.
+
+        """
+        from memmachine.common.errors import InvalidLanguageModelError
+
+        try:
+            await self._resource_manager.language_model_manager.retry_build(name)
+        except InvalidLanguageModelError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to retry building language model '%s': %s", name, e)
+            return ResourceStatus.FAILED
+        else:
+            return ResourceStatus.READY
+
+    async def retry_reranker(self, name: str) -> ResourceStatus:
+        """
+        Retry building a failed reranker.
+
+        Raises:
+            InvalidRerankerError: If the reranker is not configured.
+
+        """
+        from memmachine.common.errors import InvalidRerankerError
+
+        try:
+            await self._resource_manager.reranker_manager.retry_build(name)
+        except InvalidRerankerError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to retry building reranker '%s': %s", name, e)
+            return ResourceStatus.FAILED
+        else:
+            return ResourceStatus.READY
+
+    def update_memory_config(
+        self,
+        episodic_memory: UpdateEpisodicMemorySpec | None,
+        semantic_memory: UpdateSemanticMemorySpec | None,
+    ) -> str:
+        """
+        Update episodic and/or semantic memory configuration in-place.
+
+        Only supplied (non-None) fields are updated; the rest stay unchanged.
+        Returns a human-readable summary of what was changed.
+        """
+        config = self._resource_manager.config
+        changes: list[str] = []
+
+        if episodic_memory is not None:
+            changes.extend(
+                _apply_episodic_memory_updates(config.episodic_memory, episodic_memory)
+            )
+
+        if semantic_memory is not None:
+            changes.extend(
+                _apply_semantic_memory_updates(config.semantic_memory, semantic_memory)
+            )
+
+        if changes:
+            self._persist_config()
+            return "Updated: " + ", ".join(changes)
+        return "No changes applied."
+
+    def get_embedder_error(self, name: str) -> str | None:
+        """Get the error message for a failed embedder."""
+        error = self._resource_manager.embedder_manager.get_resource_error(name)
+        return str(error) if error else None
+
+    def get_language_model_error(self, name: str) -> str | None:
+        """Get the error message for a failed language model."""
+        error = self._resource_manager.language_model_manager.get_resource_error(name)
+        return str(error) if error else None
+
+    def get_reranker_error(self, name: str) -> str | None:
+        """Get the error message for a failed reranker."""
+        error = self._resource_manager.reranker_manager.get_resource_error(name)
+        return str(error) if error else None

--- a/src/memmachine/server/api_v2/exceptions.py
+++ b/src/memmachine/server/api_v2/exceptions.py
@@ -1,0 +1,108 @@
+"""REST API exception classes."""
+
+import logging
+import traceback
+
+from fastapi.exceptions import HTTPException, RequestValidationError
+
+from memmachine.common.api.spec import InvalidNameError, RestErrorModel
+from memmachine.common.errors import (
+    InvalidArgumentError,
+    ResourceNotReadyError,
+    SessionAlreadyExistsError,
+    SessionNotFoundError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RestError(HTTPException):
+    """
+    Exception with a structured RestErrorModel as the 'detail'.
+
+    Inherits from HTTPException, which dynamically resolves to:
+    - FastAPI's HTTPException in server environments (when FastAPI is available)
+    - A lightweight fallback Exception in client-only environments (when FastAPI is not installed)
+
+    This design allows RestError to work in both server and client contexts without
+    requiring FastAPI as a dependency for client packages. In server environments,
+    RestError behaves as a standard FastAPI HTTPException and can be raised in
+    FastAPI route handlers. In client environments, it provides the same interface
+    but without the FastAPI dependency overhead.
+    """
+
+    def __init__(
+        self,
+        code: int,
+        message: str,
+        ex: Exception | None = None,
+    ) -> None:
+        """Initialize RestError with structured error details."""
+        self.payload: RestErrorModel | None = None
+        if ex is not None:
+            if isinstance(ex, RequestValidationError):
+                trace = ""
+                message = self.format_validation_error_message(ex)
+            elif self.is_known_error(ex):
+                trace = ""
+            else:
+                trace = "".join(
+                    traceback.format_exception(
+                        type(ex),
+                        ex,
+                        ex.__traceback__,
+                    )
+                ).strip()
+
+            self.payload = RestErrorModel(
+                code=code,
+                message=message,
+                exception=type(ex).__name__,
+                internal_error=str(ex),
+                trace=trace,
+            )
+
+        # Call HTTPException with structured detail
+        if self.payload is not None:
+            logger.warning(
+                "exception handling request, code %d, message: %s, payload: %s",
+                code,
+                message,
+                self.payload,
+            )
+            super().__init__(status_code=code, detail=self.payload.model_dump())
+        else:
+            logger.info("error handling request, code %d, message: %s", code, message)
+            super().__init__(status_code=code, detail=message)
+
+    @staticmethod
+    def is_known_error(ex: Exception) -> bool:
+        known_errors = [
+            SessionAlreadyExistsError,
+            SessionNotFoundError,
+            InvalidNameError,
+            InvalidArgumentError,
+            ResourceNotReadyError,
+        ]
+        return any(isinstance(ex, err) for err in known_errors)
+
+    @staticmethod
+    def format_validation_error_message(exc: RequestValidationError) -> str:
+        parts: list[str] = []
+
+        for err in exc.errors():
+            loc = ".".join(str(p) for p in err.get("loc", []) if p != "body")
+            msg = err.get("msg", "Invalid value")
+
+            if loc:
+                parts.append(f"{loc}: {msg}")
+            else:
+                parts.append(msg)
+
+        if not parts:
+            return "Invalid request payload"
+
+        if len(parts) == 1:
+            return f"Invalid request payload: {parts[0]}"
+
+        return "Invalid request payload:\n- " + "\n- ".join(parts)

--- a/src/memmachine/server/api_v2/router.py
+++ b/src/memmachine/server/api_v2/router.py
@@ -1,11 +1,9 @@
 """API v2 router for MemMachine project and memory management endpoints."""
 
 import logging
-import traceback
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, FastAPI, Response
-from fastapi.exceptions import HTTPException, RequestValidationError
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from memmachine import MemMachine
@@ -19,12 +17,10 @@ from memmachine.common.api.spec import (
     DeleteSemanticMemorySpec,
     EpisodeCountResponse,
     GetProjectSpec,
-    InvalidNameError,
     ListMemoriesSpec,
     ListResult,
     ProjectConfig,
     ProjectResponse,
-    RestErrorModel,
     SearchMemoriesSpec,
     SearchResult,
 )
@@ -41,6 +37,8 @@ from memmachine.common.errors import (
     SessionNotFoundError,
 )
 from memmachine.main.memmachine import ALL_MEMORY_TYPES
+from memmachine.server.api_v2.config_router import config_router
+from memmachine.server.api_v2.exceptions import RestError
 from memmachine.server.api_v2.service import (
     _add_messages_to,
     _list_target_memories,
@@ -50,97 +48,6 @@ from memmachine.server.api_v2.service import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-class RestError(HTTPException):
-    """
-    Exception with a structured RestErrorModel as the 'detail'.
-
-    Inherits from HTTPException, which dynamically resolves to:
-    - FastAPI's HTTPException in server environments (when FastAPI is available)
-    - A lightweight fallback Exception in client-only environments (when FastAPI is not installed)
-
-    This design allows RestError to work in both server and client contexts without
-    requiring FastAPI as a dependency for client packages. In server environments,
-    RestError behaves as a standard FastAPI HTTPException and can be raised in
-    FastAPI route handlers. In client environments, it provides the same interface
-    but without the FastAPI dependency overhead.
-    """
-
-    def __init__(
-        self,
-        code: int,
-        message: str,
-        ex: Exception | None = None,
-    ) -> None:
-        """Initialize RestError with structured error details."""
-        self.payload: RestErrorModel | None = None
-        if ex is not None:
-            if isinstance(ex, RequestValidationError):
-                trace = ""
-                message = self.format_validation_error_message(ex)
-            elif self.is_known_error(ex):
-                trace = ""
-            else:
-                trace = "".join(
-                    traceback.format_exception(
-                        type(ex),
-                        ex,
-                        ex.__traceback__,
-                    )
-                ).strip()
-
-            self.payload = RestErrorModel(
-                code=code,
-                message=message,
-                exception=type(ex).__name__,
-                internal_error=str(ex),
-                trace=trace,
-            )
-
-        # Call HTTPException with structured detail
-        if self.payload is not None:
-            logger.warning(
-                "exception handling request, code %d, message: %s, payload: %s",
-                code,
-                message,
-                self.payload,
-            )
-            super().__init__(status_code=code, detail=self.payload.model_dump())
-        else:
-            logger.info("error handling request, code %d, message: %s", code, message)
-            super().__init__(status_code=code, detail=message)
-
-    @staticmethod
-    def is_known_error(ex: Exception) -> bool:
-        known_errors = [
-            SessionAlreadyExistsError,
-            SessionNotFoundError,
-            InvalidNameError,
-            InvalidArgumentError,
-        ]
-        return any(isinstance(ex, err) for err in known_errors)
-
-    @staticmethod
-    def format_validation_error_message(exc: RequestValidationError) -> str:
-        parts: list[str] = []
-
-        for err in exc.errors():
-            loc = ".".join(str(p) for p in err.get("loc", []) if p != "body")
-            msg = err.get("msg", "Invalid value")
-
-            if loc:
-                parts.append(f"{loc}: {msg}")
-            else:
-                parts.append(msg)
-
-        if not parts:
-            return "Invalid request payload"
-
-        if len(parts) == 1:
-            return f"Invalid request payload: {parts[0]}"
-
-        return "Invalid request payload:\n- " + "\n- ".join(parts)
 
 
 router = APIRouter()
@@ -395,7 +302,9 @@ async def health_check() -> dict[str, str]:
     }
 
 
-def load_v2_api_router(app: FastAPI) -> APIRouter:
+def load_v2_api_router(app: FastAPI, *, with_config_api: bool = False) -> APIRouter:
     """Load the API v2 router."""
     app.include_router(router, prefix="/api/v2")
+    if with_config_api:
+        app.include_router(config_router, prefix="/api/v2")
     return router

--- a/tests/memmachine/common/api/test_version.py
+++ b/tests/memmachine/common/api/test_version.py
@@ -13,8 +13,11 @@ def test_get_version():
     # 0.2.2.dev93+g2b5fd8250
     pattern = re.compile(
         r"""
-        ^\d+\.\d+\.\d+           # major.minor.patch
-        (?:\.dev\d+(?:\+[a-z0-9]+)?)?   # optional .devN[+local]
+        ^\d+\.\d+\.\d+                  # major.minor.patch
+        (?:                             # optional dev release
+            \.dev\d+                    # .devN
+            (?:\+[a-z0-9]+(?:\.[a-z0-9]+)*)?  # +local(.local)*
+        )?
         $
         """,
         re.VERBOSE,

--- a/tests/memmachine/rest_client/test_config.py
+++ b/tests/memmachine/rest_client/test_config.py
@@ -1,0 +1,274 @@
+"""Unit tests for Config class."""
+
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from memmachine.common.api.config_spec import (
+    DeleteResourceResponse,
+    GetConfigResponse,
+    ResourcesStatus,
+    UpdateEpisodicMemorySpec,
+    UpdateMemoryConfigResponse,
+    UpdateResourceResponse,
+    UpdateSemanticMemorySpec,
+)
+from memmachine.rest_client.config import Config
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock MemMachineClient."""
+    client = Mock()
+    client.closed = False
+    client.base_url = "http://localhost:8080"
+    return client
+
+
+@pytest.fixture
+def config(mock_client):
+    """Create a Config instance with a mock client."""
+    return Config(client=mock_client)
+
+
+def _mock_response(json_data: dict) -> Mock:
+    """Create a mock response with the given JSON data."""
+    resp = Mock(spec=requests.Response)
+    resp.json.return_value = json_data
+    resp.raise_for_status = Mock()
+    return resp
+
+
+class TestConfig:
+    """Test cases for the Config class."""
+
+    def test_get_config(self, config, mock_client):
+        mock_client.request.return_value = _mock_response(
+            {
+                "resources": {
+                    "embedders": [],
+                    "language_models": [],
+                    "rerankers": [],
+                    "databases": [],
+                }
+            }
+        )
+        result = config.get_config()
+        assert isinstance(result, GetConfigResponse)
+        mock_client.request.assert_called_once_with(
+            "GET",
+            "http://localhost:8080/api/v2/config",
+            timeout=None,
+        )
+
+    def test_get_config_closed_client(self, config, mock_client):
+        mock_client.closed = True
+        with pytest.raises(RuntimeError, match="client has been closed"):
+            config.get_config()
+
+    def test_get_resources(self, config, mock_client):
+        mock_client.request.return_value = _mock_response(
+            {
+                "embedders": [
+                    {"name": "default", "provider": "openai", "status": "ready"}
+                ],
+                "language_models": [],
+                "rerankers": [],
+                "databases": [],
+            }
+        )
+        result = config.get_resources()
+        assert isinstance(result, ResourcesStatus)
+        assert len(result.embedders) == 1
+        assert result.embedders[0].name == "default"
+        mock_client.request.assert_called_once_with(
+            "GET",
+            "http://localhost:8080/api/v2/config/resources",
+            timeout=None,
+        )
+
+    def test_get_resources_closed_client(self, config, mock_client):
+        mock_client.closed = True
+        with pytest.raises(RuntimeError, match="client has been closed"):
+            config.get_resources()
+
+    def test_update_memory_config(self, config, mock_client):
+        mock_client.request.return_value = _mock_response(
+            {"success": True, "message": "Memory configuration updated"}
+        )
+        result = config.update_memory_config(
+            episodic_memory=UpdateEpisodicMemorySpec(enabled=False),
+            semantic_memory=UpdateSemanticMemorySpec(enabled=True),
+        )
+        assert isinstance(result, UpdateMemoryConfigResponse)
+        assert result.success is True
+        call_args = mock_client.request.call_args
+        assert call_args[0] == ("PUT", "http://localhost:8080/api/v2/config/memory")
+        assert "episodic_memory" in call_args[1]["json"]
+
+    def test_update_memory_config_closed_client(self, config, mock_client):
+        mock_client.closed = True
+        with pytest.raises(RuntimeError, match="client has been closed"):
+            config.update_memory_config()
+
+    def test_add_embedder(self, config, mock_client):
+        mock_client.request.return_value = _mock_response(
+            {"success": True, "status": "ready", "error": None}
+        )
+        result = config.add_embedder(
+            name="my-embedder",
+            provider="openai",
+            config={"api_key": "sk-test", "model": "text-embedding-3-small"},
+        )
+        assert isinstance(result, UpdateResourceResponse)
+        assert result.success is True
+        call_args = mock_client.request.call_args
+        assert call_args[0] == (
+            "POST",
+            "http://localhost:8080/api/v2/config/resources/embedders",
+        )
+        body = call_args[1]["json"]
+        assert body["name"] == "my-embedder"
+        assert body["provider"] == "openai"
+
+    def test_add_embedder_closed_client(self, config, mock_client):
+        mock_client.closed = True
+        with pytest.raises(RuntimeError, match="client has been closed"):
+            config.add_embedder(name="x", provider="openai", config={})
+
+    def test_add_language_model(self, config, mock_client):
+        mock_client.request.return_value = _mock_response(
+            {"success": True, "status": "ready", "error": None}
+        )
+        result = config.add_language_model(
+            name="my-llm",
+            provider="openai-responses",
+            config={"api_key": "sk-test"},
+        )
+        assert isinstance(result, UpdateResourceResponse)
+        assert result.success is True
+        call_args = mock_client.request.call_args
+        assert call_args[0] == (
+            "POST",
+            "http://localhost:8080/api/v2/config/resources/language_models",
+        )
+
+    def test_add_language_model_closed_client(self, config, mock_client):
+        mock_client.closed = True
+        with pytest.raises(RuntimeError, match="client has been closed"):
+            config.add_language_model(name="x", provider="openai-responses", config={})
+
+    def test_delete_embedder(self, config, mock_client):
+        mock_client.request.return_value = _mock_response(
+            {"success": True, "message": "Embedder deleted"}
+        )
+        result = config.delete_embedder(name="my-embedder")
+        assert isinstance(result, DeleteResourceResponse)
+        assert result.success is True
+        mock_client.request.assert_called_once_with(
+            "DELETE",
+            "http://localhost:8080/api/v2/config/resources/embedders/my-embedder",
+            timeout=None,
+        )
+
+    def test_delete_embedder_closed_client(self, config, mock_client):
+        mock_client.closed = True
+        with pytest.raises(RuntimeError, match="client has been closed"):
+            config.delete_embedder(name="x")
+
+    def test_delete_language_model(self, config, mock_client):
+        mock_client.request.return_value = _mock_response(
+            {"success": True, "message": "Language model deleted"}
+        )
+        result = config.delete_language_model(name="my-llm")
+        assert isinstance(result, DeleteResourceResponse)
+        assert result.success is True
+        mock_client.request.assert_called_once_with(
+            "DELETE",
+            "http://localhost:8080/api/v2/config/resources/language_models/my-llm",
+            timeout=None,
+        )
+
+    def test_delete_language_model_closed_client(self, config, mock_client):
+        mock_client.closed = True
+        with pytest.raises(RuntimeError, match="client has been closed"):
+            config.delete_language_model(name="x")
+
+    def test_retry_embedder(self, config, mock_client):
+        mock_client.request.return_value = _mock_response(
+            {"success": True, "status": "ready", "error": None}
+        )
+        result = config.retry_embedder(name="my-embedder")
+        assert isinstance(result, UpdateResourceResponse)
+        mock_client.request.assert_called_once_with(
+            "POST",
+            "http://localhost:8080/api/v2/config/resources/embedders/my-embedder/retry",
+            timeout=None,
+        )
+
+    def test_retry_embedder_closed_client(self, config, mock_client):
+        mock_client.closed = True
+        with pytest.raises(RuntimeError, match="client has been closed"):
+            config.retry_embedder(name="x")
+
+    def test_retry_language_model(self, config, mock_client):
+        mock_client.request.return_value = _mock_response(
+            {"success": True, "status": "ready", "error": None}
+        )
+        result = config.retry_language_model(name="my-llm")
+        assert isinstance(result, UpdateResourceResponse)
+        mock_client.request.assert_called_once_with(
+            "POST",
+            "http://localhost:8080/api/v2/config/resources/language_models/my-llm/retry",
+            timeout=None,
+        )
+
+    def test_retry_language_model_closed_client(self, config, mock_client):
+        mock_client.closed = True
+        with pytest.raises(RuntimeError, match="client has been closed"):
+            config.retry_language_model(name="x")
+
+    def test_retry_reranker(self, config, mock_client):
+        mock_client.request.return_value = _mock_response(
+            {"success": True, "status": "ready", "error": None}
+        )
+        result = config.retry_reranker(name="my-reranker")
+        assert isinstance(result, UpdateResourceResponse)
+        mock_client.request.assert_called_once_with(
+            "POST",
+            "http://localhost:8080/api/v2/config/resources/rerankers/my-reranker/retry",
+            timeout=None,
+        )
+
+    def test_retry_reranker_closed_client(self, config, mock_client):
+        mock_client.closed = True
+        with pytest.raises(RuntimeError, match="client has been closed"):
+            config.retry_reranker(name="x")
+
+    def test_get_config_with_timeout(self, config, mock_client):
+        mock_client.request.return_value = _mock_response(
+            {
+                "resources": {
+                    "embedders": [],
+                    "language_models": [],
+                    "rerankers": [],
+                    "databases": [],
+                }
+            }
+        )
+        config.get_config(timeout=60)
+        mock_client.request.assert_called_once_with(
+            "GET",
+            "http://localhost:8080/api/v2/config",
+            timeout=60,
+        )
+
+    def test_request_exception_propagated(self, config, mock_client):
+        mock_client.request.side_effect = requests.ConnectionError("Connection refused")
+        with pytest.raises(requests.ConnectionError):
+            config.get_config()
+
+    def test_repr(self, config):
+        result = repr(config)
+        assert "Config" in result

--- a/tests/memmachine/server/api_v2/test_config_router.py
+++ b/tests/memmachine/server/api_v2/test_config_router.py
@@ -1,0 +1,565 @@
+"""Tests for the configuration API router."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memmachine.common.api.config_spec import ResourceStatus
+from memmachine.common.configuration import SemanticMemoryConf
+from memmachine.common.configuration.episodic_config import (
+    EpisodicMemoryConfPartial,
+    LongTermMemoryConfPartial,
+    ShortTermMemoryConfPartial,
+)
+from memmachine.common.errors import (
+    InvalidEmbedderError,
+    InvalidLanguageModelError,
+    InvalidRerankerError,
+)
+from memmachine.server.api_v2.config_router import get_config_service
+from memmachine.server.api_v2.config_service import ConfigService
+from memmachine.server.app import MemMachineAPI
+
+
+@pytest.fixture
+def mock_resource_manager():
+    """Create a mock resource manager with mock managers."""
+    resource_manager = MagicMock()
+
+    # Mock embedder manager
+    embedder_manager = MagicMock()
+    embedder_manager.get_all_names.return_value = {"openai-embedder"}
+    embedder_manager.get_resource_status.return_value = ResourceStatus.READY
+    embedder_manager.get_resource_error.return_value = None
+    embedder_manager.conf.openai = {"openai-embedder": MagicMock()}
+    embedder_manager.conf.amazon_bedrock = {}
+    embedder_manager.conf.sentence_transformer = {}
+    resource_manager.embedder_manager = embedder_manager
+
+    # Mock language model manager
+    lm_manager = MagicMock()
+    lm_manager.get_all_names.return_value = {"gpt-4"}
+    lm_manager.get_resource_status.return_value = ResourceStatus.READY
+    lm_manager.get_resource_error.return_value = None
+    lm_manager.conf.openai_responses_language_model_confs = {"gpt-4": MagicMock()}
+    lm_manager.conf.openai_chat_completions_language_model_confs = {}
+    lm_manager.conf.amazon_bedrock_language_model_confs = {}
+    resource_manager.language_model_manager = lm_manager
+
+    # Mock reranker manager
+    reranker_manager = MagicMock()
+    reranker_manager.get_all_names.return_value = {"bm25-reranker"}
+    reranker_manager.get_resource_status.return_value = ResourceStatus.READY
+    reranker_manager.get_resource_error.return_value = None
+    reranker_manager.conf.bm25 = {"bm25-reranker": MagicMock()}
+    reranker_manager.conf.cohere = {}
+    reranker_manager.conf.cross_encoder = {}
+    reranker_manager.conf.amazon_bedrock = {}
+    reranker_manager.conf.embedder = {}
+    reranker_manager.conf.identity = {}
+    reranker_manager.conf.rrf_hybrid = {}
+    resource_manager.reranker_manager = reranker_manager
+
+    # Mock database manager
+    db_manager = MagicMock()
+    db_manager.conf.neo4j_confs = {}
+    db_manager.conf.relational_db_confs = {"sqlite-db": MagicMock(dialect="sqlite")}
+    resource_manager.database_manager = db_manager
+
+    # Mock config for persistence
+    mock_config = MagicMock()
+    mock_config.config_file_path = "/tmp/test_config.yml"
+
+    # Use real memory config objects for update_memory_config tests
+    mock_config.episodic_memory = EpisodicMemoryConfPartial(
+        long_term_memory=LongTermMemoryConfPartial(
+            embedder="old-embedder",
+            reranker="old-reranker",
+            vector_graph_store="old-store",
+        ),
+        short_term_memory=ShortTermMemoryConfPartial(
+            llm_model="old-model",
+            message_capacity=500,
+        ),
+        enabled=True,
+    )
+    mock_config.semantic_memory = SemanticMemoryConf(
+        database="old-db",
+        llm_model="old-llm",
+        embedding_model="old-embedder",
+    )
+
+    resource_manager.config = mock_config
+    resource_manager.save_config = MagicMock()
+
+    return resource_manager
+
+
+@pytest.fixture
+def mock_memmachine(mock_resource_manager):
+    """Create a mock memmachine with a resource manager."""
+    memmachine = MagicMock()
+    memmachine.resource_manager = mock_resource_manager
+    return memmachine
+
+
+@pytest.fixture
+def client(mock_memmachine, mock_resource_manager):
+    """Create a test client with mocked dependencies."""
+    app = MemMachineAPI(with_config_api=True)
+    app.dependency_overrides[get_config_service] = lambda: ConfigService(
+        mock_resource_manager
+    )
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides = {}
+
+
+def test_get_config(client, mock_resource_manager):
+    """Test GET /api/v2/config returns resource status."""
+    response = client.get("/api/v2/config")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "resources" in data
+
+    resources = data["resources"]
+    assert len(resources["embedders"]) == 1
+    assert resources["embedders"][0]["name"] == "openai-embedder"
+    assert resources["embedders"][0]["status"] == "ready"
+
+    assert len(resources["language_models"]) == 1
+    assert resources["language_models"][0]["name"] == "gpt-4"
+    assert resources["language_models"][0]["status"] == "ready"
+
+    assert len(resources["rerankers"]) == 1
+    assert resources["rerankers"][0]["name"] == "bm25-reranker"
+    assert resources["rerankers"][0]["status"] == "ready"
+
+    assert len(resources["databases"]) == 1
+    assert resources["databases"][0]["name"] == "sqlite-db"
+    assert resources["databases"][0]["provider"] == "sqlite"
+
+
+def test_get_resources(client, mock_resource_manager):
+    """Test GET /api/v2/config/resources returns resource status."""
+    response = client.get("/api/v2/config/resources")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "embedders" in data
+    assert "language_models" in data
+    assert "rerankers" in data
+    assert "databases" in data
+
+
+def test_get_config_with_failed_resource(client, mock_resource_manager):
+    """Test that failed resources show error messages."""
+    mock_resource_manager.embedder_manager.get_resource_status.return_value = (
+        ResourceStatus.FAILED
+    )
+    mock_resource_manager.embedder_manager.get_resource_error.return_value = Exception(
+        "API key invalid"
+    )
+
+    response = client.get("/api/v2/config")
+    assert response.status_code == 200
+
+    data = response.json()
+    embedder = data["resources"]["embedders"][0]
+    assert embedder["status"] == "failed"
+    assert "API key invalid" in embedder["error"]
+
+
+def test_add_embedder_success(client, mock_resource_manager):
+    """Test POST /api/v2/config/resources/embedders creates a new embedder."""
+    mock_resource_manager.embedder_manager.add_embedder_config = MagicMock()
+    mock_resource_manager.embedder_manager.get_embedder = AsyncMock()
+
+    payload = {
+        "name": "new-embedder",
+        "provider": "openai",
+        "config": {
+            "api_key": "test-key",
+            "model": "text-embedding-3-small",
+        },
+    }
+
+    response = client.post("/api/v2/config/resources/embedders", json=payload)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["success"] is True
+    assert data["status"] == "ready"
+
+
+def test_add_embedder_failure(client, mock_resource_manager):
+    """Test that embedder addition returns failure status when build fails."""
+    mock_resource_manager.embedder_manager.add_embedder_config = MagicMock()
+    mock_resource_manager.embedder_manager.get_embedder = AsyncMock(
+        side_effect=Exception("Connection refused")
+    )
+    mock_resource_manager.embedder_manager.get_resource_error.return_value = Exception(
+        "Connection refused"
+    )
+
+    payload = {
+        "name": "new-embedder",
+        "provider": "openai",
+        "config": {
+            "api_key": "test-key",
+        },
+    }
+
+    response = client.post("/api/v2/config/resources/embedders", json=payload)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["success"] is False
+    assert data["status"] == "failed"
+    assert "Connection refused" in data["error"]
+
+
+def test_add_language_model_success(client, mock_resource_manager):
+    """Test POST /api/v2/config/resources/language_models creates a new model."""
+    mock_resource_manager.language_model_manager.add_language_model_config = MagicMock()
+    mock_resource_manager.language_model_manager.get_language_model = AsyncMock()
+
+    payload = {
+        "name": "new-model",
+        "provider": "openai-responses",
+        "config": {
+            "api_key": "test-key",
+            "model": "gpt-4",
+        },
+    }
+
+    response = client.post("/api/v2/config/resources/language_models", json=payload)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["success"] is True
+    assert data["status"] == "ready"
+
+
+def test_delete_embedder_success(client, mock_resource_manager):
+    """Test DELETE /api/v2/config/resources/embedders/{name} removes an embedder."""
+    mock_resource_manager.embedder_manager.remove_embedder = MagicMock(
+        return_value=True
+    )
+
+    response = client.delete("/api/v2/config/resources/embedders/openai-embedder")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["success"] is True
+    assert "removed successfully" in data["message"]
+
+
+def test_delete_embedder_not_found(client, mock_resource_manager):
+    """Test DELETE returns 404 when embedder doesn't exist."""
+    mock_resource_manager.embedder_manager.remove_embedder = MagicMock(
+        return_value=False
+    )
+
+    response = client.delete("/api/v2/config/resources/embedders/nonexistent")
+    assert response.status_code == 404
+
+
+def test_delete_language_model_success(client, mock_resource_manager):
+    """Test DELETE /api/v2/config/resources/language_models/{name} removes a model."""
+    mock_resource_manager.language_model_manager.remove_language_model = MagicMock(
+        return_value=True
+    )
+
+    response = client.delete("/api/v2/config/resources/language_models/gpt-4")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["success"] is True
+
+
+def test_retry_embedder_success(client, mock_resource_manager):
+    """Test POST /api/v2/config/resources/embedders/{name}/retry retries build."""
+    mock_resource_manager.embedder_manager.retry_build = AsyncMock()
+
+    response = client.post("/api/v2/config/resources/embedders/openai-embedder/retry")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["success"] is True
+    assert data["status"] == "ready"
+
+
+def test_retry_embedder_not_found(client, mock_resource_manager):
+    """Test retry returns 404 when embedder doesn't exist."""
+    mock_resource_manager.embedder_manager.retry_build = AsyncMock(
+        side_effect=InvalidEmbedderError("nonexistent")
+    )
+
+    response = client.post("/api/v2/config/resources/embedders/nonexistent/retry")
+    assert response.status_code == 404
+
+
+def test_retry_language_model_success(client, mock_resource_manager):
+    """Test POST /api/v2/config/resources/language_models/{name}/retry retries build."""
+    mock_resource_manager.language_model_manager.retry_build = AsyncMock()
+
+    response = client.post("/api/v2/config/resources/language_models/gpt-4/retry")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["success"] is True
+
+
+def test_retry_language_model_not_found(client, mock_resource_manager):
+    """Test retry returns 404 when model doesn't exist."""
+    mock_resource_manager.language_model_manager.retry_build = AsyncMock(
+        side_effect=InvalidLanguageModelError(
+            "Language model with name nonexistent not found."
+        )
+    )
+
+    response = client.post("/api/v2/config/resources/language_models/nonexistent/retry")
+    assert response.status_code == 404
+
+
+def test_retry_reranker_success(client, mock_resource_manager):
+    """Test POST /api/v2/config/resources/rerankers/{name}/retry retries build."""
+    mock_resource_manager.reranker_manager.retry_build = AsyncMock()
+
+    response = client.post("/api/v2/config/resources/rerankers/bm25-reranker/retry")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["success"] is True
+
+
+def test_retry_reranker_not_found(client, mock_resource_manager):
+    """Test retry returns 404 when reranker doesn't exist."""
+    mock_resource_manager.reranker_manager.retry_build = AsyncMock(
+        side_effect=InvalidRerankerError("nonexistent")
+    )
+
+    response = client.post("/api/v2/config/resources/rerankers/nonexistent/retry")
+    assert response.status_code == 404
+
+
+def test_retry_reranker_failure(client, mock_resource_manager):
+    """Test retry returns failure status when build fails again."""
+    mock_resource_manager.reranker_manager.retry_build = AsyncMock(
+        side_effect=Exception("Still failing")
+    )
+    mock_resource_manager.reranker_manager.get_resource_error.return_value = Exception(
+        "Still failing"
+    )
+
+    response = client.post("/api/v2/config/resources/rerankers/bm25-reranker/retry")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["success"] is False
+    assert data["status"] == "failed"
+
+
+def test_add_embedder_persists_config(client, mock_resource_manager):
+    """Test that adding an embedder persists the configuration to file."""
+    mock_resource_manager.embedder_manager.add_embedder_config = MagicMock()
+    mock_resource_manager.embedder_manager.get_embedder = AsyncMock()
+
+    payload = {
+        "name": "new-embedder",
+        "provider": "openai",
+        "config": {
+            "api_key": "test-key",
+            "model": "text-embedding-3-small",
+        },
+    }
+
+    response = client.post("/api/v2/config/resources/embedders", json=payload)
+    assert response.status_code == 201
+
+    # Verify save_config was called
+    mock_resource_manager.save_config.assert_called_once()
+
+
+def test_add_language_model_persists_config(client, mock_resource_manager):
+    """Test that adding a language model persists the configuration to file."""
+    mock_resource_manager.language_model_manager.add_language_model_config = MagicMock()
+    mock_resource_manager.language_model_manager.get_language_model = AsyncMock()
+
+    payload = {
+        "name": "new-model",
+        "provider": "openai-responses",
+        "config": {
+            "api_key": "test-key",
+            "model": "gpt-4",
+        },
+    }
+
+    response = client.post("/api/v2/config/resources/language_models", json=payload)
+    assert response.status_code == 201
+
+    # Verify save_config was called
+    mock_resource_manager.save_config.assert_called_once()
+
+
+def test_delete_embedder_persists_config(client, mock_resource_manager):
+    """Test that deleting an embedder persists the configuration to file."""
+    mock_resource_manager.embedder_manager.remove_embedder = MagicMock(
+        return_value=True
+    )
+
+    response = client.delete("/api/v2/config/resources/embedders/openai-embedder")
+    assert response.status_code == 200
+
+    # Verify save_config was called
+    mock_resource_manager.save_config.assert_called_once()
+
+
+def test_delete_language_model_persists_config(client, mock_resource_manager):
+    """Test that deleting a language model persists the configuration to file."""
+    mock_resource_manager.language_model_manager.remove_language_model = MagicMock(
+        return_value=True
+    )
+
+    response = client.delete("/api/v2/config/resources/language_models/gpt-4")
+    assert response.status_code == 200
+
+    # Verify save_config was called
+    mock_resource_manager.save_config.assert_called_once()
+
+
+# --- Memory Configuration Update Tests ---
+
+
+def test_update_memory_episodic_ltm(client, mock_resource_manager):
+    """Test PUT /api/v2/config/memory updates episodic LTM config."""
+    payload = {
+        "episodic_memory": {
+            "long_term_memory": {
+                "embedder": "new-embedder",
+                "reranker": "new-reranker",
+            }
+        }
+    }
+
+    response = client.put("/api/v2/config/memory", json=payload)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["success"] is True
+    assert "embedder=new-embedder" in data["message"]
+    assert "reranker=new-reranker" in data["message"]
+
+    # Verify config was persisted
+    mock_resource_manager.save_config.assert_called_once()
+
+
+def test_update_memory_episodic_stm(client, mock_resource_manager):
+    """Test PUT /api/v2/config/memory updates episodic STM config."""
+    payload = {
+        "episodic_memory": {
+            "short_term_memory": {
+                "llm_model": "new-stm-model",
+                "message_capacity": 1000,
+            }
+        }
+    }
+
+    response = client.put("/api/v2/config/memory", json=payload)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["success"] is True
+    assert "llm_model=new-stm-model" in data["message"]
+    assert "message_capacity=1000" in data["message"]
+
+
+def test_update_memory_semantic(client, mock_resource_manager):
+    """Test PUT /api/v2/config/memory updates semantic memory config."""
+    payload = {
+        "semantic_memory": {
+            "database": "new-db",
+            "llm_model": "new-llm",
+            "embedding_model": "new-embedder",
+        }
+    }
+
+    response = client.put("/api/v2/config/memory", json=payload)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["success"] is True
+    assert "database=new-db" in data["message"]
+    assert "llm_model=new-llm" in data["message"]
+    assert "embedding_model=new-embedder" in data["message"]
+
+    mock_resource_manager.save_config.assert_called_once()
+
+
+def test_update_memory_both_sections(client, mock_resource_manager):
+    """Test PUT /api/v2/config/memory updates both episodic and semantic."""
+    payload = {
+        "episodic_memory": {
+            "long_term_memory": {"embedder": "new-embedder"},
+        },
+        "semantic_memory": {
+            "llm_model": "new-llm",
+        },
+    }
+
+    response = client.put("/api/v2/config/memory", json=payload)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["success"] is True
+    assert "embedder=new-embedder" in data["message"]
+    assert "llm_model=new-llm" in data["message"]
+
+
+def test_update_memory_empty_body_returns_400(client):
+    """Test PUT /api/v2/config/memory returns 400 when both sections are null."""
+    payload = {}
+
+    response = client.put("/api/v2/config/memory", json=payload)
+    assert response.status_code == 400
+
+
+def test_update_memory_episodic_enabled_flags(client, mock_resource_manager):
+    """Test PUT /api/v2/config/memory can toggle enabled flags."""
+    payload = {
+        "episodic_memory": {
+            "long_term_memory_enabled": False,
+            "enabled": False,
+        }
+    }
+
+    response = client.put("/api/v2/config/memory", json=payload)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["success"] is True
+    assert "long_term_memory_enabled=False" in data["message"]
+    assert "enabled=False" in data["message"]
+
+
+def test_update_memory_semantic_ingestion(client, mock_resource_manager):
+    """Test PUT /api/v2/config/memory can update ingestion settings."""
+    payload = {
+        "semantic_memory": {
+            "ingestion_trigger_messages": 10,
+            "ingestion_trigger_age_seconds": 600,
+        }
+    }
+
+    response = client.put("/api/v2/config/memory", json=payload)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["success"] is True
+    assert "ingestion_trigger_messages=10" in data["message"]
+    assert "ingestion_trigger_age=600s" in data["message"]

--- a/tests/memmachine/server/api_v2/test_config_service.py
+++ b/tests/memmachine/server/api_v2/test_config_service.py
@@ -1,0 +1,381 @@
+"""Tests for the configuration service."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from memmachine.common.api.config_spec import (
+    ResourceStatus,
+    UpdateEpisodicMemorySpec,
+    UpdateLongTermMemorySpec,
+    UpdateSemanticMemorySpec,
+    UpdateShortTermMemorySpec,
+)
+from memmachine.common.configuration.episodic_config import (
+    EpisodicMemoryConfPartial,
+    LongTermMemoryConfPartial,
+    ShortTermMemoryConfPartial,
+)
+from memmachine.server.api_v2.config_service import ConfigService
+
+
+@pytest.fixture
+def mock_resource_manager():
+    """Create a mock resource manager."""
+    resource_manager = MagicMock()
+
+    # Mock config with file path set
+    mock_config = MagicMock()
+    mock_config.config_file_path = "/tmp/test_config.yml"
+    resource_manager.config = mock_config
+    resource_manager.save_config = MagicMock()
+
+    # Mock embedder manager
+    embedder_manager = MagicMock()
+    embedder_manager.add_embedder_config = MagicMock()
+    embedder_manager.remove_embedder = MagicMock(return_value=True)
+    resource_manager.embedder_manager = embedder_manager
+
+    # Mock language model manager
+    lm_manager = MagicMock()
+    lm_manager.add_language_model_config = MagicMock()
+    lm_manager.remove_language_model = MagicMock(return_value=True)
+    resource_manager.language_model_manager = lm_manager
+
+    return resource_manager
+
+
+@pytest.fixture
+def mock_resource_manager_no_file():
+    """Create a mock resource manager with no config file path."""
+    resource_manager = MagicMock()
+
+    # Mock config without file path
+    mock_config = MagicMock()
+    mock_config.config_file_path = None
+    resource_manager.config = mock_config
+    resource_manager.save_config = MagicMock()
+
+    # Mock embedder manager
+    embedder_manager = MagicMock()
+    embedder_manager.add_embedder_config = MagicMock()
+    embedder_manager.remove_embedder = MagicMock(return_value=True)
+    resource_manager.embedder_manager = embedder_manager
+
+    # Mock language model manager
+    lm_manager = MagicMock()
+    lm_manager.add_language_model_config = MagicMock()
+    lm_manager.remove_language_model = MagicMock(return_value=True)
+    resource_manager.language_model_manager = lm_manager
+
+    return resource_manager
+
+
+def test_persist_config_saves_when_file_path_set(mock_resource_manager):
+    """Test that _persist_config calls save_config when file path is set."""
+    service = ConfigService(mock_resource_manager)
+    service._persist_config()
+    mock_resource_manager.save_config.assert_called_once()
+
+
+def test_persist_config_skips_when_no_file_path(mock_resource_manager_no_file):
+    """Test that _persist_config does not save when no file path is set."""
+    service = ConfigService(mock_resource_manager_no_file)
+    service._persist_config()
+    mock_resource_manager_no_file.save_config.assert_not_called()
+
+
+def test_persist_config_handles_save_error(mock_resource_manager):
+    """Test that _persist_config handles save errors gracefully."""
+    mock_resource_manager.save_config.side_effect = Exception("Write error")
+
+    service = ConfigService(mock_resource_manager)
+    # Should not raise, just log warning
+    service._persist_config()
+    mock_resource_manager.save_config.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_add_embedder_persists_config(mock_resource_manager):
+    """Test that add_embedder persists configuration."""
+    # Mock successful embedder creation (get_embedder is async)
+    mock_resource_manager.embedder_manager.get_embedder = AsyncMock(return_value=None)
+
+    service = ConfigService(mock_resource_manager)
+    config = {"api_key": "test-key", "model": "text-embedding-3-small"}
+    status = await service.add_embedder("test-embedder", "openai", config)
+
+    assert status == ResourceStatus.READY
+    mock_resource_manager.save_config.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_add_embedder_persists_even_on_build_failure(mock_resource_manager):
+    """Test that add_embedder persists configuration even when build fails."""
+    # Mock failed embedder creation (get_embedder is async)
+    mock_resource_manager.embedder_manager.get_embedder = AsyncMock(
+        side_effect=Exception("Build failed")
+    )
+
+    service = ConfigService(mock_resource_manager)
+    config = {"api_key": "test-key", "model": "text-embedding-3-small"}
+    status = await service.add_embedder("test-embedder", "openai", config)
+
+    assert status == ResourceStatus.FAILED
+    # Config should still be persisted (configuration is added before build attempt)
+    mock_resource_manager.save_config.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_add_language_model_persists_config(mock_resource_manager):
+    """Test that add_language_model persists configuration."""
+    # Mock successful model creation (get_language_model is async)
+    mock_resource_manager.language_model_manager.get_language_model = AsyncMock(
+        return_value=None
+    )
+
+    service = ConfigService(mock_resource_manager)
+    config = {"api_key": "test-key", "model": "gpt-4"}
+    status = await service.add_language_model("test-model", "openai-responses", config)
+
+    assert status == ResourceStatus.READY
+    mock_resource_manager.save_config.assert_called_once()
+
+
+def test_remove_embedder_persists_config(mock_resource_manager):
+    """Test that remove_embedder persists configuration when removal succeeds."""
+    service = ConfigService(mock_resource_manager)
+    removed = service.remove_embedder("test-embedder")
+
+    assert removed is True
+    mock_resource_manager.save_config.assert_called_once()
+
+
+def test_remove_embedder_does_not_persist_when_not_found(mock_resource_manager):
+    """Test that remove_embedder does not persist when embedder not found."""
+    mock_resource_manager.embedder_manager.remove_embedder.return_value = False
+
+    service = ConfigService(mock_resource_manager)
+    removed = service.remove_embedder("nonexistent")
+
+    assert removed is False
+    mock_resource_manager.save_config.assert_not_called()
+
+
+def test_remove_language_model_persists_config(mock_resource_manager):
+    """Test that remove_language_model persists configuration when removal succeeds."""
+    service = ConfigService(mock_resource_manager)
+    removed = service.remove_language_model("test-model")
+
+    assert removed is True
+    mock_resource_manager.save_config.assert_called_once()
+
+
+def test_remove_language_model_does_not_persist_when_not_found(mock_resource_manager):
+    """Test that remove_language_model does not persist when model not found."""
+    mock_resource_manager.language_model_manager.remove_language_model.return_value = (
+        False
+    )
+
+    service = ConfigService(mock_resource_manager)
+    removed = service.remove_language_model("nonexistent")
+
+    assert removed is False
+    mock_resource_manager.save_config.assert_not_called()
+
+
+# --- update_memory_config tests ---
+
+
+@pytest.fixture
+def memory_resource_manager():
+    """Create a resource manager with real config objects for memory tests."""
+    resource_manager = MagicMock()
+    resource_manager.config.config_file_path = "/tmp/test_config.yml"
+    resource_manager.save_config = MagicMock()
+
+    # Use real config objects so field assignment works
+    resource_manager.config.episodic_memory = EpisodicMemoryConfPartial(
+        long_term_memory=LongTermMemoryConfPartial(
+            embedder="old-embedder",
+            reranker="old-reranker",
+            vector_graph_store="old-store",
+        ),
+        short_term_memory=ShortTermMemoryConfPartial(
+            llm_model="old-model",
+            message_capacity=500,
+        ),
+        long_term_memory_enabled=True,
+        short_term_memory_enabled=True,
+        enabled=True,
+    )
+
+    semantic_memory = MagicMock()
+    semantic_memory.database = "old-db"
+    semantic_memory.llm_model = "old-llm"
+    semantic_memory.embedding_model = "old-embedder"
+    semantic_memory.ingestion_trigger_messages = 5
+    semantic_memory.ingestion_trigger_age = timedelta(minutes=5)
+    resource_manager.config.semantic_memory = semantic_memory
+
+    return resource_manager
+
+
+def test_update_episodic_ltm_embedder(memory_resource_manager):
+    """Test updating the long-term memory embedder."""
+    spec = UpdateEpisodicMemorySpec(
+        long_term_memory=UpdateLongTermMemorySpec(embedder="new-embedder"),
+    )
+    service = ConfigService(memory_resource_manager)
+    message = service.update_memory_config(spec, None)
+
+    assert "long_term_memory.embedder=new-embedder" in message
+    em = memory_resource_manager.config.episodic_memory
+    assert em.long_term_memory.embedder == "new-embedder"
+    # Unchanged fields stay the same
+    assert em.long_term_memory.reranker == "old-reranker"
+    memory_resource_manager.save_config.assert_called_once()
+
+
+def test_update_episodic_ltm_multiple_fields(memory_resource_manager):
+    """Test updating multiple long-term memory fields."""
+    spec = UpdateEpisodicMemorySpec(
+        long_term_memory=UpdateLongTermMemorySpec(
+            embedder="new-embedder",
+            reranker="new-reranker",
+            vector_graph_store="new-store",
+        ),
+    )
+    service = ConfigService(memory_resource_manager)
+    message = service.update_memory_config(spec, None)
+
+    assert "embedder=new-embedder" in message
+    assert "reranker=new-reranker" in message
+    assert "vector_graph_store=new-store" in message
+
+    ltm = memory_resource_manager.config.episodic_memory.long_term_memory
+    assert ltm.embedder == "new-embedder"
+    assert ltm.reranker == "new-reranker"
+    assert ltm.vector_graph_store == "new-store"
+
+
+def test_update_episodic_stm_llm_model(memory_resource_manager):
+    """Test updating the short-term memory LLM model."""
+    spec = UpdateEpisodicMemorySpec(
+        short_term_memory=UpdateShortTermMemorySpec(llm_model="new-llm"),
+    )
+    service = ConfigService(memory_resource_manager)
+    message = service.update_memory_config(spec, None)
+
+    assert "llm_model=new-llm" in message
+    stm = memory_resource_manager.config.episodic_memory.short_term_memory
+    assert stm.llm_model == "new-llm"
+    assert stm.message_capacity == 500  # unchanged
+
+
+def test_update_episodic_enabled_flags(memory_resource_manager):
+    """Test updating episodic memory enabled flags."""
+    spec = UpdateEpisodicMemorySpec(
+        long_term_memory_enabled=False,
+        short_term_memory_enabled=False,
+        enabled=False,
+    )
+    service = ConfigService(memory_resource_manager)
+    message = service.update_memory_config(spec, None)
+
+    em = memory_resource_manager.config.episodic_memory
+    assert em.long_term_memory_enabled is False
+    assert em.short_term_memory_enabled is False
+    assert em.enabled is False
+    assert "long_term_memory_enabled=False" in message
+
+
+def test_update_semantic_memory_fields(memory_resource_manager):
+    """Test updating semantic memory fields."""
+    spec = UpdateSemanticMemorySpec(
+        database="new-db",
+        llm_model="new-llm",
+        embedding_model="new-embedder",
+    )
+    service = ConfigService(memory_resource_manager)
+    message = service.update_memory_config(None, spec)
+
+    sm = memory_resource_manager.config.semantic_memory
+    assert sm.database == "new-db"
+    assert sm.llm_model == "new-llm"
+    assert sm.embedding_model == "new-embedder"
+    assert "database=new-db" in message
+    memory_resource_manager.save_config.assert_called_once()
+
+
+def test_update_semantic_ingestion_settings(memory_resource_manager):
+    """Test updating semantic memory ingestion settings."""
+    spec = UpdateSemanticMemorySpec(
+        ingestion_trigger_messages=10,
+        ingestion_trigger_age_seconds=600,
+    )
+    service = ConfigService(memory_resource_manager)
+    message = service.update_memory_config(None, spec)
+
+    sm = memory_resource_manager.config.semantic_memory
+    assert sm.ingestion_trigger_messages == 10
+    assert sm.ingestion_trigger_age == timedelta(seconds=600)
+    assert "ingestion_trigger_messages=10" in message
+    assert "ingestion_trigger_age=600s" in message
+
+
+def test_update_both_episodic_and_semantic(memory_resource_manager):
+    """Test updating both memory sections in one call."""
+    episodic_spec = UpdateEpisodicMemorySpec(
+        long_term_memory=UpdateLongTermMemorySpec(embedder="new-embedder"),
+    )
+    semantic_spec = UpdateSemanticMemorySpec(llm_model="new-llm")
+
+    service = ConfigService(memory_resource_manager)
+    message = service.update_memory_config(episodic_spec, semantic_spec)
+
+    assert "long_term_memory.embedder=new-embedder" in message
+    assert "llm_model=new-llm" in message
+    memory_resource_manager.save_config.assert_called_once()
+
+
+def test_update_no_changes(memory_resource_manager):
+    """Test that no-op updates return appropriate message."""
+    # All fields are None (no actual changes)
+    episodic_spec = UpdateEpisodicMemorySpec()
+    service = ConfigService(memory_resource_manager)
+    message = service.update_memory_config(episodic_spec, None)
+
+    assert message == "No changes applied."
+    memory_resource_manager.save_config.assert_not_called()
+
+
+def test_update_ltm_creates_partial_when_none(memory_resource_manager):
+    """Test that LTM update creates a partial config when none exists."""
+    memory_resource_manager.config.episodic_memory = EpisodicMemoryConfPartial()
+
+    spec = UpdateEpisodicMemorySpec(
+        long_term_memory=UpdateLongTermMemorySpec(embedder="brand-new-embedder"),
+    )
+    service = ConfigService(memory_resource_manager)
+    service.update_memory_config(spec, None)
+
+    ltm = memory_resource_manager.config.episodic_memory.long_term_memory
+    assert ltm is not None
+    assert ltm.embedder == "brand-new-embedder"
+
+
+def test_update_stm_creates_partial_when_none(memory_resource_manager):
+    """Test that STM update creates a partial config when none exists."""
+    memory_resource_manager.config.episodic_memory = EpisodicMemoryConfPartial()
+
+    spec = UpdateEpisodicMemorySpec(
+        short_term_memory=UpdateShortTermMemorySpec(llm_model="brand-new-model"),
+    )
+    service = ConfigService(memory_resource_manager)
+    service.update_memory_config(spec, None)
+
+    stm = memory_resource_manager.config.episodic_memory.short_term_memory
+    assert stm is not None
+    assert stm.llm_model == "brand-new-model"


### PR DESCRIPTION
### Purpose of the change

MemMachine currently requires all configured resources (embedders, language models, databases) to be available at startup. If any resource is unavailable — for example, a model is not yet deployed or an API key is not set — the server crashes. This makes it impossible to start the server in a partially configured state and add resources later.

This PR adds a runtime configuration API, makes startup graceful, and provides a client SDK module so users can:
1. Start the server even when some resources are unavailable
2. Add, remove, and retry resources at runtime via REST API
3. Update memory configuration (episodic/semantic) to point at newly added resources
4. Get clear status reporting on which resources are ready, failed, or pending
5. Use the Python SDK to manage configuration programmatically

### Description

#### Graceful startup
- Resource managers (`EmbedderManager`, `LanguageModelManager`, `RerankerManager`) now track build failures instead of crashing. Failed resources are recorded with status `FAILED` and can be retried later.
- Extracted shared resource lifecycle logic into `BaseResourceManager` to reduce duplication across the three manager types.
- `SemanticMemoryConf` gains an `enabled` flag (default `True`) with a `model_validator` that auto-disables when required fields (`database`, `llm_model`, `embedding_model`) are empty.
- `MemMachine._initialize_default_episodic_configuration()` now gracefully disables long-term or short-term episodic memory when the required embedder/reranker is not configured, instead of raising an error.
- `MemMachine.start()` and `stop()` skip the semantic service when semantic memory is disabled.

#### Runtime configuration API (`/api/v2/config/...`)

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/config` | View configuration with resource status |
| `GET` | `/config/resources` | View all resources and their status |
| `PUT` | `/config/memory` | Update episodic and/or semantic memory configuration |
| `POST` | `/config/resources/embedders` | Add a new embedder |
| `POST` | `/config/resources/language_models` | Add a new language model |
| `DELETE` | `/config/resources/embedders/{name}` | Remove an embedder |
| `DELETE` | `/config/resources/language_models/{name}` | Remove a language model |
| `POST` | `/config/resources/embedders/{name}/retry` | Retry building a failed embedder |
| `POST` | `/config/resources/language_models/{name}/retry` | Retry building a failed language model |
| `POST` | `/config/resources/rerankers/{name}/retry` | Retry building a failed reranker |

- Configuration changes are persisted to the YAML config file when one is loaded.
- Error handling extracted into `RestError` in a new `exceptions.py` module.

#### Client SDK (`rest_client/config.py`)

Added a `Config` class to the Python SDK that wraps all configuration API endpoints:
- `client.config()` — convenience accessor on `MemMachineClient`
- `get_config()` / `get_resources()` — read current configuration and resource status
- `update_memory_config()` — update episodic/semantic memory settings
- `add_embedder()` / `add_language_model()` — add new resources
- `delete_embedder()` / `delete_language_model()` — remove resources
- `retry_embedder()` / `retry_language_model()` / `retry_reranker()` — retry failed resources

Follows the same patterns as the existing `Project` and `Memory` SDK classes (closed-client checks, timeout forwarding, Pydantic response parsing, exception logging).

### Fixes/Closes

Fixes #974

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (does not change functionality, e.g., code style improvements, linting)

### How Has This Been Tested?

- [x] Unit Test

890+ unit tests pass (`pytest -m "not integration and not slow"`), including:
- `test_config_router.py` — 27 tests covering all API endpoints including error cases
- `test_config_service.py` — 18 tests covering service-layer logic (add/remove/retry resources, memory config updates, persistence)
- `test_configuration.py` — 5 new tests for config save/load and `config_file_path` tracking
- `test_resource_manager.py` — 3 new tests for `save_config` and config property access
- `test_config.py` — 23 tests covering the client SDK Config class (happy paths, closed-client errors, timeout forwarding, exception propagation)

### Checklist

- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None