### PR TITLE
[GH-1006] Add memmachine charts

### DIFF
--- a/deployments/helm/Chart.yaml
+++ b/deployments/helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: memmachine
+description: MemMachine memory service
+home: https://github.com/MemMachine/MemMachine
+type: application
+version: 0.1.0
+appVersion: v0.2.5-cpu

--- a/deployments/helm/README.md
+++ b/deployments/helm/README.md
@@ -1,0 +1,343 @@
+# MemMachine Helm Chart
+
+This directory contains a Kubernetes Helm chart for deploying MemMachine, a memory service for AI agents.
+
+## Overview
+
+MemMachine is a comprehensive memory service designed to provide persistent, structured memory capabilities for AI agents. This Helm chart simplifies deployment on Kubernetes clusters by packaging MemMachine along with its required dependencies (PostgreSQL and Neo4j).
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+- Sufficient persistent volume provisioners (for PostgreSQL and Neo4j storage)
+
+## Chart Components
+
+This Helm chart deploys the following components:
+
+- **MemMachine Server**: The main API service
+- **PostgreSQL with pgvector**: Vector database for embeddings and memory storage
+- **Neo4j**: Graph database for relationship and semantic memory
+
+## Installation
+
+### Basic Installation
+
+```bash
+helm install memmachine ./deployments/helm
+```
+
+### Installation with Custom Release Name
+
+```bash
+helm install my-memmachine ./deployments/helm
+```
+
+### Installation in Specific Namespace
+
+```bash
+helm install memmachine ./deployments/helm -n memmachine --create-namespace
+```
+
+## Configuration
+
+### Key Configuration Options
+
+The chart is highly configurable through `values.yaml`. Below are the main configurable sections:
+
+#### MemMachine Server Image
+
+```yaml
+image:
+  registry: ""  # Docker registry (empty uses default)
+  repository: "memmachine/memmachine"  # Container image
+  tag: "v0.2.3-cpu"  # Tag (cpu, gpu variants available)
+  pullPolicy: "IfNotPresent"  # Image pull policy
+  pullSecrets: []  # Private registry credentials
+```
+
+#### Service Configuration
+
+```yaml
+service:
+  type: ClusterIP  # Can be ClusterIP, NodePort, or LoadBalancer
+  port: 8080  # Service port
+```
+
+#### PostgreSQL Configuration
+
+```yaml
+postgres:
+  image:
+    registry: "docker.io"
+    repository: "pgvector/pgvector"
+    tag: "pg16"
+  port: 5432
+  env:
+    POSTGRES_DB: "memmachine"
+    POSTGRES_USER: "memmachine"
+    POSTGRES_PASSWORD: "memmachine_password"  # Change this!
+  persistence:
+    enabled: true
+    size: "10Gi"  # Adjust based on your needs
+```
+
+#### Neo4j Configuration
+
+```yaml
+neo4j:
+  image:
+    registry: "docker.io"
+    repository: "neo4j"
+    tag: "5.23-community"
+  env:
+    NEO4J_AUTH: "neo4j/neo4j_password"  # Change this!
+  persistence:
+    enabled: true
+    size: "10Gi"  # Adjust based on your needs
+```
+
+#### Model Configuration (Optional)
+
+```yaml
+model:
+  embedding:
+    baseUrl: ""  # Embedding model API endpoint
+    apiKey: ""   # API key for embedding service
+    model: ""    # Model name
+    dimensions: 0  # Embedding dimensions
+  chat:
+    baseUrl: ""  # Chat model API endpoint
+    apiKey: ""   # API key for chat service
+    model: ""    # Model name
+```
+
+If no models are configured, endpoints will return 503 until models are configured at runtime.
+
+#### Resource Limits
+
+```yaml
+resources: {}
+  # limits:
+  #   cpu: 1000m
+  #   memory: 1Gi
+  # requests:
+  #   cpu: 500m
+  #   memory: 512Mi
+```
+
+#### Persistence
+
+```yaml
+persistence:
+  enabled: true
+  size: "10Gi"  # Size of persistent volume
+  storageClass: ""  # Use default or specify custom storage class
+  mountPath: "/tmp/memory_logs"
+```
+
+### Advanced Configuration Options
+
+#### Replica Count
+
+```yaml
+replicaCount: 1  # Number of MemMachine replicas
+```
+
+#### Pod Annotations and Labels
+
+```yaml
+podAnnotations: {}  # Add custom annotations
+podLabels: {}  # Add custom labels
+```
+
+#### Node Selection and Affinity
+
+```yaml
+nodeSelector: {}  # Schedule on specific nodes
+tolerations: []  # Tolerate node taints
+affinity: {}  # Node affinity rules
+```
+
+#### Service Account
+
+```yaml
+serviceAccount:
+  create: false  # Create service account if needed
+  automountServiceAccountToken: false
+  name: ""  # Custom service account name
+```
+
+#### Environment Variables
+
+```yaml
+env: {}  # Standard environment variables
+extraEnv: []  # Additional environment variables
+extraEnvFrom: []  # Environment variables from ConfigMaps/Secrets
+```
+
+## Custom Values Example
+
+Create a `custom-values.yaml` file:
+
+```yaml
+replicaCount: 2
+
+image:
+  tag: "v0.2.3-gpu"
+
+service:
+  type: LoadBalancer
+  port: 8000
+
+postgres:
+  env:
+    POSTGRES_PASSWORD: "my-secure-password"
+  persistence:
+    size: "50Gi"
+    storageClass: "fast-ssd"
+
+neo4j:
+  env:
+    NEO4J_AUTH: "neo4j/my-secure-password"
+  persistence:
+    size: "50Gi"
+
+model:
+  embedding:
+    baseUrl: "https://api.openai.com/v1"
+    apiKey: "sk-..."
+    model: "text-embedding-3-small"
+    dimensions: 1536
+  chat:
+    baseUrl: "https://api.openai.com/v1"
+    apiKey: "sk-..."
+    model: "gpt-4"
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 4Gi
+  requests:
+    cpu: 1000m
+    memory: 2Gi
+```
+
+Then install with custom values:
+
+```bash
+helm install memmachine ./deployments/helm -f custom-values.yaml
+```
+
+## Post-Installation
+
+### Verify Deployment
+
+```bash
+# Check pod status
+kubectl get pods -l app.kubernetes.io/name=memmachine
+
+# Check service
+kubectl get svc memmachine
+
+# View logs
+kubectl logs -l app.kubernetes.io/name=memmachine
+```
+
+### Port Forward for Local Testing
+
+```bash
+kubectl port-forward svc/memmachine 8080:8080
+```
+
+Then access MemMachine at `http://localhost:8080`.
+
+### Initialize Databases
+
+After deployment, databases should initialize automatically. You can verify:
+
+```bash
+# Check PostgreSQL logs
+kubectl logs -l app.kubernetes.io/name=memmachine-postgres
+
+# Check Neo4j logs
+kubectl logs -l app.kubernetes.io/name=memmachine-neo4j
+```
+
+## Upgrade
+
+To upgrade an existing release:
+
+```bash
+helm upgrade memmachine ./deployments/helm -f custom-values.yaml
+```
+
+## Uninstall
+
+To remove the Helm release:
+
+```bash
+helm uninstall memmachine
+```
+
+**Note**: This does not automatically free persistent volumes. To clean up persistent volume claims:
+
+```bash
+kubectl delete pvc -l app.kubernetes.io/name=memmachine
+```
+
+## Troubleshooting
+
+### Pods Not Starting
+
+Check pod events:
+
+```bash
+kubectl describe pod <pod-name>
+kubectl logs <pod-name>
+```
+
+### Database Connection Issues
+
+Verify network connectivity:
+
+```bash
+# Test PostgreSQL connection
+kubectl exec -it <memmachine-pod> -- psql -h memmachine-postgres -U memmachine -d memmachine
+
+# Test Neo4j connection
+kubectl exec -it <memmachine-pod> -- curl http://memmachine-neo4j:7474
+```
+
+### Persistent Volume Issues
+
+Check PVC status:
+
+```bash
+kubectl get pvc
+kubectl describe pvc <pvc-name>
+```
+
+Ensure your cluster has a default storage class or specify one in values.
+
+### Memory/Resource Issues
+
+Scale resources in `custom-values.yaml` or adjust pod limits.
+
+## Chart Details
+
+- **Chart Name**: memmachine
+- **Chart Version**: 0.1.0
+- **MemMachine Version**: v0.2.3-cpu
+- **Home**: https://github.com/OpenCSGs/memmachine
+
+## Related Documentation
+
+- [MemMachine GitHub Repository](https://github.com/OpenCSGs/memmachine)
+- [MemMachine Documentation](../../../docs/)
+- [Docker Compose Alternative](../../memmachine-compose.sh)
+
+## Support
+
+For issues, feature requests, or questions, visit the [MemMachine GitHub Issues](https://github.com/OpenCSGs/memmachine/issues).

--- a/deployments/helm/templates/_helpers.tpl
+++ b/deployments/helm/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{- define "memmachine.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "memmachine.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "memmachine.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "memmachine.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "memmachine.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "memmachine.labels" -}}
+helm.sh/chart: {{ include "memmachine.chart" . }}
+{{ include "memmachine.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "memmachine.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else -}}
+{{- include "memmachine.fullname" . -}}
+{{- end -}}
+{{- else -}}
+{{- .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "memmachine.image" -}}
+{{- $registry := .image.registry | default "" -}}
+{{- $repository := .image.repository -}}
+{{- $tag := .image.tag -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}

--- a/deployments/helm/templates/configmap.yaml
+++ b/deployments/helm/templates/configmap.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "memmachine.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "memmachine.labels" . | nindent 4 }}
+data:
+  configuration.yml: |
+    logging:
+      path: /tmp/memmachine.log
+      level: info
+
+    episode_store:
+      database: profile_storage
+
+    episodic_memory:
+      long_term_memory:
+        embedder: openai_compatible_embedder
+        reranker: default_reranker
+        vector_graph_store: graph_storage
+      short_term_memory:
+        llm_model: openai_compatible_model
+        message_capacity: 500
+
+    semantic_memory:
+      llm_model: openai_compatible_model
+      embedding_model: openai_compatible_embedder
+      database: profile_storage
+      config_database: profile_storage
+
+    session_manager:
+      database: profile_storage
+
+    prompt:
+      session:
+      - profile_prompt
+
+    {{ $model := .Values.model | default dict }}
+    resources:
+      databases:
+        profile_storage:
+          provider: postgres
+          config:
+            host: localhost
+            port: {{ .Values.postgres.port }}
+            user: {{ .Values.postgres.env.POSTGRES_USER | quote }}
+            password: {{ .Values.postgres.env.POSTGRES_PASSWORD | quote }}
+            db_name: {{ .Values.postgres.env.POSTGRES_DB | quote }}
+        graph_storage:
+          provider: neo4j
+          config:
+            uri: "bolt://localhost:{{ .Values.neo4j.ports.bolt }}"
+            {{- $neo4jAuth := splitList "/" .Values.neo4j.env.NEO4J_AUTH }}
+            {{- if gt (len $neo4jAuth) 0 }}
+            username: {{ index $neo4jAuth 0 | quote }}
+            {{- else }}
+            username: "neo4j"
+            {{- end }}
+            {{- if gt (len $neo4jAuth) 1 }}
+            password: {{ index $neo4jAuth 1 | quote }}
+            {{- else }}
+            password: "neo4j_password"
+            {{- end }}
+      embedders:
+        openai_compatible_embedder:
+          provider: openai
+          {{ with $model.embedding }}
+          config:
+            model: {{ .model | default "" | quote }}
+            api_key: {{ .apiKey | default "" | quote }}
+            base_url: {{ .baseUrl | default "" | quote }}
+            dimensions: {{ .dimensions | default 0 }}
+          {{ end }}
+      language_models:
+        openai_compatible_model:
+          provider: openai-chat-completions
+          {{ with $model.chat }}
+          config:
+            model: {{ .model | default "" | quote }}
+            api_key: {{ .apiKey | default "" | quote }}
+            base_url: {{ .baseUrl | default "" | quote }}
+          {{ end }}
+      rerankers:
+        default_reranker:
+          provider: embedder
+          config:
+            embedder_id: openai_compatible_embedder

--- a/deployments/helm/templates/deployment.yaml
+++ b/deployments/helm/templates/deployment.yaml
@@ -1,0 +1,189 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "memmachine.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "memmachine.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "memmachine.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "memmachine.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "memmachine.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: postgres
+          image: {{ include "memmachine.image" (dict "image" .Values.postgres.image) }}
+          imagePullPolicy: {{ or .Values.postgres.image.pullPolicy .Values.global.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.postgres.port }}
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.postgres.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.postgres.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: memmachine-postgres-data
+              mountPath: {{ .Values.postgres.persistence.mountPath }}
+        - name: neo4j
+          image: {{ include "memmachine.image" (dict "image" .Values.neo4j.image) }}
+          imagePullPolicy: {{ or .Values.neo4j.image.pullPolicy .Values.global.image.pullPolicy }}
+          ports:
+            - name: neo4j-http
+              containerPort: {{ .Values.neo4j.ports.http }}
+              protocol: TCP
+            - name: neo4j-https
+              containerPort: {{ .Values.neo4j.ports.https }}
+              protocol: TCP
+            - name: neo4j-bolt
+              containerPort: {{ .Values.neo4j.ports.bolt }}
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.neo4j.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.neo4j.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: memmachine-neo4j-data
+              mountPath: {{ .Values.neo4j.persistence.mounts.data }}
+            - name: memmachine-neo4j-logs
+              mountPath: {{ .Values.neo4j.persistence.mounts.logs }}
+            - name: memmachine-neo4j-import
+              mountPath: {{ .Values.neo4j.persistence.mounts.import }}
+            - name: memmachine-neo4j-plugins
+              mountPath: {{ .Values.neo4j.persistence.mounts.plugins }}
+        - name: memmachine
+          image: {{ include "memmachine.image" (dict "image" .Values.image) }}
+          imagePullPolicy: {{ or .Values.image.pullPolicy .Values.global.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: MEMORY_CONFIG
+              value: "/app/configuration.yml"
+            - name: MEMMACHINE_CONFIG_API
+              value: "1"
+            - name: HOST
+              value: "0.0.0.0"
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: memmachine-config
+              mountPath: /app/configuration.yml
+              subPath: configuration.yml
+              readOnly: true
+            {{- if .Values.persistence.enabled }}
+            - name: memmachine-data
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: memmachine-config
+          configMap:
+            name: {{ include "memmachine.fullname" . }}-config
+        {{- if .Values.persistence.enabled }}
+        - name: memmachine-data
+          persistentVolumeClaim:
+            claimName: {{ include "memmachine.fullname" . }}
+        {{- end }}
+        {{- if .Values.postgres.persistence.enabled }}
+        - name: memmachine-postgres-data
+          persistentVolumeClaim:
+            claimName: {{ include "memmachine.fullname" . }}-postgres
+        {{- else }}
+        - name: memmachine-postgres-data
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.neo4j.persistence.enabled }}
+        - name: memmachine-neo4j-data
+          persistentVolumeClaim:
+            claimName: {{ include "memmachine.fullname" . }}-neo4j-data
+        - name: memmachine-neo4j-logs
+          persistentVolumeClaim:
+            claimName: {{ include "memmachine.fullname" . }}-neo4j-logs
+        - name: memmachine-neo4j-import
+          persistentVolumeClaim:
+            claimName: {{ include "memmachine.fullname" . }}-neo4j-import
+        - name: memmachine-neo4j-plugins
+          persistentVolumeClaim:
+            claimName: {{ include "memmachine.fullname" . }}-neo4j-plugins
+        {{- else }}
+        - name: memmachine-neo4j-data
+          emptyDir: {}
+        - name: memmachine-neo4j-logs
+          emptyDir: {}
+        - name: memmachine-neo4j-import
+          emptyDir: {}
+        - name: memmachine-neo4j-plugins
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/deployments/helm/templates/pvc.yaml
+++ b/deployments/helm/templates/pvc.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "memmachine.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "memmachine.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+---
+{{- end -}}
+{{- if .Values.postgres.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "memmachine.fullname" . }}-postgres
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "memmachine.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.postgres.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.postgres.persistence.size }}
+  {{- if .Values.postgres.persistence.storageClass }}
+  storageClassName: {{ .Values.postgres.persistence.storageClass }}
+  {{- end }}
+---
+{{- end -}}
+{{- if .Values.neo4j.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "memmachine.fullname" . }}-neo4j-data
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "memmachine.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.neo4j.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.neo4j.persistence.size }}
+  {{- if .Values.neo4j.persistence.storageClass }}
+  storageClassName: {{ .Values.neo4j.persistence.storageClass }}
+  {{- end }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "memmachine.fullname" . }}-neo4j-logs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "memmachine.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.neo4j.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.neo4j.persistence.size }}
+  {{- if .Values.neo4j.persistence.storageClass }}
+  storageClassName: {{ .Values.neo4j.persistence.storageClass }}
+  {{- end }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "memmachine.fullname" . }}-neo4j-import
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "memmachine.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.neo4j.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.neo4j.persistence.size }}
+  {{- if .Values.neo4j.persistence.storageClass }}
+  storageClassName: {{ .Values.neo4j.persistence.storageClass }}
+  {{- end }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "memmachine.fullname" . }}-neo4j-plugins
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "memmachine.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.neo4j.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.neo4j.persistence.size }}
+  {{- if .Values.neo4j.persistence.storageClass }}
+  storageClassName: {{ .Values.neo4j.persistence.storageClass }}
+  {{- end }}
+---
+{{- end -}}

--- a/deployments/helm/templates/service.yaml
+++ b/deployments/helm/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "memmachine.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "memmachine.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "memmachine.selectorLabels" . | nindent 4 }}

--- a/deployments/helm/templates/serviceaccount.yaml
+++ b/deployments/helm/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "memmachine.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "memmachine.labels" . | nindent 4 }}
+{{- end -}}

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -1,0 +1,121 @@
+replicaCount: 1
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  registry: ""
+  repository: "memmachine/memmachine"
+  tag: "v0.2.5-cpu"
+  pullPolicy: "IfNotPresent"
+  pullSecrets: []
+
+service:
+  type: ClusterIP
+  port: 8080
+
+postgres:
+  image:
+    registry: "docker.io"
+    repository: "pgvector/pgvector"
+    tag: "pg16"
+    pullPolicy: "IfNotPresent"
+    pullSecrets: []
+  port: 5432
+  env:
+    POSTGRES_DB: "memmachine"
+    POSTGRES_USER: "memmachine"
+    POSTGRES_PASSWORD: "memmachine_password"
+  resources: {}
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessModes: ["ReadWriteOnce"]
+    size: "10Gi"
+    mountPath: "/var/lib/postgresql/data"
+
+neo4j:
+  image:
+    registry: "docker.io"
+    repository: "neo4j"
+    tag: "5.23-community"
+    pullPolicy: "IfNotPresent"
+    pullSecrets: []
+  ports:
+    http: 7474
+    https: 7473
+    bolt: 7687
+  env:
+    NEO4J_AUTH: "neo4j/neo4j_password"
+  resources: {}
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessModes: ["ReadWriteOnce"]
+    size: "10Gi"
+    mounts:
+      data: "/data"
+      logs: "/logs"
+      import: "/var/lib/neo4j/import"
+      plugins: "/plugins"
+
+serviceAccount:
+  create: false
+  name: ""
+  automountServiceAccountToken: false
+
+env: {}
+extraEnv: []
+extraEnvFrom: []
+
+model:
+  # Optional. Remove this entire block to start without configured models.
+  # Model-dependent endpoints will return 503 until models are configured at runtime.
+  embedding:
+    baseUrl: ""
+    apiKey: ""
+    model: ""
+    dimensions: 0
+  chat:
+    baseUrl: ""
+    apiKey: ""
+    model: ""
+
+resources: {}
+
+podAnnotations: {}
+podLabels: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+persistence:
+  enabled: true
+  storageClass: ""
+  accessModes: ["ReadWriteOnce"]
+  size: "10Gi"
+  mountPath: "/tmp/memory_logs"
+
+extraVolumes: []
+extraVolumeMounts: []
+
+livenessProbe:
+  httpGet:
+    path: /api/v2/health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /api/v2/health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3


### PR DESCRIPTION
Add mem-machine charts for k8s deploy.


### Purpose of the change

Add helm charts to deploy mem-machine into k8s.

### Description

Implement helm charts which can be used to deploy mem-machine into k8s/k3s

### Fixes/Closes

Fixes #1006 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)

### Maintainer Checklist

- [x] Confirmed all checks passed
- [x] Contributor has signed the commit(s)

### Screenshots/Gifs

N/A

### Further comments

None
