### PR TITLE
support pvc with standard storageclass

### DIFF
--- a/deployments/helm/README.md
+++ b/deployments/helm/README.md
@@ -7,7 +7,7 @@ Deploys MemMachine with optional in-cluster PostgreSQL (pgvector) and Neo4j. Bot
 | Field         | Value              |
 |---------------|--------------------|
 | Chart version | 0.1.0              |
-| App version   | v0.2.6             |
+| App version   | v0.3.0             |
 | API version   | v2 (Helm 3)        |
 
 ---
@@ -164,10 +164,11 @@ Resource IDs used in top-level sections (`default_model`, `default_embedder`, `d
 
 ### Storage
 
-| Value          | Default      | Description                                   |
-|----------------|--------------|-----------------------------------------------|
-| `storageClass` | `nfs-client` | StorageClass for all three PVCs               |
-| `pvcSize`      | `5Gi`        | Storage request size for each PVC             |
+| Value          | Default        | Description                                                                 |
+|----------------|----------------|-----------------------------------------------------------------------------|
+| `storageClass` | `nfs-client`   | StorageClass for all three PVCs (e.g., `standard` on kind/minikube)        |
+| `accessMode`   | `ReadWriteMany`| PVC access mode. Use `ReadWriteMany` for NFS-style RWX classes, or `ReadWriteOnce` for local/standard classes that do not support RWX. |
+| `pvcSize`      | `5Gi`          | Storage request size for each PVC                                           |
 
 ### Neo4j (`neo4j.*`)
 
@@ -502,11 +503,12 @@ Only the MemMachine Deployment, Service, memmachine-pvc, two ConfigMaps, and thr
 ```bash
 helm upgrade --install memmachine . \
   --namespace memmachine --create-namespace \
-  --set storageClass=local-path \
+  --set storageClass=standard \
+  --set accessMode=ReadWriteOnce \
   --set pvcSize=20Gi
 ```
 
-> **Note:** `local-path` (Rancher) does not support ReadWriteMany. If your storage class only supports `ReadWriteOnce`, you will need to modify the PVC access modes in `templates/pvc.yaml` accordingly.
+> **Note:** Not all StorageClasses support `ReadWriteMany`. The default `nfs-client` is RWX-capable. Common classes like `standard` on kind/minikube are `ReadWriteOnce` only — when using those, set `accessMode=ReadWriteOnce` (and ensure it matches what your StorageClass supports).
 
 ---
 

--- a/deployments/helm/templates/neo4j-deployment.yaml
+++ b/deployments/helm/templates/neo4j-deployment.yaml
@@ -42,10 +42,17 @@ spec:
               value: '{{ .Values.neo4j.plugins | toJson }}'
           resources:
             {{- toYaml .Values.neo4j.resources | nindent 12 }}
+          startupProbe:
+            tcpSocket:
+              port: {{ .Values.neo4j.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
           livenessProbe:
             tcpSocket:
               port: {{ .Values.neo4j.port }}
-            initialDelaySeconds: 60
+            initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 5

--- a/deployments/helm/templates/pvc.yaml
+++ b/deployments/helm/templates/pvc.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: {{ $namespace }}
 spec:
   accessModes:
-    - ReadWriteMany
+    - {{ .Values.accessMode }}
   resources:
     requests:
       storage: {{ .Values.pvcSize }}
@@ -30,7 +30,7 @@ metadata:
   namespace: {{ $namespace }}
 spec:
   accessModes:
-    - ReadWriteMany
+    - {{ .Values.accessMode }}
   resources:
     requests:
       storage: {{ .Values.pvcSize }}
@@ -44,7 +44,7 @@ metadata:
   namespace: {{ $namespace }}
 spec:
   accessModes:
-    - ReadWriteMany
+    - {{ .Values.accessMode }}
   resources:
     requests:
       storage: {{ .Values.pvcSize }}

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -6,13 +6,14 @@
 # secrets out-of-band (e.g., Vault, sealed-secrets); see README.
 #
 # Sections:
-#   storageClass / pvcSize     - shared PVC settings for all three volumes
+#   storageClass / accessMode / pvcSize     - shared PVC settings for all three volumes
 #   neo4j.*                    - Neo4j image, auth, JVM heap, and connection pool
 #   postgres.*                 - PostgreSQL image, credentials, and pool settings
 #   memmachine.*               - App image, LLM/embedder backend, and app config
 #   nodePorts.*                - NodePort assignments for external access
 
 storageClass: nfs-client
+accessMode: ReadWriteMany
 pvcSize: 5Gi
 
 neo4j:
@@ -57,7 +58,7 @@ postgres:
 
 memmachine:
   image: docker.io/memmachine/memmachine
-  tag: v0.2.6-cpu
+  tag: latest-cpu
   pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
### Purpose of the change

1. Allow to set accessMode in values.yaml instead of hardcoded with `ReadWriteMany`
1. Add startupProbe in neo4j
2. Update default image tag to latest-cpu

### Description

Please include a summary of the change and the issue it addresses. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Fixes/Closes

Fixes #1189 #1193 

### Type of change

[Please delete options that are not relevant.]

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

[Please delete options that are not relevant.]

- [ ] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

When deploy with KinD cluster, set storageclass to standard and accessmode to RWO
```
jinggong@Jings-MBP MemMachine % kubectl get pvc,services,deployments -n memmachine
NAME                                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
persistentvolumeclaim/memmachine-pvc   Bound    pvc-9fc7319d-23c4-4166-a0c6-a2739b5f9776   5Gi        RWO            standard       <unset>                 3m26s
persistentvolumeclaim/neo4j-pvc        Bound    pvc-5819d947-79fc-4a01-b989-b7cf59e395ef   5Gi        RWO            standard       <unset>                 3m26s
persistentvolumeclaim/postgres-pvc     Bound    pvc-cc81dc15-d24a-460a-b629-d0208dccdb51   5Gi        RWO            standard       <unset>                 3m26s

```

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

[If applicable, add screenshots or GIFs that show the changes in action. This is especially helpful for API responses. Otherwise, delete this section or type "N/A".]

### Further comments

[Add any other relevant information here, such as potential side effects, future considerations, or any specific questions for the reviewer. Otherwise, type "None".]
