### PR TITLE
fix: skip invalid episode_ids in semantic ingestion instead of crashing

### DIFF
--- a/src/memmachine/semantic_memory/semantic_ingestion.py
+++ b/src/memmachine/semantic_memory/semantic_ingestion.py
@@ -114,6 +114,9 @@ class IngestionService:
             )
 
         raw_messages = [m for m in raw_messages if m is not None]
+        if not raw_messages:
+            logger.warning("No valid messages for set_id %s after filtering, skipping", set_id)
+            return
         messages = TypeAdapter(list[Episode]).validate_python(raw_messages)
 
         logger.info("Processing %d messages for set %s", len(messages), set_id)


### PR DESCRIPTION
Closes #1102

When episode_ids referenced in semantic storage have been deleted or are otherwise invalid, the ingestion process crashes with a `ValueError`. This change gracefully skips invalid episode_ids with a warning log instead of failing entirely, allowing valid messages to still be processed.

As suggested in the issue discussion.