### PR TITLE
chore(ci): move Node 20 GitHub Actions jobs to Node 24

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -29,16 +29,16 @@ jobs:
     strategy:
       fail-fast: false  # Continue running all matrix jobs even if one fails
       matrix:
-        node-version: [20, 22]  # Test against multiple Node.js versions
+        node-version: [22, 24]  # Test against supported Node.js versions
 
     steps:
       # Step 1: Checkout the repository code
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Step 2: Set up Node.js for the current matrix version
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -81,3 +81,5 @@ jobs:
             echo "platform.openapi.json not found — skipping."
           fi
         working-directory: docs
+
+

--- a/.github/workflows/ts-client-publish.yml
+++ b/.github/workflows/ts-client-publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Set version from release tag

--- a/.github/workflows/ts-client-test.yml
+++ b/.github/workflows/ts-client-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.x'
+          node-version: '24.x'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
## Summary
- move docs validation matrix from Node 20/22 to 22/24
- update docs workflow to ctions/checkout@v4 and ctions/setup-node@v4
- move TypeScript client test and publish workflows from Node 20.19.x to 24.x

Closes #1221

## Validation
- 
pm install (in packages/ts-client)
- 
pm run build (in packages/ts-client)
- 
ode -e "require('./dist/index.js'); console.log('ts-client dist import smoke test: ok')" (in packages/ts-client)

Note: 
pm test -- --runInBand in packages/ts-client currently fails on the repo's existing Jest/ts-jest preset mismatch (Preset ts-jest not found), independent of this workflow-only change.