### PR TITLE
Update all OpenAI Chat GPT 4.x models to 5.x.

### DIFF
--- a/docs/examples/agents.mdx
+++ b/docs/examples/agents.mdx
@@ -111,7 +111,7 @@ MEMORY_CONFIG=/Users/<username>/Desktop/intelligent-memory/memmachine/src/cfg.ym
 LOG_LEVEL="DEBUG"
 LOG_FILE="test.txt"
 
-MODEL_ID="gpt-4.1-mini"
+MODEL_ID="gpt-5-mini"
 OPENAI_API_KEY="your-api-key-here"
 
 NEO4J_USERNAME="your-username"

--- a/docs/install_guide/cloud_deploy/aws_cloudformation.mdx
+++ b/docs/install_guide/cloud_deploy/aws_cloudformation.mdx
@@ -529,7 +529,7 @@ Resources:
               openai_model:
                 provider: openai-responses
                 config:
-                  model: "gpt-4o-mini"
+                  model: "gpt-5-mini"
                   api_key: OPENAI_API_KEY_PLACEHOLDER
                   base_url: "https://api.openai.com/v1"
             rerankers:

--- a/docs/install_guide/install_guide.mdx
+++ b/docs/install_guide/install_guide.mdx
@@ -171,7 +171,7 @@ resources:
     openai_model:
       provider: openai-responses
       config:
-        model: "gpt-4o-mini"
+        model: "gpt-5-mini"
         api_key: <YOUR_API_KEY>
         base_url: "https://api.openai.com/v1"
     aws_model:
@@ -288,7 +288,7 @@ resources:
     openai_model:
       provider: openai-responses
       config:
-        model: "gpt-4o-mini"
+        model: "gpt-5-mini"
         api_key: <YOUR_API_KEY>
         base_url: "https://api.openai.com/v1"
     aws_model:

--- a/docs/open_source/configuration.mdx
+++ b/docs/open_source/configuration.mdx
@@ -336,7 +336,7 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
         openai_model:
           provider: openai-responses
           config:
-            model: "gpt-4o-mini"
+            model: "gpt-5-mini"
             api_key: <YOUR_API_KEY>
             base_url: "https://api.openai.com/v1"
         aws_model:
@@ -361,7 +361,7 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
         openai_model: # Language Model ID
           provider: openai-responses # The language model provider type
           config: # A dictionary containing provider-specific configuration
-            model: "gpt-4o-mini" # Model name
+            model: "gpt-5-mini" # Model name
             api_key: <YOUR_API_KEY> # API key for OpenAI.
             base_url: "https://api.openai.com/v1" # The base URL for the model
         aws_model: # Language Model ID
@@ -385,7 +385,7 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
     |-------------------|----------------------------------------------------------------------|--------------------------|
     | `provider`        | The language model provider type: `openai-responses`, `openai-chat-completions`, `amazon-bedrock`. | *Required*               |
     | `config`          | A dictionary containing provider-specific configuration.             | *Required*               |
-    | `config.model`    | Model name (e.g., `gpt-4o-mini` for OpenAI).                         | Depends on provider      |
+    | `config.model`    | Model name (e.g., `gpt-5-mini` for OpenAI).                         | Depends on provider      |
     | `config.api_key`  | API key for OpenAI.                                                  | *Required for OpenAI*    |
     | `config.base_url`  | The base URL for the model                                          | Depends on provider      |
     | `config.region`   | AWS region for Bedrock.                                              | *Required for Bedrock*   |

--- a/evaluation/locomo/episodic_agent/llm_judge.py
+++ b/evaluation/locomo/episodic_agent/llm_judge.py
@@ -47,7 +47,7 @@ Just return the label CORRECT or WRONG in a json format with the key as "label".
 def evaluate_llm_judge(question: str, gold_answer: str, generated_answer: str) -> int:
     """Evaluate the generated answer against the gold answer using an LLM judge."""
     response = client.chat.completions.create(
-        model="gpt-4o-mini",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "user",

--- a/evaluation/locomo/episodic_agent/memmachine_locomo.py
+++ b/evaluation/locomo/episodic_agent/memmachine_locomo.py
@@ -36,7 +36,7 @@ class MemMachineSearch:
 
     async def answer_question_with_mcp(self, question, idx, users):
         t1 = time.time()
-        response_parsed = await locomo_response(idx, question, users, "gpt-4o-mini")
+        response_parsed = await locomo_response(idx, question, users, "gpt-5-mini")
         t2 = time.time()
         return (
             response_parsed["response"],

--- a/evaluation/locomo/episodic_agent/restapiv2_locomo_search_agent.py
+++ b/evaluation/locomo/episodic_agent/restapiv2_locomo_search_agent.py
@@ -650,7 +650,7 @@ if __name__ == "__main__":
     openai_api_key = os.getenv("OPENAI_API_KEY", "none")
     openai_api_base = os.getenv("OPENAI_API_BASE", None)
     openai_base_url = os.getenv("OPENAI_BASE_URL", None)
-    openai_model_name = os.getenv("OPENAI_MODEL_NAME", "gpt-4o-mini")
+    openai_model_name = os.getenv("OPENAI_MODEL_NAME", "gpt-5-mini")
     openai_no_think = os.getenv("OPENAI_NO_THINK")
     openai_strip_think = os.getenv("OPENAI_STRIP_THINK")
     openai_embedder_base = os.getenv("OPENAI_EMBEDDER_BASE", None)

--- a/evaluation/locomo/episodic_memory/llm_judge.py
+++ b/evaluation/locomo/episodic_memory/llm_judge.py
@@ -43,7 +43,7 @@ Just return the label CORRECT or WRONG in a json format with the key as "label".
 def evaluate_llm_judge(question, gold_answer, generated_answer) -> int:
     """Evaluate the generated answer against the gold answer using an LLM judge."""
     response = client.chat.completions.create(
-        model="gpt-4o-mini",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "user",

--- a/evaluation/locomo/episodic_memory/locomo_search.py
+++ b/evaluation/locomo/episodic_memory/locomo_search.py
@@ -115,7 +115,7 @@ async def process_question(
 
     llm_start = time.time()
     rsp = await model.responses.create(
-        model="gpt-4o-mini",
+        model="gpt-5-mini",
         max_output_tokens=4096,
         temperature=0.0,
         top_p=1,

--- a/evaluation/locomo/episodic_memory/restapiv2_locomo_search.py
+++ b/evaluation/locomo/episodic_memory/restapiv2_locomo_search.py
@@ -378,7 +378,7 @@ if __name__ == "__main__":
     openai_api_key = os.getenv("OPENAI_API_KEY", "none")
     openai_api_base = os.getenv("OPENAI_API_BASE", None)
     openai_base_url = os.getenv("OPENAI_BASE_URL", None)
-    openai_model_name = os.getenv("OPENAI_MODEL_NAME", "gpt-4o-mini")
+    openai_model_name = os.getenv("OPENAI_MODEL_NAME", "gpt-5-mini")
     openai_no_think = os.getenv("OPENAI_NO_THINK")
     openai_strip_think = os.getenv("OPENAI_STRIP_THINK")
     openai_embedder_base = os.getenv("OPENAI_EMBEDDER_BASE", None)

--- a/examples/simple_chatbot/README.md
+++ b/examples/simple_chatbot/README.md
@@ -41,7 +41,7 @@ This example provides a simple chatbot interface that showcases:
 - Preview before ingesting into MemMachine
 
 ### Multi-Provider LLM Support
-- **OpenAI**: GPT-4.1 Mini, GPT-5, GPT-5 Mini, GPT-5 Nano
+- **OpenAI**: GPT-5, GPT-5.2, GPT-5 Mini, GPT-5 Nano
 - **Anthropic (Through AWS Bedrock)**: Claude Haiku 4.5, Claude Sonnet 4.5, Claude Opus 4
 - **Google Gemini**: Gemini 3 Pro (Preview), Gemini 2.5 Pro
 

--- a/examples/simple_chatbot/app.py
+++ b/examples/simple_chatbot/app.py
@@ -16,7 +16,7 @@ from llm import chat, set_model
 from model_config import MODEL_CHOICES, MODEL_DISPLAY_NAMES
 
 # Constants
-DEFAULT_MODEL = "gpt-4.1-mini"
+DEFAULT_MODEL = "gpt-5-mini"
 DEFAULT_PERSONA = "Charlie"
 DEFAULT_SESSION_BASE = "Session"
 TYPING_SPEED = 0.02

--- a/examples/simple_chatbot/llm.py
+++ b/examples/simple_chatbot/llm.py
@@ -50,7 +50,7 @@ load_dotenv()
 # ──────────────────────────────────────────────────────────────
 # Configuration
 # ──────────────────────────────────────────────────────────────
-MODEL_STRING = "gpt-4.1-mini"  # we default on gpt-4.1-mini
+MODEL_STRING = "gpt-5-mini"  # we default on gpt-5-mini
 openai_api_key = os.getenv("OPENAI_API_KEY")
 # print(openai_api_key)  # Do NOT log secrets!
 client = openai.OpenAI(api_key=openai_api_key)

--- a/examples/simple_chatbot/model_config.py
+++ b/examples/simple_chatbot/model_config.py
@@ -2,9 +2,8 @@ import os
 
 PROVIDER_MODEL_MAP = {
     "openai": [
-        "gpt-4.1-mini",
-        "gpt-5",
         "gpt-5-mini",
+        "gpt-5.2",
         "gpt-5-nano",
     ],
     "anthropic": [
@@ -27,9 +26,8 @@ MODEL_TO_PROVIDER = {
 
 # Model display names with categories
 MODEL_DISPLAY_NAMES = {
-    "gpt-4.1-mini": "OpenAI - GPT-4.1 Mini",
-    "gpt-5": "OpenAI - GPT-5",
     "gpt-5-mini": "OpenAI - GPT-5 Mini",
+    "gpt-5.2": "OpenAI - GPT-5.2",
     "gpt-5-nano": "OpenAI - GPT-5 Nano",
     "anthropic.claude-haiku-4-5-20251001-v1:0": "AWS Bedrock - Anthropic - Claude Haiku 4.5",
     "anthropic.claude-sonnet-4-5-20250929-v1:0": "AWS Bedrock - Anthropic - Claude Sonnet 4.5",

--- a/examples/v1/crm/README.md
+++ b/examples/v1/crm/README.md
@@ -269,7 +269,7 @@ Skipped (duplicates): 0 messages
 - **Comprehensive Logging** - Detailed logging for troubleshooting
 - **Error Handling** - Graceful failure with detailed error messages
 - **Skip Counter** - Shows how many duplicate messages were skipped
-- **OpenAI Integration** - AI-powered responses using GPT-4o-mini
+- **OpenAI Integration** - AI-powered responses using GPT-5 Mini
 - **Thread Support** - Responds in threads for better conversation flow
 
 ## Troubleshooting

--- a/examples/v1/crm/slack_server.py
+++ b/examples/v1/crm/slack_server.py
@@ -285,7 +285,7 @@ async def generate_openai_response(formatted_query: str, original_query: str) ->
         )
 
         response = await client.chat.completions.create(
-            model="gpt-4o-mini",
+            model="gpt-5-mini",
             messages=messages,
             max_tokens=1000,
             temperature=0.7,

--- a/examples/v1/frontend/llm.py
+++ b/examples/v1/frontend/llm.py
@@ -15,7 +15,7 @@ load_dotenv()
 # ──────────────────────────────────────────────────────────────
 # Configuration
 # ──────────────────────────────────────────────────────────────
-MODEL_STRING = "gpt-4.1-mini"  # we default on gpt-4.1-mini
+MODEL_STRING = "gpt-5-mini"  # we default on gpt-5-mini
 api_key = os.getenv("MODEL_API_KEY")
 client = openai.OpenAI(api_key=api_key)
 bedrock_runtime = boto3.client("bedrock-runtime", region_name="us-west-2")

--- a/examples/v1/frontend/model_config.py
+++ b/examples/v1/frontend/model_config.py
@@ -1,5 +1,5 @@
 PROVIDER_MODEL_MAP = {
-    "openai": ["gpt-4.1-mini"],
+    "openai": ["gpt-5-mini"],
     "anthropic": [
         "anthropic.claude-3-sonnet-20240229-v1:0",
         "anthropic.claude-3-5-haiku-20241022-v1:0",

--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -130,8 +130,8 @@ select_llm_model() {
     case "$provider" in
         "OPENAI")
             print_prompt
-            read -p "Which OpenAI LLM model would you like to use? [gpt-4o-mini]: " llm_model
-            llm_model=$(echo "${llm_model:-gpt-4o-mini}" | tr -d '\n\r')
+            read -p "Which OpenAI LLM model would you like to use? [gpt-5-mini]: " llm_model
+            llm_model=$(echo "${llm_model:-gpt-5-mini}" | tr -d '\n\r')
             print_success "Selected OpenAI LLM model: $llm_model" >&2
             ;;
         "BEDROCK")
@@ -154,7 +154,7 @@ select_llm_model() {
             ;;
         *)
             print_warning "Unknown provider: $provider. Using default LLM model." >&2
-            llm_model="gpt-4o-mini"
+            llm_model="gpt-5-mini"
             ;;
     esac
     
@@ -999,7 +999,7 @@ case "${1:-}" in
         echo ""
         echo "Provider Options:"
         echo "  OpenAI    - Uses OpenAI's GPT models and embedding models"
-        echo "             Default LLM: gpt-4o-mini"
+        echo "             Default LLM: gpt-5-mini"
         echo "             Default embedding: text-embedding-3-small"
         echo "             Requires: OpenAI API key"
         echo "  Bedrock   - Uses AWS Bedrock models"

--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -91,7 +91,7 @@ resources:
     openai_model:
       provider: openai-responses
       config:
-        model: "gpt-4o-mini"
+        model: "gpt-5-mini"
         api_key: <YOUR_API_KEY>
         base_url: "https://api.openai.com/v1"
     aws_model:

--- a/sample_configs/episodic_memory_config.gpu.sample
+++ b/sample_configs/episodic_memory_config.gpu.sample
@@ -91,7 +91,7 @@ resources:
     openai_model:
       provider: openai-responses
       config:
-        model: "gpt-4o-mini"
+        model: "gpt-5-mini"
         api_key: <YOUR_API_KEY>
         base_url: "https://api.openai.com/v1"
     aws_model:

--- a/src/memmachine/common/api/config_spec.py
+++ b/src/memmachine/common/api/config_spec.py
@@ -272,7 +272,7 @@ class AddOpenAIResponsesLanguageModelConfig(BaseModel):
     ]
     model: Annotated[
         str,
-        Field(default="gpt-4o", description=SpecDoc.MODEL_NAME),
+        Field(default="gpt-5.2", description=SpecDoc.MODEL_NAME),
     ]
     base_url: Annotated[
         str | None,
@@ -293,7 +293,7 @@ class AddOpenAIChatCompletionsLanguageModelConfig(BaseModel):
     ]
     model: Annotated[
         str,
-        Field(default="gpt-4o", description=SpecDoc.MODEL_NAME),
+        Field(default="gpt-5.2", description=SpecDoc.MODEL_NAME),
     ]
     base_url: Annotated[
         str | None,

--- a/src/memmachine/installation/utilities.py
+++ b/src/memmachine/installation/utilities.py
@@ -38,7 +38,7 @@ gpgcheck=1
 EOF"""
 
 
-DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
+DEFAULT_OPENAI_MODEL = "gpt-5-mini"
 DEFAULT_BEDROCK_MODEL = "openai.gpt-oss-20b-1:0"
 DEFAULT_OLLAMA_MODEL = "llama3"
 DEFAULT_OPENAI_EMBEDDING_MODEL = "text-embedding-3-small"

--- a/src/memmachine/main/memmachine.py
+++ b/src/memmachine/main/memmachine.py
@@ -152,7 +152,7 @@ class MemMachine:
         assert stm is not None
 
         if stm.llm_model is None:
-            stm.llm_model = "gpt-4.1"
+            stm.llm_model = "gpt-5.2"
         if stm.summary_prompt_system is None:
             stm.summary_prompt_system = self._conf.prompt.episode_summary_system_prompt
         if stm.summary_prompt_user is None:

--- a/tests/memmachine/common/configuration/test_language_model_conf.py
+++ b/tests/memmachine/common/configuration/test_language_model_conf.py
@@ -17,7 +17,7 @@ def openai_model_conf() -> dict:
     return {
         "provider": "openai-responses",
         "config": {
-            "model": "gpt-4o-mini",
+            "model": "gpt-5-mini",
             "api_key": "open-ai-key",
         },
     }
@@ -61,7 +61,7 @@ def full_model_conf(openai_model_conf, aws_model_conf, ollama_model_conf) -> dic
 
 def test_valid_openai_model(openai_model_conf):
     conf = OpenAIResponsesLanguageModelConf(**openai_model_conf["config"])
-    assert conf.model == "gpt-4o-mini"
+    assert conf.model == "gpt-5-mini"
     assert conf.api_key == SecretStr("open-ai-key")
     assert conf.max_retry_interval_seconds == 120
 
@@ -88,7 +88,7 @@ def test_full_language_model_conf(full_model_conf):
 
     assert "openai_model" in conf.openai_responses_language_model_confs
     openai_conf = conf.openai_responses_language_model_confs["openai_model"]
-    assert openai_conf.model == "gpt-4o-mini"
+    assert openai_conf.model == "gpt-5-mini"
 
     assert "aws_model" in conf.amazon_bedrock_language_model_confs
     aws_conf = conf.amazon_bedrock_language_model_confs["aws_model"]
@@ -126,7 +126,7 @@ def test_serialize_deserialize_language_model_conf(full_model_conf):
 
 
 def test_missing_required_field_openai_model():
-    conf_dict: dict[str, Any] = {"model": "gpt-4o-mini"}
+    conf_dict: dict[str, Any] = {"model": "gpt-5-mini"}
     with pytest.raises(ValidationError) as exc_info:
         OpenAIResponsesLanguageModelConf(**conf_dict)
     assert "field required" in str(exc_info.value).lower()
@@ -158,7 +158,7 @@ def test_read_api_key_from_env(monkeypatch, openai_model_conf):
     monkeypatch.setenv("MY_API_KEY", "env-open-ai-key")
     openai_model_conf["config"]["api_key"] = "${MY_API_KEY}"
     conf = OpenAIResponsesLanguageModelConf(**openai_model_conf["config"])
-    assert conf.model == "gpt-4o-mini"
+    assert conf.model == "gpt-5-mini"
     assert conf.api_key == SecretStr("env-open-ai-key")
 
 

--- a/tests/memmachine/common/resource_manager/test_language_model_manager.py
+++ b/tests/memmachine/common/resource_manager/test_language_model_manager.py
@@ -18,7 +18,7 @@ def mock_conf():
     conf = LanguageModelsConf(
         openai_responses_language_model_confs={
             "openai_4o_mini": OpenAIResponsesLanguageModelConf(
-                model="gpt-4o-mini",
+                model="gpt-5-mini",
                 api_key=SecretStr("DUMMY_OPENAI_API_KEY_1"),
             ),
             "openai_3_5_turbo": OpenAIResponsesLanguageModelConf(

--- a/tests/memmachine/conftest.py
+++ b/tests/memmachine/conftest.py
@@ -99,7 +99,7 @@ def openai_integration_config():
 
     return {
         "api_key": open_api_key,
-        "llm_model": "gpt-4o-mini",
+        "llm_model": "gpt-5-mini",
         "embedding_model": "text-embedding-3-small",
     }
 

--- a/tests/memmachine/installation/test_configuration_wizard.py
+++ b/tests/memmachine/installation/test_configuration_wizard.py
@@ -37,7 +37,7 @@ def test_configuration_with_prompt(mock_input, conf_args):
     conf_args.prompt = True
     inputs = {
         "language model provider": "openai",
-        "openai llm model": "gpt-40-mini",
+        "openai llm model": "gpt-5-mini",
         "openai api key": "api_key_value",
         "openai base url": "https://api.my-openai.com/v1",
         "embedding model name": "text-embedding-3-small",

--- a/tests/memmachine/main/test_memmachine_mock.py
+++ b/tests/memmachine/main/test_memmachine_mock.py
@@ -166,7 +166,7 @@ def test_with_default_episodic_memory_conf_uses_fallbacks(
     assert conf.long_term_memory.embedder == "default-embedder"
     assert conf.long_term_memory.reranker == "default-reranker"
     assert conf.long_term_memory.vector_graph_store == "default_store"
-    assert conf.short_term_memory.llm_model == "gpt-4.1"
+    assert conf.short_term_memory.llm_model == "gpt-5.2"
     assert conf.short_term_memory.summary_prompt_system.startswith(
         "You are a helpful assistant."
     )

--- a/tests/memmachine/rest_client/test_config.py
+++ b/tests/memmachine/rest_client/test_config.py
@@ -410,7 +410,7 @@ class TestConfig:
             {
                 "enabled": True,
                 "database": "postgres-db",
-                "llm_model": "gpt-4",
+                "llm_model": "gpt-5.2",
                 "embedding_model": "openai-embedder",
             }
         )
@@ -418,7 +418,7 @@ class TestConfig:
         assert isinstance(result, SemanticMemoryConfigResponse)
         assert result.enabled is True
         assert result.database == "postgres-db"
-        assert result.llm_model == "gpt-4"
+        assert result.llm_model == "gpt-5.2"
         assert result.embedding_model == "openai-embedder"
         mock_client.request.assert_called_once_with(
             "GET",
@@ -438,7 +438,7 @@ class TestConfig:
         result = config.update_semantic_memory_config(
             enabled=True,
             database="postgres-db",
-            llm_model="gpt-4",
+            llm_model="gpt-5.2",
             embedding_model="openai-embedder",
             ingestion_trigger_messages=10,
             ingestion_trigger_age_seconds=3600,
@@ -453,7 +453,7 @@ class TestConfig:
         body = call_args[1]["json"]
         assert body["enabled"] is True
         assert body["database"] == "postgres-db"
-        assert body["llm_model"] == "gpt-4"
+        assert body["llm_model"] == "gpt-5.2"
         assert body["embedding_model"] == "openai-embedder"
         assert body["ingestion_trigger_messages"] == 10
         assert body["ingestion_trigger_age_seconds"] == 3600

--- a/tests/memmachine/rest_client/test_memory.py
+++ b/tests/memmachine/rest_client/test_memory.py
@@ -1677,7 +1677,7 @@ class TestMemory:
         result = memory.configure_semantic_set(
             set_id="mem_user_set_abc",
             embedder_name="openai-embed",
-            llm_name="gpt-4",
+            llm_name="gpt-5.2",
         )
 
         assert result is True
@@ -1688,7 +1688,7 @@ class TestMemory:
         json_data = call_args[1]["json"]
         assert json_data["set_id"] == "mem_user_set_abc"
         assert json_data["embedder_name"] == "openai-embed"
-        assert json_data["llm_name"] == "gpt-4"
+        assert json_data["llm_name"] == "gpt-5.2"
 
     def test_configure_semantic_set_partial(self, mock_client):
         """Test set configuration with only embedder."""

--- a/tests/memmachine/server/api_v2/test_config_router.py
+++ b/tests/memmachine/server/api_v2/test_config_router.py
@@ -39,10 +39,10 @@ def mock_resource_manager():
 
     # Mock language model manager
     lm_manager = MagicMock()
-    lm_manager.get_all_names.return_value = {"gpt-4"}
+    lm_manager.get_all_names.return_value = {"gpt-5.2"}
     lm_manager.get_resource_status.return_value = ResourceStatus.READY
     lm_manager.get_resource_error.return_value = None
-    lm_manager.conf.openai_responses_language_model_confs = {"gpt-4": MagicMock()}
+    lm_manager.conf.openai_responses_language_model_confs = {"gpt-5.2": MagicMock()}
     lm_manager.conf.openai_chat_completions_language_model_confs = {}
     lm_manager.conf.amazon_bedrock_language_model_confs = {}
     resource_manager.language_model_manager = lm_manager
@@ -133,7 +133,7 @@ def test_get_config(client, mock_resource_manager):
     assert resources["embedders"][0]["status"] == "ready"
 
     assert len(resources["language_models"]) == 1
-    assert resources["language_models"][0]["name"] == "gpt-4"
+    assert resources["language_models"][0]["name"] == "gpt-5.2"
     assert resources["language_models"][0]["status"] == "ready"
 
     assert len(resources["rerankers"]) == 1
@@ -234,7 +234,7 @@ def test_add_language_model_success(client, mock_resource_manager):
         "provider": "openai-responses",
         "config": {
             "api_key": "test-key",
-            "model": "gpt-4",
+            "model": "gpt-5.2",
         },
     }
 
@@ -276,7 +276,7 @@ def test_delete_language_model_success(client, mock_resource_manager):
         return_value=True
     )
 
-    response = client.delete("/api/v2/config/resources/language_models/gpt-4")
+    response = client.delete("/api/v2/config/resources/language_models/gpt-5.2")
     assert response.status_code == 200
 
     data = response.json()
@@ -309,7 +309,7 @@ def test_retry_language_model_success(client, mock_resource_manager):
     """Test POST /api/v2/config/resources/language_models/{name}/retry retries build."""
     mock_resource_manager.language_model_manager.retry_build = AsyncMock()
 
-    response = client.post("/api/v2/config/resources/language_models/gpt-4/retry")
+    response = client.post("/api/v2/config/resources/language_models/gpt-5.2/retry")
     assert response.status_code == 200
 
     data = response.json()
@@ -397,7 +397,7 @@ def test_add_language_model_persists_config(client, mock_resource_manager):
         "provider": "openai-responses",
         "config": {
             "api_key": "test-key",
-            "model": "gpt-4",
+            "model": "gpt-5.2",
         },
     }
 
@@ -427,7 +427,7 @@ def test_delete_language_model_persists_config(client, mock_resource_manager):
         return_value=True
     )
 
-    response = client.delete("/api/v2/config/resources/language_models/gpt-4")
+    response = client.delete("/api/v2/config/resources/language_models/gpt-5.2")
     assert response.status_code == 200
 
     # Verify save_config was called
@@ -776,7 +776,7 @@ def test_update_semantic_memory_config_all_fields(client, mock_resource_manager)
     payload = {
         "enabled": True,
         "database": "postgres-db",
-        "llm_model": "gpt-4",
+        "llm_model": "gpt-5.2",
         "embedding_model": "openai-embedder",
         "ingestion_trigger_messages": 10,
         "ingestion_trigger_age_seconds": 3600,
@@ -789,7 +789,7 @@ def test_update_semantic_memory_config_all_fields(client, mock_resource_manager)
     assert data["success"] is True
     assert "enabled=True" in data["message"]
     assert "database=postgres-db" in data["message"]
-    assert "llm_model=gpt-4" in data["message"]
+    assert "llm_model=gpt-5.2" in data["message"]
     assert "embedding_model=openai-embedder" in data["message"]
     assert "ingestion_trigger_messages=10" in data["message"]
     assert "ingestion_trigger_age=3600s" in data["message"]
@@ -798,7 +798,7 @@ def test_update_semantic_memory_config_all_fields(client, mock_resource_manager)
 def test_update_semantic_memory_config_partial(client, mock_resource_manager):
     """Test PUT /api/v2/config/memory/semantic with partial fields."""
     payload = {
-        "llm_model": "gpt-4o",
+        "llm_model": "gpt-5.2",
     }
 
     response = client.put("/api/v2/config/memory/semantic", json=payload)
@@ -806,7 +806,7 @@ def test_update_semantic_memory_config_partial(client, mock_resource_manager):
 
     data = response.json()
     assert data["success"] is True
-    assert "llm_model=gpt-4o" in data["message"]
+    assert "llm_model=gpt-5.2" in data["message"]
 
 
 def test_get_episodic_memory_config(client, mock_resource_manager):

--- a/tests/memmachine/server/api_v2/test_config_service.py
+++ b/tests/memmachine/server/api_v2/test_config_service.py
@@ -134,7 +134,7 @@ async def test_add_language_model_persists_config(mock_resource_manager):
     )
 
     service = ConfigService(mock_resource_manager)
-    config = {"api_key": "test-key", "model": "gpt-4"}
+    config = {"api_key": "test-key", "model": "gpt-5.2"}
     status = await service.add_language_model("test-model", "openai-responses", config)
 
     assert status == ResourceStatus.READY

--- a/tests/memmachine/server/api_v2/test_router.py
+++ b/tests/memmachine/server/api_v2/test_router.py
@@ -1089,7 +1089,7 @@ def test_configure_semantic_set(client, mock_memmachine):
         "project_id": "test_proj",
         "set_id": "mem_user_set_abc",
         "embedder_name": "openai-embed",
-        "llm_name": "gpt-4",
+        "llm_name": "gpt-5.2",
     }
 
     response = client.post("/api/v2/memories/semantic/set/configure", json=payload)
@@ -1099,7 +1099,7 @@ def test_configure_semantic_set(client, mock_memmachine):
     call_args = mock_memmachine.configure_semantic_set.call_args[1]
     assert call_args["set_id"] == "mem_user_set_abc"
     assert call_args["embedder_name"] == "openai-embed"
-    assert call_args["llm_name"] == "gpt-4"
+    assert call_args["llm_name"] == "gpt-5.2"
 
 
 def test_configure_semantic_set_partial(client, mock_memmachine):


### PR DESCRIPTION
### Purpose of the change

OpenAI is deprecating all GPT-4.x models effective February 13th, 2026. This PR replaces all occurrences of gpt-4* with their gpt-5* equivalents.

### Description

Here are the model mappings and the files touched. The model names were obtained from https://developers.openai.com/api/docs/models.

This is a search-and-replace PR. No other changes were made.

**Model Mapping**

Old Model | New Model | Occurrences
-- | -- | --
gpt-4o-mini | gpt-5-mini | 25
gpt-4o | gpt-5.2 | 4
gpt-4 | gpt-5.2 | 20
gpt-4.1-mini | gpt-5-mini | 8
gpt-4.1 | gpt-5.2 | 2

  Files Changed (34 files)

  Source Code (3 files)

  - src/memmachine/installation/utilities.py — DEFAULT_OPENAI_MODEL default
  - src/memmachine/common/api/config_spec.py — OpenAI Responses and Chat Completions model defaults
  - src/memmachine/main/memmachine.py — Short-term memory LLM default

  Shell Scripts (1 file)

  - memmachine-compose.sh — OpenAI model prompt, default fallback, and help text (4 references)

  Sample Configs (2 files)

  - sample_configs/episodic_memory_config.gpu.sample
  - sample_configs/episodic_memory_config.cpu.sample

  Documentation (4 files)

  - docs/open_source/configuration.mdx — Config examples and parameter table
  - docs/install_guide/install_guide.mdx — Install guide YAML examples
  - docs/install_guide/cloud_deploy/aws_cloudformation.mdx — CloudFormation template
  - docs/examples/agents.mdx — Agent example env var

  Examples (7 files)

  - examples/simple_chatbot/app.py — Default model constant
  - examples/simple_chatbot/llm.py — Model string default
  - examples/simple_chatbot/model_config.py — Provider model map and display names
  - examples/simple_chatbot/README.md — Multi-provider LLM list
  - examples/v1/frontend/llm.py — Model string default
  - examples/v1/frontend/model_config.py — Provider model map
  - examples/v1/crm/slack_server.py — OpenAI chat completion model
  - examples/v1/crm/README.md — Feature description

  Evaluation Scripts (6 files)

  - evaluation/locomo/episodic_agent/memmachine_locomo.py
  - evaluation/locomo/episodic_agent/restapiv2_locomo_search_agent.py
  - evaluation/locomo/episodic_agent/llm_judge.py
  - evaluation/locomo/episodic_memory/locomo_search.py
  - evaluation/locomo/episodic_memory/restapiv2_locomo_search.py
  - evaluation/locomo/episodic_memory/llm_judge.py

  Tests (11 files)

  - tests/memmachine/conftest.py — Integration config fixture
  - tests/memmachine/main/test_memmachine_mock.py — STM default assertion
  - tests/memmachine/installation/test_configuration_wizard.py — Wizard prompt test input
  - tests/memmachine/common/configuration/test_language_model_conf.py — Model config fixtures and assertions
  - tests/memmachine/common/resource_manager/test_language_model_manager.py — Manager mock config
  - tests/memmachine/rest_client/test_config.py — Semantic memory config tests
  - tests/memmachine/rest_client/test_memory.py — Semantic set configure tests
  - tests/memmachine/server/api_v2/test_config_router.py — Resource and memory config endpoint tests
  - tests/memmachine/server/api_v2/test_config_service.py — Config service persistence test
  - tests/memmachine/server/api_v2/test_router.py — Semantic set configure endpoint test


### Fixes/Closes

Fixes #1005 

### Type of change

- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

I only verified that MemMachine starts. I HAVE NOT done any end-to-end testing or QA. This needs to be done using the nightly testing before approval and merging. 

- [x] Manual verification (list step-by-step instructions)

The following `grep` found no mentions of GPT 4 models in the source code.
```
$ grep -Rsi "gpt-4" *
```

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None
