### PR TITLE
set `COMPOSE_CMD` when running with commands

### DIFF
--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -949,7 +949,8 @@ main() {
     show_service_info
 }
 
-# Handle script arguments
+# Handle script arguments (ensure COMPOSE_CMD is set for stop/restart/logs/clean)
+find_docker_compose
 case "${1:-}" in
     "stop")
         print_info "Stopping MemMachine services..."


### PR DESCRIPTION
### Purpose of the change

Fix the issue that `COMPOSE_CMD` is not set when running `memmachine-compose.sh` with `stop`, `clean` commands

### Description

The issue is that `COMPOSE_CMD` is not set when running `memmachine-compose.sh` with commands
```
[memmachine@rocky9 MemMachine]$ ./memmachine-compose.sh clean
[WARNING] This will remove all data and volumes!
[PROMPT] Are you sure? (y/N): y
[INFO] Cleaning up MemMachine services and data...
./memmachine-compose.sh: line 975: down: command not found
```

### Fixes/Closes

### Type of change

[Please delete options that are not relevant.]

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

[Please delete options that are not relevant.]

- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]
Before fix
```
[memmachine@rocky9 MemMachine]$ ./memmachine-compose.sh clean
[WARNING] This will remove all data and volumes!
[PROMPT] Are you sure? (y/N): y
[INFO] Cleaning up MemMachine services and data...
./memmachine-compose.sh: line 975: down: command not found
```
After fix
```
jinggong@Jings-MBP MemMachine % ./memmachine-compose.sh stop
[SUCCESS] Docker and Docker Compose are available
[INFO] Stopping MemMachine services...
[+] Running 4/4
 ✔ Container memmachine-app       Removed                                                                       0.6s
 ✔ Container memmachine-postgres  Removed                                                                       0.4s
 ✔ Container memmachine-neo4j     Removed                                                                       6.7s
 ✔ Network memmachine-network     Removed                                                                       0.1s
[SUCCESS] Services stopped
jinggong@Jings-MBP MemMachine % ./memmachine-compose.sh clean
[SUCCESS] Docker and Docker Compose are available
[WARNING] This will remove all data and volumes!
[PROMPT] Are you sure? (y/N): y
[INFO] Cleaning up MemMachine services and data...
[+] Running 6/6
 ✔ Volume memmachine_neo4j_logs       Removed                                                                   0.0s
 ✔ Volume memmachine_neo4j_plugins    Removed                                                                   0.0s
 ✔ Volume memmachine_neo4j_import     Removed                                                                   0.2s
 ✔ Volume memmachine_postgres_data    Removed                                                                   0.2s
 ✔ Volume memmachine_neo4j_data       Removed                                                                   0.2s
 ✔ Volume memmachine_memmachine_logs  Removed                                                                   0.0s
[SUCCESS] Cleanup completed
```

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

[If applicable, add screenshots or GIFs that show the changes in action. This is especially helpful for API responses. Otherwise, delete this section or type "N/A".]

### Further comments

[Add any other relevant information here, such as potential side effects, future considerations, or any specific questions for the reviewer. Otherwise, type "None".]
