### PR TITLE
feat(ts-client): support batch memory delete

### DIFF
--- a/packages/ts-client/package-lock.json
+++ b/packages/ts-client/package-lock.json
@@ -64,6 +64,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2460,6 +2461,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2531,6 +2533,7 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -3011,6 +3014,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3297,6 +3301,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -3474,6 +3479,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4296,6 +4302,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4360,6 +4367,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4870,9 +4878,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5990,6 +5998,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -6826,9 +6835,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8647,6 +8656,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8776,6 +8786,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8937,6 +8948,7 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -9579,6 +9591,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10010,6 +10023,7 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/packages/ts-client/src/memory/memmachine-memory.ts
+++ b/packages/ts-client/src/memory/memmachine-memory.ts
@@ -107,15 +107,15 @@ export class MemMachineMemory {
   }
 
   /**
-   * Deletes a memory from MemMachine.
+   * Deletes one or more memories from MemMachine.
    *
-   * @param id - The unique identifier of the memory to be deleted.
+   * @param ids - The unique identifier or list of identifiers of the memories to be deleted.
    * @param type - The type of memory to delete.
    * @returns A promise that resolves when the memory is successfully deleted.
    * @throws {@link MemMachineAPIError} if the API request fails.
    */
-  delete(id: string, type: MemoryType): Promise<void> {
-    return this._deleteMemory(id, type)
+  delete(ids: string | string[], type: MemoryType): Promise<void> {
+    return this._deleteMemory(ids, type)
   }
 
   /**
@@ -251,29 +251,35 @@ export class MemMachineMemory {
   }
 
   /**
-   * Implements the logic to delete a memory from MemMachine.
+   * Implements the logic to delete one or more memories from MemMachine.
    *
-   * @param id - The unique identifier of the memory to be deleted.
+   * @param ids - The unique identifier or list of identifiers of the memories to be deleted.
    * @param memoryType - The type of memory to delete.
    * @returns A promise that resolves when the memory is successfully deleted.
    * @throws {@link MemMachineAPIError} if the API request fails.
    */
-  private async _deleteMemory(id: string, memoryType: MemoryType): Promise<void> {
-    if (!id || !id.trim()) {
-      throw new MemMachineAPIError('Memory ID must be a non-empty string')
+  private async _deleteMemory(ids: string | string[], memoryType: MemoryType): Promise<void> {
+    this._validateMemoryType(memoryType)
+
+    const rawIds = Array.isArray(ids) ? ids : [ids]
+    if (rawIds.some(i => typeof i !== 'string')) {
+      throw new MemMachineAPIError('All memory IDs must be strings')
     }
 
-    this._validateMemoryType(memoryType)
+    const normalizedIds = [...new Set(rawIds.map(i => i.trim()).filter(Boolean))]
+    if (normalizedIds.length === 0) {
+      throw new MemMachineAPIError('At least one non-empty memory ID must be provided')
+    }
 
     const urlMap: Record<MemoryType, string> = {
       episodic: '/memories/episodic/delete',
       semantic: '/memories/semantic/delete'
     }
 
+    const idField = memoryType === 'episodic' ? 'episodic_ids' : 'semantic_ids'
     const payload = {
       ...this.projectContext,
-      ...(memoryType === 'episodic' ? { episodic_id: id } : {}),
-      ...(memoryType === 'semantic' ? { semantic_id: id } : {})
+      [idField]: normalizedIds
     }
 
     try {

--- a/packages/ts-client/src/memory/memmachine-memory.ts
+++ b/packages/ts-client/src/memory/memmachine-memory.ts
@@ -255,7 +255,7 @@ export class MemMachineMemory {
    *
    * @param ids - The unique identifier or list of identifiers of the memories to be deleted.
    * @param memoryType - The type of memory to delete.
-   * @returns A promise that resolves when the memory is successfully deleted.
+   * @returns A promise that resolves when the specified memory or memories are successfully deleted.
    * @throws {@link MemMachineAPIError} if the API request fails.
    */
   private async _deleteMemory(ids: string | string[], memoryType: MemoryType): Promise<void> {

--- a/packages/ts-client/src/memory/memmachine-memory.ts
+++ b/packages/ts-client/src/memory/memmachine-memory.ts
@@ -111,7 +111,7 @@ export class MemMachineMemory {
    *
    * @param ids - The unique identifier or list of identifiers of the memories to be deleted.
    * @param type - The type of memory to delete.
-   * @returns A promise that resolves when the memory is successfully deleted.
+   * @returns A promise that resolves when the memory or memories are successfully deleted.
    * @throws {@link MemMachineAPIError} if the API request fails.
    */
   delete(ids: string | string[], type: MemoryType): Promise<void> {

--- a/packages/ts-client/tests/memmachine-memory.spec.ts
+++ b/packages/ts-client/tests/memmachine-memory.spec.ts
@@ -144,31 +144,37 @@ describe('MemMachine Memory', () => {
 
   it('should delete episodic memory successfully', async () => {
     const client = new MemMachineClient({ api_key: 'test-api-key' })
-    jest.spyOn(client.client, 'post').mockResolvedValue({
-      data: null
-    })
+    const postSpy = jest.spyOn(client.client, 'post').mockResolvedValue({ data: null })
     const project = client.project(mockProjectContext)
     const memory = project.memory(mockMemoryContext)
     const deleteResponse = await memory.delete('1', 'episodic')
     expect(deleteResponse).toBeUndefined()
+    expect(postSpy).toHaveBeenCalledWith('/memories/episodic/delete', {
+      ...mockProjectContext,
+      episodic_ids: ['1']
+    })
   })
 
   it('should delete semantic memory successfully', async () => {
     const client = new MemMachineClient({ api_key: 'test-api-key' })
-    jest.spyOn(client.client, 'post').mockResolvedValue({
-      data: null
-    })
+    const postSpy = jest.spyOn(client.client, 'post').mockResolvedValue({ data: null })
     const project = client.project(mockProjectContext)
     const memory = project.memory(mockMemoryContext)
     const deleteResponse = await memory.delete('1', 'semantic')
     expect(deleteResponse).toBeUndefined()
+    expect(postSpy).toHaveBeenCalledWith('/memories/semantic/delete', {
+      ...mockProjectContext,
+      semantic_ids: ['1']
+    })
   })
 
   it('should throw error if id is empty when deleting memory', async () => {
     const client = new MemMachineClient({ api_key: 'test-api-key' })
     const project = client.project(mockProjectContext)
     const memory = project.memory(mockMemoryContext)
-    await expect(memory.delete('', 'episodic')).rejects.toThrow('Memory ID must be a non-empty string')
+    await expect(memory.delete('', 'episodic')).rejects.toThrow(
+      'At least one non-empty memory ID must be provided'
+    )
   })
 
   it('should throw error if memory type is invalid when deleting memory', async () => {
@@ -179,6 +185,16 @@ describe('MemMachine Memory', () => {
     await expect(memory.delete('1', 'invalid-type')).rejects.toThrow('Invalid memory type: invalid-type')
   })
 
+  it('should throw MemMachineAPIError when array contains a non-string ID', async () => {
+    const client = new MemMachineClient({ api_key: 'test-api-key' })
+    const postSpy = jest.spyOn(client.client, 'post')
+    const project = client.project(mockProjectContext)
+    const memory = project.memory(mockMemoryContext)
+    // @ts-ignore
+    await expect(memory.delete(['id1', null], 'episodic')).rejects.toThrow('All memory IDs must be strings')
+    expect(postSpy).not.toHaveBeenCalled()
+  })
+
   it('should handle error when deleting memory', async () => {
     const client = new MemMachineClient({ api_key: 'test-api-key' })
     jest.spyOn(client.client, 'post').mockRejectedValue(new Error('Network Error'))
@@ -187,5 +203,45 @@ describe('MemMachine Memory', () => {
     await expect(memory.delete('1', 'episodic')).rejects.toThrow(
       /Failed to delete episodic memory with payload: .*: Network Error/
     )
+  })
+
+  it('should post episodic_ids payload when batch-deleting episodic memories', async () => {
+    const client = new MemMachineClient({ api_key: 'test-api-key' })
+    const postSpy = jest.spyOn(client.client, 'post').mockResolvedValue({ data: null })
+    const project = client.project(mockProjectContext)
+    const memory = project.memory(mockMemoryContext)
+
+    await memory.delete(['id1', 'id2'], 'episodic')
+
+    expect(postSpy).toHaveBeenCalledWith('/memories/episodic/delete', {
+      ...mockProjectContext,
+      episodic_ids: ['id1', 'id2']
+    })
+  })
+
+  it('should post semantic_ids payload when batch-deleting semantic memories', async () => {
+    const client = new MemMachineClient({ api_key: 'test-api-key' })
+    const postSpy = jest.spyOn(client.client, 'post').mockResolvedValue({ data: null })
+    const project = client.project(mockProjectContext)
+    const memory = project.memory(mockMemoryContext)
+
+    await memory.delete(['id1', 'id2'], 'semantic')
+
+    expect(postSpy).toHaveBeenCalledWith('/memories/semantic/delete', {
+      ...mockProjectContext,
+      semantic_ids: ['id1', 'id2']
+    })
+  })
+
+  it('should throw before making any request when deleting with an empty array', async () => {
+    const client = new MemMachineClient({ api_key: 'test-api-key' })
+    const postSpy = jest.spyOn(client.client, 'post')
+    const project = client.project(mockProjectContext)
+    const memory = project.memory(mockMemoryContext)
+
+    await expect(memory.delete([], 'episodic')).rejects.toThrow(
+      'At least one non-empty memory ID must be provided'
+    )
+    expect(postSpy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
### Purpose of the change

Support deleting multiple memories in a single API call from the TypeScript client, aligning with the existing server-side batch delete capability.

### Description

The server's DeleteEpisodicMemorySpec and DeleteSemanticMemorySpec already accept both a single ID (episodic_id/semantic_id) and a list (episodic_ids/semantic_ids). This PR updates the TS client's MemMachineMemory.delete() to expose that capability.

### Fixes/Closes

Fixes #1249 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- [x] Unit Test
- [x] Manual verification (list step-by-step instructions)

1. Call memory.delete('id123', 'episodic') — single delete, backward compatible
2. Call memory.delete(['id123', 'id456'], 'episodic') — batch delete, sends episodic_ids array in payload
3. Call memory.delete([], 'episodic') — throws MemMachineAPIError client-side before any request is sent

**Test Results:** Verified locally against a running MemMachine server instance.

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Further comments

package-lock.json changes are from npm audit fix — upgrades flatted (3.3.3→3.4.2) and markdown-it (14.1.0→14.1.1) to address security advisories, along with peer dependency metadata corrections.