### PR TITLE
Remove nltk setup from BM25 reranker tests

### DIFF
--- a/tests/memmachine/common/reranker/test_bm25_reranker.py
+++ b/tests/memmachine/common/reranker/test_bm25_reranker.py
@@ -2,13 +2,11 @@ import re
 
 import pytest
 
-from memmachine import setup_nltk
 from memmachine.common.reranker.bm25_reranker import BM25Reranker, BM25RerankerParams
 
 
 @pytest.fixture
 def reranker():
-    setup_nltk()
     return BM25Reranker(
         BM25RerankerParams(
             tokenize=lambda text: re.sub(r"\W+", " ", text).lower().split(),

--- a/tests/memmachine/common/test_utils.py
+++ b/tests/memmachine/common/test_utils.py
@@ -9,6 +9,13 @@ from memmachine.common.utils import (
 )
 
 
+@pytest.fixture(autouse=True)
+def setup_nltk_data():
+    import nltk
+
+    nltk.download("punkt_tab")
+
+
 def test_chunk_text():
     text = ""
     assert chunk_text(text, max_length=5) == []


### PR DESCRIPTION
### Purpose of the change

BM25 reranker tests do not need NLTK.

### Description

Remove setup_nltk() from fixture. Fix other tests by adding fixture to another test file.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

Existing tests should pass.

- [ ] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected