### PR TITLE
Change Local Docker Image message from WARNING to INFO

### DIFF
--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -767,7 +767,7 @@ start_services() {
         # Pull failed
         if echo "$pull_output" | grep -q 'manifest unknown'; then
             # This is the expected error for local-only images
-            print_warning "Image '${target_image}' not found in Docker Hub registry (manifest unknown). Assuming local image."
+            print_info "Image '${target_image}' not found in Docker Hub registry (manifest unknown). Assuming local image."
         else
             # Some other error (auth, network, etc) - show it!
             print_error "Docker pull failed with unexpected error:"


### PR DESCRIPTION
### Purpose of the change

Change the message type from WARNING to INFO when no Docker Hub image is found, so we assume the image is local

### Description

Changes from:

```
[WARNING] Image 'memmachine/memmachine:tom1-cpu' not found in Docker Hub registry (manifest unknown). Assuming local image.
```

to

```
[INFO] Image 'memmachine/memmachine:tom1-cpu' not found in Docker Hub registry (manifest unknown). Assuming local image.
```

### Fixes/Closes

Fixes #913 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual verification (list step-by-step instructions)

Validated that the new message type appears when the user selects a local Docker image.

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

See above

### Further comments
