### PR TITLE
Switch semantic to stream results from database

### DIFF
--- a/src/memmachine/main/memmachine.py
+++ b/src/memmachine/main/memmachine.py
@@ -597,15 +597,20 @@ class MemMachine:
 
         if MemoryType.Semantic in target_memories:
             semantic_session = await self._resources.get_semantic_session_manager()
-            semantic_task = asyncio.create_task(
-                semantic_session.search(
-                    message=query,
-                    session_data=session_data,
-                    set_metadata=set_metadata,
-                    limit=limit,
-                    search_filter=property_filter,
-                )
-            )
+
+            async def _collect_semantic_results() -> list[SemanticFeature]:
+                return [
+                    feature
+                    async for feature in semantic_session.search(
+                        message=query,
+                        session_data=session_data,
+                        set_metadata=set_metadata,
+                        limit=limit,
+                        search_filter=property_filter,
+                    )
+                ]
+
+            semantic_task = asyncio.create_task(_collect_semantic_results())
 
         return MemMachine.SearchResponse(
             episodic_memory=await episodic_task if episodic_task else None,
@@ -669,15 +674,20 @@ class MemMachine:
 
         if MemoryType.Semantic in target_memories:
             semantic_session = await self._resources.get_semantic_session_manager()
-            semantic_task = asyncio.create_task(
-                semantic_session.get_set_features(
-                    session_data=session_data,
-                    set_metadata=set_metadata,
-                    search_filter=search_filter_expr,
-                    page_size=page_size,
-                    page_num=page_num,
-                )
-            )
+
+            async def _collect_semantic_results() -> list[SemanticFeature]:
+                return [
+                    feature
+                    async for feature in semantic_session.get_set_features(
+                        session_data=session_data,
+                        set_metadata=set_metadata,
+                        search_filter=search_filter_expr,
+                        page_size=page_size,
+                        page_num=page_num,
+                    )
+                ]
+
+            semantic_task = asyncio.create_task(_collect_semantic_results())
 
         episodic_result = await episodic_task if episodic_task else None
         semantic_result = await semantic_task if semantic_task else None

--- a/src/memmachine/semantic_memory/config_store/config_store.py
+++ b/src/memmachine/semantic_memory/config_store/config_store.py
@@ -1,5 +1,6 @@
 """Abstract interface for storing semantic configuration data."""
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
@@ -34,8 +35,8 @@ class SemanticConfigStorage(Protocol):
 
         embedder_name: str | None
         llm_name: str | None
-        disabled_categories: list[str] | None
-        categories: list[SemanticCategory]
+        disabled_categories: Sequence[str] | None
+        categories: Sequence[SemanticCategory]
 
     async def get_setid_config(
         self,
@@ -69,7 +70,7 @@ class SemanticConfigStorage(Protocol):
         self,
         *,
         category_id: CategoryIdT,
-    ) -> list[SetIdT]: ...
+    ) -> Sequence[SetIdT]: ...
 
     async def create_category(
         self,
@@ -121,7 +122,7 @@ class SemanticConfigStorage(Protocol):
         self,
         *,
         set_type_id: str,
-    ) -> list[SemanticCategory]: ...
+    ) -> Sequence[SemanticCategory]: ...
 
     @dataclass(frozen=True)
     class Tag:
@@ -164,11 +165,11 @@ class SemanticConfigStorage(Protocol):
         *,
         org_id: str,
         org_level_set: bool = False,
-        metadata_tags: list[str],
+        metadata_tags: Sequence[str],
         name: str | None = None,
         description: str | None = None,
     ) -> str: ...
 
-    async def list_set_type_ids(self, *, org_id: str) -> list[SetTypeEntry]: ...
+    async def list_set_type_ids(self, *, org_id: str) -> Sequence[SetTypeEntry]: ...
 
     async def delete_set_type_id(self, *, set_type_id: str) -> None: ...

--- a/src/memmachine/semantic_memory/config_store/config_store_sqlalchemy.py
+++ b/src/memmachine/semantic_memory/config_store/config_store_sqlalchemy.py
@@ -1,6 +1,7 @@
 """SQLAlchemy-backed implementation of the semantic config storage."""
 
 import logging
+from collections.abc import Sequence
 
 from sqlalchemy import (
     CheckConstraint,
@@ -413,7 +414,7 @@ class SemanticConfigStorageSqlAlchemy(SemanticConfigStorage):
         self,
         *,
         set_type_id: str,
-    ) -> list[SemanticCategory]:
+    ) -> Sequence[SemanticCategory]:
         set_type_id_int = int(set_type_id)
 
         stmt = (
@@ -459,7 +460,7 @@ class SemanticConfigStorageSqlAlchemy(SemanticConfigStorage):
         self,
         *,
         category_id: CategoryIdT,
-    ) -> list[SetIdT]:
+    ) -> Sequence[SetIdT]:
         category_id_int = int(category_id)
 
         async with self._create_session() as session:
@@ -710,7 +711,7 @@ class SemanticConfigStorageSqlAlchemy(SemanticConfigStorage):
         *,
         org_id: str,
         org_level_set: bool = False,
-        metadata_tags: list[str],
+        metadata_tags: Sequence[str],
         name: str | None = None,
         description: str | None = None,
     ) -> str:
@@ -757,7 +758,7 @@ class SemanticConfigStorageSqlAlchemy(SemanticConfigStorage):
 
         return str(set_type_id)
 
-    async def list_set_type_ids(self, *, org_id: str) -> list[SetTypeEntry]:
+    async def list_set_type_ids(self, *, org_id: str) -> Sequence[SetTypeEntry]:
         stmt = select(SetType).where(SetType.org_id == org_id)
 
         async with self._create_session() as session:

--- a/src/memmachine/semantic_memory/semantic_llm.py
+++ b/src/memmachine/semantic_memory/semantic_llm.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections.abc import Mapping, MutableMapping, Sequence
 
 from pydantic import (
     BaseModel,
@@ -20,9 +21,9 @@ logger = logging.getLogger(__name__)
 
 
 def _features_to_llm_format(
-    features: list[SemanticFeature],
-) -> dict[str, dict[str, str]]:
-    structured_features: dict[str, dict[str, str]] = {}
+    features: Sequence[SemanticFeature],
+) -> Mapping[str, Mapping[str, str]]:
+    structured_features: MutableMapping[str, MutableMapping[str, str]] = {}
 
     for feature in features:
         if feature.tag not in structured_features:
@@ -38,16 +39,16 @@ def _features_to_llm_format(
 class _SemanticFeatureUpdateRes(BaseModel):
     """Schema used to validate parsed feature-update commands returned by the LLM."""
 
-    commands: list[SemanticCommand] = Field(default_factory=list)
+    commands: Sequence[SemanticCommand] = Field(default_factory=list)
 
 
 @validate_call
 async def llm_feature_update(
-    features: list[SemanticFeature],
+    features: Sequence[SemanticFeature],
     message_content: str,
     model: InstanceOf[LanguageModel],
     update_prompt: str,
-) -> list[SemanticCommand]:
+) -> Sequence[SemanticCommand]:
     """Generate feature update commands from an incoming message using the LLM."""
     user_prompt = (
         "The old feature set is provided below:\n"
@@ -87,14 +88,14 @@ class LLMReducedFeature(BaseModel):
 class SemanticConsolidateMemoryRes(BaseModel):
     """LLM response describing merged features and ids of features to retain."""
 
-    consolidated_memories: list[LLMReducedFeature] = Field(default_factory=list)
-    keep_memories: list[EpisodeIdT] | None
+    consolidated_memories: Sequence[LLMReducedFeature] = Field(default_factory=list)
+    keep_memories: Sequence[EpisodeIdT] | None
     model_config = ConfigDict(coerce_numbers_to_str=True)
 
 
 @validate_call
 async def llm_consolidate_features(
-    features: list[SemanticFeature],
+    features: Sequence[SemanticFeature],
     model: InstanceOf[LanguageModel],
     consolidate_prompt: str,
 ) -> SemanticConsolidateMemoryRes | None:

--- a/src/memmachine/semantic_memory/semantic_memory.py
+++ b/src/memmachine/semantic_memory/semantic_memory.py
@@ -10,14 +10,13 @@ information extraction and a vector database for semantic search capabilities.
 import asyncio
 import logging
 from asyncio import Task
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable, Mapping, MutableMapping, Sequence
 from datetime import UTC, datetime, timedelta
-from typing import Any, Protocol, cast, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 from pydantic import BaseModel, InstanceOf
 
-from memmachine.common.data_types import FilterablePropertyValue
 from memmachine.common.embedder import Embedder
 from memmachine.common.episode_store import EpisodeIdT, EpisodeStorage
 from memmachine.common.errors import (
@@ -26,6 +25,7 @@ from memmachine.common.errors import (
 )
 from memmachine.common.filter.filter_parser import And, Comparison, FilterExpr
 from memmachine.common.language_model import LanguageModel
+from memmachine.common.utils import merge_async_iterators
 
 from .config_store.config_store import SemanticConfigStorage
 from .semantic_ingestion import IngestionService
@@ -43,13 +43,13 @@ from .storage.storage_base import SemanticStorage
 logger = logging.getLogger(__name__)
 
 
-def _consolidate_errors_and_raise(possible_errors: list[Any], msg: str) -> None:
+def _consolidate_errors_and_raise(possible_errors: Sequence[Any], msg: str) -> None:
     errors = [r for r in possible_errors if isinstance(r, Exception)]
     if len(errors) > 0:
         raise ExceptionGroup(msg, errors)
 
 
-DefaultCategoryRetriever = Callable[[SetIdT], list[SemanticCategory]]
+DefaultCategoryRetriever = Callable[[SetIdT], Sequence[SemanticCategory]]
 
 
 @runtime_checkable
@@ -62,7 +62,7 @@ class ResourceManager(Protocol):
 
 
 def _with_has_set_ids(
-    set_ids: list[SetIdT],
+    set_ids: Sequence[SetIdT],
     filter_expr: FilterExpr | None,
 ) -> FilterExpr:
     if len(set_ids) == 0:
@@ -71,7 +71,7 @@ def _with_has_set_ids(
     set_expr = Comparison(
         field="set_id",
         op="in",
-        value=cast(list[FilterablePropertyValue], list(set_ids)),
+        value=list(set_ids),
     )
 
     if filter_expr is None:
@@ -120,9 +120,9 @@ class SemanticService:
         self._default_embedder: Embedder = params.default_embedder
         self._default_embedder_name: str = params.default_embedder_name
         self._default_language_model: LanguageModel = params.default_language_model
-        self._default_category_retriever: Callable[[SetIdT], list[SemanticCategory]] = (
-            params.default_category_retriever
-        )
+        self._default_category_retriever: Callable[
+            [SetIdT], Sequence[SemanticCategory]
+        ] = params.default_category_retriever
 
         self._consolidation_threshold = params.consolidation_threshold
 
@@ -159,18 +159,18 @@ class SemanticService:
         self,
         *,
         set_id: str,
-        embedding: list[float],
+        embedding: Sequence[float],
         min_distance: float | None = None,
         limit: int | None = 30,
         load_citations: bool = False,
         filter_expr: FilterExpr | None = None,
-    ) -> list[SemanticFeature]:
+    ) -> AsyncIterator[SemanticFeature]:
         filter_expr = _with_has_set_ids(
             set_ids=[set_id],
             filter_expr=filter_expr,
         )
 
-        return await self._semantic_storage.get_feature_set(
+        async for feature in self._semantic_storage.get_feature_set(
             filter_expr=filter_expr,
             page_size=limit,
             vector_search_opts=SemanticStorage.VectorSearchOpts(
@@ -178,51 +178,48 @@ class SemanticService:
                 min_distance=min_distance,
             ),
             load_citations=load_citations,
-        )
+        ):
+            yield feature
 
     async def search(
         self,
-        set_ids: list[SetIdT],
+        set_ids: Sequence[SetIdT],
         query: str,
         *,
         min_distance: float | None = None,
         limit: int | None = 30,
         load_citations: bool = False,
         filter_expr: FilterExpr | None = None,
-    ) -> list[SemanticFeature]:
+    ) -> AsyncIterator[SemanticFeature]:
         logger.debug("Searching for %s in set ids %s", query, set_ids)
 
-        embeddings: dict[str, list[float]] = await self._set_ids_embed(
+        embeddings: Mapping[str, Sequence[float]] = await self._set_ids_embed(
             set_ids=set_ids,
             query=query,
         )
 
         assert set(set_ids) == set(embeddings.keys())
 
-        tasks: list[asyncio.Task[list[SemanticFeature]]] = []
-        async with asyncio.TaskGroup() as tg:
-            for set_id in set_ids:
-                t = tg.create_task(
-                    self._set_id_search(
-                        set_id=set_id,
-                        embedding=embeddings[set_id],
-                        min_distance=min_distance,
-                        limit=limit,
-                        load_citations=load_citations,
-                        filter_expr=filter_expr,
-                    )
-                )
-                tasks.append(t)
+        # Create iterators for each set_id search (parallel)
+        iterators = [
+            self._set_id_search(
+                set_id=set_id,
+                embedding=embeddings[set_id],
+                min_distance=min_distance,
+                limit=limit,
+                load_citations=load_citations,
+                filter_expr=filter_expr,
+            )
+            for set_id in set_ids
+        ]
 
-        t_res = [t.result() for t in tasks]
+        # Merge and yield results as they become available
+        async for feature in merge_async_iterators(iterators):
+            yield feature
 
-        res: list[SemanticFeature] = []
-        for t_list in t_res:
-            res = res + t_list
-
-        return res
-
-    async def add_messages(self, set_id: SetIdT, history_ids: list[EpisodeIdT]) -> None:
+    async def add_messages(
+        self, set_id: SetIdT, history_ids: Sequence[EpisodeIdT]
+    ) -> None:
         logger.info("Adding messages to set %s: %s", set_id, history_ids)
 
         res = await asyncio.gather(
@@ -241,7 +238,7 @@ class SemanticService:
     async def add_message_to_sets(
         self,
         history_id: EpisodeIdT,
-        set_ids: list[SetIdT],
+        set_ids: Sequence[SetIdT],
     ) -> None:
         assert len(set_ids) == len(set(set_ids))
 
@@ -260,12 +257,12 @@ class SemanticService:
 
         _consolidate_errors_and_raise(res, "Failed to add message to sets")
 
-    async def delete_messages(self, *, set_ids: list[SetIdT]) -> None:
+    async def delete_messages(self, *, set_ids: Sequence[SetIdT]) -> None:
         logger.info("Deleting messages from sets %s", set_ids)
 
         await self._semantic_storage.delete_history_set(set_ids=set_ids)
 
-    async def number_of_uningested(self, set_ids: list[SetIdT]) -> int:
+    async def number_of_uningested(self, set_ids: Sequence[SetIdT]) -> int:
         logger.debug("Getting number of uningested messages for set ids %s", set_ids)
 
         return await self._semantic_storage.get_history_messages_count(
@@ -281,8 +278,8 @@ class SemanticService:
         feature: str,
         value: str,
         tag: str,
-        metadata: dict[str, str] | None = None,
-        citations: list[EpisodeIdT] | None = None,
+        metadata: Mapping[str, str] | None = None,
+        citations: Sequence[EpisodeIdT] | None = None,
     ) -> FeatureIdT:
         logger.info("Adding new feature %s to set %s", feature, set_id)
 
@@ -325,15 +322,15 @@ class SemanticService:
     async def get_set_features(
         self,
         *,
-        set_ids: list[SetIdT],
+        set_ids: Sequence[SetIdT],
         filter_expr: FilterExpr | None = None,
         page_size: int | None = None,
         page_num: int | None = None,
         with_citations: bool = False,
-    ) -> list[SemanticFeature]:
+    ) -> AsyncIterator[SemanticFeature]:
         logger.debug("Getting features for set ids %s", set_ids)
 
-        return await self._semantic_storage.get_feature_set(
+        async for feature in self._semantic_storage.get_feature_set(
             filter_expr=_with_has_set_ids(
                 set_ids=set_ids,
                 filter_expr=filter_expr,
@@ -341,7 +338,8 @@ class SemanticService:
             page_size=page_size,
             page_num=page_num,
             load_citations=with_citations,
-        )
+        ):
+            yield feature
 
     async def update_feature(
         self,
@@ -352,7 +350,7 @@ class SemanticService:
         feature: str | None = None,
         value: str | None = None,
         tag: str | None = None,
-        metadata: dict[str, str] | None = None,
+        metadata: Mapping[str, str] | None = None,
     ) -> None:
         logger.info("Updating feature %s", feature_id)
         embedding = None
@@ -393,12 +391,12 @@ class SemanticService:
             embedding=embedding,
         )
 
-    async def delete_history(self, history_ids: list[EpisodeIdT]) -> None:
+    async def delete_history(self, history_ids: Sequence[EpisodeIdT]) -> None:
         logger.info("Deleting history ids %s", history_ids)
 
         await self._semantic_storage.delete_history(history_ids)
 
-    async def delete_features(self, feature_ids: list[FeatureIdT]) -> None:
+    async def delete_features(self, feature_ids: Sequence[FeatureIdT]) -> None:
         logger.info("Deleting features ids %s", feature_ids)
 
         await self._semantic_storage.delete_features(feature_ids)
@@ -406,7 +404,7 @@ class SemanticService:
     async def delete_feature_set(
         self,
         *,
-        set_ids: list[SetIdT],
+        set_ids: Sequence[SetIdT],
         filter_expr: FilterExpr | None = None,
     ) -> None:
         logger.info("Deleting filter feature set ids %s", set_ids)
@@ -421,11 +419,11 @@ class SemanticService:
     async def _set_ids_embed(
         self,
         *,
-        set_ids: list[SetIdT],
+        set_ids: Sequence[SetIdT],
         query: str,
-    ) -> dict[str, list[float]]:
-        set_id_embedders: dict[str, str | None]
-        embedders: dict[str, Embedder]
+    ) -> Mapping[str, Sequence[float]]:
+        set_id_embedders: Mapping[str, str | None]
+        embedders: Mapping[str, Embedder]
         has_default_embedder: bool
 
         (
@@ -434,8 +432,8 @@ class SemanticService:
             has_default_embedder,
         ) = await self._set_ids_embedders(set_ids=set_ids)
 
-        tasks: dict[str, asyncio.Task[list[list[float]]]] = {}
-        default_task: asyncio.Task[list[list[float]]] | None = None
+        tasks: MutableMapping[str, asyncio.Task[Sequence[Sequence[float]]]] = {}
+        default_task: asyncio.Task[Sequence[Sequence[float]]] | None = None
         async with asyncio.TaskGroup() as tg:
             for e_str, e_cls in embedders.items():
                 tasks[e_str] = tg.create_task(e_cls.search_embed(queries=[query]))
@@ -445,7 +443,7 @@ class SemanticService:
                     self._default_embedder.search_embed(queries=[query])
                 )
 
-        results: dict[str, list[float]] = {}
+        results: MutableMapping[str, Sequence[float]] = {}
         for set_id in set_ids:
             embedder_str = set_id_embedders[set_id]
 
@@ -461,20 +459,20 @@ class SemanticService:
     async def _set_ids_embedders(
         self,
         *,
-        set_ids: list[SetIdT],
-    ) -> tuple[dict[str, str | None], dict[str, Embedder], bool]:
+        set_ids: Sequence[SetIdT],
+    ) -> tuple[Mapping[str, str | None], Mapping[str, Embedder], bool]:
         async def _get_embedder_name(s_id: SetIdT) -> str | None:
             cfg = await self._semantic_config_storage.get_setid_config(set_id=s_id)
             return cfg.embedder_name
 
-        tasks: dict[str, asyncio.Task[str | None]] = {}
+        tasks: MutableMapping[str, asyncio.Task[str | None]] = {}
         async with asyncio.TaskGroup() as tg:
             for s_id in set_ids:
                 tasks[s_id] = tg.create_task(_get_embedder_name(s_id))
 
         set_id_embedders = {s_id: task.result() for s_id, task in tasks.items()}
 
-        embedders: dict[str, Embedder] = {}
+        embedders: MutableMapping[str, Embedder] = {}
         has_default_embedder = False
         for embedder_name in set_id_embedders.values():
             if embedder_name is None:
@@ -527,7 +525,7 @@ class SemanticService:
             if category.name not in disabled_categories
         ]
 
-        categories = user_categories + enabled_default
+        categories = [*user_categories, *enabled_default]
 
         return Resources(
             embedder=embedder,
@@ -535,7 +533,7 @@ class SemanticService:
             semantic_categories=categories,
         )
 
-    async def delete_set_id(self, *, set_ids: list[SetIdT]) -> None:
+    async def delete_set_id(self, *, set_ids: Sequence[SetIdT]) -> None:
         logger.info("Deleting set ids %s", set_ids)
 
         async with asyncio.TaskGroup() as tg:
@@ -547,7 +545,7 @@ class SemanticService:
             )
             tg.create_task(self._semantic_storage.reset_set_ids(set_ids=set_ids))
 
-    async def get_set_id_category_names(self, *, set_id: SetIdT) -> list[str]:
+    async def get_set_id_category_names(self, *, set_id: SetIdT) -> Sequence[str]:
         logger.debug("Getting category names for set id %s", set_id)
 
         resources = await self._set_id_resource(set_id=set_id)
@@ -568,9 +566,12 @@ class SemanticService:
         ).embedder_name
 
         if embedder_name != current_set_id_embedder_name:
+            has_features = False
+            async for _ in self.get_set_features(set_ids=[set_id]):
+                has_features = True
+                break
             valid_changing_embedder = (
-                current_set_id_embedder_name is None
-                and len(await self.get_set_features(set_ids=[set_id])) == 0
+                current_set_id_embedder_name is None and not has_features
             )
             if not valid_changing_embedder:
                 raise InvalidSetIdConfigurationError(set_id=set_id)
@@ -636,7 +637,7 @@ class SemanticService:
 
     async def get_set_type_categories(
         self, *, set_type_id: str
-    ) -> list[SemanticCategory]:
+    ) -> Sequence[SemanticCategory]:
         logger.debug("Getting set type categories for %s", set_type_id)
 
         return await self._semantic_config_storage.get_set_type_categories(
@@ -670,7 +671,7 @@ class SemanticService:
         self,
         *,
         category_id: CategoryIdT,
-    ) -> list[SetIdT]:
+    ) -> Sequence[SetIdT]:
         logger.debug("Getting set_ids for category %s", category_id)
 
         return await self._semantic_config_storage.get_category_set_ids(
@@ -758,10 +759,11 @@ class SemanticService:
 
         await self._semantic_config_storage.delete_tag(tag_id=tag_id)
 
-    async def list_set_id_starts_with(self, prefix: str) -> list[SetIdT]:
+    async def list_set_id_starts_with(self, prefix: str) -> AsyncIterator[SetIdT]:
         logger.debug("Listing set ids starts with %s", prefix)
 
-        return await self._semantic_storage.get_set_ids_starts_with(prefix)
+        async for set_id in self._semantic_storage.get_set_ids_starts_with(prefix):
+            yield set_id
 
     async def _background_ingestion_task(self) -> None:
         ingestion_service = IngestionService(
@@ -773,17 +775,31 @@ class SemanticService:
         )
 
         while not self._is_shutting_down:
-            dirty_sets = await self._semantic_storage.get_history_set_ids(
+            dirty_sets = self._semantic_storage.get_history_set_ids(
                 min_uningested_messages=self._feature_update_message_limit,
                 older_than=datetime.now(tz=UTC) - self._feature_time_limit,
             )
 
-            if len(dirty_sets) == 0:
+            first_set_id: SetIdT | None = None
+            async for set_id in dirty_sets:
+                first_set_id = set_id
+                break
+
+            if first_set_id is None:
                 await asyncio.sleep(self._background_ingestion_interval_sec)
                 continue
 
+            async def _stream_set_ids(
+                first_id: SetIdT, remaining: AsyncIterator[SetIdT]
+            ) -> AsyncIterator[SetIdT]:
+                yield first_id
+                async for set_id in remaining:
+                    yield set_id
+
             try:
-                await ingestion_service.process_set_ids(dirty_sets)
+                await ingestion_service.process_set_ids(
+                    _stream_set_ids(first_set_id, dirty_sets)
+                )
             except Exception:
                 if self._debug_fail_loudly:
                     raise

--- a/src/memmachine/semantic_memory/semantic_model.py
+++ b/src/memmachine/semantic_memory/semantic_model.py
@@ -1,6 +1,6 @@
 """Core data models for semantic memory features and retrieval."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Literal, Protocol, runtime_checkable
@@ -45,7 +45,7 @@ class RawSemanticPrompt:
 class StructuredSemanticPrompt(BaseModel):
     """Pair of prompt templates driving update and consolidation LLM calls."""
 
-    tags: dict[str, str]
+    tags: Mapping[str, str]
     description: str | None = None
 
     @property
@@ -66,9 +66,9 @@ class SemanticFeature(BaseModel):
     class Metadata(BaseModel):
         """Storage metadata for a semantic feature, including id and citations."""
 
-        citations: list[EpisodeIdT] | None = None
+        citations: Sequence[EpisodeIdT] | None = None
         id: FeatureIdT | None = None
-        other: dict[str, Any] | None = None
+        other: Mapping[str, Any] | None = None
 
     set_id: SetIdT | None = None
     category: str
@@ -79,9 +79,11 @@ class SemanticFeature(BaseModel):
 
     @staticmethod
     def group_features(
-        features: list["SemanticFeature"],
-    ) -> dict[tuple[str, str, str], list["SemanticFeature"]]:
-        grouped_features: dict[tuple[str, str, str], list[SemanticFeature]] = {}
+        features: Sequence["SemanticFeature"],
+    ) -> Mapping[tuple[str, str, str], Sequence["SemanticFeature"]]:
+        grouped_features: MutableMapping[
+            tuple[str, str, str], list[SemanticFeature]
+        ] = {}
 
         for f in features:
             key = (f.category, f.tag, f.feature_name)
@@ -95,9 +97,9 @@ class SemanticFeature(BaseModel):
 
     @staticmethod
     def group_features_by_tag(
-        features: list["SemanticFeature"],
-    ) -> dict[str, list["SemanticFeature"]]:
-        grouped_features: dict[str, list[SemanticFeature]] = {}
+        features: Sequence["SemanticFeature"],
+    ) -> Mapping[str, Sequence["SemanticFeature"]]:
+        grouped_features: MutableMapping[str, list[SemanticFeature]] = {}
 
         for f in features:
             key = f.tag
@@ -141,7 +143,7 @@ class Resources(BaseModel):
 
     embedder: InstanceOf[Embedder]
     language_model: InstanceOf[LanguageModel]
-    semantic_categories: list[InstanceOf[SemanticCategory]]
+    semantic_categories: Sequence[InstanceOf[SemanticCategory]]
 
 
 class SetTypeEntry(BaseModel):
@@ -149,7 +151,7 @@ class SetTypeEntry(BaseModel):
 
     id: str | None = None
     is_org_level: bool
-    tags: list[str]
+    tags: Sequence[str]
     name: str | None = None
     description: str | None = None
 

--- a/src/memmachine/semantic_memory/storage/neo4j_semantic_storage.py
+++ b/src/memmachine/semantic_memory/storage/neo4j_semantic_storage.py
@@ -6,7 +6,14 @@ import asyncio
 import json
 import re
 from asyncio import Lock
-from collections.abc import Callable, Mapping
+from collections.abc import (
+    AsyncIterator,
+    Callable,
+    Mapping,
+    MutableMapping,
+    MutableSequence,
+    Sequence,
+)
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, LiteralString, cast
@@ -52,8 +59,8 @@ class _FeatureEntry:
     feature_name: str
     value: str
     embedding: np.ndarray
-    metadata: dict[str, Any] | None
-    citations: list[EpisodeIdT]
+    metadata: Mapping[str, Any] | None
+    citations: Sequence[EpisodeIdT]
     created_at_ts: float
     updated_at_ts: float
 
@@ -115,12 +122,12 @@ class Neo4jSemanticStorage(SemanticStorage):
         self._owns_driver = owns_driver
         # Exposed for fixtures to know which backend is in use
         self.backend_name = "neo4j"
-        self._vector_index_by_set: dict[str, int] = {}
-        self._set_embedding_dimensions: dict[str, int] = {}
+        self._vector_index_by_set: MutableMapping[str, int] = {}
+        self._set_embedding_dimensions: MutableMapping[str, int] = {}
         self._filter_param_counter = 0
 
         self._vector_global_lock = Lock()
-        self._vector_index_creation_lock: dict[str, Lock] = {}
+        self._vector_index_creation_lock: MutableMapping[str, Lock] = {}
 
     async def startup(self) -> None:
         await self._driver.execute_query(
@@ -199,7 +206,7 @@ class Neo4jSemanticStorage(SemanticStorage):
                 set_id=set_id,
             )
 
-    async def reset_set_ids(self, set_ids: list[SetIdT]) -> None:
+    async def reset_set_ids(self, set_ids: Sequence[SetIdT]) -> None:
         async with asyncio.TaskGroup() as tg:
             for set_id in set_ids:
                 tg.create_task(self._drop_set_id_vector_index(set_id))
@@ -207,13 +214,13 @@ class Neo4jSemanticStorage(SemanticStorage):
     async def add_feature(
         self,
         *,
-        set_id: str,
+        set_id: SetIdT,
         category_name: str,
         feature: str,
         value: str,
         tag: str,
         embedding: InstanceOf[np.ndarray],
-        metadata: dict[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
     ) -> FeatureIdT:
         timestamp = _utc_timestamp()
         dimensions = len(np.array(embedding, dtype=float))
@@ -265,13 +272,13 @@ class Neo4jSemanticStorage(SemanticStorage):
         self,
         feature_id: FeatureIdT,
         *,
-        set_id: str | None = None,
+        set_id: SetIdT | None = None,
         category_name: str | None = None,
         feature: str | None = None,
         value: str | None = None,
         tag: str | None = None,
         embedding: InstanceOf[np.ndarray] | None = None,
-        metadata: dict[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
     ) -> None:
         record = await self._get_feature_dimensions(feature_id)
         if record is None:
@@ -340,11 +347,11 @@ class Neo4jSemanticStorage(SemanticStorage):
         value: str | None,
         tag: str | None,
         embedding: InstanceOf[np.ndarray] | None,
-        metadata: dict[str, Any] | None,
+        metadata: Mapping[str, Any] | None,
         target_dimensions: int,
-    ) -> tuple[list[str], dict[str, Any], dict[str, Any] | None]:
+    ) -> tuple[Sequence[str], MutableMapping[str, Any], Mapping[str, Any] | None]:
         assignments = ["f.updated_at_ts = $updated_at_ts"]
-        params: dict[str, Any] = {
+        params: MutableMapping[str, Any] = {
             "feature_id": str(feature_id),
             "updated_at_ts": _utc_timestamp(),
             "embedding_dimensions": target_dimensions,
@@ -369,7 +376,7 @@ class Neo4jSemanticStorage(SemanticStorage):
             assignments.append("f.embedding = $embedding")
             params["embedding"] = embedding_param
 
-        metadata_props: dict[str, Any] | None = None
+        metadata_props: MutableMapping[str, Any] | None = None
         if metadata is not None:
             metadata_json, metadata_props = self._prepare_metadata_storage(metadata)
             assignments.append("f.metadata_json = $metadata_json")
@@ -384,7 +391,7 @@ class Neo4jSemanticStorage(SemanticStorage):
     @staticmethod
     def _embedding_param(
         embedding: InstanceOf[np.ndarray] | None,
-    ) -> list[float] | None:
+    ) -> Sequence[float] | None:
         if embedding is None:
             return None
         return [float(x) for x in np.array(embedding, dtype=float).tolist()]
@@ -393,7 +400,7 @@ class Neo4jSemanticStorage(SemanticStorage):
         self,
         existing_set_id: str | None,
         new_set_id: str | None,
-    ) -> list[str]:
+    ) -> Sequence[str]:
         if new_set_id is None or new_set_id == existing_set_id:
             return []
 
@@ -425,7 +432,7 @@ class Neo4jSemanticStorage(SemanticStorage):
         entry = self._node_to_entry(records[0]["f"])
         return self._entry_to_model(entry, load_citations=load_citations)
 
-    async def delete_features(self, feature_ids: list[FeatureIdT]) -> None:
+    async def delete_features(self, feature_ids: Sequence[FeatureIdT]) -> None:
         if not feature_ids:
             return
 
@@ -449,7 +456,7 @@ class Neo4jSemanticStorage(SemanticStorage):
         tag_threshold: int | None = None,
         load_citations: bool = False,
         filter_expr: FilterExpr | None = None,
-    ) -> list[SemanticFeature]:
+    ) -> AsyncIterator[SemanticFeature]:
         if page_num is not None:
             if page_size is None:
                 raise InvalidArgumentError("Cannot specify offset without limit")
@@ -457,17 +464,18 @@ class Neo4jSemanticStorage(SemanticStorage):
                 raise InvalidArgumentError("Offset must be non-negative")
 
         page_offset = page_num or 0
+        entries: list[_FeatureEntry]
         if vector_search_opts is not None:
-            entries = await self._vector_search_entries(
-                limit=page_size,
-                offset=page_offset,
-                vector_search_opts=vector_search_opts,
-                filter_expr=filter_expr,
+            entries = list(
+                await self._vector_search_entries(
+                    limit=page_size,
+                    offset=page_offset,
+                    vector_search_opts=vector_search_opts,
+                    filter_expr=filter_expr,
+                )
             )
         else:
-            entries = await self._load_feature_entries(
-                filter_expr=filter_expr,
-            )
+            entries = list(await self._load_feature_entries(filter_expr=filter_expr))
             entries.sort(key=lambda e: (e.created_at_ts, str(e.feature_id)))
             if page_size is not None:
                 start = page_size * page_offset
@@ -479,10 +487,8 @@ class Neo4jSemanticStorage(SemanticStorage):
             counts = Counter(entry.tag for entry in entries)
             entries = [entry for entry in entries if counts[entry.tag] >= tag_threshold]
 
-        return [
-            self._entry_to_model(entry, load_citations=load_citations)
-            for entry in entries
-        ]
+        for entry in entries:
+            yield self._entry_to_model(entry, load_citations=load_citations)
 
     async def delete_feature_set(
         self,
@@ -492,13 +498,16 @@ class Neo4jSemanticStorage(SemanticStorage):
         vector_search_opts: SemanticStorage.VectorSearchOpts | None = None,
         filter_expr: FilterExpr | None = None,
     ) -> None:
-        entries = await self.get_feature_set(
-            page_size=limit,
-            vector_search_opts=vector_search_opts,
-            tag_threshold=thresh,
-            filter_expr=filter_expr,
-            load_citations=False,
-        )
+        entries = [
+            entry
+            async for entry in self.get_feature_set(
+                page_size=limit,
+                vector_search_opts=vector_search_opts,
+                tag_threshold=thresh,
+                filter_expr=filter_expr,
+                load_citations=False,
+            )
+        ]
         await self.delete_features(
             [FeatureIdT(entry.metadata.id) for entry in entries if entry.metadata.id],
         )
@@ -506,7 +515,7 @@ class Neo4jSemanticStorage(SemanticStorage):
     async def add_citations(
         self,
         feature_id: FeatureIdT,
-        history_ids: list[EpisodeIdT],
+        history_ids: Sequence[EpisodeIdT],
     ) -> None:
         if not history_ids:
             return
@@ -542,10 +551,10 @@ class Neo4jSemanticStorage(SemanticStorage):
     async def get_history_messages(
         self,
         *,
-        set_ids: list[str] | None = None,
+        set_ids: Sequence[SetIdT] | None = None,
         limit: int | None = None,
         is_ingested: bool | None = None,
-    ) -> list[EpisodeIdT]:
+    ) -> AsyncIterator[EpisodeIdT]:
         query = ["MATCH (h:SetHistory)"]
         conditions = []
         params: dict[str, Any] = {}
@@ -565,12 +574,13 @@ class Neo4jSemanticStorage(SemanticStorage):
             _neo4j_query("\n".join(query)),
             **params,
         )
-        return [EpisodeIdT(record["history_id"]) for record in records]
+        for record in records:
+            yield EpisodeIdT(record["history_id"])
 
     async def get_history_messages_count(
         self,
         *,
-        set_ids: list[str] | None = None,
+        set_ids: Sequence[SetIdT] | None = None,
         is_ingested: bool | None = None,
     ) -> int:
         query = ["MATCH (h:SetHistory)"]
@@ -591,68 +601,103 @@ class Neo4jSemanticStorage(SemanticStorage):
         )
         return int(records[0]["cnt"]) if records else 0
 
-    async def get_history_set_ids(
+    @staticmethod
+    def _extract_unique_set_ids(
+        records: Sequence[Mapping[str, Any]],
+        seen: set[str],
+    ) -> Sequence[SetIdT]:
+        yielded: list[SetIdT] = []
+        for record in records:
+            raw_set_id = record.get("set_id")
+            if raw_set_id is None:
+                continue
+            set_id = str(raw_set_id)
+            if set_id in seen:
+                continue
+            seen.add(set_id)
+            yielded.append(SetIdT(set_id))
+        return yielded
+
+    async def _fetch_set_ids_min_uningested(
+        self,
+        min_uningested_messages: int,
+    ) -> Sequence[Mapping[str, Any]]:
+        records, _, _ = await self._driver.execute_query(
+            _neo4j_query(
+                """
+                MATCH (h:SetHistory)
+                WITH h.set_id AS set_id,
+                     sum(CASE WHEN coalesce(h.is_ingested, false) = false THEN 1 ELSE 0 END) AS uningested_count
+                WHERE uningested_count >= $min_uningested_messages
+                RETURN set_id
+                """
+            ),
+            min_uningested_messages=min_uningested_messages,
+        )
+        return records
+
+    async def _fetch_set_ids_older_than(
+        self,
+        older_than: datetime,
+    ) -> Sequence[Mapping[str, Any]]:
+        records, _, _ = await self._driver.execute_query(
+            """
+            MATCH (h:SetHistory)
+            WHERE coalesce(h.is_ingested, false) = false
+              AND h.created_at <= $older_than
+            RETURN DISTINCT h.set_id AS set_id
+            """,
+            older_than=older_than,
+        )
+        return records
+
+    async def _fetch_set_ids_all(self) -> Sequence[Mapping[str, Any]]:
+        records, _, _ = await self._driver.execute_query(
+            """
+            MATCH (h:SetHistory)
+            RETURN DISTINCT h.set_id AS set_id
+            """,
+        )
+        return records
+
+    async def _iter_history_set_ids(
         self,
         *,
         min_uningested_messages: int | None = None,
         older_than: datetime | None = None,
-    ) -> list[str]:
-        set_ids: set[str] = set()
+    ) -> AsyncIterator[SetIdT]:
+        seen: set[str] = set()
         filters_applied = False
 
         if min_uningested_messages is not None and min_uningested_messages > 0:
             filters_applied = True
-            records, _, _ = await self._driver.execute_query(
-                _neo4j_query(
-                    """
-                    MATCH (h:SetHistory)
-                    WITH h.set_id AS set_id,
-                         sum(CASE WHEN coalesce(h.is_ingested, false) = false THEN 1 ELSE 0 END) AS uningested_count
-                    WHERE uningested_count >= $min_uningested_messages
-                    RETURN set_id
-                    """
-                ),
-                min_uningested_messages=min_uningested_messages,
-            )
-            set_ids.update(
-                str(record.get("set_id"))
-                for record in records
-                if record.get("set_id") is not None
-            )
+            records = await self._fetch_set_ids_min_uningested(min_uningested_messages)
+            for set_id in self._extract_unique_set_ids(records, seen):
+                yield set_id
 
         if older_than is not None:
             filters_applied = True
-            records, _, _ = await self._driver.execute_query(
-                """
-                MATCH (h:SetHistory)
-                WHERE coalesce(h.is_ingested, false) = false
-                  AND h.created_at <= $older_than
-                RETURN DISTINCT h.set_id AS set_id
-                """,
-                older_than=older_than,
-            )
-            set_ids.update(
-                str(record.get("set_id"))
-                for record in records
-                if record.get("set_id") is not None
-            )
+            records = await self._fetch_set_ids_older_than(older_than)
+            for set_id in self._extract_unique_set_ids(records, seen):
+                yield set_id
 
         if not filters_applied:
-            records, _, _ = await self._driver.execute_query(
-                """
-                MATCH (h:SetHistory)
-                RETURN DISTINCT h.set_id AS set_id
-                """,
-            )
-            set_ids.update(
-                str(record.get("set_id"))
-                for record in records
-                if record.get("set_id") is not None
-            )
+            records = await self._fetch_set_ids_all()
+            for set_id in self._extract_unique_set_ids(records, seen):
+                yield set_id
 
-        return list(set_ids)
+    def get_history_set_ids(
+        self,
+        *,
+        min_uningested_messages: int | None = None,
+        older_than: datetime | None = None,
+    ) -> AsyncIterator[SetIdT]:
+        return self._iter_history_set_ids(
+            min_uningested_messages=min_uningested_messages,
+            older_than=older_than,
+        )
 
-    async def get_set_ids_starts_with(self, prefix: str) -> list[SetIdT]:
+    async def get_set_ids_starts_with(self, prefix: str) -> AsyncIterator[SetIdT]:
         records, _, _ = await self._driver.execute_query(
             """
             MATCH (f:Feature)
@@ -665,13 +710,12 @@ class Neo4jSemanticStorage(SemanticStorage):
             """,
             prefix=prefix,
         )
-        return [
-            SetIdT(str(record["set_id"]))
-            for record in records
-            if record.get("set_id") is not None
-        ]
+        for record in records:
+            if record.get("set_id") is None:
+                continue
+            yield SetIdT(str(record["set_id"]))
 
-    async def add_history_to_set(self, set_id: str, history_id: EpisodeIdT) -> None:
+    async def add_history_to_set(self, set_id: SetIdT, history_id: EpisodeIdT) -> None:
         await self._driver.execute_query(
             """
             MERGE (h:SetHistory {set_id: $set_id, history_id: $history_id})
@@ -683,7 +727,7 @@ class Neo4jSemanticStorage(SemanticStorage):
             created_at=datetime.now(UTC),
         )
 
-    async def delete_history(self, history_ids: list[EpisodeIdT]) -> None:
+    async def delete_history(self, history_ids: Sequence[EpisodeIdT]) -> None:
         if not history_ids:
             return
 
@@ -696,7 +740,7 @@ class Neo4jSemanticStorage(SemanticStorage):
             history_ids=[str(history_id) for history_id in history_ids],
         )
 
-    async def delete_history_set(self, set_ids: list[SetIdT]) -> None:
+    async def delete_history_set(self, set_ids: Sequence[SetIdT]) -> None:
         if not set_ids:
             return
 
@@ -712,8 +756,8 @@ class Neo4jSemanticStorage(SemanticStorage):
     async def mark_messages_ingested(
         self,
         *,
-        set_id: str,
-        history_ids: list[EpisodeIdT],
+        set_id: SetIdT,
+        history_ids: Sequence[EpisodeIdT],
     ) -> None:
         if not history_ids:
             raise ValueError("No ids provided")
@@ -731,7 +775,7 @@ class Neo4jSemanticStorage(SemanticStorage):
         self,
         *,
         filter_expr: FilterExpr | None,
-    ) -> list[_FeatureEntry]:
+    ) -> Sequence[_FeatureEntry]:
         query = ["MATCH (f:Feature)"]
         conditions, params = self._build_filter_conditions(
             alias="f",
@@ -772,7 +816,7 @@ class Neo4jSemanticStorage(SemanticStorage):
         )
 
     @staticmethod
-    def _parse_metadata(props: Mapping[str, Any]) -> dict[str, Any] | None:
+    def _parse_metadata(props: Mapping[str, Any]) -> Mapping[str, Any] | None:
         metadata_json = props.get("metadata_json")
         if isinstance(metadata_json, str) and metadata_json:
             try:
@@ -790,12 +834,12 @@ class Neo4jSemanticStorage(SemanticStorage):
 
     def _prepare_metadata_storage(
         self,
-        metadata: dict[str, Any] | None,
-    ) -> tuple[str | None, dict[str, Any]]:
+        metadata: Mapping[str, Any] | None,
+    ) -> tuple[str | None, MutableMapping[str, Any]]:
         if metadata is None:
             return None, {}
         metadata_json = json.dumps(metadata)
-        metadata_props: dict[str, Any] = {}
+        metadata_props: MutableMapping[str, Any] = {}
         for raw_key, raw_value in metadata.items():
             if raw_value is None:
                 continue
@@ -827,7 +871,7 @@ class Neo4jSemanticStorage(SemanticStorage):
         *,
         load_citations: bool,
     ) -> SemanticFeature:
-        citations: list[EpisodeIdT] | None = None
+        citations: Sequence[EpisodeIdT] | None = None
         if load_citations:
             citations = list(entry.citations)
         return SemanticFeature(
@@ -850,7 +894,7 @@ class Neo4jSemanticStorage(SemanticStorage):
         offset: int,
         vector_search_opts: SemanticStorage.VectorSearchOpts,
         filter_expr: FilterExpr | None,
-    ) -> list[_FeatureEntry]:
+    ) -> Sequence[_FeatureEntry]:
         embedding_array = np.array(vector_search_opts.query_embedding, dtype=float)
         embedding = [float(x) for x in embedding_array.tolist()]
         embedding_dims = len(embedding)
@@ -893,13 +937,13 @@ class Neo4jSemanticStorage(SemanticStorage):
     def _vector_query_params(
         self,
         *,
-        embedding: list[float],
-        filter_params: dict[str, Any],
+        embedding: Sequence[float],
+        filter_params: Mapping[str, Any],
         candidate_limit: int,
         min_distance: float | None,
-        conditions: list[str],
-    ) -> dict[str, Any]:
-        params: dict[str, Any] = {
+        conditions: MutableSequence[str],
+    ) -> Mapping[str, Any]:
+        params: MutableMapping[str, Any] = {
             "candidate_limit": candidate_limit,
             "embedding": embedding,
             **filter_params,
@@ -910,7 +954,7 @@ class Neo4jSemanticStorage(SemanticStorage):
         return params
 
     @staticmethod
-    def _vector_query_text(conditions: list[str]) -> str:
+    def _vector_query_text(conditions: Sequence[str]) -> str:
         query_parts = [
             "CALL db.index.vector.queryNodes($index_name, $candidate_limit, $embedding)",
             "YIELD node, score",
@@ -925,7 +969,7 @@ class Neo4jSemanticStorage(SemanticStorage):
         self,
         filter_expr: FilterExpr | None,
         expected_dims: int,
-    ) -> list[str]:
+    ) -> Sequence[str]:
         requested_set_ids = self._extract_set_ids(filter_expr)
         candidate_ids = self._deduplicated_set_ids(requested_set_ids)
         return [
@@ -934,7 +978,9 @@ class Neo4jSemanticStorage(SemanticStorage):
             if self._set_embedding_dimensions.get(set_id) == expected_dims
         ]
 
-    def _deduplicated_set_ids(self, requested_set_ids: list[str] | None) -> list[str]:
+    def _deduplicated_set_ids(
+        self, requested_set_ids: Sequence[str] | None
+    ) -> Sequence[str]:
         if requested_set_ids is None:
             return list(self._set_embedding_dimensions.keys())
 
@@ -951,8 +997,8 @@ class Neo4jSemanticStorage(SemanticStorage):
         self,
         query_text: str,
         index_name: str,
-        params_base: dict[str, Any],
-    ) -> list[tuple[float, _FeatureEntry]]:
+        params_base: Mapping[str, Any],
+    ) -> Sequence[tuple[float, _FeatureEntry]]:
         params = dict(params_base)
         params["index_name"] = index_name
         records, _, _ = await self._driver.execute_query(
@@ -969,9 +1015,9 @@ class Neo4jSemanticStorage(SemanticStorage):
         *,
         alias: str,
         filter_expr: FilterExpr | None = None,
-    ) -> tuple[list[str], dict[str, Any]]:
+    ) -> tuple[MutableSequence[str], MutableMapping[str, Any]]:
         conditions: list[str] = []
-        params: dict[str, Any] = {}
+        params: MutableMapping[str, Any] = {}
         if filter_expr is not None:
             expr_condition, expr_params = self._render_filter_expr(alias, filter_expr)
             if expr_condition:
@@ -979,7 +1025,7 @@ class Neo4jSemanticStorage(SemanticStorage):
                 params.update(expr_params)
         return conditions, params
 
-    def _extract_set_ids(self, expr: FilterExpr | None) -> list[str] | None:
+    def _extract_set_ids(self, expr: FilterExpr | None) -> Sequence[str] | None:
         if expr is None:
             return None
 
@@ -1031,7 +1077,7 @@ class Neo4jSemanticStorage(SemanticStorage):
         self,
         alias: str,
         expr: FilterExpr,
-    ) -> tuple[str, dict[str, Any]]:
+    ) -> tuple[str, MutableMapping[str, Any]]:
         if isinstance(expr, FilterComparison):
             field_ref, value_adapter = self._resolve_field_reference(
                 alias,
@@ -1061,9 +1107,9 @@ class Neo4jSemanticStorage(SemanticStorage):
         field_ref: str,
         expr: FilterComparison,
         value_adapter: Callable[[FilterablePropertyValue], Any] | None,
-    ) -> tuple[str, dict[str, Any]]:
+    ) -> tuple[str, MutableMapping[str, Any]]:
         op = expr.op
-        params: dict[str, Any] = {}
+        params: MutableMapping[str, Any] = {}
 
         if op == "in":
             if not isinstance(expr.value, list):
@@ -1360,7 +1406,7 @@ class Neo4jSemanticStorage(SemanticStorage):
     async def _get_feature_dimensions(
         self,
         feature_id: FeatureIdT,
-    ) -> dict[str, Any] | None:
+    ) -> Mapping[str, Any] | None:
         records, _, _ = await self._driver.execute_query(
             _neo4j_query(
                 f"""

--- a/src/memmachine/semantic_memory/storage/storage_base.py
+++ b/src/memmachine/semantic_memory/storage/storage_base.py
@@ -1,6 +1,7 @@
 """Abstract interfaces for semantic storage implementations."""
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -38,7 +39,7 @@ class SemanticStorage(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def reset_set_ids(self, set_ids: list[SetIdT]) -> None:
+    async def reset_set_ids(self, set_ids: Sequence[SetIdT]) -> None:
         """Reset the set ids for the provided feature sets."""
         raise NotImplementedError
 
@@ -61,7 +62,7 @@ class SemanticStorage(ABC):
         value: str,
         tag: str,
         embedding: InstanceOf[np.ndarray],
-        metadata: dict[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
     ) -> FeatureIdT:
         """Add a new feature to the user."""
         raise NotImplementedError
@@ -77,13 +78,13 @@ class SemanticStorage(ABC):
         value: str | None = None,
         tag: str | None = None,
         embedding: InstanceOf[np.ndarray] | None = None,
-        metadata: dict[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
     ) -> None:
         """Update an existing feature with any provided fields."""
         raise NotImplementedError
 
     @abstractmethod
-    async def delete_features(self, feature_ids: list[FeatureIdT]) -> None:
+    async def delete_features(self, feature_ids: Sequence[FeatureIdT]) -> None:
         """Delete the requested feature ids."""
         raise NotImplementedError
 
@@ -95,7 +96,7 @@ class SemanticStorage(ABC):
         min_distance: float | None = None
 
     @abstractmethod
-    async def get_feature_set(
+    def get_feature_set(
         self,
         *,
         filter_expr: FilterExpr | None = None,
@@ -104,12 +105,12 @@ class SemanticStorage(ABC):
         vector_search_opts: VectorSearchOpts | None = None,
         tag_threshold: int | None = None,
         load_citations: bool = False,
-    ) -> list[SemanticFeature]:
+    ) -> AsyncIterator[SemanticFeature]:
         """
         Retrieve features matching the provided filters.
 
         Returns:
-            A list of features with their metadata and timestamps.
+            An async iterator of features with their metadata and timestamps.
 
         """
         raise NotImplementedError
@@ -127,19 +128,19 @@ class SemanticStorage(ABC):
     async def add_citations(
         self,
         feature_id: FeatureIdT,
-        history_ids: list[EpisodeIdT],
+        history_ids: Sequence[EpisodeIdT],
     ) -> None:
         """Associate history ids as citations for a feature."""
         raise NotImplementedError
 
     @abstractmethod
-    async def get_history_messages(
+    def get_history_messages(
         self,
         *,
-        set_ids: list[SetIdT] | None = None,
+        set_ids: Sequence[SetIdT] | None = None,
         limit: int | None = None,
         is_ingested: bool | None = None,
-    ) -> list[EpisodeIdT]:
+    ) -> AsyncIterator[EpisodeIdT]:
         """Retrieve history messages with optional ingestion status."""
         raise NotImplementedError
 
@@ -147,7 +148,7 @@ class SemanticStorage(ABC):
     async def get_history_messages_count(
         self,
         *,
-        set_ids: list[SetIdT] | None = None,
+        set_ids: Sequence[SetIdT] | None = None,
         is_ingested: bool | None = None,
     ) -> int:
         """Return the count of history messages."""
@@ -159,11 +160,11 @@ class SemanticStorage(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def delete_history(self, history_ids: list[EpisodeIdT]) -> None:
+    async def delete_history(self, history_ids: Sequence[EpisodeIdT]) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    async def delete_history_set(self, set_ids: list[SetIdT]) -> None:
+    async def delete_history_set(self, set_ids: Sequence[SetIdT]) -> None:
         raise NotImplementedError
 
     @abstractmethod
@@ -171,22 +172,22 @@ class SemanticStorage(ABC):
         self,
         *,
         set_id: SetIdT,
-        history_ids: list[EpisodeIdT],
+        history_ids: Sequence[EpisodeIdT],
     ) -> None:
         """Mark the provided history messages as ingested."""
         raise NotImplementedError
 
     @abstractmethod
-    async def get_history_set_ids(
+    def get_history_set_ids(
         self,
         *,
         min_uningested_messages: int | None = None,
         older_than: datetime | None = None,
-    ) -> list[SetIdT]:
+    ) -> AsyncIterator[SetIdT]:
         """Return all set id's that match the specified filters."""
         raise NotImplementedError
 
     @abstractmethod
-    async def get_set_ids_starts_with(self, prefix: str) -> list[SetIdT]:
+    def get_set_ids_starts_with(self, prefix: str) -> AsyncIterator[SetIdT]:
         """Return all set id's that start with the specified prefix."""
         raise NotImplementedError

--- a/src/memmachine/semantic_memory/util/semantic_prompt_template.py
+++ b/src/memmachine/semantic_memory/util/semantic_prompt_template.py
@@ -1,7 +1,9 @@
 """Prompt templates used by the semantic memory pipeline."""
 
+from collections.abc import Mapping
 
-def build_update_prompt(*, tags: dict[str, str], description: str = "") -> str:
+
+def build_update_prompt(*, tags: Mapping[str, str], description: str = "") -> str:
     """Create an update prompt for extracting profile changes from a query."""
     return (
         """

--- a/src/memmachine/server/api_v2/router.py
+++ b/src/memmachine/server/api_v2/router.py
@@ -383,8 +383,16 @@ async def get_feature(
         value=feature.value,
         metadata=SemanticFeature.Metadata(
             id=feature.metadata.id if feature.metadata else None,
-            citations=feature.metadata.citations if feature.metadata else None,
-            other=feature.metadata.other if feature.metadata else None,
+            citations=(
+                list(feature.metadata.citations)
+                if feature.metadata and feature.metadata.citations is not None
+                else None
+            ),
+            other=(
+                dict(feature.metadata.other)
+                if feature.metadata and feature.metadata.other is not None
+                else None
+            ),
         ),
     )
 
@@ -464,7 +472,7 @@ async def list_semantic_set_types(
             SemanticSetTypeEntry(
                 id=st.id,
                 is_org_level=st.is_org_level,
-                tags=st.tags,
+                tags=list(st.tags),
                 name=st.name,
                 description=st.description,
             )
@@ -542,7 +550,7 @@ async def list_semantic_set_ids(
             SemanticSetEntry(
                 id=s.id,
                 is_org_level=s.is_org_level,
-                tags=s.tags,
+                tags=list(s.tags),
                 name=s.name,
                 description=s.description,
             )

--- a/tests/memmachine/main/test_memmachine_mock.py
+++ b/tests/memmachine/main/test_memmachine_mock.py
@@ -273,17 +273,21 @@ async def test_query_search_runs_targeted_memory_tasks(
     )
     monkeypatch.setattr(MemMachine, "_search_episodic_memory", async_episodic)
 
+    semantic_features = [
+        SemanticFeature(
+            category="profile",
+            tag="name",
+            feature_name="value",
+            value="semantic-response",
+        )
+    ]
+
+    async def mock_search(*args, **kwargs):
+        for feature in semantic_features:
+            yield feature
+
     semantic_manager = MagicMock()
-    semantic_manager.search = AsyncMock(
-        return_value=[
-            SemanticFeature(
-                category="profile",
-                tag="name",
-                feature_name="value",
-                value="semantic-response",
-            )
-        ]
-    )
+    semantic_manager.search = mock_search
     patched_resource_manager.get_semantic_session_manager = AsyncMock(
         return_value=semantic_manager
     )
@@ -297,10 +301,9 @@ async def test_query_search_runs_targeted_memory_tasks(
     )
 
     async_episodic.assert_awaited_once()
-    semantic_manager.search.assert_awaited_once()
 
     assert result.episodic_memory is async_episodic.return_value
-    assert result.semantic_memory == semantic_manager.search.return_value
+    assert result.semantic_memory == semantic_features
 
 
 @pytest.mark.asyncio
@@ -322,17 +325,21 @@ async def test_query_search_skips_unrequested_memories(
     )
     monkeypatch.setattr(MemMachine, "_search_episodic_memory", async_episodic)
 
+    semantic_features = [
+        SemanticFeature(
+            category="profile",
+            tag="name",
+            feature_name="value",
+            value="semantic-response",
+        )
+    ]
+
+    async def mock_search(*args, **kwargs):
+        for feature in semantic_features:
+            yield feature
+
     semantic_manager = MagicMock()
-    semantic_manager.search = AsyncMock(
-        return_value=[
-            SemanticFeature(
-                category="profile",
-                tag="name",
-                feature_name="value",
-                value="semantic-response",
-            )
-        ]
-    )
+    semantic_manager.search = mock_search
     patched_resource_manager.get_semantic_session_manager = AsyncMock(
         return_value=semantic_manager
     )
@@ -346,10 +353,9 @@ async def test_query_search_skips_unrequested_memories(
     )
 
     async_episodic.assert_not_called()
-    semantic_manager.search.assert_awaited_once()
 
     assert result.episodic_memory is None
-    assert result.semantic_memory == semantic_manager.search.return_value
+    assert result.semantic_memory == semantic_features
 
 
 @pytest.mark.asyncio

--- a/tests/memmachine/semantic_memory/mock_semantic_memory_objects.py
+++ b/tests/memmachine/semantic_memory/mock_semantic_memory_objects.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncIterator, Mapping, Sequence
 from datetime import datetime
 from typing import Any
 from unittest.mock import AsyncMock
@@ -37,7 +38,7 @@ class MockSemanticStorage(SemanticStorage):
     async def delete_all(self):
         raise NotImplementedError
 
-    async def reset_set_ids(self, set_ids: list[SetIdT]) -> None:
+    async def reset_set_ids(self, set_ids: Sequence[SetIdT]) -> None:
         raise NotImplementedError
 
     async def get_feature(
@@ -56,7 +57,7 @@ class MockSemanticStorage(SemanticStorage):
         value: str,
         tag: str,
         embedding: InstanceOf[np.ndarray],
-        metadata: dict[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
     ) -> FeatureIdT:
         return await self.add_feature_mock(
             set_id=set_id,
@@ -78,11 +79,11 @@ class MockSemanticStorage(SemanticStorage):
         value: str | None = None,
         tag: str | None = None,
         embedding: InstanceOf[np.ndarray] | None = None,
-        metadata: dict[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
     ) -> None:
         raise NotImplementedError
 
-    async def delete_features(self, feature_ids: list[FeatureIdT]) -> None:
+    async def delete_features(self, feature_ids: Sequence[FeatureIdT]) -> None:
         await self.delete_features_mock(feature_ids)
 
     async def get_feature_set(
@@ -94,8 +95,8 @@ class MockSemanticStorage(SemanticStorage):
         vector_search_opts: SemanticStorage.VectorSearchOpts | None = None,
         tag_threshold: int | None = None,
         load_citations: bool = False,
-    ) -> list[SemanticFeature]:
-        return await self.get_feature_set_mock(
+    ) -> AsyncIterator[SemanticFeature]:
+        features = await self.get_feature_set_mock(
             filter_expr=filter_expr,
             page_size=page_size,
             page_num=page_num,
@@ -103,6 +104,8 @@ class MockSemanticStorage(SemanticStorage):
             tag_threshold=tag_threshold,
             load_citations=load_citations,
         )
+        for feature in features:
+            yield feature
 
     async def delete_feature_set(
         self,
@@ -116,14 +119,14 @@ class MockSemanticStorage(SemanticStorage):
     async def add_citations(
         self,
         feature_id: FeatureIdT,
-        history_ids: list[EpisodeIdT],
+        history_ids: Sequence[EpisodeIdT],
     ) -> None:
         await self.add_citations_mock(feature_id, history_ids)
 
     async def add_history(
         self,
         content: str,
-        metadata: dict[str, str] | None = None,
+        metadata: Mapping[str, str] | None = None,
         created_at: datetime | None = None,
     ) -> EpisodeIdT:
         raise NotImplementedError
@@ -131,7 +134,7 @@ class MockSemanticStorage(SemanticStorage):
     async def get_history(self, history_id: EpisodeIdT):
         raise NotImplementedError
 
-    async def delete_history(self, history_ids: list[EpisodeIdT]) -> None:
+    async def delete_history(self, history_ids: Sequence[EpisodeIdT]) -> None:
         raise NotImplementedError
 
     async def delete_history_messages(
@@ -145,20 +148,22 @@ class MockSemanticStorage(SemanticStorage):
     async def get_history_messages(
         self,
         *,
-        set_ids: list[SetIdT] | None = None,
+        set_ids: Sequence[SetIdT] | None = None,
         limit: int | None = None,
         is_ingested: bool | None = None,
-    ) -> list[EpisodeIdT]:
-        return await self.get_history_messages_mock(
+    ) -> AsyncIterator[EpisodeIdT]:
+        messages = await self.get_history_messages_mock(
             set_ids=set_ids,
             limit=limit,
             is_ingested=is_ingested,
         )
+        for message in messages:
+            yield message
 
     async def get_history_messages_count(
         self,
         *,
-        set_ids: list[SetIdT] | None = None,
+        set_ids: Sequence[SetIdT] | None = None,
         is_ingested: bool | None = None,
     ) -> int:
         raise NotImplementedError
@@ -170,22 +175,22 @@ class MockSemanticStorage(SemanticStorage):
         self,
         *,
         set_id: SetIdT,
-        history_ids: list[EpisodeIdT],
+        history_ids: Sequence[EpisodeIdT],
     ) -> None:
         await self.mark_messages_ingested_mock(set_id=set_id, ids=history_ids)
 
-    async def delete_history_set(self, set_ids: list[SetIdT]) -> None:
+    async def delete_history_set(self, set_ids: Sequence[SetIdT]) -> None:
         raise NotImplementedError
 
-    async def get_history_set_ids(
+    def get_history_set_ids(
         self,
         *,
         min_uningested_messages: int | None = None,
         older_than: datetime | None = None,
-    ) -> list[SetIdT]:
+    ) -> AsyncIterator[SetIdT]:
         raise NotImplementedError
 
-    async def get_set_ids_starts_with(self, prefix: str) -> list[SetIdT]:
+    def get_set_ids_starts_with(self, prefix: str) -> AsyncIterator[SetIdT]:
         raise NotImplementedError
 
 

--- a/tests/memmachine/semantic_memory/storage/in_memory_semantic_storage.py
+++ b/tests/memmachine/semantic_memory/storage/in_memory_semantic_storage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import Counter
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
@@ -103,7 +103,7 @@ class InMemorySemanticStorage(SemanticStorage):
                 return None
             return self._feature_to_model(entry, load_citations=load_citations)
 
-    async def reset_set_ids(self, set_ids: list[SetIdT]) -> None:
+    async def reset_set_ids(self, set_ids: Sequence[SetIdT]) -> None:
         pass
 
     async def add_feature(
@@ -115,7 +115,7 @@ class InMemorySemanticStorage(SemanticStorage):
         value: str,
         tag: str,
         embedding: InstanceOf[np.ndarray],
-        metadata: dict[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
     ) -> FeatureIdT:
         metadata = dict(metadata or {}) or None
         async with self._lock:
@@ -146,7 +146,7 @@ class InMemorySemanticStorage(SemanticStorage):
         value: str | None = None,
         tag: str | None = None,
         embedding: InstanceOf[np.ndarray] | None = None,
-        metadata: dict[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
     ) -> None:
         async with self._lock:
             feature_id = self._normalize_feature_id(feature_id)
@@ -167,7 +167,7 @@ class InMemorySemanticStorage(SemanticStorage):
 
             entry.updated_at = _utcnow()
 
-    async def delete_features(self, feature_ids: list[FeatureIdT]):
+    async def delete_features(self, feature_ids: Sequence[FeatureIdT]):
         if not feature_ids:
             return
 
@@ -188,7 +188,7 @@ class InMemorySemanticStorage(SemanticStorage):
         vector_search_opts: SemanticStorage.VectorSearchOpts | None = None,
         tag_threshold: int | None = None,
         load_citations: bool = False,
-    ) -> list[SemanticFeature]:
+    ) -> AsyncIterator[SemanticFeature]:
         if page_num is not None:
             if page_size is None:
                 raise InvalidArgumentError("Cannot specify offset without limit")
@@ -213,10 +213,12 @@ class InMemorySemanticStorage(SemanticStorage):
             if page_size is not None:
                 start_index = page_size * (page_num or 0)
                 entries = entries[start_index : start_index + page_size]
-            return [
+            features = [
                 self._feature_to_model(entry, load_citations=load_citations)
                 for entry in entries
             ]
+        for feature in features:
+            yield feature
 
     async def delete_feature_set(
         self,
@@ -241,7 +243,7 @@ class InMemorySemanticStorage(SemanticStorage):
     async def add_citations(
         self,
         feature_id: FeatureIdT,
-        history_ids: list[EpisodeIdT],
+        history_ids: Sequence[EpisodeIdT],
     ) -> None:
         if not history_ids:
             return
@@ -263,10 +265,10 @@ class InMemorySemanticStorage(SemanticStorage):
     async def get_history_messages(
         self,
         *,
-        set_ids: list[SetIdT] | None = None,
+        set_ids: Sequence[SetIdT] | None = None,
         limit: int | None = None,
         is_ingested: bool | None = None,
-    ) -> list[EpisodeIdT]:
+    ) -> AsyncIterator[EpisodeIdT]:
         async with self._lock:
             rows = self._history_rows_for_sets(set_ids)
             rows = self._filter_history_rows(rows, is_ingested)
@@ -275,12 +277,13 @@ class InMemorySemanticStorage(SemanticStorage):
             if limit is not None:
                 history_ids = history_ids[:limit]
 
-            return history_ids
+        for history_id in history_ids:
+            yield history_id
 
     async def get_history_messages_count(
         self,
         *,
-        set_ids: list[SetIdT] | None = None,
+        set_ids: Sequence[SetIdT] | None = None,
         is_ingested: bool | None = None,
     ) -> int:
         async with self._lock:
@@ -288,54 +291,63 @@ class InMemorySemanticStorage(SemanticStorage):
             filtered_rows = self._filter_history_rows(rows, is_ingested)
             return len(filtered_rows)
 
-    async def get_history_set_ids(
+    def get_history_set_ids(
         self,
         *,
         min_uningested_messages: int | None = None,
         older_than: datetime | None = None,
-    ) -> list[SetIdT]:
-        async with self._lock:
-            if (
-                min_uningested_messages is None or min_uningested_messages <= 0
-            ) and older_than is None:
-                return list(self._set_history_map.keys())
+    ) -> AsyncIterator[SetIdT]:
+        async def _iter() -> AsyncIterator[SetIdT]:
+            async with self._lock:
+                if (
+                    min_uningested_messages is None or min_uningested_messages <= 0
+                ) and older_than is None:
+                    results = list(self._set_history_map.keys())
+                else:
+                    results: list[str] = []
+                    for set_id, history_map in self._set_history_map.items():
+                        meets_uningested_threshold = False
+                        if (
+                            min_uningested_messages is not None
+                            and min_uningested_messages > 0
+                        ):
+                            uningested_count = sum(
+                                1 for ingested in history_map.values() if not ingested
+                            )
+                            meets_uningested_threshold = (
+                                uningested_count >= min_uningested_messages
+                            )
 
-            set_ids: list[str] = []
-            for set_id, history_map in self._set_history_map.items():
-                meets_uningested_threshold = False
-                if min_uningested_messages is not None and min_uningested_messages > 0:
-                    uningested_count = sum(
-                        1 for ingested in history_map.values() if not ingested
-                    )
-                    meets_uningested_threshold = (
-                        uningested_count >= min_uningested_messages
-                    )
+                        has_older_history = False
+                        if older_than is not None:
+                            has_older_history = any(
+                                self._history_created_at.get(
+                                    (set_id, history_id),
+                                    _utcnow(),
+                                )
+                                <= older_than
+                                for history_id, ingested in history_map.items()
+                                if not ingested
+                            )
 
-                has_older_history = False
-                if older_than is not None:
-                    has_older_history = any(
-                        self._history_created_at.get(
-                            (set_id, history_id),
-                            _utcnow(),
-                        )
-                        <= older_than
-                        for history_id, ingested in history_map.items()
-                        if not ingested
-                    )
+                        if meets_uningested_threshold or has_older_history:
+                            results.append(set_id)
 
-                if meets_uningested_threshold or has_older_history:
-                    set_ids.append(set_id)
+            for set_id in results:
+                yield set_id
 
-            return set_ids
+        return _iter()
 
-    async def get_set_ids_starts_with(self, prefix: str) -> list[SetIdT]:
+    async def get_set_ids_starts_with(self, prefix: str) -> AsyncIterator[SetIdT]:
         async with self._lock:
             set_ids = {
                 set_id
                 for set_id in set(self._feature_ids_by_set) | set(self._set_history_map)
                 if set_id.startswith(prefix)
             }
-            return list(set_ids)
+            results = list(set_ids)
+        for set_id in results:
+            yield set_id
 
     def _handle_set_change(
         self,
@@ -356,7 +368,7 @@ class InMemorySemanticStorage(SemanticStorage):
         value: str | None,
         tag: str | None,
         embedding: InstanceOf[np.ndarray] | None,
-        metadata: dict[str, Any] | None,
+        metadata: Mapping[str, Any] | None,
     ) -> None:
         simple_updates = {
             "semantic_type_id": category_name,
@@ -403,7 +415,7 @@ class InMemorySemanticStorage(SemanticStorage):
 
     def _history_rows_for_sets(
         self,
-        set_ids: list[SetIdT] | None,
+        set_ids: Sequence[SetIdT] | None,
     ) -> list[tuple[EpisodeIdT, bool]]:
         rows = [
             (history_id, ingested)
@@ -439,7 +451,7 @@ class InMemorySemanticStorage(SemanticStorage):
                 history_id
             ]
 
-    async def delete_history(self, history_ids: list[EpisodeIdT]) -> None:
+    async def delete_history(self, history_ids: Sequence[EpisodeIdT]) -> None:
         if not history_ids:
             return
 
@@ -460,7 +472,7 @@ class InMemorySemanticStorage(SemanticStorage):
                     if not history_map:
                         self._set_history_map.pop(set_id, None)
 
-    async def delete_history_set(self, set_ids: list[SetIdT]) -> None:
+    async def delete_history_set(self, set_ids: Sequence[SetIdT]) -> None:
         if not set_ids:
             return
 
@@ -484,7 +496,7 @@ class InMemorySemanticStorage(SemanticStorage):
         self,
         *,
         set_id: SetIdT,
-        history_ids: list[EpisodeIdT],
+        history_ids: Sequence[EpisodeIdT],
     ) -> None:
         if not history_ids:
             raise ValueError("No ids provided")

--- a/tests/memmachine/semantic_memory/storage/test_semantic_storage.py
+++ b/tests/memmachine/semantic_memory/storage/test_semantic_storage.py
@@ -18,6 +18,22 @@ def _expr(spec: str | None) -> FilterExpr | None:
     return parse_filter(spec) if spec else None
 
 
+async def _collect(iterator):
+    return [item async for item in iterator]
+
+
+async def _collect_feature_set(storage: SemanticStorage, **kwargs):
+    return [item async for item in storage.get_feature_set(**kwargs)]
+
+
+async def _collect_history_messages(storage: SemanticStorage, **kwargs):
+    return [item async for item in storage.get_history_messages(**kwargs)]
+
+
+async def _collect_set_ids_starts_with(storage: SemanticStorage, prefix: str):
+    return [item async for item in storage.get_set_ids_starts_with(prefix)]
+
+
 async def _add_episode(
     episode_storage: EpisodeStorage,
     *,
@@ -72,9 +88,7 @@ async def test_get_set_ids_starts_with(
         embedding=np.array([0.0] * 1536, dtype=float),
     )
 
-    set_ids = await semantic_storage.get_set_ids_starts_with("user")
-
-    set_ids = sorted(set_ids)
+    set_ids = sorted(await _collect(semantic_storage.get_set_ids_starts_with("user")))
     assert set_ids == ["user1", "user2"]
 
 
@@ -82,7 +96,7 @@ async def test_get_set_ids_starts_with(
 async def test_get_set_ids_starts_with_with_no_results(
     semantic_storage: SemanticStorage,
 ):
-    set_ids = await semantic_storage.get_set_ids_starts_with("no_results")
+    set_ids = await _collect(semantic_storage.get_set_ids_starts_with("no_results"))
     assert set_ids == []
 
 
@@ -112,9 +126,7 @@ async def test_get_set_ids_starts_with_with_cross_table(
         history_id="episode_id_c",
     )
 
-    set_ids = await semantic_storage.get_set_ids_starts_with("user")
-
-    set_ids = sorted(set_ids)
+    set_ids = sorted(await _collect(semantic_storage.get_set_ids_starts_with("user")))
     assert set_ids == ["user1", "user2"]
 
 
@@ -149,7 +161,8 @@ async def test_add_features_with_different_embedding_lengths(
     assert id_b is not None
 
     # Expect to be able to search the memory without errors
-    res = await semantic_storage.get_feature_set(
+    res = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr("set_id IN (user_a)"),
         vector_search_opts=SemanticStorage.VectorSearchOpts(query_embedding=embed_a),
     )
@@ -161,7 +174,10 @@ async def test_add_features_with_different_embedding_lengths(
 @pytest.mark.asyncio
 async def test_empty_storage(semantic_storage: SemanticStorage):
     assert (
-        await semantic_storage.get_feature_set(filter_expr=_expr("set_id IN (user)"))
+        await _collect_feature_set(
+            semantic_storage,
+            filter_expr=_expr("set_id IN (user)"),
+        )
         == []
     )
 
@@ -173,8 +189,9 @@ async def test_multiple_features(
 ):
     # Given a storage with two features
     # When we retrieve the profile
-    profile_result = await semantic_storage.get_feature_set(
-        filter_expr=_expr("set_id IN (user)")
+    profile_result = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=_expr("set_id IN (user)"),
     )
     grouped_profile = SemanticFeature.group_features(profile_result)
 
@@ -206,12 +223,14 @@ async def test_feature_value_comparison_filters(semantic_storage: SemanticStorag
     ]
 
     try:
-        greater_than_one = await semantic_storage.get_feature_set(
+        greater_than_one = await _collect_feature_set(
+            semantic_storage,
             filter_expr=_expr("value > '1'"),
         )
         assert {f.value for f in greater_than_one} == {"2", "3"}
 
-        up_to_two = await semantic_storage.get_feature_set(
+        up_to_two = await _collect_feature_set(
+            semantic_storage,
             filter_expr=_expr("value <= '2'"),
         )
         assert {f.value for f in up_to_two} == {"1", "2"}
@@ -231,8 +250,9 @@ async def test_delete_feature(semantic_storage: SemanticStorage):
     )
 
     # Given a storage with a single feature
-    features = await semantic_storage.get_feature_set(
-        filter_expr=_expr("set_id IN (user)")
+    features = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=_expr("set_id IN (user)"),
     )
     assert len(features) == 1
     assert features[0].value == "pizza"
@@ -240,8 +260,9 @@ async def test_delete_feature(semantic_storage: SemanticStorage):
     # When we delete the feature
     await semantic_storage.delete_features([idx_a])
 
-    features = await semantic_storage.get_feature_set(
-        filter_expr=_expr("set_id IN (user)")
+    features = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=_expr("set_id IN (user)"),
     )
 
     # Then the feature should no longer exist
@@ -254,13 +275,15 @@ async def test_delete_feature_set_by_set_id(
     with_multiple_sets,
 ):
     # Given a storage with two sets
-    res_a = await semantic_storage.get_feature_set(
-        filter_expr=_expr("set_id IN (user1)")
+    res_a = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=_expr("set_id IN (user1)"),
     )
     grouped_a = SemanticFeature.group_features(res_a)
 
-    res_b = await semantic_storage.get_feature_set(
-        filter_expr=_expr("set_id IN (user2)")
+    res_b = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=_expr("set_id IN (user2)"),
     )
     grouped_b = SemanticFeature.group_features(res_b)
 
@@ -276,14 +299,16 @@ async def test_delete_feature_set_by_set_id(
     await semantic_storage.delete_feature_set(filter_expr=_expr("set_id IN (user1)"))
 
     # Then the first set should be empty
-    res_delete_a = await semantic_storage.get_feature_set(
-        filter_expr=_expr("set_id IN (user1)")
+    res_delete_a = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=_expr("set_id IN (user1)"),
     )
     assert res_delete_a == []
 
     # And the second set should still exist
-    res_delete_b = await semantic_storage.get_feature_set(
-        filter_expr=_expr("set_id IN (user2)")
+    res_delete_b = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=_expr("set_id IN (user2)"),
     )
     grouped_delete_b = SemanticFeature.group_features(res_delete_b)
     set_delete_b = [{"value": f.value} for f in grouped_delete_b[key]]
@@ -307,17 +332,20 @@ async def test_get_feature_set_with_page_offset(
     ]
 
     try:
-        first_page = await semantic_storage.get_feature_set(
+        first_page = await _collect_feature_set(
+            semantic_storage,
             filter_expr=_expr("set_id IN (user)"),
             page_size=2,
             page_num=0,
         )
-        second_page = await semantic_storage.get_feature_set(
+        second_page = await _collect_feature_set(
+            semantic_storage,
             filter_expr=_expr("set_id IN (user)"),
             page_size=2,
             page_num=1,
         )
-        final_page = await semantic_storage.get_feature_set(
+        final_page = await _collect_feature_set(
+            semantic_storage,
             filter_expr=_expr("set_id IN (user)"),
             page_size=2,
             page_num=2,
@@ -335,7 +363,10 @@ async def test_get_feature_set_offset_without_limit_errors(
     semantic_storage: SemanticStorage,
 ):
     with pytest.raises(InvalidArgumentError):
-        await semantic_storage.get_feature_set(page_num=1)
+        await _collect_feature_set(
+            semantic_storage,
+            page_num=1,
+        )
 
 
 @pytest_asyncio.fixture
@@ -384,7 +415,8 @@ async def test_get_feature_set_basic_vector_search(
     _embed_b, value_b = oposite_vector_features[1]
 
     # When doing a vector search
-    results = await semantic_storage.get_feature_set(
+    results = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr("set_id IN (user)"),
         page_size=10,
         vector_search_opts=SemanticStorage.VectorSearchOpts(
@@ -408,7 +440,8 @@ async def test_get_feature_set_min_cos_vector_search(
     embed_a, value_a = oposite_vector_features[0]
 
     # When doing a vector search with a min_cos threshold
-    results = await semantic_storage.get_feature_set(
+    results = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr("set_id IN (user)"),
         page_size=10,
         vector_search_opts=SemanticStorage.VectorSearchOpts(
@@ -637,8 +670,8 @@ async def test_delete_history_removes_set_associations(
     await semantic_storage.delete_history([h2_id, h3_id])
 
     assert await semantic_storage.get_history_messages_count(set_ids=None) == 1
-    alpha_history = await semantic_storage.get_history_messages(set_ids=["alpha"])
-    beta_history = await semantic_storage.get_history_messages(set_ids=["beta"])
+    alpha_history = await _collect_history_messages(semantic_storage, set_ids=["alpha"])
+    beta_history = await _collect_history_messages(semantic_storage, set_ids=["beta"])
 
     assert alpha_history == [h1_id]
     assert beta_history == []
@@ -657,14 +690,16 @@ async def test_delete_history_set_removes_target_set(
     await semantic_storage.add_history_to_set(set_id="beta", history_id=h1_id)
     await semantic_storage.add_history_to_set(set_id="beta", history_id=h2_id)
 
-    assert set(await semantic_storage.get_history_set_ids()) == {"alpha", "beta"}
+    set_ids = {sid async for sid in semantic_storage.get_history_set_ids()}
+    assert set_ids == {"alpha", "beta"}
 
     await semantic_storage.delete_history_set(set_ids=["alpha"])
 
-    assert await semantic_storage.get_history_messages(set_ids=["alpha"]) == []
-    remaining = await semantic_storage.get_history_messages(set_ids=["beta"])
+    assert await _collect_history_messages(semantic_storage, set_ids=["alpha"]) == []
+    remaining = await _collect_history_messages(semantic_storage, set_ids=["beta"])
     assert set(map(str, remaining)) == {str(h1_id), str(h2_id)}
-    assert set(await semantic_storage.get_history_set_ids()) == {"beta"}
+    set_ids = {sid async for sid in semantic_storage.get_history_set_ids()}
+    assert set_ids == {"beta"}
 
 
 @pytest.mark.asyncio
@@ -695,12 +730,17 @@ async def test_delete_history_set_handles_multiple_ids(
     await semantic_storage.delete_history_set(set_ids=["alpha", "beta", "missing"])
 
     assert await semantic_storage.get_history_messages_count(set_ids=None) == 2
-    assert set(map(str, await semantic_storage.get_history_set_ids())) == {
+    set_ids = {str(sid) async for sid in semantic_storage.get_history_set_ids()}
+    assert set_ids == {
         "gamma",
         "delta",
     }
-    assert await semantic_storage.get_history_messages(set_ids=["gamma"]) == [h3_id]
-    assert await semantic_storage.get_history_messages(set_ids=["delta"]) == [h2_id]
+    assert await _collect_history_messages(semantic_storage, set_ids=["gamma"]) == [
+        h3_id
+    ]
+    assert await _collect_history_messages(semantic_storage, set_ids=["delta"]) == [
+        h2_id
+    ]
 
 
 @pytest.mark.asyncio
@@ -732,22 +772,23 @@ async def test_complex_feature_lifecycle(semantic_storage: SemanticStorage):
         embedding=embed,
     )
 
-    profile_default = await semantic_storage.get_feature_set(
-        filter_expr=_expr("set_id IN (user)")
+    profile_default = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=_expr("set_id IN (user)"),
     )
     grouped_default = SemanticFeature.group_features(profile_default)
     assert ("default", "food", "likes") in grouped_default
 
-    likes_entries = grouped_default[("default", "food", "likes")]
-    if not isinstance(likes_entries, list):
-        likes_entries = [likes_entries]
+    likes_entries = list(grouped_default[("default", "food", "likes")])
     assert {item.value for item in likes_entries} == {"pizza", "sushi"}
 
-    tenant_profile = await semantic_storage.get_feature_set(
-        filter_expr=_expr("set_id IN (user) AND category_name IN (tenant_A)")
+    tenant_profile = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=_expr("set_id IN (user) AND category_name IN (tenant_A)"),
     )
     grouped_tenant = SemanticFeature.group_features(tenant_profile)
-    assert grouped_tenant[("tenant_A", "prefs", "color")][0].value == "blue"
+    tenant_entries = list(grouped_tenant[("tenant_A", "prefs", "color")])
+    assert tenant_entries[0].value == "blue"
 
     await semantic_storage.delete_feature_set(
         filter_expr=_expr(
@@ -755,8 +796,9 @@ async def test_complex_feature_lifecycle(semantic_storage: SemanticStorage):
         )
     )
 
-    after_delete = await semantic_storage.get_feature_set(
-        filter_expr=_expr("set_id IN (user)")
+    after_delete = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=_expr("set_id IN (user)"),
     )
     grouped_after_delete = SemanticFeature.group_features(after_delete)
     assert ("default", "food", "likes") not in grouped_after_delete
@@ -764,14 +806,18 @@ async def test_complex_feature_lifecycle(semantic_storage: SemanticStorage):
     await semantic_storage.delete_feature_set(
         filter_expr=_expr("set_id IN (user) AND category_name IN (tenant_A)")
     )
-    tenant_only = await semantic_storage.get_feature_set(
-        filter_expr=_expr("set_id IN (user) AND category_name IN (tenant_A)")
+    tenant_only = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=_expr("set_id IN (user) AND category_name IN (tenant_A)"),
     )
     assert tenant_only == []
 
     await semantic_storage.delete_feature_set(filter_expr=_expr("set_id IN (user)"))
     assert (
-        await semantic_storage.get_feature_set(filter_expr=_expr("set_id IN (user)"))
+        await _collect_feature_set(
+            semantic_storage,
+            filter_expr=_expr("set_id IN (user)"),
+        )
         == []
     )
 
@@ -807,12 +853,14 @@ async def test_filter_by_metadata_nullity(semantic_storage: SemanticStorage):
         embedding=embed,
     )
 
-    null_results = await semantic_storage.get_feature_set(
+    null_results = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr("metadata.details IS NULL"),
     )
     assert {feature.value for feature in null_results} == {"second", "third"}
 
-    not_null_results = await semantic_storage.get_feature_set(
+    not_null_results = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr("metadata.details IS NOT NULL"),
     )
     assert [feature.value for feature in not_null_results] == ["first"]
@@ -832,7 +880,8 @@ async def test_get_feature_set_unknown_filter_column_errors(
     )
 
     # No errors occurs
-    await semantic_storage.get_feature_set(
+    await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr("missing_column IN (foo)"),
     )
 
@@ -890,7 +939,8 @@ async def test_complex_semantic_search_and_citations(
         embedding=np.array([0.0, 1.0]),
     )
 
-    results = await semantic_storage.get_feature_set(
+    results = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr("set_id IN (user)"),
         page_size=10,
         vector_search_opts=SemanticStorage.VectorSearchOpts(
@@ -906,7 +956,8 @@ async def test_complex_semantic_search_and_citations(
     assert results[0].metadata.citations is not None
     assert results[0].metadata.citations[0] == history_id
 
-    filtered = await semantic_storage.get_feature_set(
+    filtered = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr("set_id IN (user)"),
         page_size=1,
         vector_search_opts=SemanticStorage.VectorSearchOpts(
@@ -930,10 +981,11 @@ async def test_complex_semantic_search_and_citations(
         entry.metadata.id for entry in results if entry.metadata.id is not None
     ]
     await semantic_storage.delete_features(feature_ids[:1])
-    remaining = await semantic_storage.get_feature_set(
+    remaining = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr(
             "set_id IN (user) AND category_name IN (default) AND tag IN (facts) AND feature IN (topic)"
-        )
+        ),
     )
     assert len(remaining) == 1
     assert remaining[0].value == "music"
@@ -995,7 +1047,7 @@ async def test_get_set_ids(
         history_id="fake_c",
     )
 
-    set_ids = await semantic_storage.get_history_set_ids()
+    set_ids = [sid async for sid in semantic_storage.get_history_set_ids()]
     set_ids.sort()
 
     assert set_ids == ["user_a", "user_b", "user_c"]
@@ -1035,22 +1087,31 @@ async def test_get_set_ids_with_min_uningested(
         history_ids=["fake_c"],
     )
 
-    set_ids = await semantic_storage.get_history_set_ids(
-        min_uningested_messages=0,
-    )
+    set_ids = [
+        sid
+        async for sid in semantic_storage.get_history_set_ids(
+            min_uningested_messages=0,
+        )
+    ]
     set_ids.sort()
 
     assert set_ids == ["user_a", "user_b", "user_c"]
 
-    set_ids = await semantic_storage.get_history_set_ids(
-        min_uningested_messages=1,
-    )
+    set_ids = [
+        sid
+        async for sid in semantic_storage.get_history_set_ids(
+            min_uningested_messages=1,
+        )
+    ]
     set_ids.sort()
     assert set_ids == ["user_a", "user_c"]
 
-    set_ids = await semantic_storage.get_history_set_ids(
-        min_uningested_messages=2,
-    )
+    set_ids = [
+        sid
+        async for sid in semantic_storage.get_history_set_ids(
+            min_uningested_messages=2,
+        )
+    ]
     assert set_ids == ["user_c"]
 
 
@@ -1075,11 +1136,9 @@ async def test_get_set_ids_with_older_than(
         history_id=recent_history_id,
     )
 
-    set_ids = set(
-        await semantic_storage.get_history_set_ids(
-            older_than=cutoff,
-        )
-    )
+    set_ids = {
+        sid async for sid in semantic_storage.get_history_set_ids(older_than=cutoff)
+    }
 
     assert set_ids == {"old_user"}
 
@@ -1088,11 +1147,9 @@ async def test_get_set_ids_with_older_than(
         history_ids=[early_history_id],
     )
 
-    set_ids_after_ingest = set(
-        await semantic_storage.get_history_set_ids(
-            older_than=cutoff,
-        )
-    )
+    set_ids_after_ingest = {
+        sid async for sid in semantic_storage.get_history_set_ids(older_than=cutoff)
+    }
 
     assert set_ids_after_ingest == set()
 
@@ -1127,12 +1184,13 @@ async def test_get_set_ids_with_older_than_and_min_uningested(
         history_id=fresh_history_id,
     )
 
-    set_ids = set(
-        await semantic_storage.get_history_set_ids(
+    set_ids = {
+        sid
+        async for sid in semantic_storage.get_history_set_ids(
             min_uningested_messages=2,
             older_than=cutoff,
         )
-    )
+    }
 
     assert set_ids == {"old_user", "busy_user"}
 
@@ -1141,10 +1199,13 @@ async def test_get_set_ids_with_older_than_and_min_uningested(
         history_ids=[early_history_id],
     )
 
-    set_ids = await semantic_storage.get_history_set_ids(
-        min_uningested_messages=2,
-        older_than=cutoff,
-    )
+    set_ids = [
+        sid
+        async for sid in semantic_storage.get_history_set_ids(
+            min_uningested_messages=2,
+            older_than=cutoff,
+        )
+    ]
 
     assert set_ids == ["busy_user"]
 
@@ -1179,14 +1240,16 @@ async def test_filter_features_by_created_at_date(
     )
 
     # Filter for features created before cutoff
-    old_features = await semantic_storage.get_feature_set(
+    old_features = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr(f"created_at<date('{cutoff.isoformat()}')"),
     )
     assert len(old_features) == 1
     assert old_features[0].value == "old_note"
 
     # Filter for features created after cutoff
-    new_features = await semantic_storage.get_feature_set(
+    new_features = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr(f"created_at>=date('{cutoff.isoformat()}')"),
     )
     assert len(new_features) == 1
@@ -1241,7 +1304,8 @@ async def test_filter_features_by_created_at_with_other_filters(
     )
 
     # Filter for user1's important features created before cutoff
-    results = await semantic_storage.get_feature_set(
+    results = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr(
             f"set_id='user1' AND tag='important' AND created_at<date('{cutoff.isoformat()}')"
         ),
@@ -1250,7 +1314,8 @@ async def test_filter_features_by_created_at_with_other_filters(
     assert results[0].value == "user1_old"
 
     # Filter for features created after cutoff
-    new_results = await semantic_storage.get_feature_set(
+    new_results = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr(f"created_at>=date('{cutoff.isoformat()}')"),
     )
     assert len(new_results) == 2
@@ -1300,7 +1365,8 @@ async def test_filter_features_by_created_at_range(
     )
 
     # Filter for features in the middle time range
-    results = await semantic_storage.get_feature_set(
+    results = await _collect_feature_set(
+        semantic_storage,
         filter_expr=_expr(
             f"created_at>=date('{start_time.isoformat()}') AND created_at<date('{end_time.isoformat()}')"
         ),

--- a/tests/memmachine/semantic_memory/test_semantic_memory.py
+++ b/tests/memmachine/semantic_memory/test_semantic_memory.py
@@ -15,6 +15,10 @@ from tests.memmachine.semantic_memory.semantic_test_utils import (
 pytestmark = pytest.mark.asyncio
 
 
+async def _collect_async(iterator):
+    return [item async for item in iterator]
+
+
 async def test_store_custom_embedder(
     semantic_service: SemanticService,
 ):
@@ -53,9 +57,11 @@ async def test_use_length_embedder(
         tag="writing_style",
     )
 
-    response = await semantic_service.search(
-        set_ids=["user-length-1234"],
-        query="Why does alpha prefer quiet chats?",
+    response = await _collect_async(
+        semantic_service.search(
+            set_ids=["user-length-1234"],
+            query="Why does alpha prefer quiet chats?",
+        )
     )
 
     assert len(response) == 1
@@ -171,8 +177,10 @@ async def test_add_new_feature_stores_entry(
     )
 
     # When retrieving the stored features
-    features = await semantic_service.get_set_features(
-        set_ids=["user-123"],
+    features = await _collect_async(
+        semantic_service.get_set_features(
+            set_ids=["user-123"],
+        )
     )
 
     # Then the feature is persisted with embeddings recorded
@@ -206,9 +214,11 @@ async def test_get_set_features_filters_by_tag(
     )
 
     # When filtering on a specific tag
-    filtered = await semantic_service.get_set_features(
-        set_ids=["user-42"],
-        filter_expr=parse_filter("tag IN ('writing_style')"),
+    filtered = await _collect_async(
+        semantic_service.get_set_features(
+            set_ids=["user-42"],
+            filter_expr=parse_filter("tag IN ('writing_style')"),
+        )
     )
 
     # Then only matching features are returned
@@ -303,8 +313,10 @@ async def test_delete_feature_set_applies_filters(
     )
 
     # Then only the non-matching feature remains
-    remaining = await semantic_service.get_set_features(
-        set_ids=["user-88"],
+    remaining = await _collect_async(
+        semantic_service.get_set_features(
+            set_ids=["user-88"],
+        )
     )
     assert len(remaining) == 1
     assert remaining[0].feature_name == "favorite_color"
@@ -380,10 +392,12 @@ async def test_search_returns_matching_features(
     )
 
     # When searching with an alpha-focused query
-    results = await semantic_service.search(
-        set_ids=["user-search"],
-        query="Why does alpha prefer quiet chats?",
-        min_distance=0.5,
+    results = await _collect_async(
+        semantic_service.search(
+            set_ids=["user-search"],
+            query="Why does alpha prefer quiet chats?",
+            min_distance=0.5,
+        )
     )
 
     # Then only the matching feature is returned using the query embedding
@@ -438,8 +452,10 @@ async def test_delete_category_deletes_underlying_features(
     )
 
     # Verify features exist
-    features_before = await semantic_service.get_set_features(
-        set_ids=[set_id],
+    features_before = await _collect_async(
+        semantic_service.get_set_features(
+            set_ids=[set_id],
+        )
     )
     assert len(features_before) == 3
     test_category_features = [
@@ -459,8 +475,10 @@ async def test_delete_category_deletes_underlying_features(
     assert category is None
 
     # Verify only TestCategory features are deleted
-    features_after = await semantic_service.get_set_features(
-        set_ids=[set_id],
+    features_after = await _collect_async(
+        semantic_service.get_set_features(
+            set_ids=[set_id],
+        )
     )
     assert len(features_after) == 1
     assert features_after[0].category == "OtherCategory"
@@ -521,8 +539,10 @@ async def test_delete_set_type_category_deletes_inherited_features(
     )
 
     # Verify features exist in all sets
-    all_features = await semantic_service.get_set_features(
-        set_ids=[set_id_1, set_id_2, set_id_3],
+    all_features = await _collect_async(
+        semantic_service.get_set_features(
+            set_ids=[set_id_1, set_id_2, set_id_3],
+        )
     )
     assert len(all_features) == 3
     assert all(f.category == "SharedCategory" for f in all_features)
@@ -531,8 +551,10 @@ async def test_delete_set_type_category_deletes_inherited_features(
     await semantic_service.delete_category(category_id=category_id)
 
     # Verify all features are deleted from all set_ids
-    remaining_features = await semantic_service.get_set_features(
-        set_ids=[set_id_1, set_id_2, set_id_3],
+    remaining_features = await _collect_async(
+        semantic_service.get_set_features(
+            set_ids=[set_id_1, set_id_2, set_id_3],
+        )
     )
     assert len(remaining_features) == 0
 
@@ -591,8 +613,10 @@ async def test_delete_set_type_category_only_deletes_non_overridden_features(
     )
 
     # Verify both features exist
-    all_features_before = await semantic_service.get_set_features(
-        set_ids=[set_id_inherit, set_id_override],
+    all_features_before = await _collect_async(
+        semantic_service.get_set_features(
+            set_ids=[set_id_inherit, set_id_override],
+        )
     )
     assert len(all_features_before) == 2
 
@@ -600,8 +624,10 @@ async def test_delete_set_type_category_only_deletes_non_overridden_features(
     await semantic_service.delete_category(category_id=set_type_category_id)
 
     # Verify only the inherited feature is deleted
-    remaining_features = await semantic_service.get_set_features(
-        set_ids=[set_id_inherit, set_id_override],
+    remaining_features = await _collect_async(
+        semantic_service.get_set_features(
+            set_ids=[set_id_inherit, set_id_override],
+        )
     )
     assert len(remaining_features) == 1
     assert remaining_features[0].set_id == set_id_override
@@ -663,7 +689,7 @@ async def test_add_new_feature_succeeds_with_valid_category(
     assert feature_id is not None
 
     # Verify the feature was created
-    features = await semantic_service.get_set_features(set_ids=[set_id])
+    features = await _collect_async(semantic_service.get_set_features(set_ids=[set_id]))
     assert len(features) == 1
     assert features[0].category == "ValidCategory"
 

--- a/tests/memmachine/semantic_memory/test_semantic_memory_background.py
+++ b/tests/memmachine/semantic_memory/test_semantic_memory_background.py
@@ -20,6 +20,11 @@ from tests.memmachine.semantic_memory.storage.in_memory_semantic_storage import 
     SemanticStorage,
 )
 
+
+async def _collect_feature_set(storage: SemanticStorage, **kwargs):
+    return [item async for item in storage.get_feature_set(**kwargs)]
+
+
 pytestmark = pytest.mark.asyncio
 
 
@@ -131,7 +136,8 @@ async def test_background_ingestion_processes_messages_on_message_limit(
     )
 
     filter_str = f"set_id IN ('user-123') AND category_name IN ('{semantic_type.name}')"
-    features = await semantic_storage.get_feature_set(
+    features = await _collect_feature_set(
+        semantic_storage,
         filter_expr=parse_filter(filter_str),
     )
 
@@ -198,7 +204,8 @@ async def test_consolidation_threshold_not_reached(
     filter_str = (
         f"set_id IN ('user-consolidate') AND category_name IN ('{semantic_type.name}')"
     )
-    features_before = await semantic_storage.get_feature_set(
+    features_before = await _collect_feature_set(
+        semantic_storage,
         filter_expr=parse_filter(filter_str),
     )
     count_before = len(features_before)
@@ -211,7 +218,8 @@ async def test_consolidation_threshold_not_reached(
     await asyncio.sleep(0.2)
 
     # Features should not be consolidated
-    features_after = await semantic_storage.get_feature_set(
+    features_after = await _collect_feature_set(
+        semantic_storage,
         filter_expr=parse_filter(filter_str),
     )
 
@@ -326,10 +334,12 @@ async def test_multiple_sets_processed_independently(
     # Verify both sets were processed independently
     filter_a = f"set_id IN ('user-a') AND category_name IN ('{semantic_type.name}')"
     filter_b = f"set_id IN ('user-b') AND category_name IN ('{semantic_type.name}')"
-    features_a = await semantic_storage.get_feature_set(
+    features_a = await _collect_feature_set(
+        semantic_storage,
         filter_expr=parse_filter(filter_a),
     )
-    features_b = await semantic_storage.get_feature_set(
+    features_b = await _collect_feature_set(
+        semantic_storage,
         filter_expr=parse_filter(filter_b),
     )
 

--- a/tests/memmachine/semantic_memory/test_semantic_memory_integration.py
+++ b/tests/memmachine/semantic_memory/test_semantic_memory_integration.py
@@ -29,6 +29,10 @@ from memmachine.server.prompt.coding_style_prompt import CodingStyleSemanticCate
 from memmachine.server.prompt.profile_prompt import UserProfileSemanticCategory
 
 
+async def _collect_async(iterator):
+    return [item async for item in iterator]
+
+
 @pytest.fixture
 def embedder(openai_embedder):
     return openai_embedder
@@ -168,12 +172,13 @@ class TestLongMemEvalIngestion:
         question_str: str,
         llm_model: OpenAIResponsesLanguageModel,
     ):
-        semantic_search_resp = list(
-            await semantic_memory.search(
+        semantic_search_resp = [
+            result
+            async for result in semantic_memory.search(
                 message=question_str,
                 session_data=session_data,
             )
-        )
+        ]
         semantic_search_resp = semantic_search_resp[:4]
 
         system_prompt = (
@@ -241,8 +246,10 @@ class TestLongMemEvalIngestion:
         if count != 0:
             pytest.fail(f"Messages are not ingested, count={count}")
 
-        memories = await semantic_memory.get_set_features(
-            session_data=basic_session_data,
+        memories = await _collect_async(
+            semantic_memory.get_set_features(
+                session_data=basic_session_data,
+            )
         )
         assert len(memories) > 0
 

--- a/tests/memmachine/semantic_memory/test_semantic_session_manager.py
+++ b/tests/memmachine/semantic_memory/test_semantic_session_manager.py
@@ -23,6 +23,23 @@ from tests.memmachine.semantic_memory.storage.in_memory_semantic_storage import 
 pytestmark = pytest.mark.asyncio
 
 
+async def _collect_async(iterator):
+    return [item async for item in iterator]
+
+
+async def _aiter(items):
+    for item in items:
+        yield item
+
+
+async def _collect_feature_set(storage: SemanticStorage, **kwargs):
+    return [item async for item in storage.get_feature_set(**kwargs)]
+
+
+async def _collect_history_messages(storage: SemanticStorage, **kwargs):
+    return [item async for item in storage.get_history_messages(**kwargs)]
+
+
 @dataclass
 class _SessionData:
     org_id: str
@@ -52,12 +69,12 @@ async def session_manager(
 def mock_semantic_service() -> MagicMock:
     service = MagicMock(spec=SemanticService)
     service.add_message_to_sets = AsyncMock()
-    service.search = AsyncMock(return_value=[])
+    service.search = MagicMock(return_value=_aiter([]))
     service.number_of_uningested = AsyncMock(return_value=0)
     service.add_new_feature = AsyncMock(return_value=101)
     service.get_feature = AsyncMock(return_value="feature")
     service.update_feature = AsyncMock()
-    service.get_set_features = AsyncMock(return_value=["features"])
+    service.get_set_features = MagicMock(return_value=_aiter(["features"]))
     return service
 
 
@@ -103,11 +120,13 @@ async def test_add_message_records_history_and_uningested_counts(
         metadata={},
     )
 
-    profile_messages = await semantic_storage.get_history_messages(
+    profile_messages = await _collect_history_messages(
+        semantic_storage,
         set_ids=[profile_id],
         is_ingested=False,
     )
-    session_messages = await semantic_storage.get_history_messages(
+    session_messages = await _collect_history_messages(
+        semantic_storage,
         set_ids=[session_id],
         is_ingested=False,
     )
@@ -154,8 +173,8 @@ async def test_search_returns_relevant_features(
     )
 
     # When searching with an alpha-focused query
-    matches = list(
-        await session_manager.search(
+    matches = await _collect_async(
+        session_manager.search(
             message="Why does alpha stay calm?",
             session_data=session_data,
             min_distance=0.5,
@@ -187,11 +206,13 @@ async def test_add_feature_isolation(
     )
 
     # When retrieving features for each set id
-    a_features = await semantic_storage.get_feature_set(
-        filter_expr=parse_filter(f"set_id IN ('{set_id_a}')")
+    a_features = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=parse_filter(f"set_id IN ('{set_id_a}')"),
     )
-    b_features = await semantic_storage.get_feature_set(
-        filter_expr=parse_filter(f"set_id IN ('{set_id_b}')")
+    b_features = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=parse_filter(f"set_id IN ('{set_id_b}')"),
     )
 
     # Then only the profile receives the new feature and embeddings were generated
@@ -245,11 +266,13 @@ async def test_delete_feature_set_removes_filtered_entries(
     )
 
     # Then profile features are cleared while session-scoped entries remain
-    org_features = await semantic_storage.get_feature_set(
-        filter_expr=parse_filter(f"set_id IN ('{set_type_id}')")
+    org_features = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=parse_filter(f"set_id IN ('{set_type_id}')"),
     )
-    project_features = await semantic_storage.get_feature_set(
-        filter_expr=parse_filter(f"set_id IN ('{project_set_id}')")
+    project_features = await _collect_feature_set(
+        semantic_storage,
+        filter_expr=parse_filter(f"set_id IN ('{project_set_id}')"),
     )
 
     assert org_features == []
@@ -348,19 +371,21 @@ async def test_search_passes_set_ids_and_filters(
     mock_semantic_service: MagicMock,
     session_data,
 ):
-    mock_semantic_service.search.return_value = ["result"]
+    mock_semantic_service.search.return_value = _aiter(["result"])
 
     filter_str = "tag IN ('facts') AND feature_name IN ('alpha_fact')"
-    result = await mock_session_manager.search(
-        message="Find alpha info",
-        session_data=session_data,
-        search_filter=parse_filter(filter_str),
-        limit=5,
-        load_citations=True,
+    result = await _collect_async(
+        mock_session_manager.search(
+            message="Find alpha info",
+            session_data=session_data,
+            search_filter=parse_filter(filter_str),
+            limit=5,
+            load_citations=True,
+        )
     )
 
-    mock_semantic_service.search.assert_awaited_once()
-    kwargs = mock_semantic_service.search.await_args.kwargs
+    mock_semantic_service.search.assert_called_once()
+    kwargs = mock_semantic_service.search.call_args.kwargs
 
     set_type_id = mock_session_manager._generate_set_id(
         org_id=session_data.org_id,
@@ -480,15 +505,17 @@ async def test_get_set_features_wraps_opts(
     session_data,
 ):
     filter_str = "tag IN ('facts') AND feature_name IN ('alpha_fact')"
-    result = await mock_session_manager.get_set_features(
-        session_data=session_data,
-        search_filter=parse_filter(filter_str),
-        page_size=7,
-        load_citations=True,
+    result = await _collect_async(
+        mock_session_manager.get_set_features(
+            session_data=session_data,
+            search_filter=parse_filter(filter_str),
+            page_size=7,
+            load_citations=True,
+        )
     )
 
-    mock_semantic_service.get_set_features.assert_awaited_once()
-    kwargs = mock_semantic_service.get_set_features.await_args.kwargs
+    mock_semantic_service.get_set_features.assert_called_once()
+    kwargs = mock_semantic_service.get_set_features.call_args.kwargs
     assert kwargs["page_size"] == 7
     assert kwargs["with_citations"] is True
     assert result == ["features"]
@@ -857,10 +884,12 @@ async def test_search_with_time_filter_str(
     session_data,
 ):
     filter_str = "created_at < date('2026-01-19T01:56:41.513342Z')"
-    _ = await session_manager.search(
-        message="Find alpha info",
-        session_data=session_data,
-        search_filter=parse_filter(filter_str),
+    _ = await _collect_async(
+        session_manager.search(
+            message="Find alpha info",
+            session_data=session_data,
+            search_filter=parse_filter(filter_str),
+        )
     )
 
     # Add features
@@ -880,8 +909,10 @@ async def test_search_with_time_filter_str(
         value="alpha_value",
     )
 
-    _ = await session_manager.search(
-        message="Find alpha info",
-        session_data=session_data,
-        search_filter=parse_filter(filter_str),
+    _ = await _collect_async(
+        session_manager.search(
+            message="Find alpha info",
+            session_data=session_data,
+            search_filter=parse_filter(filter_str),
+        )
     )


### PR DESCRIPTION
Switches semantic memory to stream results from the database and operate on the stream.
Reducing memory overhead from rebuilding lists multiple times.

Will also enable any future work on making the REST api support streaming results.