### PR TITLE
Switch uvicorn from websockets (deprecated) to websockets-sansio to resolve the deprecation warnings at startup

### DIFF
--- a/src/memmachine/server/app.py
+++ b/src/memmachine/server/app.py
@@ -136,6 +136,7 @@ def start_http() -> None:
         workers=workers,
         access_log=True,
         log_level=str(config.logging.level).lower(),
+        ws="websockets-sansio",
     )
 
 

--- a/src/memmachine/server/mcp_http.py
+++ b/src/memmachine/server/mcp_http.py
@@ -23,7 +23,9 @@ async def run_mcp_http(host: str, port: int) -> None:
         )
         async with global_memory_lifespan():
             await uvicorn.Server(
-                uvicorn.Config(mcp.get_app(), host=host, port=int(port)),
+                uvicorn.Config(
+                    mcp.get_app(), host=host, port=int(port), ws="websockets-sansio"
+                ),
             ).serve()
     except Exception:
         logger.exception("MemMachine MCP HTTP server crashed")


### PR DESCRIPTION
### Purpose of the change

Remove the deprecation warnings when MemMachine starts. WHile harmless, they point to the fact we're using a deprecated and insecure `websockets` package/feature.

### Description

This implements the workaround from https://github.com/Kludex/uvicorn/discussions/2476#discussioncomment-14524118. It has no impact on MemMachine or the FastAPI/uvicorn services. It seems unlikely that FastAPI will change its code to move off the deprecated websockets library, as it's embedded throughout uvicorn. The workaround is satisfactory for MemMachine.

### Fixes/Closes

Fixes #888 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Unit Test
- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

Before (current behavior)

```bash
$ ./memmachine-compose.sh logs | grep -E memmachine-app
memmachine-app       | INFO:memmachine.common.configuration:Loading configuration from 'configuration.yml'
memmachine-app       | INFO:memmachine.common.configuration.log_conf:applying log configuration: level=INFO, format=%(asctime)s [%(levelname)s] %(name)s - %(message)s, path=mem-machine.log
memmachine-app       | 2026-02-11 22:31:34,992 [INFO] memmachine.server.api_v2.mcp - Configuration file 'configuration.yml' loaded.
memmachine-app       | 2026-02-11 22:31:34,992 [INFO] memmachine.server.app - Starting server with 5 workers
memmachine-app       | INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
memmachine-app       | INFO:     Started parent process [6]
memmachine-app       | /app/.venv/lib/python3.12/site-packages/websockets/legacy/__init__.py:6: DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
memmachine-app       |   warnings.warn(  # deprecated in 14.0 - 2024-11-09
memmachine-app       | /app/.venv/lib/python3.12/site-packages/websockets/legacy/__init__.py:6: DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
memmachine-app       |   warnings.warn(  # deprecated in 14.0 - 2024-11-09
memmachine-app       | /app/.venv/lib/python3.12/site-packages/websockets/legacy/__init__.py:6: DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
memmachine-app       |   warnings.warn(  # deprecated in 14.0 - 2024-11-09
memmachine-app       | /app/.venv/lib/python3.12/site-packages/websockets/legacy/__init__.py:6: DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
memmachine-app       |   warnings.warn(  # deprecated in 14.0 - 2024-11-09
memmachine-app       | /app/.venv/lib/python3.12/site-packages/websockets/legacy/__init__.py:6: DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
memmachine-app       |   warnings.warn(  # deprecated in 14.0 - 2024-11-09
memmachine-app       | /app/.venv/lib/python3.12/site-packages/uvicorn/protocols/websockets/websockets_impl.py:17: DeprecationWarning: websockets.server.WebSocketServerProtocol is deprecated
memmachine-app       |   from websockets.server import WebSocketServerProtocol
memmachine-app       | /app/.venv/lib/python3.12/site-packages/uvicorn/protocols/websockets/websockets_impl.py:17: DeprecationWarning: websockets.server.WebSocketServerProtocol is deprecated
memmachine-app       |   from websockets.server import WebSocketServerProtocol
memmachine-app       | /app/.venv/lib/python3.12/site-packages/uvicorn/protocols/websockets/websockets_impl.py:17: DeprecationWarning: websockets.server.WebSocketServerProtocol is deprecated
memmachine-app       |   from websockets.server import WebSocketServerProtocol
memmachine-app       | /app/.venv/lib/python3.12/site-packages/uvicorn/protocols/websockets/websockets_impl.py:17: DeprecationWarning: websockets.server.WebSocketServerProtocol is deprecated
memmachine-app       |   from websockets.server import WebSocketServerProtocol
memmachine-app       | /app/.venv/lib/python3.12/site-packages/uvicorn/protocols/websockets/websockets_impl.py:17: DeprecationWarning: websockets.server.WebSocketServerProtocol is deprecated
memmachine-app       |   from websockets.server import WebSocketServerProtocol
```

After, with the proposed workaround.

```bash
$ ./memmachine-compose.sh logs | grep -E memmachine-app
memmachine-app       | INFO:memmachine.common.configuration:Loading configuration from 'configuration.yml'
memmachine-app       | INFO:memmachine.common.configuration.log_conf:applying log configuration: level=INFO, format=%(asctime)s [%(levelname)s] %(name)s - %(message)s, path=mem-machine.log
memmachine-app       | 2026-02-11 22:50:35,937 [INFO] memmachine.server.api_v2.mcp - Configuration file 'configuration.yml' loaded.
memmachine-app       | 2026-02-11 22:50:35,937 [INFO] memmachine.server.app - Starting server with 5 workers
memmachine-app       | INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
memmachine-app       | INFO:     Started parent process [7]
memmachine-app       | INFO:     Started server process [26]
memmachine-app       | INFO:     Started server process [22]
memmachine-app       | INFO:     Waiting for application startup.
memmachine-app       | INFO:     Waiting for application startup.
memmachine-app       | INFO:     Started server process [25]
memmachine-app       | INFO:     Waiting for application startup.
memmachine-app       | INFO:     Started server process [24]
memmachine-app       | INFO:     Waiting for application startup.
memmachine-app       | 2026-02-11 22:50:38,587 [INFO] memmachine.server.api_v2.mcp - Configuration file 'configuration.yml' loaded.
```

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

See logs comparrison above.

### Further comments

None
