### PR TITLE
Automate docs/openapi.json

### DIFF
--- a/packages/server/src/memmachine_server/server/api_v2/router.py
+++ b/packages/server/src/memmachine_server/server/api_v2/router.py
@@ -1003,7 +1003,23 @@ async def configure_long_term_memory(
         ) from e
 
 
-@router.get("/metrics", description=RouterDoc.METRICS_PROMETHEUS, tags=["System"])
+@router.get(
+    "/metrics",
+    description=RouterDoc.METRICS_PROMETHEUS,
+    tags=["System"],
+    responses={
+        200: {
+            "content": {
+                "text/plain": {
+                    "schema": {
+                        "type": "string",
+                        "description": "Prometheus metrics in text format",
+                    }
+                }
+            }
+        }
+    },
+)
 async def metrics() -> Response:
     """Expose Prometheus metrics endpoint."""
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)


### PR DESCRIPTION
### Purpose of the change

This change adds metadata tags (categories) to the FastAPI server endpoints. These tags are used to auto generate the `openapi.json` that is required for the public documentation on docs.memmachine.ai. This PR also includes automation to pull the latest MemMachine Platform API (openapi.json) and store it as `docs/platform.openapi.json` that is also displayed in the public docs.

### Description

As stated above. This solves the problem of humans needing to manually generate the `openapi.json` each time the APIs are modified, or at release time.

It's critical to organize the API endpoints for developer friendly organization and findability.

### Fixes/Closes

Fixes #317 

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

The scripts have been tested and the resulting `openapi.json` and `platform.openapi.json` tested and validated in an offline Mintlify dev environment.

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

N/A