### PR TITLE
fix: reduce docs Docker image size by cleaning npm cache

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,10 +1,15 @@
-FROM alpine:latest
-
-# Install Node.js and npm
-RUN apk add --no-cache nodejs npm
+FROM node:22-alpine AS builder
 
 # Install Mintlify globally
-RUN npm install -g mint
+RUN npm install -g mint && \
+    npm cache clean --force && \
+    rm -rf /tmp/* /root/.npm
+
+FROM node:22-alpine
+
+# Copy only the global Mintlify installation from builder
+COPY --from=builder /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=builder /usr/local/bin/mint /usr/local/bin/mint
 
 # Create working directory
 WORKDIR /docs
@@ -14,4 +19,3 @@ EXPOSE 3000
 
 # Default command
 CMD ["mint", "dev"]
-


### PR DESCRIPTION
Addresses #1110

The `memmachine-docs` Docker image is ~1.12GB, which is excessive for a documentation server. The main contributor is the npm cache and temp files left behind after `npm install -g mint`.

This fix cleans up `npm cache`, `/tmp`, and `~/.npm` in the same `RUN` layer as the install, which should significantly reduce the final image size.