### PR TITLE
Strip the leading 'v' from VERSION_INPUT

### DIFF
--- a/.github/workflows/openclaw_plugin_publish.yml
+++ b/.github/workflows/openclaw_plugin_publish.yml
@@ -32,7 +32,7 @@ jobs:
           VERSION_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          VERSION="${VERSION_INPUT}"
+          VERSION="${VERSION_INPUT#v}"
           if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
             echo "Version must be numeric semver-like without a 'v' prefix (for example: 0.3.0). Got: ${VERSION}"
             exit 1


### PR DESCRIPTION
### Purpose of the change

Publishing the package to NPMJS failed because the version string is "v0.3.1", but the expected string is "0.3.1" (without the 'v').

### Description

This fix strips the "v" from the version string.

### Fixes/Closes

None

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)

### How Has This Been Tested?

Can only test through GH Actions

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None