### PR TITLE
fix(compose): remove explicit container and network names for parallel stacks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   # PostgreSQL with pgvector extension for profile memory storage
   postgres:
     image: pgvector/pgvector:pg16
-    container_name: memmachine-postgres
     restart: unless-stopped
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
@@ -25,7 +24,6 @@ services:
   # Neo4j database for graph storage
   neo4j:
     image: neo4j:5.23-community
-    container_name: memmachine-neo4j
     restart: unless-stopped
     ports:
       - "${NEO4J_HTTP_PORT:-7474}:7474"  # HTTP
@@ -60,7 +58,6 @@ services:
   memmachine:
     image: ${MEMMACHINE_IMAGE:-memmachine/memmachine}
     pull_policy: ${PULL_POLICY:-always}
-    container_name: memmachine-app
     restart: unless-stopped
     ports:
       - "${MEMORY_SERVER_PORT:-8080}:8080"
@@ -133,4 +130,3 @@ volumes:
 networks:
   memmachine-network:
     driver: bridge
-    name: memmachine-network


### PR DESCRIPTION
Fixes #1140

## Summary

Remove hardcoded `container_name` and network `name` directives from `docker-compose.yml` so multiple stacks can run side by side.

## Problem

The current compose file sets explicit names:
- `container_name: memmachine-postgres`
- `container_name: memmachine-neo4j`
- `container_name: memmachine-app`
- `name: memmachine-network`

This prevents running two stacks simultaneously (e.g. main branch + feature branch worktree), because Docker requires container and network names to be unique.

## Fix

Remove all `container_name` directives and the explicit network `name`. Docker Compose automatically scopes names using the project name (directory name or `COMPOSE_PROJECT_NAME`), so:
- Stack in `~/MemMachine/` → containers named `memmachine-postgres-1`, etc.
- Stack in `~/MemMachine-cleanup/` → containers named `memmachine-cleanup-postgres-1`, etc.

Users who need a specific prefix can set `COMPOSE_PROJECT_NAME` in `.env`.

## Note

`memmachine-compose.sh` also uses `docker exec memmachine-postgres` (lines 801, 810). A follow-up PR could migrate those to `docker compose exec postgres` for full compatibility with parallel stacks.