### PR TITLE
[GH-1024] Fix set_id sql migration script

### DIFF
--- a/src/memmachine/semantic_memory/storage/alembic_pg/versions/b65f7f4a9d2c_migrate_legacy_set_ids.py
+++ b/src/memmachine/semantic_memory/storage/alembic_pg/versions/b65f7f4a9d2c_migrate_legacy_set_ids.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Iterable, Mapping, Sequence
-from typing import NamedTuple
 
 import sqlalchemy as sa
 from alembic import op
@@ -27,82 +26,11 @@ SESSION_PREFIX = "mem_session_"
 ROLE_PREFIX = "mem_role_"
 
 
-class ResolvedContext(NamedTuple):
-    """Resolved identifiers for a legacy set id."""
-
-    org_id: str | None
-    project_id: str | None
-    producer_id: str | None
-    role_id: str | None
-    session_key: str | None
-
-
-class ContextAccumulator:
-    """Collects context values linked to a legacy set id."""
-
-    __slots__ = ("producer_ids", "producer_roles", "session_keys")
-
-    def __init__(self) -> None:
-        """Initialize empty context sets."""
-        self.session_keys: set[str] = set()
-        self.producer_ids: set[str] = set()
-        self.producer_roles: set[str] = set()
-
-    def add(
-        self,
-        *,
-        session_key: str | None,
-        producer_id: str | None,
-        producer_role: str | None,
-    ) -> None:
-        session_clean = _clean(session_key)
-        if session_clean:
-            self.session_keys.add(session_clean)
-
-        producer_clean = _clean(producer_id)
-        if producer_clean:
-            self.producer_ids.add(producer_clean)
-
-        role_clean = _clean(producer_role)
-        if role_clean:
-            self.producer_roles.add(role_clean)
-
-    def resolve(self, *, set_id: str) -> ResolvedContext:
-        session_key = _select_single(self.session_keys, "session_key", set_id)
-        org_id: str | None = None
-        project_id: str | None = None
-        if session_key is not None:
-            org_id, project_id = _split_session_key(session_key, set_id)
-
-        producer_id = _select_single(self.producer_ids, "producer_id", set_id)
-        role_id = _select_single(self.producer_roles, "producer_role", set_id)
-
-        return ResolvedContext(
-            org_id=org_id,
-            project_id=project_id,
-            producer_id=producer_id,
-            role_id=role_id,
-            session_key=session_key,
-        )
-
-    def is_empty(self) -> bool:
-        return not (self.session_keys or self.producer_ids or self.producer_roles)
-
-
 def _clean(value: str | None) -> str | None:
     if value is None:
         return None
     cleaned = value.strip()
     return cleaned or None
-
-
-def _select_single(values: set[str], label: str, set_id: str) -> str | None:
-    non_empty = {v for v in values if v}
-    if len(non_empty) > 1:
-        raise RuntimeError(
-            f"Conflicting {label} values for {set_id}: {sorted(non_empty)}"
-        )
-    return next(iter(non_empty)) if non_empty else None
 
 
 def _split_session_key(session_key: str, set_id: str) -> tuple[str, str | None]:
@@ -194,226 +122,26 @@ def _collect_candidate_set_ids(conn: sa.Connection) -> set[str]:
     return candidates
 
 
-def _collect_contexts(
-    conn: sa.Connection,
-    *,
-    set_ids: set[str],
-) -> dict[str, ResolvedContext]:
-    if not set_ids:
-        return {}
-
-    accumulators = {sid: ContextAccumulator() for sid in set_ids}
-
-    history_links = _collect_history_links(conn, set_ids)
-    citation_links = _collect_citation_links(conn, set_ids)
-
-    all_history_ids = set(history_links.keys()) | set(citation_links.keys())
-    episodes = _fetch_episode_rows(conn, all_history_ids)
-
-    for history_id, parents in history_links.items():
-        episode = episodes.get(history_id)
-        if episode is None:
-            continue
-        for set_id in parents:
-            accumulators[set_id].add(
-                session_key=episode["session_key"],
-                producer_id=episode["producer_id"],
-                producer_role=episode["producer_role"],
-            )
-
-    for history_id, parents in citation_links.items():
-        episode = episodes.get(history_id)
-        if episode is None:
-            continue
-        for set_id in parents:
-            accumulators[set_id].add(
-                session_key=episode["session_key"],
-                producer_id=episode["producer_id"],
-                producer_role=episode["producer_role"],
-            )
-
-    resolved: dict[str, ResolvedContext] = {}
-    for set_id, accumulator in accumulators.items():
-        if accumulator.is_empty():
-            continue
-        resolved[set_id] = accumulator.resolve(set_id=set_id)
-
-    return resolved
-
-
-def _collect_history_links(
-    conn: sa.Connection,
-    set_ids: set[str],
-) -> dict[int, list[str]]:
-    if not set_ids or not inspect(conn).has_table("set_ingested_history"):
-        return {}
-
-    table = sa.table(
-        "set_ingested_history",
-        sa.column("set_id", sa.String),
-        sa.column("history_id", sa.String),
-    )
-
-    stmt = sa.select(table.c.set_id, table.c.history_id).where(
-        table.c.set_id.in_(tuple(set_ids))
-    )
-
-    mapping: dict[int, list[str]] = {}
-    for set_id, history_id in conn.execute(stmt):
-        if history_id is None:
-            continue
-        history_str = str(history_id)
-        if not history_str.isdigit():
-            continue
-        history_int = int(history_str)
-        mapping.setdefault(history_int, []).append(set_id)
-
-    return mapping
-
-
-def _collect_citation_links(
-    conn: sa.Connection,
-    set_ids: set[str],
-) -> dict[int, list[str]]:
-    inspector = inspect(conn)
-    if (
-        not set_ids
-        or not inspector.has_table("citations")
-        or not inspector.has_table("feature")
-    ):
-        return {}
-
-    feature_table = sa.table(
-        "feature",
-        sa.column("id", sa.Integer),
-        sa.column("set_id", sa.String),
-    )
-    citations_table = sa.table(
-        "citations",
-        sa.column("feature_id", sa.Integer),
-        sa.column("history_id", sa.String),
-    )
-
-    stmt = (
-        sa.select(feature_table.c.set_id, citations_table.c.history_id)
-        .join(citations_table, feature_table.c.id == citations_table.c.feature_id)
-        .where(feature_table.c.set_id.in_(tuple(set_ids)))
-    )
-
-    mapping: dict[int, list[str]] = {}
-    for set_id, history_id in conn.execute(stmt):
-        if history_id is None:
-            continue
-        history_str = str(history_id)
-        if not history_str.isdigit():
-            continue
-        history_int = int(history_str)
-        mapping.setdefault(history_int, []).append(set_id)
-
-    return mapping
-
-
-def _fetch_episode_rows(
-    conn: sa.Connection,
-    history_ids: set[int],
-) -> dict[int, dict[str, str | None]]:
-    inspector = inspect(conn)
-    if not history_ids or not inspector.has_table("episodestore"):
-        raise RuntimeError(
-            "episodestore table is required to migrate legacy set identifiers"
-        )
-
-    episodes_table = sa.table(
-        "episodestore",
-        sa.column("id", sa.BigInteger),
-        sa.column("session_key", sa.String),
-        sa.column("producer_id", sa.String),
-        sa.column("producer_role", sa.String),
-    )
-
-    results: dict[int, dict[str, str | None]] = {}
-    id_list = list(history_ids)
-    chunk_size = 1000
-
-    for start in range(0, len(id_list), chunk_size):
-        chunk = id_list[start : start + chunk_size]
-        stmt = sa.select(episodes_table).where(episodes_table.c.id.in_(chunk))
-        for row in conn.execute(stmt):
-            history_id = int(row.id)
-            results[history_id] = {
-                "session_key": row.session_key,
-                "producer_id": row.producer_id,
-                "producer_role": row.producer_role,
-            }
-
-    return results
-
-
-def _build_migration_plan(
-    conn: sa.Connection,
-) -> tuple[dict[str, str], dict[str, ResolvedContext]]:
+def _build_migration_plan(conn: sa.Connection) -> dict[str, str]:
     candidate_set_ids = _collect_candidate_set_ids(conn)
-    contexts = _collect_contexts(conn, set_ids=candidate_set_ids)
 
     plan: dict[str, str] = {}
     for set_id in sorted(candidate_set_ids):
-        if set_id.startswith(SESSION_PREFIX):
-            new_id = _translate_session_set_id(set_id, contexts.get(set_id))
-        elif set_id.startswith(USER_PREFIX):
-            context = contexts.get(set_id)
-            if context is None or context.org_id is None or context.producer_id is None:
-                raise RuntimeError(
-                    "Unable to resolve org/project/producer for legacy user set "
-                    f"{set_id}. Ensure episodic history exists for these entries."
-                )
-            new_id = _generate_set_id(
-                org_id=context.org_id,
-                project_id=None,
-                metadata={"producer_id": context.producer_id},
-            )
-        elif set_id.startswith(ROLE_PREFIX):
-            context = contexts.get(set_id)
-            if context is None or context.org_id is None:
-                raise RuntimeError(
-                    f"Unable to resolve org/project for legacy role set {set_id}."
-                )
-            role_identifier = context.role_id or set_id[len(ROLE_PREFIX) :].strip()
-            if not role_identifier:
-                raise RuntimeError(f"Unable to determine role identifier for {set_id}")
-            new_id = _generate_set_id(
-                org_id=context.org_id,
-                project_id=context.project_id,
-                metadata={"role_id": role_identifier},
-            )
-        else:
+        if not set_id.startswith(SESSION_PREFIX):
             continue
-
+        new_id = _translate_session_set_id(set_id)
         if new_id != set_id:
             plan[set_id] = new_id
 
-    return plan, contexts
+    return plan
 
 
-def _translate_session_set_id(
-    set_id: str,
-    context: ResolvedContext | None,
-) -> str:
+def _translate_session_set_id(set_id: str) -> str:
     raw_session_key = set_id[len(SESSION_PREFIX) :].strip()
     if not raw_session_key:
         raise RuntimeError(f"Unable to parse session key from {set_id}")
 
     org_id, project_id = _split_session_key(raw_session_key, set_id)
-
-    if context is not None:
-        if context.org_id is not None and context.org_id != org_id:
-            raise RuntimeError(
-                f"Session key mismatch for {set_id}: {context.org_id} != {org_id}"
-            )
-        if context.project_id is not None and context.project_id != project_id:
-            raise RuntimeError(
-                f"Session project mismatch for {set_id}: "
-                f"{context.project_id} != {project_id}"
-            )
 
     return _generate_set_id(org_id=org_id, project_id=project_id, metadata={})
 
@@ -455,7 +183,6 @@ def _apply_updates(
     conn: sa.Connection,
     *,
     plan: Mapping[str, str],
-    contexts: Mapping[str, ResolvedContext],
 ) -> None:
     if not plan:
         return
@@ -463,7 +190,7 @@ def _apply_updates(
     _update_table(conn, "feature", "set_id", plan)
     _update_table(conn, "set_ingested_history", "set_id", plan)
     _update_table(conn, "semantic_config_setidresources", "set_id", plan)
-    _update_config_settype(conn, plan=plan, contexts=contexts)
+    _update_table(conn, "semantic_config_setidresources_settype", "set_id", plan)
     _update_table(
         conn,
         "semantic_config_setidresources_disabledcategories",
@@ -492,82 +219,10 @@ def _update_table(
         conn.execute(stmt, {"old_id": old_id, "new_id": new_id})
 
 
-def _update_config_settype(
-    conn: sa.Connection,
-    *,
-    plan: Mapping[str, str],
-    contexts: Mapping[str, ResolvedContext],
-) -> None:
-    table_name = "semantic_config_setidresources_settype"
-    if not inspect(conn).has_table(table_name):
-        return
-
-    base_stmt = sa.text(
-        "UPDATE semantic_config_setidresources_settype "
-        "SET set_id = :new_id WHERE set_id = :old_id"
-    )
-
-    specialized_stmt = sa.text(
-        "UPDATE semantic_config_setidresources_settype "
-        "SET set_id = :new_id, set_type_id = :set_type_id "
-        "WHERE set_id = :old_id"
-    )
-
-    for old_id, new_id in plan.items():
-        if old_id == new_id:
-            continue
-
-        if old_id.startswith(USER_PREFIX):
-            context = contexts.get(old_id)
-            if context is None or context.org_id is None:
-                raise RuntimeError(
-                    f"Missing context for user set {old_id} during config migration"
-                )
-            set_type_id = _ensure_user_set_type(conn, context.org_id)
-            conn.execute(
-                specialized_stmt,
-                {
-                    "old_id": old_id,
-                    "new_id": new_id,
-                    "set_type_id": set_type_id,
-                },
-            )
-        else:
-            conn.execute(base_stmt, {"old_id": old_id, "new_id": new_id})
-
-
-def _ensure_user_set_type(conn: sa.Connection, org_id: str) -> int:
-    stmt = sa.text(
-        "SELECT id FROM set_type "
-        "WHERE org_id = :org_id AND org_level_set = TRUE "
-        "AND metadata_tags_sig = :sig"
-    )
-
-    existing = conn.execute(stmt, {"org_id": org_id, "sig": "producer_id"}).first()
-    if existing:
-        return int(existing[0])
-
-    insert_stmt = sa.text(
-        "INSERT INTO set_type (org_id, org_level_set, metadata_tags_sig, name, description) "
-        "VALUES (:org_id, TRUE, :sig, :name, :description) RETURNING id"
-    )
-
-    result = conn.execute(
-        insert_stmt,
-        {
-            "org_id": org_id,
-            "sig": "producer_id",
-            "name": "User Profile",
-            "description": "Semantic memory scoped to producer identifiers.",
-        },
-    )
-    return int(result.scalar_one())
-
-
 def _migrate_legacy_set_ids(conn: sa.Connection) -> None:
-    plan, contexts = _build_migration_plan(conn)
+    plan = _build_migration_plan(conn)
     _assert_no_config_collisions(conn, plan)
-    _apply_updates(conn, plan=plan, contexts=contexts)
+    _apply_updates(conn, plan=plan)
 
 
 def upgrade() -> None:

--- a/tests/memmachine/semantic_memory/storage/alembic_pg/test_set_id_migration.py
+++ b/tests/memmachine/semantic_memory/storage/alembic_pg/test_set_id_migration.py
@@ -54,231 +54,13 @@ async def _run_upgrade(engine: AsyncEngine, target: str) -> None:
         await conn.run_sync(_upgrade)
 
 
-async def _create_supporting_tables(engine: AsyncEngine) -> None:
-    async with engine.begin() as conn:
-        await conn.execute(
-            sa.text(
-                """
-                CREATE TABLE episodestore (
-                    id BIGINT PRIMARY KEY,
-                    session_key TEXT NOT NULL,
-                    producer_id TEXT NOT NULL,
-                    producer_role TEXT
-                )
-                """
-            )
-        )
-
-        await conn.execute(
-            sa.text(
-                """
-                CREATE TABLE IF NOT EXISTS set_type (
-                    id SERIAL PRIMARY KEY,
-                    org_id TEXT NOT NULL,
-                    org_level_set BOOLEAN NOT NULL,
-                    metadata_tags_sig TEXT NOT NULL,
-                    name TEXT,
-                    description TEXT
-                )
-                """
-            )
-        )
-
-        await conn.execute(
-            sa.text(
-                """
-                CREATE TABLE IF NOT EXISTS semantic_config_setidresources (
-                    set_id TEXT PRIMARY KEY
-                )
-                """
-            )
-        )
-
-        await conn.execute(
-            sa.text(
-                """
-                CREATE TABLE IF NOT EXISTS semantic_config_setidresources_settype (
-                    set_id TEXT PRIMARY KEY,
-                    set_type_id INTEGER NOT NULL REFERENCES set_type(id)
-                )
-                """
-            )
-        )
-
-        await conn.execute(
-            sa.text(
-                """
-                CREATE TABLE IF NOT EXISTS semantic_config_setidresources_disabledcategories (
-                    set_id TEXT NOT NULL,
-                    disabled_category TEXT NOT NULL,
-                    PRIMARY KEY (set_id, disabled_category)
-                )
-                """
-            )
-        )
-
-        await conn.execute(
-            sa.text(
-                """
-                CREATE TABLE IF NOT EXISTS semantic_config_category (
-                    id SERIAL PRIMARY KEY,
-                    set_id TEXT,
-                    name TEXT NOT NULL,
-                    prompt TEXT NOT NULL
-                )
-                """
-            )
-        )
-
-
-@pytest.mark.asyncio
-async def test_legacy_set_ids_are_transformed(sqlalchemy_pg_engine: AsyncEngine):
-    await _reset_database(sqlalchemy_pg_engine)
-
-    await _run_upgrade(sqlalchemy_pg_engine, "62dff1150a46")
-
-    await _create_supporting_tables(sqlalchemy_pg_engine)
-
-    legacy_session_id = "mem_session_acme/project-x"
-    legacy_user_id = "mem_user_alice"
-    legacy_role_id = "mem_role_admin"
-    untouched_set_id = "custom-set"
-
-    async with sqlalchemy_pg_engine.begin() as conn:
-        await conn.execute(
-            sa.text(
-                "INSERT INTO episodestore (id, session_key, producer_id, producer_role) "
-                "VALUES (:id, :session_key, :producer_id, :producer_role)"
-            ),
-            {
-                "id": 101,
-                "session_key": "acme/project-x",
-                "producer_id": "alice",
-                "producer_role": "admin",
-            },
-        )
-
-        await conn.execute(
-            sa.text(
-                "INSERT INTO set_type (org_id, org_level_set, metadata_tags_sig, name, description) "
-                "VALUES ('acme', FALSE, 'legacy', 'Legacy Type', 'Legacy mapping')"
-            )
-        )
-
-        await conn.execute(
-            sa.text(
-                "INSERT INTO semantic_config_setidresources (set_id) VALUES (:set_id)"
-            ),
-            {"set_id": legacy_user_id},
-        )
-
-        await conn.execute(
-            sa.text(
-                "INSERT INTO semantic_config_setidresources_settype (set_id, set_type_id) "
-                "VALUES (:set_id, 1)"
-            ),
-            {"set_id": legacy_user_id},
-        )
-
-        await conn.execute(
-            sa.text(
-                "INSERT INTO semantic_config_setidresources_disabledcategories (set_id, disabled_category) "
-                "VALUES (:set_id, 'legacy-cat')"
-            ),
-            {"set_id": legacy_user_id},
-        )
-
-        await conn.execute(
-            sa.text(
-                "INSERT INTO semantic_config_category (set_id, name, prompt) "
-                "VALUES (:set_id, 'legacy-category', 'prompt')"
-            ),
-            {"set_id": legacy_user_id},
-        )
-
-        await conn.execute(
-            sa.text(
-                "INSERT INTO feature "
-                "(set_id, semantic_category_id, tag_id, feature, value) "
-                "VALUES (:set_id, 'profile', 'tag', 'topic', 'value')"
-            ),
-            {"set_id": legacy_session_id},
-        )
-        await conn.execute(
-            sa.text(
-                "INSERT INTO feature "
-                "(set_id, semantic_category_id, tag_id, feature, value) "
-                "VALUES (:set_id, 'profile', 'tag', 'topic', 'other')"
-            ),
-            {"set_id": untouched_set_id},
-        )
-        await conn.execute(
-            sa.text(
-                "INSERT INTO set_ingested_history (set_id, history_id, ingested) "
-                "VALUES (:set_id, :history_id, FALSE)"
-            ),
-            {"set_id": legacy_session_id, "history_id": "legacy-history"},
-        )
-        await conn.execute(
-            sa.text(
-                "INSERT INTO set_ingested_history (set_id, history_id, ingested) "
-                "VALUES (:set_id, :history_id, FALSE)"
-            ),
-            {"set_id": untouched_set_id, "history_id": "other-history"},
-        )
-
-        await conn.execute(
-            sa.text(
-                "INSERT INTO feature (set_id, semantic_category_id, tag_id, feature, value) "
-                "VALUES (:set_id, 'profile', 'tag', 'topic', 'user-value')"
-            ),
-            {"set_id": legacy_user_id},
-        )
-
-        await conn.execute(
-            sa.text(
-                "INSERT INTO feature (set_id, semantic_category_id, tag_id, feature, value) "
-                "VALUES (:set_id, 'profile', 'tag', 'topic', 'role-value')"
-            ),
-            {"set_id": legacy_role_id},
-        )
-
-        await conn.execute(
-            sa.text(
-                "INSERT INTO set_ingested_history (set_id, history_id, ingested) "
-                "VALUES (:set_id, :history_id, FALSE)"
-            ),
-            {"set_id": legacy_user_id, "history_id": "101"},
-        )
-
-        await conn.execute(
-            sa.text(
-                "INSERT INTO set_ingested_history (set_id, history_id, ingested) "
-                "VALUES (:set_id, :history_id, FALSE)"
-            ),
-            {"set_id": legacy_role_id, "history_id": "101"},
-        )
-
-    await _run_upgrade(sqlalchemy_pg_engine, "head")
-
-    expected_project_set_id = SemanticSessionManager._generate_set_id(
-        org_id="acme",
-        project_id="project-x",
-        metadata={},
-    )
-
-    expected_user_set_id = SemanticSessionManager.generate_user_set_id(
-        org_id="acme",
-        producer_id="alice",
-    )
-
-    expected_role_set_id = SemanticSessionManager._generate_set_id(
-        org_id="acme",
-        project_id="project-x",
-        metadata={"role_id": "admin"},
-    )
-
-    async with sqlalchemy_pg_engine.connect() as conn:
+async def _fetch_migration_state(
+    engine: AsyncEngine,
+) -> tuple[
+    set[str],
+    set[str],
+]:
+    async with engine.connect() as conn:
         feature_rows = await conn.execute(sa.text("SELECT set_id FROM feature"))
         feature_set_ids = {row[0] for row in feature_rows}
 
@@ -287,59 +69,115 @@ async def test_legacy_set_ids_are_transformed(sqlalchemy_pg_engine: AsyncEngine)
         )
         history_set_ids = {row[0] for row in history_rows}
 
-        config_rows = await conn.execute(
-            sa.text("SELECT set_id FROM semantic_config_setidresources")
-        )
-        config_set_ids = {row[0] for row in config_rows}
+    return (
+        feature_set_ids,
+        history_set_ids,
+    )
 
-        mapping_rows = await conn.execute(
+
+def _split_session_key_for_test(session_key: str) -> tuple[str, str | None]:
+    cleaned = session_key.strip()
+    if "/" in cleaned:
+        org_id, project_id = cleaned.split("/", 1)
+    else:
+        org_id, project_id = cleaned, None
+    return org_id, project_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "legacy_set_id",
+    [
+        "mem_session_acme/project-x",
+        "mem_session_universal/project_6fdqmczu_empty_fields",
+    ],
+)
+async def test_legacy_set_ids_are_transformed(
+    sqlalchemy_pg_engine: AsyncEngine,
+    legacy_set_id: str,
+):
+    await _reset_database(sqlalchemy_pg_engine)
+
+    await _run_upgrade(sqlalchemy_pg_engine, "d1a9df11343b")
+
+    session_key = legacy_set_id.removeprefix("mem_session_").strip()
+    org_id, project_id = _split_session_key_for_test(session_key)
+
+    async with sqlalchemy_pg_engine.begin() as conn:
+        await conn.execute(
             sa.text(
-                "SELECT set_id, set_type_id FROM semantic_config_setidresources_settype"
-            )
+                "INSERT INTO feature "
+                "(set_id, semantic_category_id, tag_id, feature, value) "
+                "VALUES (:set_id, 'profile', 'tag', 'topic', 'value')"
+            ),
+            {"set_id": legacy_set_id},
         )
-        mapping_data = [(row[0], row[1]) for row in mapping_rows]
 
-        set_type_rows = await conn.execute(
-            sa.text("SELECT id, metadata_tags_sig FROM set_type")
-        )
-        set_type_by_sig = {row[1]: row[0] for row in set_type_rows}
-
-        disabled_rows = await conn.execute(
+        await conn.execute(
             sa.text(
-                "SELECT set_id FROM semantic_config_setidresources_disabledcategories"
+                "INSERT INTO set_ingested_history (set_id, history_id, ingested) "
+                "VALUES (:set_id, :history_id, FALSE)"
+            ),
+            {"set_id": legacy_set_id, "history_id": "101"},
+        )
+
+    await _run_upgrade(sqlalchemy_pg_engine, "head")
+
+    expected_set_id = SemanticSessionManager._generate_set_id(
+        org_id=org_id,
+        project_id=project_id,
+        metadata={},
+    )
+
+    feature_set_ids, history_set_ids = await _fetch_migration_state(
+        sqlalchemy_pg_engine
+    )
+
+    assert expected_set_id in feature_set_ids
+    assert expected_set_id in history_set_ids
+    assert legacy_set_id not in feature_set_ids
+    assert legacy_set_id not in history_set_ids
+
+    await _reset_database(sqlalchemy_pg_engine)
+
+
+@pytest.mark.asyncio
+async def test_user_and_role_set_ids_are_unchanged(
+    sqlalchemy_pg_engine: AsyncEngine,
+) -> None:
+    await _reset_database(sqlalchemy_pg_engine)
+
+    await _run_upgrade(sqlalchemy_pg_engine, "d1a9df11343b")
+
+    user_set_id = "mem_user_legacy"
+    role_set_id = "mem_role_operator"
+
+    async with sqlalchemy_pg_engine.begin() as conn:
+        for legacy_id in (user_set_id, role_set_id):
+            await conn.execute(
+                sa.text(
+                    "INSERT INTO feature (set_id, semantic_category_id, tag_id, feature, value) "
+                    "VALUES (:set_id, 'profile', 'tag', 'topic', 'value')"
+                ),
+                {"set_id": legacy_id},
             )
-        )
-        disabled_set_ids = {row[0] for row in disabled_rows}
 
-        category_rows = await conn.execute(
-            sa.text("SELECT set_id FROM semantic_config_category")
-        )
-        category_set_ids = {row[0] for row in category_rows}
+            await conn.execute(
+                sa.text(
+                    "INSERT INTO set_ingested_history (set_id, history_id, ingested) "
+                    "VALUES (:set_id, :history_id, FALSE)"
+                ),
+                {"set_id": legacy_id, "history_id": "101"},
+            )
 
-    assert expected_project_set_id in feature_set_ids
-    assert expected_user_set_id in feature_set_ids
-    assert expected_role_set_id in feature_set_ids
-    assert untouched_set_id in feature_set_ids
-    assert expected_project_set_id in history_set_ids
-    assert expected_user_set_id in history_set_ids
-    assert expected_role_set_id in history_set_ids
-    assert untouched_set_id in history_set_ids
-    assert legacy_session_id not in feature_set_ids
-    assert legacy_user_id not in feature_set_ids
-    assert legacy_role_id not in feature_set_ids
-    assert legacy_session_id not in history_set_ids
-    assert legacy_user_id not in history_set_ids
-    assert legacy_role_id not in history_set_ids
+    await _run_upgrade(sqlalchemy_pg_engine, "head")
 
-    assert expected_user_set_id in config_set_ids
+    feature_set_ids, history_set_ids = await _fetch_migration_state(
+        sqlalchemy_pg_engine
+    )
 
-    assert expected_user_set_id in disabled_set_ids
-    assert expected_user_set_id in category_set_ids
-
-    user_set_type_id = set_type_by_sig.get("producer_id")
-    assert user_set_type_id is not None
-    assert (expected_user_set_id, user_set_type_id) in mapping_data
-
-    assert legacy_user_id not in config_set_ids
+    for legacy_id in (user_set_id, role_set_id):
+        assert legacy_id in feature_set_ids
+        assert legacy_id in history_set_ids
 
     await _reset_database(sqlalchemy_pg_engine)


### PR DESCRIPTION
Fix how the set_id migration is done, ensuring that the set_id gets properly converted from the old set_id format to the new set_id format.
This way users won't loose access to old data.

Drops migration support for user and role isolations. These weren't used by Memmachine rest api and makes the migration script much more complicated. 

fixes #1024 