### PR TITLE
fix: stop semantic ingestion retry loop on context_length_exceeded

### DIFF
--- a/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 import pytest_asyncio
 
+from memmachine_server.common.data_types import ExternalServiceAPIError
 from memmachine_server.common.episode_store import (
     EpisodeEntry,
     EpisodeIdT,
@@ -210,6 +211,49 @@ async def test_process_single_set_applies_commands(
     )
     assert list(ingested) == [message_id]
     assert embedder_double.ingest_calls == [["blue"]]
+
+
+@pytest.mark.asyncio
+async def test_process_single_set_marks_context_length_errors_as_ingested(
+    ingestion_service: IngestionService,
+    semantic_storage: SemanticStorage,
+    episode_storage: EpisodeStorage,
+    monkeypatch,
+):
+    class ContextLengthExceededError(Exception):
+        code = "context_length_exceeded"
+
+    message_id = await add_history(
+        episode_storage,
+        content="very long message that exceeds model context",
+    )
+    await semantic_storage.add_history_to_set(
+        set_id="user-context-overflow",
+        history_id=message_id,
+    )
+
+    async def mock_context_length_error(*args, **kwargs):
+        err = ContextLengthExceededError("input exceeds context window")
+        raise ExternalServiceAPIError("LLM request failed") from err
+
+    monkeypatch.setattr(
+        "memmachine_server.semantic_memory.semantic_ingestion.llm_feature_update",
+        mock_context_length_error,
+    )
+
+    await ingestion_service._process_single_set("user-context-overflow")
+
+    assert (
+        await semantic_storage.get_history_messages(
+            set_ids=["user-context-overflow"],
+            is_ingested=False,
+        )
+        == []
+    )
+    assert await semantic_storage.get_history_messages(
+        set_ids=["user-context-overflow"],
+        is_ingested=True,
+    ) == [message_id]
 
 
 @pytest.mark.asyncio

--- a/packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py
+++ b/packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py
@@ -30,6 +30,27 @@ from memmachine_server.semantic_memory.storage.storage_base import SemanticStora
 logger = logging.getLogger(__name__)
 
 
+def _is_context_length_exceeded_error(error: Exception) -> bool:
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        code = getattr(current, "code", None)
+        if isinstance(code, str) and code.lower() == "context_length_exceeded":
+            return True
+
+        message = str(current).lower()
+        if (
+            "context_length_exceeded" in message
+            or "exceeds the context window" in message
+        ):
+            return True
+
+        current = current.__cause__ or current.__context__
+
+    return False
+
+
 class IngestionService:
     """
     Processes un-ingested history for each set_id and updates semantic features.
@@ -177,7 +198,17 @@ class IngestionService:
                         model=resources.language_model,
                         update_prompt=semantic_category.prompt.update_prompt,
                     )
-                except Exception:
+                except Exception as err:
+                    if _is_context_length_exceeded_error(err):
+                        logger.warning(
+                            "Skipping message %s for semantic type %s due to non-retryable context length error",
+                            message.uid,
+                            semantic_category.name,
+                        )
+                        if message.uid not in mark_messages:
+                            mark_messages.append(message.uid)
+                        continue
+
                     logger.exception(
                         "Failed to process message %s for semantic type %s",
                         message.uid,


### PR DESCRIPTION
### Purpose of the change

Prevent semantic ingestion from retrying indefinitely on messages that can never be processed because they exceed the model context window.

### Description

This change treats `context_length_exceeded` failures as non-retryable during semantic ingestion. When that error is detected (including wrapped exception chains), the message is skipped and marked ingested so it does not remain in the dirty set forever.

It also adds a regression test that reproduces a wrapped external API error with underlying `context_length_exceeded` and verifies the message is marked ingested.

### Fixes/Closes

Fixes #1252

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Unit Test

**Test Results:**

- `uv run ruff check packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py`
- `uv run pytest packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_memory_background.py -q`

### Checklist

- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Screenshots/Gifs

N/A

### Further comments

None