### PR TITLE
feat: enhance memmachine-compose.sh first-run setup wizard

### DIFF
--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -957,16 +957,110 @@ build_image() {
     docker build --build-arg GPU=$gpu --build-arg SCM_VERSION="$scm_version" -t "$name" .
 }
 
+# Configure reranker settings
+configure_reranker() {
+    if [ "$is_first_run" != true ]; then
+        return
+    fi
+
+    if [ ! -f "configuration.yml" ]; then
+        return
+    fi
+
+    local is_gpu=false
+    if [[ "$MEMMACHINE_IMAGE" == *"latest-gpu"* ]]; then
+        is_gpu=true
+    fi
+
+    if [ "$is_gpu" = true ]; then
+        print_info "Default reranker: RRF hybrid (identity + BM25 + cross-encoder)"
+        print_prompt
+        read -p "Replace cross-encoder provider? (None/Cohere/AWS) [None]: " reranker_choice
+    else
+        print_info "Default reranker: RRF hybrid (identity + BM25)"
+        print_prompt
+        read -p "Add optional neural reranker? (None/Cohere/AWS) [None]: " reranker_choice
+    fi
+
+    local reranker=$(echo "${reranker_choice:-None}" | tr '[:lower:]' '[:upper:]')
+
+    case "$reranker" in
+        COHERE)
+            print_prompt
+            read -p "Would you like to set your Cohere API key? (y/N) " reply
+            if [[ $reply =~ ^[Yy]$ ]]; then
+                print_prompt
+                read -sp "Enter your Cohere API key: " cohere_key
+                echo
+                safe_sed_inplace "s|cohere_key: <COHERE_API_KEY>|cohere_key: $cohere_key|g" configuration.yml
+                print_success "Set Cohere API key in configuration.yml"
+            else
+                safe_sed_inplace "s|cohere_key: <COHERE_API_KEY>|cohere_key: EMPTY|g" configuration.yml
+                print_warning "Cohere API key set to 'EMPTY'. Update it later if needed."
+            fi
+
+            print_prompt
+            read -p "Cohere reranker model [rerank-english-v3.0]: " cohere_model
+            cohere_model=${cohere_model:-rerank-english-v3.0}
+            safe_sed_inplace "/cohere_reranker_id:/,/model:/ s|model: .*|model: \"$cohere_model\"|" configuration.yml
+
+            if [ "$is_gpu" = true ]; then
+                safe_sed_inplace "s|- ce_ranker_id|- cohere_reranker_id|" configuration.yml
+            else
+                if ! grep -q "cohere_reranker_id" <(awk '/my_reranker_id:/,/^    [a-zA-Z]/' configuration.yml); then
+                    safe_sed_inplace "/reranker_ids:/,/^    [a-zA-Z]/ { /- bm_ranker_id/a\\          - cohere_reranker_id
+                    }" configuration.yml
+                fi
+            fi
+            print_success "Added Cohere reranker to hybrid configuration"
+            ;;
+        AWS)
+            print_prompt
+            read -sp "Enter your AWS Access Key ID: " aws_access_key
+            echo
+            print_prompt
+            read -sp "Enter your AWS Secret Access Key: " aws_secret_key
+            echo
+            print_prompt
+            read -p "Enter your AWS Region [us-west-2]: " aws_region
+            aws_region=${aws_region:-us-west-2}
+            print_prompt
+            read -p "AWS reranker model ID [amazon.rerank-v1:0]: " aws_model
+            aws_model=${aws_model:-amazon.rerank-v1:0}
+
+            safe_sed_inplace "s|aws_access_key_id: <AWS_ACCESS_KEY_ID>|aws_access_key_id: $aws_access_key|g" configuration.yml
+            safe_sed_inplace "s|aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>|aws_secret_access_key: $aws_secret_key|g" configuration.yml
+            safe_sed_inplace "/aws_reranker_id:/,/model_id:/ s|region: .*|region: \"$aws_region\"|" configuration.yml
+            safe_sed_inplace "/aws_reranker_id:/,/model_id:/ s|model_id: .*|model_id: \"$aws_model\"|" configuration.yml
+            print_success "Set AWS Bedrock reranker credentials in configuration.yml"
+
+            if [ "$is_gpu" = true ]; then
+                safe_sed_inplace "s|- ce_ranker_id|- aws_reranker_id|" configuration.yml
+            else
+                if ! grep -q "aws_reranker_id" <(awk '/my_reranker_id:/,/^    [a-zA-Z]/' configuration.yml); then
+                    safe_sed_inplace "/reranker_ids:/,/^    [a-zA-Z]/ { /- bm_ranker_id/a\\          - aws_reranker_id
+                    }" configuration.yml
+                fi
+            fi
+            print_success "Added AWS Bedrock reranker to hybrid configuration"
+            ;;
+        *)
+            print_success "Using default reranker configuration"
+            ;;
+    esac
+}
+
 # Main execution
 main() {
     echo "MemMachine Docker Startup Script"
     echo "===================================="
     echo ""
-    
+
     find_docker_compose
     check_env_file
     check_config_file
     set_provider_api_keys
+    configure_reranker
     check_required_env
     check_required_config
     start_services

--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -628,6 +628,11 @@ set_provider_api_keys() {
                     safe_sed_inplace "s|OPENAI_API_KEY=.*|OPENAI_API_KEY=$api_key|" .env
                     safe_sed_inplace "s|api_key: <YOUR_API_KEY>|api_key: $api_key|g" configuration.yml
                     print_success "Set OPENAI_API_KEY in .env and configuration.yml"
+                else
+                    # Auto-populate with EMPTY to prevent runtime errors (e.g. vLLM doesn't require API keys)
+                    safe_sed_inplace "s|OPENAI_API_KEY=.*|OPENAI_API_KEY=EMPTY|" .env
+                    safe_sed_inplace "s|api_key: <YOUR_API_KEY>|api_key: EMPTY|g" configuration.yml
+                    print_warning "API key set to 'EMPTY'. Update it later if your provider requires authentication."
                 fi
             else
                 print_success "API key for OpenAI-compatible provider appears to be configured"
@@ -704,6 +709,8 @@ check_required_env() {
                 print_warning "Please set your API key in the .env file for the OpenAI-compatible provider"
                 print_prompt
                 read -p "Press Enter to continue anyway (some features may not work)..."
+            elif [ "$OPENAI_API_KEY" = "EMPTY" ]; then
+                print_info "OPENAI_API_KEY is set to 'EMPTY' (no authentication - OK for providers like vLLM)"
             else
                 print_success "OPENAI_API_KEY is configured (OpenAI-compatible provider)"
             fi

--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -544,22 +544,35 @@ check_config_file() {
 }
 
 select_openai_compatible_base_url() {
-    local base_url=""
+    local llm_base_url=""
+    local embedder_base_url=""
     local reply=""
 
     if [ "$is_first_run" = true ]; then
         print_prompt
-        read -p "Model base URL is not set. Would you like to configure a custom model base URL? (y/N) " reply
+        read -p "Model base URL is not set. Would you like to configure custom base URLs? (y/N) " reply
         if [[ $reply =~ ^[Yy]$ ]]; then
             print_prompt
-            read -p "OpenAI-compatible base URL [https://api.openai.com/v1]: " base_url
-            base_url=$(echo "${base_url:-https://api.openai.com/v1}" | tr -d '\n\r')
-            if [ -n "$base_url" ]; then
-                # Update base_url under openai_compatible_model / openai_compatible_embedder.
-                # Note: these entries exist in sample_configs/* and are included when provider=OPENAI_COMPATIBLE.
-                safe_sed_inplace "/openai_compatible_model:/,/base_url:/ s|base_url: .*|base_url: \"$base_url\"|" configuration.yml
-                safe_sed_inplace "/openai_compatible_embedder:/,/base_url:/ s|base_url: .*|base_url: \"$base_url\"|" configuration.yml
-                print_success "Set OpenAI-compatible base URL to $base_url"
+            read -p "LLM base URL [https://api.openai.com/v1]: " llm_base_url
+            llm_base_url=$(echo "${llm_base_url:-https://api.openai.com/v1}" | tr -d '\n\r')
+
+            print_prompt
+            read -p "Use a different base URL for embedding? (y/N) " reply
+            if [[ $reply =~ ^[Yy]$ ]]; then
+                print_prompt
+                read -p "Embedding base URL [${llm_base_url}]: " embedder_base_url
+                embedder_base_url=$(echo "${embedder_base_url:-$llm_base_url}" | tr -d '\n\r')
+            else
+                embedder_base_url="$llm_base_url"
+            fi
+
+            if [ -n "$llm_base_url" ]; then
+                safe_sed_inplace "/openai_compatible_model:/,/base_url:/ s|base_url: .*|base_url: \"$llm_base_url\"|" configuration.yml
+                print_success "Set LLM base URL to $llm_base_url"
+            fi
+            if [ -n "$embedder_base_url" ]; then
+                safe_sed_inplace "/openai_compatible_embedder:/,/base_url:/ s|base_url: .*|base_url: \"$embedder_base_url\"|" configuration.yml
+                print_success "Set embedding base URL to $embedder_base_url"
             fi
         fi
     else
@@ -656,7 +669,7 @@ set_provider_api_keys() {
             print_prompt
             read -p "Ollama base URL [http://host.docker.internal:11434/v1]: " base_url
             base_url=${base_url:-http://host.docker.internal:11434/v1}
-            
+
             safe_sed_inplace "s|base_url: .*|base_url: \"$base_url\"|g" configuration.yml
             print_success "Set Ollama base URL: $base_url"
         fi


### PR DESCRIPTION
### Purpose of the change
Improve the `memmachine-compose.sh` setup wizard to support separate base URLs for LLM and embedding services, handle providers that don't require API keys, and add interactive reranker configuration during first-run setup.

### Description
The current setup script assumes a single base URL for both LLM and embedding, requires a valid API key, and does not provide any reranker configuration prompts. This is limiting for on-premise setups where LLM and embedding services run on different endpoints, providers like vLLM don't require API keys, and users may want to configure Cohere or AWS Bedrock rerankers during initial setup.

This PR makes three changes to `memmachine-compose.sh`:

1. **Separate base URLs for LLM and embedding**: Split the single `base_url` prompt into two — one for LLM and one for embedding. If the user doesn't need a separate embedding URL, it defaults to the LLM URL.
2. **Graceful API key handling**: When the user declines to enter an API key, auto-populate it with `EMPTY` instead of leaving the placeholder `<YOUR_API_KEY>`, which would cause runtime errors. The `check_required_env` step also recognizes `EMPTY` as a valid value for keyless providers like vLLM.
3. **Reranker configuration prompts**: Add a new `configure_reranker` function to the first-run setup flow. On GPU images, it offers to replace the default cross-encoder with Cohere or AWS Bedrock. On CPU images, it offers to add an optional neural reranker alongside the default RRF hybrid (identity + BM25). Handles API key input, model selection, and `configuration.yml` patching for both providers.

### Fixes/Closes
Fixes #1213 (partially fix improvement 1,3,4)

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
- [x] Manual verification (list step-by-step instructions)

**Test Results:** 

```
$ ./memmachine-compose.sh
[SUCCESS] Docker and Docker Compose are available
MemMachine Docker Startup Script
====================================

[SUCCESS] Docker and Docker Compose are available
[SUCCESS] .env file found
[WARNING] configuration.yml file not found. Creating from template...
[PROMPT] Which configuration would you like to use for the Docker Image? (CPU/GPU) [CPU]: GPU
[INFO] GPU configuration selected.
[PROMPT] Which provider would you like to use? (OpenAI/Bedrock/Ollama/OpenAI-compatible) [OpenAI]: OpenAI-compatible
[INFO] Selected provider: OPENAI_COMPATIBLE
[SUCCESS] Set MEMMACHINE_IMAGE to memmachine/memmachine:latest-gpu in .env file
[PROMPT] Which OpenAI-compatible LLM model would you like to use? [qwen-flash]:
[SUCCESS] Selected OpenAI-compatible LLM model: qwen-flash
[PROMPT] Which OpenAI-compatible embedding model would you like to use? [text-embedding-v4]:
[SUCCESS] Selected OpenAI-compatible embedding model: text-embedding-v4
[INFO] Generating configuration file for OPENAI_COMPATIBLE provider...
[SUCCESS] Generated configuration file with OPENAI_COMPATIBLE provider settings
[PROMPT] API key is not set. Would you like to set your API key for the OpenAI-compatible provider? (y/N)
[WARNING] API key set to 'EMPTY'. Update it later if your provider requires authentication.     <----
[PROMPT] Model base URL is not set. Would you like to configure custom base URLs? (y/N) y
[PROMPT] LLM base URL [https://api.openai.com/v1]: http://localhost:8080/v1
[PROMPT] Use a different base URL for embedding? (y/N) y     <----
[PROMPT] Embedding base URL [http://localhost:8080/v1]: http://localhost:9090/v1     <----
[SUCCESS] Set LLM base URL to http://localhost:8080/v1
[SUCCESS] Set embedding base URL to http://localhost:9090/v1
[INFO] Default reranker: RRF hybrid (identity + BM25 + cross-encoder)     <----
[PROMPT] Replace cross-encoder provider? (None/Cohere/AWS) [None]: Cohere     <----
[PROMPT] Would you like to set your Cohere API key? (y/N)     <----
[WARNING] Cohere API key set to 'EMPTY'. Update it later if needed.
[PROMPT] Cohere reranker model [rerank-english-v3.0]:     <----
[SUCCESS] Added Cohere reranker to hybrid configuration
[INFO] OPENAI_API_KEY is set to 'EMPTY' (no authentication - OK for providers like vLLM)
[SUCCESS] OpenAI-compatible base URL appears to be configured
[SUCCESS] API key in configuration.yml appears to be configured
[SUCCESS] Database credentials in configuration.yml appear to be configured
[INFO] Pulling and starting MemMachine services...
```

Snippet of `configuration.yml`

``` yaml
..
   openai_compatible_embedder:
      provider: openai
      config:
        max_input_length: 2048
        model: "text-embedding-v4"
        api_key: EMPTY     <----
        base_url: "http://localhost:9090/v1"     <----
        dimensions: 1536
..
    openai_compatible_model:
      provider: openai-chat-completions
      config:
        model: "qwen-flash"
        api_key: EMPTY     <----
        base_url: "http://localhost:8080/v1"     <----
..
 rerankers:
    my_reranker_id:
      provider: "rrf-hybrid"
      config:
        reranker_ids:
          - id_ranker_id
          - bm_ranker_id
          - cohere_reranker_id     <----
..
    cohere_reranker_id:
      provider: "cohere"
      config:
        cohere_key: EMPTY     <----
        model: "rerank-english-v3.0"
````

### Checklist
- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist
- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs
N/A

### Further comments
None