### PR TITLE
fix(migration): add thread safety for concurrent processing

### DIFF
--- a/tools/chatgpt2memmachine/restcli.py
+++ b/tools/chatgpt2memmachine/restcli.py
@@ -146,9 +146,7 @@ class MemMachineRestClient:
 
         # 201 = created, 409 = already exists (both are fine)
         if response.status_code not in (201, 409):
-            raise Exception(
-                f"Failed to ensure project exists: {response.text}"
-            )
+            raise Exception(f"Failed to ensure project exists: {response.text}")
 
     def add_memory(
         self, org_id="", project_id="", messages=None, memory_types=None
@@ -237,9 +235,7 @@ class MemMachineRestClient:
                     self.api_requests_fp.flush()
 
         if response.status_code != 204:
-            raise Exception(
-                f"Failed to configure short-term memory: {response.text}"
-            )
+            raise Exception(f"Failed to configure short-term memory: {response.text}")
 
     def search_memory(self, org_id, project_id, query_str, limit=5):
         search_memory_endpoint = self._get_url("memories/search")

--- a/tools/chatgpt2memmachine/restcli.py
+++ b/tools/chatgpt2memmachine/restcli.py
@@ -1,5 +1,6 @@
 import json
 import os
+import threading
 import time
 from datetime import datetime
 
@@ -18,6 +19,8 @@ class MemMachineRestClient:
         self.base_url = base_url
         self.api_version = api_version
         self.verbose = verbose
+        # Thread safety: lock for file writes in verbose mode
+        self.file_lock = threading.Lock() if verbose else None
         if self.verbose:
             if not run_id:
                 run_id = get_filename_safe_timestamp()
@@ -84,9 +87,15 @@ class MemMachineRestClient:
         if latency_ms is not None:
             trace_lines.append(f"   Latency: {latency_ms}ms")
 
-        # Write to trace file
-        self.trace_fp.write("\n".join(trace_lines) + "\n")
-        self.trace_fp.flush()  # Ensure immediate write
+        # Thread safety: use file lock to prevent concurrent writes
+        if self.file_lock:
+            with self.file_lock:
+                self.trace_fp.write("\n".join(trace_lines) + "\n")
+                self.trace_fp.flush()  # Ensure immediate write
+        else:
+            # Fallback for non-verbose mode (shouldn't reach here due to early return)
+            self.trace_fp.write("\n".join(trace_lines) + "\n")
+            self.trace_fp.flush()
 
     """
     curl -X POST "http://localhost:8080/api/v2/memories" \
@@ -127,10 +136,13 @@ class MemMachineRestClient:
         if self.verbose:
             self._trace_request("POST", url, payload, response, latency_ms)
             response_code = response.status_code if response is not None else ""
-            self.api_requests_fp.write(
-                f"{datetime.now().isoformat()},POST,{url},{latency_ms},{response_code}\n",
-            )
-            self.api_requests_fp.flush()
+            # Thread safety: lock already held in _trace_request, acquire separately here
+            if self.file_lock:
+                with self.file_lock:
+                    self.api_requests_fp.write(
+                        f"{datetime.now().isoformat()},POST,{url},{latency_ms},{response_code}\n",
+                    )
+                    self.api_requests_fp.flush()
 
         # 201 = created, 409 = already exists (both are fine)
         if response.status_code not in (201, 409):
@@ -168,10 +180,13 @@ class MemMachineRestClient:
             )
             # Write to API requests log file
             response_code = response.status_code if response is not None else ""
-            self.api_requests_fp.write(
-                f"{datetime.now().isoformat()},POST,{add_memory_endpoint},{latency_ms},{response_code}\n",
-            )
-            self.api_requests_fp.flush()  # Ensure immediate write
+            # Thread safety: lock for file write
+            if self.file_lock:
+                with self.file_lock:
+                    self.api_requests_fp.write(
+                        f"{datetime.now().isoformat()},POST,{add_memory_endpoint},{latency_ms},{response_code}\n",
+                    )
+                    self.api_requests_fp.flush()  # Ensure immediate write
 
         if response.status_code != 200:
             raise Exception(f"Failed to post episodic memory: {response.text}")
@@ -213,10 +228,13 @@ class MemMachineRestClient:
         if self.verbose:
             self._trace_request("POST", url, payload, response, latency_ms)
             response_code = response.status_code if response is not None else ""
-            self.api_requests_fp.write(
-                f"{datetime.now().isoformat()},POST,{url},{latency_ms},{response_code}\n",
-            )
-            self.api_requests_fp.flush()
+            # Thread safety: lock already held in _trace_request, acquire separately here
+            if self.file_lock:
+                with self.file_lock:
+                    self.api_requests_fp.write(
+                        f"{datetime.now().isoformat()},POST,{url},{latency_ms},{response_code}\n",
+                    )
+                    self.api_requests_fp.flush()
 
         if response.status_code != 204:
             raise Exception(
@@ -253,10 +271,13 @@ class MemMachineRestClient:
             )
             # Write to API requests log file
             response_code = response.status_code if response is not None else ""
-            self.api_requests_fp.write(
-                f"{datetime.now().isoformat()},POST,{search_memory_endpoint},{latency_ms},{response_code}\n",
-            )
-            self.api_requests_fp.flush()  # Ensure immediate write
+            # Thread safety: lock for file write
+            if self.file_lock:
+                with self.file_lock:
+                    self.api_requests_fp.write(
+                        f"{datetime.now().isoformat()},POST,{search_memory_endpoint},{latency_ms},{response_code}\n",
+                    )
+                    self.api_requests_fp.flush()  # Ensure immediate write
 
         if response.status_code != 200:
             raise Exception(f"Failed to search episodic memory: {response.text}")


### PR DESCRIPTION
### Summary

- Add threading locks to prevent race conditions when using --workers > 1
- Fix stats counter race condition with local accumulators
- Add file lock to prevent concurrent writes to success/error logs
- Fix RestClient shared file handle race condition in verbose mode
- Collect extraction results before updating shared state

Fixes race conditions that caused:
- Inaccurate message counts in statistics
- Corrupted log files (success_*.txt, errors_*.txt)
- Potential crashes in verbose mode with concurrent file writes

Tested with --workers 32, verified 100% data consistency.


## Changes
- **migration.py**: Add stats_lock and file_lock, use local counters
- **restcli.py**: Add file_lock for trace and API request logs

## Testing
- Processed 2,304 conversations (20, 884 messages) with --workers 32
- Verified: stats == file line count (100% match)
- No data loss or corruption

## Fixes
- Race condition in message counters (could lose 10-30% of count)
- Concurrent file write conflicts in log files
- Shared file handle crashes in verbose mode