### PR TITLE
update legacy LoCoMo eval scripts to current MemMachine API

### DIFF
--- a/evaluation/episodic_memory/locomo_config.yaml
+++ b/evaluation/episodic_memory/locomo_config.yaml
@@ -1,31 +1,46 @@
-long_term_memory:
-  embedder: my_embedder_id
-  reranker: my_reranker_id
-  vector_graph_store: my_storage_id
+logging:
+  level: info
+  path: ""
 
-sessiondb:
-  uri: sqlitetest.db
+episode_store:
+  database: db_sqlite
 
-vector_graph_store:
-  my_storage_id:
-    provider: neo4j
-    config:
-      uri: 'bolt://localhost:7687'
-      username: neo4j
-      password: <NEO4J_PASSWORD>
+episodic_memory:
+  long_term_memory:
+    embedder: my_embedder_id
+    reranker: my_reranker_id
+    vector_graph_store: my_storage_id
 
-embedder:
-  my_embedder_id:
-    provider: "openai"
-    config:
-      model: "text-embedding-3-small"
-      api_key: <OPENAI_API_KEY>
+semantic_memory:
+  enabled: false
 
-reranker:
-  my_reranker_id:
-    provider: "amazon-bedrock"
-    config:
-      region: "us-west-2"
-      aws_access_key_id: <AWS_ACCESS_KEY_ID>
-      aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>
-      model_id: "cohere.rerank-v3-5:0"
+session_manager:
+  database: db_sqlite
+
+resources:
+  databases:
+    db_sqlite:
+      provider: sqlite
+      config:
+        path: sqlitetest.db
+    my_storage_id:
+      provider: neo4j
+      config:
+        uri: 'bolt://localhost:7687'
+        username: neo4j
+        password: <NEO4J_PASSWORD>
+  embedders:
+    my_embedder_id:
+      provider: openai
+      config:
+        model: text-embedding-3-small
+        api_key: <OPENAI_API_KEY>
+  rerankers:
+    my_reranker_id:
+      provider: amazon-bedrock
+      config:
+        region: us-west-2
+        aws_access_key_id: <AWS_ACCESS_KEY_ID>
+        aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>
+        model_id: cohere.rerank-v3-5:0
+  language_models: {}

--- a/evaluation/episodic_memory/locomo_config.yaml
+++ b/evaluation/episodic_memory/locomo_config.yaml
@@ -1,31 +1,54 @@
-long_term_memory:
-  embedder: my_embedder_id
-  reranker: my_reranker_id
-  vector_graph_store: my_storage_id
+logging:
+  level: info
+  path: ""
 
-sessiondb:
-  uri: sqlitetest.db
+episode_store:
+  database: db_sqlite
 
-vector_graph_store:
-  my_storage_id:
-    provider: neo4j
-    config:
-      uri: 'bolt://localhost:7687'
-      username: neo4j
-      password: <NEO4J_PASSWORD>
+episodic_memory:
+  long_term_memory:
+    embedder: my_embedder_id
+    reranker: my_reranker_id
+    vector_graph_store: my_storage_id
 
-embedder:
-  my_embedder_id:
-    provider: "openai"
-    config:
-      model: "text-embedding-3-small"
-      api_key: <OPENAI_API_KEY>
+semantic_memory:
+  enabled: false
+  config_database: db_sqlite
 
-reranker:
-  my_reranker_id:
-    provider: "amazon-bedrock"
-    config:
-      region: "us-west-2"
-      aws_access_key_id: <AWS_ACCESS_KEY_ID>
-      aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>
-      model_id: "cohere.rerank-v3-5:0"
+session_manager:
+  database: db_sqlite
+
+resources:
+  databases:
+    db_sqlite:
+      provider: sqlite
+      config:
+        path: sqlitetest.db
+    my_storage_id:
+      provider: neo4j
+      config:
+        uri: 'bolt://localhost:7687'
+        user: neo4j
+        password: <NEO4J_PASSWORD>
+  embedders:
+    my_embedder_id:
+      provider: openai
+      config:
+        model: text-embedding-3-small
+        api_key: <OPENAI_API_KEY>
+  rerankers:
+    my_reranker_id:
+      provider: amazon-bedrock
+      config:
+        region: us-west-2
+        aws_access_key_id: <AWS_ACCESS_KEY_ID>
+        aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>
+        model_id: cohere.rerank-v3-5:0
+  language_models:
+    openai_model:
+      provider: openai-responses
+      config:
+        model: "gpt-4o-mini"
+        api_key: <YOUR_API_KEY>
+        base_url: "https://api.openai.com/v1"
+

--- a/evaluation/episodic_memory/locomo_delete.py
+++ b/evaluation/episodic_memory/locomo_delete.py
@@ -53,7 +53,7 @@ async def main() -> None:
             ),
         )
 
-        await memory.delete_data()
+        await memory.delete_session_episodes()
         await memory.close()
 
     tasks = [

--- a/evaluation/episodic_memory/locomo_delete.py
+++ b/evaluation/episodic_memory/locomo_delete.py
@@ -1,13 +1,16 @@
 import argparse
 import asyncio
 import json
-from typing import cast
+import sys
+from pathlib import Path
 
 from dotenv import load_dotenv
-from memmachine_server.episodic_memory.episodic_memory import EpisodicMemory
-from memmachine_server.episodic_memory.episodic_memory_manager import (
-    EpisodicMemoryManager,
-)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from evaluation.utils import agent_utils  # noqa: E402
 
 
 async def main() -> None:
@@ -22,14 +25,11 @@ async def main() -> None:
     with open(data_path, "r") as f:
         locomo_data = json.load(f)
 
-    memory_manager = EpisodicMemoryManager.create_episodic_memory_manager(
-        "locomo_config.yaml",
-    )
+    resource_manager = agent_utils.load_eval_config("locomo_config.yaml")
 
     async def process_conversation(
         idx,
         item,
-        memory_manager: EpisodicMemoryManager,
     ) -> None:
         if "conversation" not in item:
             return
@@ -44,20 +44,16 @@ async def main() -> None:
 
         group_id = f"group_{idx}"
 
-        memory = cast(
-            "EpisodicMemory",
-            await memory_manager.get_episodic_memory_instance(
-                group_id=group_id,
-                session_id=group_id,
-                user_id=[speaker_a, speaker_b],
-            ),
+        memory, _, _ = await agent_utils.init_memmachine_params(
+            resource_manager=resource_manager,
+            session_id=group_id,
         )
 
         await memory.delete_session_episodes()
         await memory.close()
 
     tasks = [
-        process_conversation(idx, item, memory_manager)
+        process_conversation(idx, item)
         for idx, item in enumerate(locomo_data)
     ]
     await asyncio.gather(*tasks)

--- a/evaluation/episodic_memory/locomo_delete.py
+++ b/evaluation/episodic_memory/locomo_delete.py
@@ -57,10 +57,7 @@ async def main() -> None:
         await memory.delete_session_episodes()
         await memory.close()
 
-    tasks = [
-        process_conversation(idx, item)
-        for idx, item in enumerate(locomo_data)
-    ]
+    tasks = [process_conversation(idx, item) for idx, item in enumerate(locomo_data)]
     await asyncio.gather(*tasks)
 
 

--- a/evaluation/episodic_memory/locomo_delete.py
+++ b/evaluation/episodic_memory/locomo_delete.py
@@ -17,6 +17,11 @@ async def main() -> None:
     parser = argparse.ArgumentParser()
 
     parser.add_argument("--data-path", required=True, help="Path to the data file")
+    parser.add_argument(
+        "--config-path",
+        default="locomo_config.yaml",
+        help="Path to configuration.yml",
+    )
 
     args = parser.parse_args()
 
@@ -25,7 +30,7 @@ async def main() -> None:
     with open(data_path, "r") as f:
         locomo_data = json.load(f)
 
-    resource_manager = agent_utils.load_eval_config("locomo_config.yaml")
+    resource_manager = agent_utils.load_eval_config(args.config_path)
 
     async def process_conversation(
         idx,

--- a/evaluation/episodic_memory/locomo_ingest.py
+++ b/evaluation/episodic_memory/locomo_ingest.py
@@ -2,7 +2,7 @@ import argparse
 import asyncio
 import json
 from collections import deque
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import cast
 
 from dotenv import load_dotenv
@@ -11,6 +11,12 @@ from memmachine_server.episodic_memory.episodic_memory import EpisodicMemory
 from memmachine_server.episodic_memory.episodic_memory_manager import (
     EpisodicMemoryManager,
 )
+
+
+def datetime_from_locomo_time(locomo_time_str: str) -> datetime:
+    return datetime.strptime(locomo_time_str, "%I:%M %p on %d %B, %Y").replace(
+        tzinfo=UTC
+    )
 
 
 async def main() -> None:
@@ -66,9 +72,10 @@ async def main() -> None:
 
             session = conversation[session_id]
             session_date_time = conversation[f"{session_id}_date_time"]
+            session_datetime = datetime_from_locomo_time(session_date_time)
 
             context_messages: deque[str] = deque(maxlen=5)
-            for message in session:
+            for message_index, message in enumerate(session):
                 speaker = message["speaker"]
                 blip_caption = message.get("blip_caption")
                 message_text = message["text"]
@@ -83,7 +90,8 @@ async def main() -> None:
                     episode_content=message_text,
                     episode_type="default",
                     content_type=ContentType.STRING,
-                    timestamp=datetime.now(tz=UTC),
+                    timestamp=session_datetime
+                    + message_index * timedelta(seconds=1),
                     metadata={
                         "source_timestamp": session_date_time,
                         "source_speaker": speaker,

--- a/evaluation/episodic_memory/locomo_ingest.py
+++ b/evaluation/episodic_memory/locomo_ingest.py
@@ -1,16 +1,19 @@
 import argparse
 import asyncio
 import json
-from collections import deque
+import sys
 from datetime import UTC, datetime, timedelta
-from typing import cast
+from pathlib import Path
+from uuid import uuid4
 
 from dotenv import load_dotenv
-from memmachine_server.common.episode_store import ContentType
-from memmachine_server.episodic_memory.episodic_memory import EpisodicMemory
-from memmachine_server.episodic_memory.episodic_memory_manager import (
-    EpisodicMemoryManager,
-)
+from memmachine_server.common.episode_store.episode_model import Episode
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from evaluation.utils import agent_utils  # noqa: E402
 
 
 def datetime_from_locomo_time(locomo_time_str: str) -> datetime:
@@ -31,14 +34,11 @@ async def main() -> None:
     with open(data_path, "r") as f:
         locomo_data = json.load(f)
 
-    memory_manager = EpisodicMemoryManager.create_episodic_memory_manager(
-        "locomo_config.yaml",
-    )
+    resource_manager = agent_utils.load_eval_config("locomo_config.yaml")
 
     async def process_conversation(
         idx,
         item,
-        memory_manager: EpisodicMemoryManager,
     ) -> None:
         if "conversation" not in item:
             return
@@ -53,13 +53,9 @@ async def main() -> None:
 
         group_id = f"group_{idx}"
 
-        memory = cast(
-            "EpisodicMemory",
-            await memory_manager.get_episodic_memory_instance(
-                group_id=group_id,
-                session_id=group_id,
-                user_id=[speaker_a, speaker_b],
-            ),
+        memory, _, _ = await agent_utils.init_memmachine_params(
+            resource_manager=resource_manager,
+            session_id=group_id,
         )
 
         session_idx = 0
@@ -101,7 +97,7 @@ async def main() -> None:
         await memory.close()
 
     tasks = [
-        process_conversation(idx, item, memory_manager)
+        process_conversation(idx, item)
         for idx, item in enumerate(locomo_data)
     ]
     await asyncio.gather(*tasks)

--- a/evaluation/episodic_memory/locomo_ingest.py
+++ b/evaluation/episodic_memory/locomo_ingest.py
@@ -74,29 +74,28 @@ async def main() -> None:
             session_date_time = conversation[f"{session_id}_date_time"]
             session_datetime = datetime_from_locomo_time(session_date_time)
 
-            context_messages: deque[str] = deque(maxlen=5)
             for message_index, message in enumerate(session):
                 speaker = message["speaker"]
                 blip_caption = message.get("blip_caption")
                 message_text = message["text"]
 
-                context_messages.append(
-                    f"[{session_date_time}] {speaker}: {message_text}",
-                )
-
-                await memory.add_memory_episode(
-                    producer=speaker,
-                    produced_for=speaker,
-                    episode_content=message_text,
-                    episode_type="default",
-                    content_type=ContentType.STRING,
-                    timestamp=session_datetime
-                    + message_index * timedelta(seconds=1),
-                    metadata={
-                        "source_timestamp": session_date_time,
-                        "source_speaker": speaker,
-                        "blip_caption": blip_caption,
-                    },
+                await memory.add_memory_episodes(
+                    episodes=[
+                        Episode(
+                            uid=str(uuid4()),
+                            content=message_text,
+                            session_key=group_id,
+                            created_at=session_datetime
+                            + message_index * timedelta(seconds=1),
+                            producer_id=speaker,
+                            producer_role=speaker,
+                            metadata={
+                                "source_timestamp": session_date_time,
+                                "source_speaker": speaker,
+                                "blip_caption": blip_caption,
+                            },
+                        )
+                    ],
                 )
 
         await memory.close()

--- a/evaluation/episodic_memory/locomo_ingest.py
+++ b/evaluation/episodic_memory/locomo_ingest.py
@@ -101,10 +101,7 @@ async def main() -> None:
 
         await memory.close()
 
-    tasks = [
-        process_conversation(idx, item)
-        for idx, item in enumerate(locomo_data)
-    ]
+    tasks = [process_conversation(idx, item) for idx, item in enumerate(locomo_data)]
     await asyncio.gather(*tasks)
 
 

--- a/evaluation/episodic_memory/locomo_ingest.py
+++ b/evaluation/episodic_memory/locomo_ingest.py
@@ -26,6 +26,11 @@ async def main() -> None:
     parser = argparse.ArgumentParser()
 
     parser.add_argument("--data-path", required=True, help="Path to the data file")
+    parser.add_argument(
+        "--config-path",
+        default="locomo_config.yaml",
+        help="Path to configuration.yml",
+    )
 
     args = parser.parse_args()
 
@@ -34,7 +39,7 @@ async def main() -> None:
     with open(data_path, "r") as f:
         locomo_data = json.load(f)
 
-    resource_manager = agent_utils.load_eval_config("locomo_config.yaml")
+    resource_manager = agent_utils.load_eval_config(args.config_path)
 
     async def process_conversation(
         idx,

--- a/evaluation/episodic_memory/locomo_search.py
+++ b/evaluation/episodic_memory/locomo_search.py
@@ -106,6 +106,8 @@ async def process_question(
     summary = summaries[0] if summaries else ""
     memory_end = time.time()
 
+    await memory.close()
+
     formatted_context = format_memory(episodes, summary)
     prompt = ANSWER_PROMPT.format(
         conversation_memories=formatted_context,

--- a/evaluation/episodic_memory/locomo_search.py
+++ b/evaluation/episodic_memory/locomo_search.py
@@ -81,7 +81,6 @@ def format_memory(episodes, summary) -> str:
 async def process_question(
     memory,
     answer_model,
-    user,
     question,
     answer,
     category,
@@ -169,9 +168,6 @@ async def main() -> None:
         if "conversation" not in item:
             continue
 
-        conversation = item["conversation"]
-        user = conversation["speaker_a"]
-
         qa_list = item["qa"]
 
         print(f"Processing questions for group {idx}...")
@@ -194,7 +190,6 @@ async def main() -> None:
             question_response = await process_question(
                 memory,
                 answer_model,
-                user,
                 question,
                 answer,
                 category,

--- a/evaluation/episodic_memory/locomo_search.py
+++ b/evaluation/episodic_memory/locomo_search.py
@@ -94,7 +94,9 @@ async def process_question(
         session_id=group_id,
     )
 
-    query_response = await memory.query_memory(query=question, limit=30, expand_context=3)
+    query_response = await memory.query_memory(
+        query=question, limit=30, expand_context=3
+    )
 
     if query_response is None:
         long_term_episodes = []

--- a/evaluation/episodic_memory/locomo_search.py
+++ b/evaluation/episodic_memory/locomo_search.py
@@ -160,6 +160,11 @@ async def main() -> None:
         help="Path to the source data file",
     )
     parser.add_argument(
+        "--config-path",
+        default="locomo_config.yaml",
+        help="Path to configuration.yml",
+    )
+    parser.add_argument(
         "--target-path",
         required=True,
         help="Path to the target data file",
@@ -173,7 +178,7 @@ async def main() -> None:
     with open(data_path, "r") as f:
         locomo_data = json.load(f)
 
-    resource_manager = agent_utils.load_eval_config("locomo_config.yaml")
+    resource_manager = agent_utils.load_eval_config(args.config_path)
 
     model = AsyncOpenAI(
         api_key=os.getenv("OPENAI_API_KEY"),

--- a/evaluation/episodic_memory/locomo_search.py
+++ b/evaluation/episodic_memory/locomo_search.py
@@ -62,7 +62,7 @@ def format_memory(episodes, summary) -> str:
         "<LONG TERM MEMORY EPISODES>\n"
         + "\n".join(
             [
-                f"[{episode.user_metadata['source_timestamp']}] {episode.user_metadata['source_speaker']}: {episode.content}{f' [ATTACHED: {episode.user_metadata["blip_caption"]}]' if episode.user_metadata.get('blip_caption') else ''}"
+                f"[{episode.metadata['source_timestamp']}] {episode.metadata['source_speaker']}: {episode.content}{f' [ATTACHED: {episode.metadata["blip_caption"]}]' if episode.metadata.get('blip_caption') else ''}"
                 for episode in episodes
             ],
         )

--- a/evaluation/episodic_memory/locomo_search.py
+++ b/evaluation/episodic_memory/locomo_search.py
@@ -79,8 +79,8 @@ def format_memory(episodes, summary) -> str:
 
 
 async def process_question(
-    resource_manager,
-    group_id,
+    memory,
+    answer_model,
     user,
     question,
     answer,
@@ -89,11 +89,6 @@ async def process_question(
     adversarial_answer,
 ):
     memory_start = time.time()
-    memory, answer_model, _ = await agent_utils.init_memmachine_params(
-        resource_manager=resource_manager,
-        session_id=group_id,
-    )
-
     query_response = await memory.query_memory(
         query=question, limit=30, expand_context=3
     )
@@ -110,8 +105,6 @@ async def process_question(
     episodes = long_term_episodes + short_term_episodes
     summary = summaries[0] if summaries else ""
     memory_end = time.time()
-
-    await memory.close()
 
     formatted_context = format_memory(episodes, summary)
     prompt = ANSWER_PROMPT.format(
@@ -185,6 +178,11 @@ async def main() -> None:
 
         group_id = f"group_{idx}"
 
+        memory, answer_model, _ = await agent_utils.init_memmachine_params(
+            resource_manager=resource_manager,
+            session_id=group_id,
+        )
+
         async def respond_question(qa):
             question = qa["question"]
             answer = qa.get("answer", "")
@@ -194,8 +192,8 @@ async def main() -> None:
             adversarial_answer = qa.get("adversarial_answer", "")
 
             question_response = await process_question(
-                resource_manager,
-                group_id,
+                memory,
+                answer_model,
                 user,
                 question,
                 answer,
@@ -208,9 +206,12 @@ async def main() -> None:
                 question_response,
             )
 
-        responses = []
-        for qa in qa_list:
-            responses.append(await respond_question(qa))
+        try:
+            responses = []
+            for qa in qa_list:
+                responses.append(await respond_question(qa))
+        finally:
+            await memory.close()
 
         for category, response in responses:
             category_result = results.get(category, [])

--- a/evaluation/episodic_memory/locomo_search.py
+++ b/evaluation/episodic_memory/locomo_search.py
@@ -97,11 +97,17 @@ async def process_question(
         ),
     )
 
-    (
-        short_term_episodes,
-        long_term_episodes,
-        summaries,
-    ) = await memory.query_memory(query=question, limit=30, expand_context=3)
+    query_response = await memory.query_memory(query=question, limit=30, expand_context=3)
+
+    if query_response is None:
+        long_term_episodes = []
+        short_term_episodes = []
+        summaries = []
+    else:
+        long_term_episodes = query_response.long_term_memory.episodes
+        short_term_episodes = query_response.short_term_memory.episodes
+        summaries = query_response.short_term_memory.episode_summary
+
     episodes = long_term_episodes + short_term_episodes
     summary = summaries[0] if summaries else ""
     memory_end = time.time()

--- a/evaluation/episodic_memory/locomo_search.py
+++ b/evaluation/episodic_memory/locomo_search.py
@@ -1,14 +1,12 @@
 import argparse
 import asyncio
 import json
-import os
 import sys
 import time
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from dotenv import load_dotenv
-from openai import AsyncOpenAI
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -82,7 +80,6 @@ def format_memory(episodes, summary) -> str:
 
 async def process_question(
     resource_manager,
-    model: AsyncOpenAI,
     group_id,
     user,
     question,
@@ -92,7 +89,7 @@ async def process_question(
     adversarial_answer,
 ):
     memory_start = time.time()
-    memory, _, _ = await agent_utils.init_memmachine_params(
+    memory, answer_model, _ = await agent_utils.init_memmachine_params(
         resource_manager=resource_manager,
         session_id=group_id,
     )
@@ -121,16 +118,8 @@ async def process_question(
     )
 
     llm_start = time.time()
-    rsp = await model.responses.create(
-        model="gpt-4o-mini",
-        max_output_tokens=4096,
-        temperature=0.0,
-        top_p=1,
-        input=[{"role": "user", "content": prompt}],
-    )
+    rsp_text, _ = await answer_model.generate_response(user_prompt=prompt)
     llm_end = time.time()
-
-    rsp_text = rsp.output_text
 
     print(
         f"Question: {question}\n"
@@ -180,10 +169,6 @@ async def main() -> None:
 
     resource_manager = agent_utils.load_eval_config(args.config_path)
 
-    model = AsyncOpenAI(
-        api_key=os.getenv("OPENAI_API_KEY"),
-    )
-
     results: dict[str, Any] = {}
     for idx, item in enumerate(locomo_data):
         if "conversation" not in item:
@@ -208,7 +193,6 @@ async def main() -> None:
 
             question_response = await process_question(
                 resource_manager,
-                model,
                 group_id,
                 user,
                 question,

--- a/evaluation/episodic_memory/locomo_search.py
+++ b/evaluation/episodic_memory/locomo_search.py
@@ -2,15 +2,19 @@ import argparse
 import asyncio
 import json
 import os
+import sys
 import time
+from pathlib import Path
 from typing import Any, cast
 
 from dotenv import load_dotenv
-from memmachine_server.episodic_memory.episodic_memory import EpisodicMemory
-from memmachine_server.episodic_memory.episodic_memory_manager import (
-    EpisodicMemoryManager,
-)
 from openai import AsyncOpenAI
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from evaluation.utils import agent_utils  # noqa: E402
 
 # This is adapted from Mem0 (https://github.com/mem0ai/mem0/blob/main/evaluation/prompts.py).
 # It is modified to work with MemMachine.
@@ -77,7 +81,7 @@ def format_memory(episodes, summary) -> str:
 
 
 async def process_question(
-    memory_manager: EpisodicMemoryManager,
+    resource_manager,
     model: AsyncOpenAI,
     group_id,
     user,
@@ -88,13 +92,9 @@ async def process_question(
     adversarial_answer,
 ):
     memory_start = time.time()
-    memory = cast(
-        "EpisodicMemory",
-        await memory_manager.get_episodic_memory_instance(
-            group_id=group_id,
-            session_id=group_id,
-            user_id=[user],
-        ),
+    memory, _, _ = await agent_utils.init_memmachine_params(
+        resource_manager=resource_manager,
+        session_id=group_id,
     )
 
     query_response = await memory.query_memory(query=question, limit=30, expand_context=3)
@@ -173,9 +173,7 @@ async def main() -> None:
     with open(data_path, "r") as f:
         locomo_data = json.load(f)
 
-    memory_manager = EpisodicMemoryManager.create_episodic_memory_manager(
-        "locomo_config.yaml",
-    )
+    resource_manager = agent_utils.load_eval_config("locomo_config.yaml")
 
     model = AsyncOpenAI(
         api_key=os.getenv("OPENAI_API_KEY"),
@@ -204,7 +202,7 @@ async def main() -> None:
             adversarial_answer = qa.get("adversarial_answer", "")
 
             question_response = await process_question(
-                memory_manager,
+                resource_manager,
                 model,
                 group_id,
                 user,


### PR DESCRIPTION
### Purpose of the change
The LoCoMo evaluation scripts are broken and cannot run against the current MemMachine API. This PR updates all three eval scripts and the config file to be compatible with the latest interfaces.

### Description
The LoCoMo evaluation pipeline (`locomo_ingest.py`, `locomo_delete.py`, `locomo_search.py`) and its config (`locomo_config.yaml`) relied on deprecated/removed APIs such as `EpisodicMemoryManager`, `add_memory_episode()`, `delete_data()`, tuple-based `query_memory()` return, and `episode.user_metadata`. Additionally, `locomo_search.py` had a hardcoded OpenAI `gpt-4o-mini` dependency instead of using the configured language model.

This PR migrates all scripts to the current MemMachine API surface:
- Rewrite `locomo_config.yaml` to the new `Configuration` schema (`resources`, `episodic_memory`, `session_manager`, etc.)
- Replace `EpisodicMemoryManager.create_episodic_memory_manager()` with `agent_utils.load_eval_config()` and `agent_utils.init_memmachine_params()`
- `add_memory_episode()` → `add_memory_episodes(Episode(...))`
- `delete_data()` → `delete_session_episodes()`
- `query_memory()` tuple return → `QueryResponse` object field access
- `episode.user_metadata` → `episode.metadata`
- Replace hardcoded OpenAI client with config-specified `answer_model.generate_response()`
- Add `--config-path` CLI argument to all three scripts
- Fix missing `memory.close()` call in `locomo_search.py`
- Use actual session timestamps from the dataset instead of `datetime.now()` during ingestion

### Fixes/Closes
Fixes #1210

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- [x] Manual verification (list step-by-step instructions)

In the `evaluation/episodic_memory` directory, run the commands below.

``` bash
python locomo_ingest.py --config-path ../../configuration.yaml --data-path ../data/locomo10.json
python locomo_search.py --config-path ../../configuration.yaml --data-path ../data/locomo10.json --target-path results.json
python locomo_delete.py --config-path ../../configuration.yaml --data-path ../data/locomo10.json
```

**Test Results:** N/A

### Checklist
- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist
- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs
N/A

### Further comments
None