### PR TITLE
Reduce set_id pseudo-batch size to 5

### DIFF
--- a/src/memmachine/semantic_memory/semantic_ingestion.py
+++ b/src/memmachine/semantic_memory/semantic_ingestion.py
@@ -79,7 +79,7 @@ class IngestionService:
 
         history_ids = await self._semantic_storage.get_history_messages(
             set_ids=[set_id],
-            limit=50,
+            limit=5,
             is_ingested=False,
         )
 


### PR DESCRIPTION
Using some models users have reported ~30 messages taking over 2 hours to ingest. 
Reduce pseudo-batch size to 5 to maintain good responsiveness in terms of memory ingestion.