### PR TITLE
ci: swap to smaller Ollama models to fix installation-test timeouts

### DIFF
--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -160,7 +160,7 @@ jobs:
           command: |
             set -eo pipefail
 
-            models=("qwen3:0.6b" "nomic-embed-text")
+            models=("smollm:135m" "all-minilm")
             for model in "${models[@]}"; do
               echo "Pulling model $model..."
               response=$(curl -sS http://localhost:11434/api/pull -d "{\"name\": \"$model\"}")
@@ -177,11 +177,11 @@ jobs:
           memmachine-configure << EOF
           y
           Ollama
-          qwen3:0.6b
+          smollm:135m
 
           http://localhost:11434/v1
-          nomic-embed-text
-          768
+          all-minilm
+          384
           localhost
           8080
           EOF


### PR DESCRIPTION

### Purpose of the change

Fix CI installation-test workflow timeouts caused by Qwen3 thinking mode generating extra reasoning tokens on CPU-only GitHub Actions runners.

### Description

Swap to smaller, faster Ollama models for the installation-test CI workflow:

- **LLM**: qwen3:0.6b (600M params) -> smollm:135m (135M params) — ~4x smaller, no thinking mode overhead
- **Embeddings**: nomic-embed-text (137M params) -> all-minilm (23M params) — ~6x smaller, 384 dimensions instead of 768

This reduces both download times (~145MB total vs ~674MB) and inference latency on CPU-only runners.

### Fixes/Closes

N/A

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)

### How Has This Been Tested?

- [x] End-to-end Test

The installation-test workflow will run automatically on this PR across all 4 OS matrix entries (Ubuntu, macOS ARM, macOS Intel, Windows).

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

### Screenshots/Gifs

N/A

### Further comments

None