### PR TITLE
[GH-1145] Reduce semantic memory log noise: demote routine trace logs to DEBUG

### DIFF
--- a/packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py
+++ b/packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py
@@ -63,7 +63,7 @@ class IngestionService:
                 logger.exception("Failed to process set_id %s", set_id)
                 raise
 
-        logger.info("Starting ingestion processing for set ids: %s", set_ids)
+        logger.debug("Starting ingestion processing for set ids: %s", set_ids)
 
         results = await asyncio.gather(
             *[_run(set_id) for set_id in set_ids],
@@ -84,7 +84,7 @@ class IngestionService:
         )
 
         if len(resources.semantic_categories) == 0:
-            logger.info(
+            logger.debug(
                 "No semantic categories configured for set %s, skipping ingestion",
                 set_id,
             )
@@ -133,7 +133,7 @@ class IngestionService:
 
         messages = TypeAdapter(list[Episode]).validate_python(raw_messages)
 
-        logger.info("Processing %d messages for set %s", len(messages), set_id)
+        logger.debug("Processing %d messages for set %s", len(messages), set_id)
 
         async def process_semantic_type(
             semantic_category: InstanceOf[SemanticCategory],
@@ -195,7 +195,7 @@ class IngestionService:
 
         await asyncio.gather(*semantic_category_runners)
 
-        logger.info(
+        logger.debug(
             "Finished processing %d messages out of %d for set %s",
             len(mark_messages),
             len(messages),

--- a/packages/server/src/memmachine_server/semantic_memory/semantic_memory.py
+++ b/packages/server/src/memmachine_server/semantic_memory/semantic_memory.py
@@ -226,7 +226,7 @@ class SemanticService:
         return res
 
     async def add_messages(self, set_id: SetIdT, history_ids: list[EpisodeIdT]) -> None:
-        logger.info("Adding messages to set %s: %s", set_id, history_ids)
+        logger.debug("Adding messages to set %s: %s", set_id, history_ids)
 
         res = await asyncio.gather(
             *[
@@ -248,7 +248,7 @@ class SemanticService:
     ) -> None:
         assert len(set_ids) == len(set(set_ids))
 
-        logger.info("Adding message id %s to sets %s", history_id, set_ids)
+        logger.debug("Adding message id %s to sets %s", history_id, set_ids)
 
         res = await asyncio.gather(
             *[
@@ -282,7 +282,7 @@ class SemanticService:
         metadata: dict[str, str] | None = None,
         citations: list[EpisodeIdT] | None = None,
     ) -> FeatureIdT:
-        logger.info("Adding new feature %s to set %s", feature, set_id)
+        logger.debug("Adding new feature %s to set %s", feature, set_id)
 
         resources = await self._set_id_resource(set_id=set_id)
 
@@ -352,7 +352,7 @@ class SemanticService:
         tag: str | None = None,
         metadata: dict[str, str] | None = None,
     ) -> None:
-        logger.info("Updating feature %s", feature_id)
+        logger.debug("Updating feature %s", feature_id)
         embedding = None
 
         if category_name is not None or value is not None:
@@ -392,12 +392,12 @@ class SemanticService:
         )
 
     async def delete_history(self, history_ids: list[EpisodeIdT]) -> None:
-        logger.info("Deleting history ids %s", history_ids)
+        logger.debug("Deleting history ids %s", history_ids)
 
         await self._semantic_storage.delete_history(history_ids)
 
     async def delete_features(self, feature_ids: list[FeatureIdT]) -> None:
-        logger.info("Deleting features ids %s", feature_ids)
+        logger.debug("Deleting features ids %s", feature_ids)
 
         await self._semantic_storage.delete_features(feature_ids)
 
@@ -407,7 +407,7 @@ class SemanticService:
         set_ids: list[SetIdT],
         filter_expr: FilterExpr | None = None,
     ) -> None:
-        logger.info("Deleting filter feature set ids %s", set_ids)
+        logger.debug("Deleting filter feature set ids %s", set_ids)
 
         await self._semantic_storage.delete_feature_set(
             filter_expr=_with_has_set_ids(
@@ -534,7 +534,7 @@ class SemanticService:
         )
 
     async def delete_set_id(self, *, set_ids: list[SetIdT]) -> None:
-        logger.info("Deleting set ids %s", set_ids)
+        logger.debug("Deleting set ids %s", set_ids)
 
         async with asyncio.TaskGroup() as tg:
             tg.create_task(


### PR DESCRIPTION
### Purpose of the change

Addresses the excessive `[INFO]` log spam reported in #1145. The \"skipping ingestion\" and other high-frequency per-call messages were logging at `INFO`, flooding production logs on every `add_memory` call even when behaviour was entirely correct.

### Description

Reviewed all `logger.*` calls in `semantic_memory/` and demoted two categories of messages from `INFO` to `DEBUG`:

**`semantic_ingestion.py`** — ingestion pipeline per-set-id trace messages:
- `Starting ingestion processing for set ids`
- `Processing N messages for set`
- `No semantic categories configured for set …, skipping ingestion` (already fixed in preceding commit)
- `Finished processing N messages out of M for set`

**`semantic_memory.py`** — high-frequency per-call CRUD trace messages:
- `Adding messages to set` / `Adding message id … to sets`
- `Adding new feature … to set`
- `Updating feature`
- `Deleting history ids` / `Deleting features ids` / `Deleting filter feature set ids` / `Deleting set ids`

Infrequent lifecycle and config-mutation events remain at `INFO` (service start/stop, category/tag create/update/delete, set-id config changes), since those represent meaningful state changes worth surfacing by default.

### Fixes/Closes

Fixes #1145

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (does not change functionality, e.g., code style improvements, linting)

### How Has This Been Tested?

- [x] Manual verification — confirmed `ruff check` passes on changed files with no warnings.
- The log level changes are observable by running the server with `LOG_LEVEL=DEBUG` to see the demoted messages, or `LOG_LEVEL=INFO` to confirm they are suppressed.

**Test Results:** `ruff check` — all checks passed.

### Checklist

- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Further comments

None.