### PR TITLE
Add semantic similarity to top level interface

### DIFF
--- a/src/memmachine/main/memmachine.py
+++ b/src/memmachine/main/memmachine.py
@@ -603,7 +603,7 @@ class MemMachine:
                     session_data=session_data,
                     set_metadata=set_metadata,
                     limit=limit,
-                    min_distance=score_threshold,
+                    distance_threshold=score_threshold,
                     search_filter=property_filter,
                 )
             )

--- a/src/memmachine/main/memmachine.py
+++ b/src/memmachine/main/memmachine.py
@@ -603,6 +603,7 @@ class MemMachine:
                     session_data=session_data,
                     set_metadata=set_metadata,
                     limit=limit,
+                    min_distance=score_threshold,
                     search_filter=property_filter,
                 )
             )

--- a/src/memmachine/semantic_memory/semantic_memory.py
+++ b/src/memmachine/semantic_memory/semantic_memory.py
@@ -160,7 +160,7 @@ class SemanticService:
         *,
         set_id: str,
         embedding: list[float],
-        min_distance: float | None = None,
+        distance_threshold: float | None = None,
         limit: int | None = 30,
         load_citations: bool = False,
         filter_expr: FilterExpr | None = None,
@@ -175,7 +175,7 @@ class SemanticService:
             page_size=limit,
             vector_search_opts=SemanticStorage.VectorSearchOpts(
                 query_embedding=np.array(embedding),
-                min_distance=min_distance,
+                distance_threshold=distance_threshold,
             ),
             load_citations=load_citations,
         )
@@ -185,7 +185,7 @@ class SemanticService:
         set_ids: list[SetIdT],
         query: str,
         *,
-        min_distance: float | None = None,
+        distance_threshold: float | None = None,
         limit: int | None = 30,
         load_citations: bool = False,
         filter_expr: FilterExpr | None = None,
@@ -206,7 +206,7 @@ class SemanticService:
                     self._set_id_search(
                         set_id=set_id,
                         embedding=embeddings[set_id],
-                        min_distance=min_distance,
+                        distance_threshold=distance_threshold,
                         limit=limit,
                         load_citations=load_citations,
                         filter_expr=filter_expr,

--- a/src/memmachine/semantic_memory/semantic_session_manager.py
+++ b/src/memmachine/semantic_memory/semantic_session_manager.py
@@ -176,7 +176,7 @@ class SemanticSessionManager:
         session_data: SessionData,
         *,
         set_metadata: Mapping[str, JsonValue] | None = None,
-        min_distance: float | None = None,
+        distance_threshold: float | None = None,
         limit: int | None = None,
         load_citations: bool = False,
         search_filter: FilterExpr | None = None,
@@ -191,7 +191,7 @@ class SemanticSessionManager:
         return await self._semantic_service.search(
             set_ids=list(set_ids),
             query=message,
-            min_distance=min_distance,
+            distance_threshold=distance_threshold,
             limit=limit,
             load_citations=load_citations,
             filter_expr=search_filter,

--- a/src/memmachine/semantic_memory/storage/neo4j_semantic_storage.py
+++ b/src/memmachine/semantic_memory/storage/neo4j_semantic_storage.py
@@ -871,7 +871,7 @@ class Neo4jSemanticStorage(SemanticStorage):
                 effective_limit or 0,
                 self._DEFAULT_VECTOR_QUERY_CANDIDATES,
             ),
-            min_distance=vector_search_opts.min_distance,
+            distance_threshold=vector_search_opts.distance_threshold,
             conditions=conditions,
         )
         query_text = self._vector_query_text(conditions)
@@ -896,7 +896,7 @@ class Neo4jSemanticStorage(SemanticStorage):
         embedding: list[float],
         filter_params: dict[str, Any],
         candidate_limit: int,
-        min_distance: float | None,
+        distance_threshold: float | None,
         conditions: list[str],
     ) -> dict[str, Any]:
         params: dict[str, Any] = {
@@ -904,9 +904,9 @@ class Neo4jSemanticStorage(SemanticStorage):
             "embedding": embedding,
             **filter_params,
         }
-        if min_distance is not None and min_distance > 0.0:
+        if distance_threshold is not None and distance_threshold > 0.0:
             conditions.append("score >= $min_distance")
-            params["min_distance"] = min_distance
+            params["min_distance"] = distance_threshold
         return params
 
     @staticmethod

--- a/src/memmachine/semantic_memory/storage/sqlalchemy_pgvector_semantic.py
+++ b/src/memmachine/semantic_memory/storage/sqlalchemy_pgvector_semantic.py
@@ -537,8 +537,8 @@ class SqlAlchemyPgVectorSemanticStorage(SemanticStorage):
         stmt: Select[Any],
         vector_search_opts: SemanticStorage.VectorSearchOpts,
     ) -> Select[Any]:
-        if vector_search_opts.min_distance is not None:
-            threshold = 1 - vector_search_opts.min_distance
+        if vector_search_opts.distance_threshold is not None:
+            threshold = 1 - vector_search_opts.distance_threshold
             stmt = stmt.where(
                 Feature.embedding.cosine_distance(
                     vector_search_opts.query_embedding,

--- a/src/memmachine/semantic_memory/storage/storage_base.py
+++ b/src/memmachine/semantic_memory/storage/storage_base.py
@@ -92,7 +92,7 @@ class SemanticStorage(ABC):
         """Parameters controlling vector similarity constraints for retrieval."""
 
         query_embedding: InstanceOf[np.ndarray]
-        min_distance: float | None = None
+        distance_threshold: float | None = None
 
     @abstractmethod
     async def get_feature_set(

--- a/tests/memmachine/main/test_memmachine_mock.py
+++ b/tests/memmachine/main/test_memmachine_mock.py
@@ -259,6 +259,7 @@ async def test_query_search_runs_targeted_memory_tasks(
     minimal_conf, patched_resource_manager, monkeypatch
 ):
     dummy_session = DummySessionData("s1")
+    score_threshold = 0.42
 
     async_episodic = AsyncMock(
         return_value=EpisodicMemory.QueryResponse(
@@ -294,10 +295,25 @@ async def test_query_search_runs_targeted_memory_tasks(
         dummy_session,
         target_memories=[MemoryType.Episodic, MemoryType.Semantic],
         query="hello world",
+        score_threshold=score_threshold,
     )
 
-    async_episodic.assert_awaited_once()
-    semantic_manager.search.assert_awaited_once()
+    async_episodic.assert_awaited_once_with(
+        session_data=dummy_session,
+        query="hello world",
+        limit=None,
+        expand_context=0,
+        score_threshold=score_threshold,
+        search_filter=None,
+    )
+    semantic_manager.search.assert_awaited_once_with(
+        message="hello world",
+        session_data=dummy_session,
+        set_metadata=None,
+        limit=None,
+        min_distance=score_threshold,
+        search_filter=None,
+    )
 
     assert result.episodic_memory is async_episodic.return_value
     assert result.semantic_memory == semantic_manager.search.return_value

--- a/tests/memmachine/main/test_memmachine_mock.py
+++ b/tests/memmachine/main/test_memmachine_mock.py
@@ -311,7 +311,7 @@ async def test_query_search_runs_targeted_memory_tasks(
         session_data=dummy_session,
         set_metadata=None,
         limit=None,
-        min_distance=score_threshold,
+        distance_threshold=score_threshold,
         search_filter=None,
     )
 

--- a/tests/memmachine/semantic_memory/storage/in_memory_semantic_storage.py
+++ b/tests/memmachine/semantic_memory/storage/in_memory_semantic_storage.py
@@ -743,7 +743,7 @@ class InMemorySemanticStorage(SemanticStorage):
             )
             if not self._passes_min_distance(
                 similarity,
-                vector_search_opts.min_distance,
+                vector_search_opts.distance_threshold,
             ):
                 continue
             scored_entries.append((similarity, entry))

--- a/tests/memmachine/semantic_memory/storage/test_semantic_storage.py
+++ b/tests/memmachine/semantic_memory/storage/test_semantic_storage.py
@@ -389,7 +389,7 @@ async def test_get_feature_set_basic_vector_search(
         page_size=10,
         vector_search_opts=SemanticStorage.VectorSearchOpts(
             query_embedding=embed_a,
-            min_distance=None,
+            distance_threshold=None,
         ),
     )
 
@@ -413,7 +413,7 @@ async def test_get_feature_set_min_cos_vector_search(
         page_size=10,
         vector_search_opts=SemanticStorage.VectorSearchOpts(
             query_embedding=embed_a,
-            min_distance=0.5,
+            distance_threshold=0.5,
         ),
     )
 
@@ -895,7 +895,7 @@ async def test_complex_semantic_search_and_citations(
         page_size=10,
         vector_search_opts=SemanticStorage.VectorSearchOpts(
             query_embedding=np.array([1.0, 0.0]),
-            min_distance=0.0,
+            distance_threshold=0.0,
         ),
         load_citations=True,
     )
@@ -911,7 +911,7 @@ async def test_complex_semantic_search_and_citations(
         page_size=1,
         vector_search_opts=SemanticStorage.VectorSearchOpts(
             query_embedding=np.array([1.0, 0.0]),
-            min_distance=0.5,
+            distance_threshold=0.5,
         ),
         # include_citations=False,
     )

--- a/tests/memmachine/semantic_memory/test_semantic_memory.py
+++ b/tests/memmachine/semantic_memory/test_semantic_memory.py
@@ -383,7 +383,7 @@ async def test_search_returns_matching_features(
     results = await semantic_service.search(
         set_ids=["user-search"],
         query="Why does alpha prefer quiet chats?",
-        min_distance=0.5,
+        distance_threshold=0.5,
     )
 
     # Then only the matching feature is returned using the query embedding

--- a/tests/memmachine/semantic_memory/test_semantic_session_manager.py
+++ b/tests/memmachine/semantic_memory/test_semantic_session_manager.py
@@ -158,7 +158,7 @@ async def test_search_returns_relevant_features(
         await session_manager.search(
             message="Why does alpha stay calm?",
             session_data=session_data,
-            min_distance=0.5,
+            distance_threshold=0.5,
         )
     )
 


### PR DESCRIPTION
Connects the similarity threshold of `memmachine` to the similarity argument for semantic memory.
This allows users to filter by similarity when using semantic memory.
