### PR TITLE
Auto ts client versioning from git tag on publish

### DIFF
--- a/.github/workflows/ts-client-publish.yml
+++ b/.github/workflows/ts-client-publish.yml
@@ -5,6 +5,11 @@ name: Publish TypeScript Client Package to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.3.0, without v prefix)'
+        required: true
 
 permissions:
   contents: read
@@ -24,6 +29,17 @@ jobs:
         with:
           node-version: '20.19.x'
           registry-url: 'https://registry.npmjs.org/'
+
+      - name: Set version from release tag
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          npm version "$VERSION" --no-git-tag-version
 
       - name: Install dependencies
         run: npm install

--- a/packages/ts-client/package-lock.json
+++ b/packages/ts-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memmachine/client",
-  "version": "0.2.5",
+  "version": "0.0.0-development",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memmachine/client",
-      "version": "0.2.5",
+      "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.12.2",

--- a/packages/ts-client/package.json
+++ b/packages/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memmachine/client",
-  "version": "0.2.5",
+  "version": "0.0.0-development",
   "description": "TypeScript client for MemMachine RESTful APIs",
   "homepage": "https://memmachine.ai",
   "repository": {


### PR DESCRIPTION
### Purpose of the change

Fix TypeScript client failing to publish to npm on release because the version was hardcoded in `package.json`. Now the version is automatically derived from the git release tag, consistent with how Python packages work via setuptools-scm.

### Description

- `package.json` / `package-lock.json`: version set to `0.0.0-development` as a placeholder; CI always overrides it at publish time.
- `ts-client-publish.yml`: added a step to inject version from the git tag (`GITHUB_REF_NAME`) before `npm publish`. Also added `workflow_dispatch` trigger for manual testing after merge.

### Fixes/Closes

Fixes #1184 

### Type of change

- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)

### How Has This Been Tested?

- [x] Manual verification (list step-by-step instructions)

Triggered manually via Actions → Publish TypeScript Client Package to npm → Run workflow, with a test version input (e.g. 0.3.0). Confirmed version was correctly set and the build and publish steps completed successfully.

**Test Results:** To be verified after merge via workflow_dispatch.

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A