### PR TITLE
 Add SQL filter compilation for properties JSON

### DIFF
--- a/packages/client/client_tests/test_integration_complete.py
+++ b/packages/client/client_tests/test_integration_complete.py
@@ -353,7 +353,7 @@ class TestMemMachineIntegration:
         try:
             results = memory.search(
                 "What do I like to drink?",
-                filter_dict={"time": "morning"},
+                filter_dict={"m.time": "morning"},
                 limit=10,
             )
             assert isinstance(results, SearchResult)
@@ -488,7 +488,7 @@ class TestMemMachineIntegration:
         )
 
         # Search with custom filters only - built-in filters are automatically merged
-        custom_filters = {"category": "profession"}
+        custom_filters = {"m.category": "profession"}
         try:
             results = memory.search(
                 "What is my profession?",

--- a/packages/server/server_tests/memmachine_server/common/filter/test_sql_filter_util.py
+++ b/packages/server/server_tests/memmachine_server/common/filter/test_sql_filter_util.py
@@ -3,21 +3,43 @@
 These tests verify that JSON metadata filtering handles numeric types correctly
 (integer ordering, float ordering, boolean equality) rather than falling back
 to string/lexicographic comparison.
+
+Properties-JSON tests additionally verify the type-tagged {"t": …, "v": …} format
+against both SQLite and PostgreSQL (via testcontainers).
 """
 
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any, cast
+
 import pytest
+import pytest_asyncio
 from sqlalchemy import JSON, Column, Integer, String, create_engine, select
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Session
 
-from memmachine_server.common.filter.filter_parser import parse_filter
+from memmachine_server.common.filter.filter_parser import (
+    And,
+    Comparison,
+    In,
+    IsNull,
+    Not,
+    Or,
+    parse_filter,
+)
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
+from memmachine_server.common.properties_json import encode_properties
+
+# ============================================================================
+# Raw JSON ("json" kind) + direct column ("column" kind) tests — sync SQLite
+# ============================================================================
 
 
-class Base(DeclarativeBase):
+class _JsonBase(DeclarativeBase):
     pass
 
 
-class Item(Base):
+class _Item(_JsonBase):
     __tablename__ = "items"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -25,32 +47,32 @@ class Item(Base):
     json_metadata = Column(JSON, nullable=True)
 
 
-def _resolve_field(field: str):
-    """Field resolver for the Item model."""
+def _resolve_json_field(field: str):
+    """Field resolver for the Item model: column + json kinds."""
     normalized = field.lower()
     field_mapping = {
-        "id": Item.id,
-        "name": Item.name,
+        "id": _Item.id.expression,
+        "name": _Item.name.expression,
     }
     if normalized in field_mapping:
-        return field_mapping[normalized], False
+        return field_mapping[normalized], "column"
 
     if normalized.startswith(("m.", "metadata.")):
         key = normalized.split(".", 1)[1]
-        return Item.json_metadata[key], True
+        return _Item.json_metadata[key], "json"
 
-    return None, False
+    raise ValueError(f"Unknown filter field: {field!r}")
 
 
 @pytest.fixture
-def session():
+def json_session():
     """Create an in-memory SQLite database with seeded rows."""
     engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
+    _JsonBase.metadata.create_all(engine)
     with Session(engine) as s:
         s.add_all(
             [
-                Item(
+                _Item(
                     name="alpha",
                     json_metadata={
                         "count": 5,
@@ -59,7 +81,7 @@ def session():
                         "tag": "a",
                     },
                 ),
-                Item(
+                _Item(
                     name="beta",
                     json_metadata={
                         "count": 10,
@@ -68,7 +90,7 @@ def session():
                         "tag": "b",
                     },
                 ),
-                Item(
+                _Item(
                     name="gamma",
                     json_metadata={
                         "count": 15,
@@ -77,7 +99,7 @@ def session():
                         "tag": "c",
                     },
                 ),
-                Item(
+                _Item(
                     name="delta",
                     json_metadata={
                         "count": 20,
@@ -86,179 +108,505 @@ def session():
                         "tag": "d",
                     },
                 ),
-                Item(name="epsilon", json_metadata=None),
+                _Item(name="epsilon", json_metadata=None),
             ]
         )
         s.commit()
         yield s
 
 
-def _query_names(session: Session, filter_str: str) -> set[str]:
+def _query_json_names(session: Session, filter_str: str) -> set[str]:
     """Parse filter, compile to SQL, execute, and return set of matching names."""
     expr = parse_filter(filter_str)
-    clause = compile_sql_filter(expr, _resolve_field)
-    assert clause is not None
-    stmt = select(Item.name).where(clause)
+    clause = compile_sql_filter(expr, _resolve_json_field)
+    stmt = select(_Item.name).where(clause)
     return {row[0] for row in session.execute(stmt)}
 
 
-# --- Integer ordering (the core bug) ---
+# --- Integer ordering ---
 
 
-def test_int_greater_than(session):
-    result = _query_names(session, "m.count > 10")
-    assert result == {"gamma", "delta"}
+def test_json_int_greater_than(json_session):
+    assert _query_json_names(json_session, "m.count > 10") == {"gamma", "delta"}
 
 
-def test_int_greater_equal(session):
-    result = _query_names(session, "m.count >= 10")
-    assert result == {"beta", "gamma", "delta"}
+def test_json_int_greater_equal(json_session):
+    assert _query_json_names(json_session, "m.count >= 10") == {
+        "beta",
+        "gamma",
+        "delta",
+    }
 
 
-def test_int_less_than(session):
-    result = _query_names(session, "m.count < 10")
-    assert result == {"alpha"}
+def test_json_int_less_than(json_session):
+    assert _query_json_names(json_session, "m.count < 10") == {"alpha"}
 
 
-def test_int_less_equal(session):
-    result = _query_names(session, "m.count <= 10")
-    assert result == {"alpha", "beta"}
+def test_json_int_less_equal(json_session):
+    assert _query_json_names(json_session, "m.count <= 10") == {"alpha", "beta"}
 
 
 # --- Integer equality ---
 
 
-def test_int_equality(session):
-    result = _query_names(session, "m.count = 10")
-    assert result == {"beta"}
+def test_json_int_equality(json_session):
+    assert _query_json_names(json_session, "m.count = 10") == {"beta"}
 
 
-def test_int_not_equal(session):
-    result = _query_names(session, "m.count != 10")
-    assert result == {"alpha", "gamma", "delta"}
+def test_json_int_not_equal(json_session):
+    assert _query_json_names(json_session, "m.count != 10") == {
+        "alpha",
+        "gamma",
+        "delta",
+    }
 
 
 # --- Float ordering ---
 
 
-def test_float_greater_than(session):
-    result = _query_names(session, "m.score > 2.0")
-    assert result == {"beta", "gamma", "delta"}
+def test_json_float_greater_than(json_session):
+    assert _query_json_names(json_session, "m.score > 2.0") == {
+        "beta",
+        "gamma",
+        "delta",
+    }
 
 
-def test_float_less_than(session):
-    result = _query_names(session, "m.score < 3.0")
-    assert result == {"alpha", "beta"}
+def test_json_float_less_than(json_session):
+    assert _query_json_names(json_session, "m.score < 3.0") == {"alpha", "beta"}
 
 
-def test_float_less_equal(session):
-    result = _query_names(session, "m.score <= 2.5")
-    assert result == {"alpha", "beta"}
+def test_json_float_less_equal(json_session):
+    assert _query_json_names(json_session, "m.score <= 2.5") == {"alpha", "beta"}
 
 
 # --- Boolean equality ---
 
 
-def test_bool_equality_true(session):
-    result = _query_names(session, "m.active = true")
-    assert result == {"alpha", "gamma"}
+def test_json_bool_true(json_session):
+    assert _query_json_names(json_session, "m.active = true") == {"alpha", "gamma"}
 
 
-def test_bool_equality_false(session):
-    result = _query_names(session, "m.active = false")
-    assert result == {"beta", "delta"}
+def test_json_bool_false(json_session):
+    assert _query_json_names(json_session, "m.active = false") == {"beta", "delta"}
 
 
 # --- String equality ---
 
 
-def test_string_equality(session):
-    result = _query_names(session, "m.tag = 'a'")
-    assert result == {"alpha"}
+def test_json_string_equality(json_session):
+    assert _query_json_names(json_session, "m.tag = 'a'") == {"alpha"}
 
 
-def test_string_not_equal(session):
-    result = _query_names(session, "m.tag != 'a'")
-    assert result == {"beta", "gamma", "delta"}
+def test_json_string_not_equal(json_session):
+    assert _query_json_names(json_session, "m.tag != 'a'") == {
+        "beta",
+        "gamma",
+        "delta",
+    }
 
 
-# --- IN with integers ---
+# --- IN ---
 
 
-def test_int_in(session):
-    result = _query_names(session, "m.count IN (5, 15)")
-    assert result == {"alpha", "gamma"}
+def test_json_int_in(json_session):
+    assert _query_json_names(json_session, "m.count IN (5, 15)") == {"alpha", "gamma"}
 
 
-# --- IN with strings ---
+def test_json_string_in(json_session):
+    assert _query_json_names(json_session, "m.tag IN ('a', 'b')") == {"alpha", "beta"}
 
 
-def test_string_in(session):
-    result = _query_names(session, "m.tag IN ('a', 'b')")
-    assert result == {"alpha", "beta"}
+# --- IS NULL ---
 
 
-# --- IS NULL (missing metadata entirely) ---
-
-
-def test_is_null(session):
-    result = _query_names(session, "m.tag IS NULL")
-    assert result == {"epsilon"}
+def test_json_is_null(json_session):
+    assert _query_json_names(json_session, "m.tag IS NULL") == {"epsilon"}
 
 
 # --- NOT / NOT IN ---
 
 
-def test_not_comparison(session):
-    result = _query_names(session, "NOT m.count > 10")
-    # NOT (count > 10) => count <= 10 => alpha(5), beta(10)
-    # epsilon has null metadata, so it won't match either side
-    assert result == {"alpha", "beta"}
+def test_json_not_comparison(json_session):
+    assert _query_json_names(json_session, "NOT m.count > 10") == {"alpha", "beta"}
 
 
-def test_not_in(session):
-    result = _query_names(session, "m.tag NOT IN ('a', 'b')")
-    assert result == {"gamma", "delta"}
+def test_json_not_in(json_session):
+    assert _query_json_names(json_session, "m.tag NOT IN ('a', 'b')") == {
+        "gamma",
+        "delta",
+    }
 
 
-# --- Non-metadata column (bypasses JSON casting) ---
+# --- Non-metadata column ---
 
 
-def test_non_metadata_equality(session):
-    result = _query_names(session, "name = 'alpha'")
-    assert result == {"alpha"}
+def test_column_equality(json_session):
+    assert _query_json_names(json_session, "name = 'alpha'") == {"alpha"}
 
 
-def test_non_metadata_in(session):
-    result = _query_names(session, "name IN ('alpha', 'beta')")
-    assert result == {"alpha", "beta"}
+def test_column_in(json_session):
+    assert _query_json_names(json_session, "name IN ('alpha', 'beta')") == {
+        "alpha",
+        "beta",
+    }
 
 
-# --- NOT with And/Or compound expressions ---
+# --- Compound ---
 
 
-def test_not_and_compound(session):
-    # NOT (count > 10 AND active = true) => NOT(gamma, delta) => alpha, beta, epsilon
-    # But only gamma satisfies count > 10 AND active = true
-    # So NOT of that is: alpha, beta, delta, epsilon (since epsilon has null metadata)
-    # Actually, gamma has count=15, active=True, so it matches inner.
-    # Alpha has count=5, so doesn't match inner (count > 10 is false)
-    # Beta has count=10 (10 > 10 is false), so doesn't match inner
-    # Delta has count=20, active=False, so doesn't match inner (active != true)
-    # Epsilon has null metadata, so doesn't match inner
-    # So NOT of inner means: everything except gamma
-    result = _query_names(session, "NOT (m.count > 10 AND m.active = true)")
-    # Only gamma satisfies the inner condition (count=15 > 10, active=True)
-    # So NOT gives us everyone except gamma
+def test_json_not_and_compound(json_session):
+    result = _query_json_names(json_session, "NOT (m.count > 10 AND m.active = true)")
     assert result == {"alpha", "beta", "delta"}
 
 
-def test_or_simple(session):
-    result = _query_names(session, "m.tag = 'a' OR m.tag = 'c'")
-    assert result == {"alpha", "gamma"}
+def test_json_or(json_session):
+    assert _query_json_names(json_session, "m.tag = 'a' OR m.tag = 'c'") == {
+        "alpha",
+        "gamma",
+    }
 
 
-def test_not_or_compound(session):
-    # NOT (tag = 'a' OR tag = 'b') => NOT(alpha, beta) => gamma, delta
-    result = _query_names(session, "NOT (m.tag = 'a' OR m.tag = 'b')")
-    assert result == {"gamma", "delta"}
+def test_json_not_or_compound(json_session):
+    assert _query_json_names(json_session, "NOT (m.tag = 'a' OR m.tag = 'b')") == {
+        "gamma",
+        "delta",
+    }
+
+
+# --- Error paths ---
+
+
+def test_unknown_field_raises(json_session):
+    with pytest.raises(ValueError, match="Unknown filter field"):
+        _query_json_names(json_session, "nonexistent = 1")
+
+
+def test_unsupported_expr_type():
+    with pytest.raises(TypeError, match="Unsupported filter expression type"):
+        compile_sql_filter("bad", _resolve_json_field)
+
+
+# ============================================================================
+# Properties JSON ("properties_json" kind) tests — async, SQLite + PostgreSQL
+# ============================================================================
+
+_JSON_AUTO = JSON().with_variant(JSONB, "postgresql")
+
+
+class _PropsBase(DeclarativeBase):
+    pass
+
+
+class _PropsRow(_PropsBase):
+    __tablename__ = "test_properties_json_filters"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False)
+    properties = Column(_JSON_AUTO, nullable=False)
+
+
+def _resolve_properties_json_field(field: str):
+    return _PropsRow.properties[field], "properties_json"
+
+
+@pytest_asyncio.fixture
+async def properties_session(sqlalchemy_engine: AsyncEngine):
+    """Create tables, seed properties-JSON rows, yield session, then drop tables."""
+    async with sqlalchemy_engine.begin() as conn:
+        await conn.run_sync(_PropsBase.metadata.create_all)
+
+    est = timezone(timedelta(hours=-5))
+    jst = timezone(timedelta(hours=9))
+
+    async with AsyncSession(sqlalchemy_engine) as s:
+        s.add_all(
+            [
+                _PropsRow(
+                    name="alpha",
+                    properties=encode_properties(
+                        {
+                            "count": 5,
+                            "score": 1.5,
+                            "active": True,
+                            "tag": "a",
+                            "ts": datetime(2024, 1, 10, 12, 0, 0, tzinfo=UTC),
+                        }
+                    ),
+                ),
+                _PropsRow(
+                    name="beta",
+                    properties=encode_properties(
+                        {
+                            "count": 10,
+                            "score": 2.5,
+                            "active": False,
+                            "tag": "b",
+                            "ts": datetime(2024, 3, 15, 8, 0, 0, tzinfo=est),
+                        }
+                    ),
+                ),
+                _PropsRow(
+                    name="gamma",
+                    properties=encode_properties(
+                        {
+                            "count": 15,
+                            "score": 3.5,
+                            "active": True,
+                            "tag": "c",
+                            "ts": datetime(2024, 6, 20, 21, 0, 0, tzinfo=jst),
+                        }
+                    ),
+                ),
+                _PropsRow(
+                    name="delta",
+                    properties=encode_properties(
+                        {
+                            "count": 20,
+                            "score": 4.5,
+                            "active": False,
+                            "tag": "d",
+                            "ts": datetime(2024, 9, 1, 0, 0, 0, tzinfo=UTC),
+                        }
+                    ),
+                ),
+                _PropsRow(
+                    name="epsilon",
+                    properties=encode_properties({"count": 0, "active": True}),
+                ),
+            ]
+        )
+        await s.commit()
+        yield s
+
+    async with sqlalchemy_engine.begin() as conn:
+        await conn.run_sync(_PropsBase.metadata.drop_all)
+
+
+async def _query_props_names(session: AsyncSession, expr) -> set[str]:
+    clause = compile_sql_filter(expr, _resolve_properties_json_field)
+    result = await session.execute(select(_PropsRow.name).where(clause))
+    return {row[0] for row in result}
+
+
+class TestPropsJsonIntFilters:
+    @pytest.mark.asyncio
+    async def test_eq(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("count", "=", 10)
+        ) == {"beta"}
+
+    @pytest.mark.asyncio
+    async def test_neq(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("count", "!=", 10)
+        ) == {
+            "alpha",
+            "gamma",
+            "delta",
+            "epsilon",
+        }
+
+    @pytest.mark.asyncio
+    async def test_gt(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("count", ">", 10)
+        ) == {
+            "gamma",
+            "delta",
+        }
+
+    @pytest.mark.asyncio
+    async def test_gte(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("count", ">=", 10)
+        ) == {
+            "beta",
+            "gamma",
+            "delta",
+        }
+
+    @pytest.mark.asyncio
+    async def test_lt(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("count", "<", 10)
+        ) == {
+            "alpha",
+            "epsilon",
+        }
+
+    @pytest.mark.asyncio
+    async def test_lte(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("count", "<=", 10)
+        ) == {
+            "alpha",
+            "beta",
+            "epsilon",
+        }
+
+
+class TestPropsJsonFloatFilters:
+    @pytest.mark.asyncio
+    async def test_gt(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("score", ">", 2.0)
+        ) == {
+            "beta",
+            "gamma",
+            "delta",
+        }
+
+    @pytest.mark.asyncio
+    async def test_lt(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("score", "<", 3.0)
+        ) == {
+            "alpha",
+            "beta",
+        }
+
+
+class TestPropsJsonBoolFilters:
+    @pytest.mark.asyncio
+    async def test_true(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("active", "=", True)
+        ) == {
+            "alpha",
+            "gamma",
+            "epsilon",
+        }
+
+    @pytest.mark.asyncio
+    async def test_false(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("active", "=", False)
+        ) == {
+            "beta",
+            "delta",
+        }
+
+
+class TestPropsJsonStringFilters:
+    @pytest.mark.asyncio
+    async def test_eq(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("tag", "=", "a")
+        ) == {"alpha"}
+
+    @pytest.mark.asyncio
+    async def test_neq(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("tag", "!=", "a")
+        ) == {
+            "beta",
+            "gamma",
+            "delta",
+        }
+
+
+class TestPropsJsonDatetimeFilters:
+    @pytest.mark.asyncio
+    async def test_gt(self, properties_session):
+        cutoff = datetime(2024, 6, 1, 0, 0, 0, tzinfo=UTC)
+        assert await _query_props_names(
+            properties_session, Comparison("ts", ">", cutoff)
+        ) == {
+            "gamma",
+            "delta",
+        }
+
+    @pytest.mark.asyncio
+    async def test_lt(self, properties_session):
+        cutoff = datetime(2024, 6, 1, 0, 0, 0, tzinfo=UTC)
+        assert await _query_props_names(
+            properties_session, Comparison("ts", "<", cutoff)
+        ) == {
+            "alpha",
+            "beta",
+        }
+
+    @pytest.mark.asyncio
+    async def test_cross_timezone(self, properties_session):
+        jst = timezone(timedelta(hours=9))
+        cutoff = datetime(2024, 3, 15, 22, 0, 0, tzinfo=jst)  # = 13:00 UTC
+        assert await _query_props_names(
+            properties_session, Comparison("ts", ">=", cutoff)
+        ) == {
+            "beta",
+            "gamma",
+            "delta",
+        }
+
+
+class TestPropsJsonInFilters:
+    @pytest.mark.asyncio
+    async def test_int_in(self, properties_session):
+        assert await _query_props_names(properties_session, In("count", [5, 15])) == {
+            "alpha",
+            "gamma",
+        }
+
+    @pytest.mark.asyncio
+    async def test_string_in(self, properties_session):
+        assert await _query_props_names(properties_session, In("tag", ["a", "b"])) == {
+            "alpha",
+            "beta",
+        }
+
+    @pytest.mark.asyncio
+    async def test_empty_in(self, properties_session):
+        assert await _query_props_names(properties_session, In("tag", [])) == set()
+
+
+class TestPropsJsonIsNullFilter:
+    @pytest.mark.asyncio
+    async def test_is_null(self, properties_session):
+        assert await _query_props_names(properties_session, IsNull("tag")) == {
+            "epsilon"
+        }
+
+
+class TestPropsJsonLogicalFilters:
+    @pytest.mark.asyncio
+    async def test_and(self, properties_session):
+        expr = And(Comparison("count", ">", 10), Comparison("active", "=", True))
+        assert await _query_props_names(properties_session, expr) == {"gamma"}
+
+    @pytest.mark.asyncio
+    async def test_or(self, properties_session):
+        expr = Or(Comparison("tag", "=", "a"), Comparison("tag", "=", "c"))
+        assert await _query_props_names(properties_session, expr) == {"alpha", "gamma"}
+
+    @pytest.mark.asyncio
+    async def test_not(self, properties_session):
+        expr = Not(Comparison("count", ">", 10))
+        assert await _query_props_names(properties_session, expr) == {
+            "alpha",
+            "beta",
+            "epsilon",
+        }
+
+    @pytest.mark.asyncio
+    async def test_not_in(self, properties_session):
+        expr = Not(In("tag", ["a", "b"]))
+        assert await _query_props_names(properties_session, expr) == {"gamma", "delta"}
+
+    @pytest.mark.asyncio
+    async def test_compound_not_and(self, properties_session):
+        inner = And(Comparison("count", ">", 10), Comparison("active", "=", True))
+        assert await _query_props_names(properties_session, Not(inner)) == {
+            "alpha",
+            "beta",
+            "delta",
+            "epsilon",
+        }
+
+
+class TestPropsJsonCompileErrors:
+    @pytest.mark.asyncio
+    async def test_unsupported_operator(self, properties_session):
+        with pytest.raises(ValueError, match="Unsupported operator"):
+            await _query_props_names(
+                properties_session, Comparison("count", cast(Any, "LIKE"), 10)
+            )

--- a/packages/server/server_tests/memmachine_server/common/filter/test_sql_filter_util.py
+++ b/packages/server/server_tests/memmachine_server/common/filter/test_sql_filter_util.py
@@ -3,21 +3,43 @@
 These tests verify that JSON metadata filtering handles numeric types correctly
 (integer ordering, float ordering, boolean equality) rather than falling back
 to string/lexicographic comparison.
+
+Properties-JSON tests additionally verify the type-tagged {"t": …, "v": …} format
+against both SQLite and PostgreSQL (via testcontainers).
 """
 
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any, cast
+
 import pytest
+import pytest_asyncio
 from sqlalchemy import JSON, Column, Integer, String, create_engine, select
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Session
 
-from memmachine_server.common.filter.filter_parser import parse_filter
+from memmachine_server.common.filter.filter_parser import (
+    And,
+    Comparison,
+    In,
+    IsNull,
+    Not,
+    Or,
+    parse_filter,
+)
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
+from memmachine_server.common.properties_json import encode_properties
+
+# ============================================================================
+# Raw JSON ("json" kind) + direct column ("column" kind) tests — sync SQLite
+# ============================================================================
 
 
-class Base(DeclarativeBase):
+class _JsonBase(DeclarativeBase):
     pass
 
 
-class Item(Base):
+class _Item(_JsonBase):
     __tablename__ = "items"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -25,32 +47,32 @@ class Item(Base):
     json_metadata = Column(JSON, nullable=True)
 
 
-def _resolve_field(field: str):
-    """Field resolver for the Item model."""
+def _resolve_json_field(field: str):
+    """Field resolver for the Item model: column + json kinds."""
     normalized = field.lower()
     field_mapping = {
-        "id": Item.id,
-        "name": Item.name,
+        "id": _Item.id.expression,
+        "name": _Item.name.expression,
     }
     if normalized in field_mapping:
-        return field_mapping[normalized], False
+        return field_mapping[normalized], "column"
 
     if normalized.startswith(("m.", "metadata.")):
         key = normalized.split(".", 1)[1]
-        return Item.json_metadata[key], True
+        return _Item.json_metadata[key], "json"
 
-    return None, False
+    raise ValueError(f"Unknown filter field: {field!r}")
 
 
 @pytest.fixture
-def session():
+def json_session():
     """Create an in-memory SQLite database with seeded rows."""
     engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
+    _JsonBase.metadata.create_all(engine)
     with Session(engine) as s:
         s.add_all(
             [
-                Item(
+                _Item(
                     name="alpha",
                     json_metadata={
                         "count": 5,
@@ -59,7 +81,7 @@ def session():
                         "tag": "a",
                     },
                 ),
-                Item(
+                _Item(
                     name="beta",
                     json_metadata={
                         "count": 10,
@@ -68,7 +90,7 @@ def session():
                         "tag": "b",
                     },
                 ),
-                Item(
+                _Item(
                     name="gamma",
                     json_metadata={
                         "count": 15,
@@ -77,7 +99,7 @@ def session():
                         "tag": "c",
                     },
                 ),
-                Item(
+                _Item(
                     name="delta",
                     json_metadata={
                         "count": 20,
@@ -86,178 +108,505 @@ def session():
                         "tag": "d",
                     },
                 ),
-                Item(name="epsilon", json_metadata=None),
+                _Item(name="epsilon", json_metadata=None),
             ]
         )
         s.commit()
         yield s
 
 
-def _query_names(session: Session, filter_str: str) -> set[str]:
+def _query_json_names(session: Session, filter_str: str) -> set[str]:
     """Parse filter, compile to SQL, execute, and return set of matching names."""
     expr = parse_filter(filter_str)
-    clause = compile_sql_filter(expr, _resolve_field)
-    stmt = select(Item.name).where(clause)
+    clause = compile_sql_filter(expr, _resolve_json_field)
+    stmt = select(_Item.name).where(clause)
     return {row[0] for row in session.execute(stmt)}
 
 
-# --- Integer ordering (the core bug) ---
+# --- Integer ordering ---
 
 
-def test_int_greater_than(session):
-    result = _query_names(session, "m.count > 10")
-    assert result == {"gamma", "delta"}
+def test_json_int_greater_than(json_session):
+    assert _query_json_names(json_session, "m.count > 10") == {"gamma", "delta"}
 
 
-def test_int_greater_equal(session):
-    result = _query_names(session, "m.count >= 10")
-    assert result == {"beta", "gamma", "delta"}
+def test_json_int_greater_equal(json_session):
+    assert _query_json_names(json_session, "m.count >= 10") == {
+        "beta",
+        "gamma",
+        "delta",
+    }
 
 
-def test_int_less_than(session):
-    result = _query_names(session, "m.count < 10")
-    assert result == {"alpha"}
+def test_json_int_less_than(json_session):
+    assert _query_json_names(json_session, "m.count < 10") == {"alpha"}
 
 
-def test_int_less_equal(session):
-    result = _query_names(session, "m.count <= 10")
-    assert result == {"alpha", "beta"}
+def test_json_int_less_equal(json_session):
+    assert _query_json_names(json_session, "m.count <= 10") == {"alpha", "beta"}
 
 
 # --- Integer equality ---
 
 
-def test_int_equality(session):
-    result = _query_names(session, "m.count = 10")
-    assert result == {"beta"}
+def test_json_int_equality(json_session):
+    assert _query_json_names(json_session, "m.count = 10") == {"beta"}
 
 
-def test_int_not_equal(session):
-    result = _query_names(session, "m.count != 10")
-    assert result == {"alpha", "gamma", "delta"}
+def test_json_int_not_equal(json_session):
+    assert _query_json_names(json_session, "m.count != 10") == {
+        "alpha",
+        "gamma",
+        "delta",
+    }
 
 
 # --- Float ordering ---
 
 
-def test_float_greater_than(session):
-    result = _query_names(session, "m.score > 2.0")
-    assert result == {"beta", "gamma", "delta"}
+def test_json_float_greater_than(json_session):
+    assert _query_json_names(json_session, "m.score > 2.0") == {
+        "beta",
+        "gamma",
+        "delta",
+    }
 
 
-def test_float_less_than(session):
-    result = _query_names(session, "m.score < 3.0")
-    assert result == {"alpha", "beta"}
+def test_json_float_less_than(json_session):
+    assert _query_json_names(json_session, "m.score < 3.0") == {"alpha", "beta"}
 
 
-def test_float_less_equal(session):
-    result = _query_names(session, "m.score <= 2.5")
-    assert result == {"alpha", "beta"}
+def test_json_float_less_equal(json_session):
+    assert _query_json_names(json_session, "m.score <= 2.5") == {"alpha", "beta"}
 
 
 # --- Boolean equality ---
 
 
-def test_bool_equality_true(session):
-    result = _query_names(session, "m.active = true")
-    assert result == {"alpha", "gamma"}
+def test_json_bool_true(json_session):
+    assert _query_json_names(json_session, "m.active = true") == {"alpha", "gamma"}
 
 
-def test_bool_equality_false(session):
-    result = _query_names(session, "m.active = false")
-    assert result == {"beta", "delta"}
+def test_json_bool_false(json_session):
+    assert _query_json_names(json_session, "m.active = false") == {"beta", "delta"}
 
 
 # --- String equality ---
 
 
-def test_string_equality(session):
-    result = _query_names(session, "m.tag = 'a'")
-    assert result == {"alpha"}
+def test_json_string_equality(json_session):
+    assert _query_json_names(json_session, "m.tag = 'a'") == {"alpha"}
 
 
-def test_string_not_equal(session):
-    result = _query_names(session, "m.tag != 'a'")
-    assert result == {"beta", "gamma", "delta"}
+def test_json_string_not_equal(json_session):
+    assert _query_json_names(json_session, "m.tag != 'a'") == {
+        "beta",
+        "gamma",
+        "delta",
+    }
 
 
-# --- IN with integers ---
+# --- IN ---
 
 
-def test_int_in(session):
-    result = _query_names(session, "m.count IN (5, 15)")
-    assert result == {"alpha", "gamma"}
+def test_json_int_in(json_session):
+    assert _query_json_names(json_session, "m.count IN (5, 15)") == {"alpha", "gamma"}
 
 
-# --- IN with strings ---
+def test_json_string_in(json_session):
+    assert _query_json_names(json_session, "m.tag IN ('a', 'b')") == {"alpha", "beta"}
 
 
-def test_string_in(session):
-    result = _query_names(session, "m.tag IN ('a', 'b')")
-    assert result == {"alpha", "beta"}
+# --- IS NULL ---
 
 
-# --- IS NULL (missing metadata entirely) ---
-
-
-def test_is_null(session):
-    result = _query_names(session, "m.tag IS NULL")
-    assert result == {"epsilon"}
+def test_json_is_null(json_session):
+    assert _query_json_names(json_session, "m.tag IS NULL") == {"epsilon"}
 
 
 # --- NOT / NOT IN ---
 
 
-def test_not_comparison(session):
-    result = _query_names(session, "NOT m.count > 10")
-    # NOT (count > 10) => count <= 10 => alpha(5), beta(10)
-    # epsilon has null metadata, so it won't match either side
-    assert result == {"alpha", "beta"}
+def test_json_not_comparison(json_session):
+    assert _query_json_names(json_session, "NOT m.count > 10") == {"alpha", "beta"}
 
 
-def test_not_in(session):
-    result = _query_names(session, "m.tag NOT IN ('a', 'b')")
-    assert result == {"gamma", "delta"}
+def test_json_not_in(json_session):
+    assert _query_json_names(json_session, "m.tag NOT IN ('a', 'b')") == {
+        "gamma",
+        "delta",
+    }
 
 
-# --- Non-metadata column (bypasses JSON casting) ---
+# --- Non-metadata column ---
 
 
-def test_non_metadata_equality(session):
-    result = _query_names(session, "name = 'alpha'")
-    assert result == {"alpha"}
+def test_column_equality(json_session):
+    assert _query_json_names(json_session, "name = 'alpha'") == {"alpha"}
 
 
-def test_non_metadata_in(session):
-    result = _query_names(session, "name IN ('alpha', 'beta')")
-    assert result == {"alpha", "beta"}
+def test_column_in(json_session):
+    assert _query_json_names(json_session, "name IN ('alpha', 'beta')") == {
+        "alpha",
+        "beta",
+    }
 
 
-# --- NOT with And/Or compound expressions ---
+# --- Compound ---
 
 
-def test_not_and_compound(session):
-    # NOT (count > 10 AND active = true) => NOT(gamma, delta) => alpha, beta, epsilon
-    # But only gamma satisfies count > 10 AND active = true
-    # So NOT of that is: alpha, beta, delta, epsilon (since epsilon has null metadata)
-    # Actually, gamma has count=15, active=True, so it matches inner.
-    # Alpha has count=5, so doesn't match inner (count > 10 is false)
-    # Beta has count=10 (10 > 10 is false), so doesn't match inner
-    # Delta has count=20, active=False, so doesn't match inner (active != true)
-    # Epsilon has null metadata, so doesn't match inner
-    # So NOT of inner means: everything except gamma
-    result = _query_names(session, "NOT (m.count > 10 AND m.active = true)")
-    # Only gamma satisfies the inner condition (count=15 > 10, active=True)
-    # So NOT gives us everyone except gamma
+def test_json_not_and_compound(json_session):
+    result = _query_json_names(json_session, "NOT (m.count > 10 AND m.active = true)")
     assert result == {"alpha", "beta", "delta"}
 
 
-def test_or_simple(session):
-    result = _query_names(session, "m.tag = 'a' OR m.tag = 'c'")
-    assert result == {"alpha", "gamma"}
+def test_json_or(json_session):
+    assert _query_json_names(json_session, "m.tag = 'a' OR m.tag = 'c'") == {
+        "alpha",
+        "gamma",
+    }
 
 
-def test_not_or_compound(session):
-    # NOT (tag = 'a' OR tag = 'b') => NOT(alpha, beta) => gamma, delta
-    result = _query_names(session, "NOT (m.tag = 'a' OR m.tag = 'b')")
-    assert result == {"gamma", "delta"}
+def test_json_not_or_compound(json_session):
+    assert _query_json_names(json_session, "NOT (m.tag = 'a' OR m.tag = 'b')") == {
+        "gamma",
+        "delta",
+    }
+
+
+# --- Error paths ---
+
+
+def test_unknown_field_raises(json_session):
+    with pytest.raises(ValueError, match="Unknown filter field"):
+        _query_json_names(json_session, "nonexistent = 1")
+
+
+def test_unsupported_expr_type():
+    with pytest.raises(TypeError, match="Unsupported filter expression type"):
+        compile_sql_filter("bad", _resolve_json_field)
+
+
+# ============================================================================
+# Properties JSON ("properties_json" kind) tests — async, SQLite + PostgreSQL
+# ============================================================================
+
+_JSON_AUTO = JSON().with_variant(JSONB, "postgresql")
+
+
+class _PropsBase(DeclarativeBase):
+    pass
+
+
+class _PropsRow(_PropsBase):
+    __tablename__ = "test_properties_json_filters"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False)
+    properties = Column(_JSON_AUTO, nullable=False)
+
+
+def _resolve_properties_json_field(field: str):
+    return _PropsRow.properties[field], "properties_json"
+
+
+@pytest_asyncio.fixture
+async def properties_session(sqlalchemy_engine: AsyncEngine):
+    """Create tables, seed properties-JSON rows, yield session, then drop tables."""
+    async with sqlalchemy_engine.begin() as conn:
+        await conn.run_sync(_PropsBase.metadata.create_all)
+
+    est = timezone(timedelta(hours=-5))
+    jst = timezone(timedelta(hours=9))
+
+    async with AsyncSession(sqlalchemy_engine) as s:
+        s.add_all(
+            [
+                _PropsRow(
+                    name="alpha",
+                    properties=encode_properties(
+                        {
+                            "count": 5,
+                            "score": 1.5,
+                            "active": True,
+                            "tag": "a",
+                            "ts": datetime(2024, 1, 10, 12, 0, 0, tzinfo=UTC),
+                        }
+                    ),
+                ),
+                _PropsRow(
+                    name="beta",
+                    properties=encode_properties(
+                        {
+                            "count": 10,
+                            "score": 2.5,
+                            "active": False,
+                            "tag": "b",
+                            "ts": datetime(2024, 3, 15, 8, 0, 0, tzinfo=est),
+                        }
+                    ),
+                ),
+                _PropsRow(
+                    name="gamma",
+                    properties=encode_properties(
+                        {
+                            "count": 15,
+                            "score": 3.5,
+                            "active": True,
+                            "tag": "c",
+                            "ts": datetime(2024, 6, 20, 21, 0, 0, tzinfo=jst),
+                        }
+                    ),
+                ),
+                _PropsRow(
+                    name="delta",
+                    properties=encode_properties(
+                        {
+                            "count": 20,
+                            "score": 4.5,
+                            "active": False,
+                            "tag": "d",
+                            "ts": datetime(2024, 9, 1, 0, 0, 0, tzinfo=UTC),
+                        }
+                    ),
+                ),
+                _PropsRow(
+                    name="epsilon",
+                    properties=encode_properties({"count": 0, "active": True}),
+                ),
+            ]
+        )
+        await s.commit()
+        yield s
+
+    async with sqlalchemy_engine.begin() as conn:
+        await conn.run_sync(_PropsBase.metadata.drop_all)
+
+
+async def _query_props_names(session: AsyncSession, expr) -> set[str]:
+    clause = compile_sql_filter(expr, _resolve_properties_json_field)
+    result = await session.execute(select(_PropsRow.name).where(clause))
+    return {row[0] for row in result}
+
+
+class TestPropsJsonIntFilters:
+    @pytest.mark.asyncio
+    async def test_eq(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("count", "=", 10)
+        ) == {"beta"}
+
+    @pytest.mark.asyncio
+    async def test_neq(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("count", "!=", 10)
+        ) == {
+            "alpha",
+            "gamma",
+            "delta",
+            "epsilon",
+        }
+
+    @pytest.mark.asyncio
+    async def test_gt(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("count", ">", 10)
+        ) == {
+            "gamma",
+            "delta",
+        }
+
+    @pytest.mark.asyncio
+    async def test_gte(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("count", ">=", 10)
+        ) == {
+            "beta",
+            "gamma",
+            "delta",
+        }
+
+    @pytest.mark.asyncio
+    async def test_lt(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("count", "<", 10)
+        ) == {
+            "alpha",
+            "epsilon",
+        }
+
+    @pytest.mark.asyncio
+    async def test_lte(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("count", "<=", 10)
+        ) == {
+            "alpha",
+            "beta",
+            "epsilon",
+        }
+
+
+class TestPropsJsonFloatFilters:
+    @pytest.mark.asyncio
+    async def test_gt(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("score", ">", 2.0)
+        ) == {
+            "beta",
+            "gamma",
+            "delta",
+        }
+
+    @pytest.mark.asyncio
+    async def test_lt(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("score", "<", 3.0)
+        ) == {
+            "alpha",
+            "beta",
+        }
+
+
+class TestPropsJsonBoolFilters:
+    @pytest.mark.asyncio
+    async def test_true(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("active", "=", True)
+        ) == {
+            "alpha",
+            "gamma",
+            "epsilon",
+        }
+
+    @pytest.mark.asyncio
+    async def test_false(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("active", "=", False)
+        ) == {
+            "beta",
+            "delta",
+        }
+
+
+class TestPropsJsonStringFilters:
+    @pytest.mark.asyncio
+    async def test_eq(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("tag", "=", "a")
+        ) == {"alpha"}
+
+    @pytest.mark.asyncio
+    async def test_neq(self, properties_session):
+        assert await _query_props_names(
+            properties_session, Comparison("tag", "!=", "a")
+        ) == {
+            "beta",
+            "gamma",
+            "delta",
+        }
+
+
+class TestPropsJsonDatetimeFilters:
+    @pytest.mark.asyncio
+    async def test_gt(self, properties_session):
+        cutoff = datetime(2024, 6, 1, 0, 0, 0, tzinfo=UTC)
+        assert await _query_props_names(
+            properties_session, Comparison("ts", ">", cutoff)
+        ) == {
+            "gamma",
+            "delta",
+        }
+
+    @pytest.mark.asyncio
+    async def test_lt(self, properties_session):
+        cutoff = datetime(2024, 6, 1, 0, 0, 0, tzinfo=UTC)
+        assert await _query_props_names(
+            properties_session, Comparison("ts", "<", cutoff)
+        ) == {
+            "alpha",
+            "beta",
+        }
+
+    @pytest.mark.asyncio
+    async def test_cross_timezone(self, properties_session):
+        jst = timezone(timedelta(hours=9))
+        cutoff = datetime(2024, 3, 15, 22, 0, 0, tzinfo=jst)  # = 13:00 UTC
+        assert await _query_props_names(
+            properties_session, Comparison("ts", ">=", cutoff)
+        ) == {
+            "beta",
+            "gamma",
+            "delta",
+        }
+
+
+class TestPropsJsonInFilters:
+    @pytest.mark.asyncio
+    async def test_int_in(self, properties_session):
+        assert await _query_props_names(properties_session, In("count", [5, 15])) == {
+            "alpha",
+            "gamma",
+        }
+
+    @pytest.mark.asyncio
+    async def test_string_in(self, properties_session):
+        assert await _query_props_names(properties_session, In("tag", ["a", "b"])) == {
+            "alpha",
+            "beta",
+        }
+
+    @pytest.mark.asyncio
+    async def test_empty_in(self, properties_session):
+        assert await _query_props_names(properties_session, In("tag", [])) == set()
+
+
+class TestPropsJsonIsNullFilter:
+    @pytest.mark.asyncio
+    async def test_is_null(self, properties_session):
+        assert await _query_props_names(properties_session, IsNull("tag")) == {
+            "epsilon"
+        }
+
+
+class TestPropsJsonLogicalFilters:
+    @pytest.mark.asyncio
+    async def test_and(self, properties_session):
+        expr = And(Comparison("count", ">", 10), Comparison("active", "=", True))
+        assert await _query_props_names(properties_session, expr) == {"gamma"}
+
+    @pytest.mark.asyncio
+    async def test_or(self, properties_session):
+        expr = Or(Comparison("tag", "=", "a"), Comparison("tag", "=", "c"))
+        assert await _query_props_names(properties_session, expr) == {"alpha", "gamma"}
+
+    @pytest.mark.asyncio
+    async def test_not(self, properties_session):
+        expr = Not(Comparison("count", ">", 10))
+        assert await _query_props_names(properties_session, expr) == {
+            "alpha",
+            "beta",
+            "epsilon",
+        }
+
+    @pytest.mark.asyncio
+    async def test_not_in(self, properties_session):
+        expr = Not(In("tag", ["a", "b"]))
+        assert await _query_props_names(properties_session, expr) == {"gamma", "delta"}
+
+    @pytest.mark.asyncio
+    async def test_compound_not_and(self, properties_session):
+        inner = And(Comparison("count", ">", 10), Comparison("active", "=", True))
+        assert await _query_props_names(properties_session, Not(inner)) == {
+            "alpha",
+            "beta",
+            "delta",
+            "epsilon",
+        }
+
+
+class TestPropsJsonCompileErrors:
+    @pytest.mark.asyncio
+    async def test_unsupported_operator(self, properties_session):
+        with pytest.raises(ValueError, match="Unsupported operator"):
+            await _query_props_names(
+                properties_session, Comparison("count", cast(Any, "LIKE"), 10)
+            )

--- a/packages/server/server_tests/memmachine_server/common/test_properties_json.py
+++ b/packages/server/server_tests/memmachine_server/common/test_properties_json.py
@@ -1,0 +1,101 @@
+"""Tests for properties_json: encode/decode round-trips."""
+
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any, cast
+
+import pytest
+
+from memmachine_server.common.properties_json import (
+    decode_properties,
+    encode_properties,
+)
+
+
+class TestEncodeDecodeRoundTrip:
+    def test_bool(self):
+        original = {"flag": True}
+        assert decode_properties(encode_properties(original)) == original
+
+    def test_int(self):
+        original = {"count": 42}
+        assert decode_properties(encode_properties(original)) == original
+
+    def test_float(self):
+        original = {"score": 3.14}
+        assert decode_properties(encode_properties(original)) == original
+
+    def test_str(self):
+        original = {"name": "hello"}
+        assert decode_properties(encode_properties(original)) == original
+
+    def test_datetime_utc(self):
+        dt = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
+        result = decode_properties(encode_properties({"ts": dt}))
+        assert result["ts"] == dt
+
+    def test_datetime_positive_offset(self):
+        tz = timezone(timedelta(hours=5, minutes=30))
+        dt = datetime(2024, 6, 15, 17, 30, 0, tzinfo=tz)
+        result = decode_properties(encode_properties({"ts": dt}))
+        assert result["ts"] == dt
+        ts = result["ts"]
+        assert isinstance(ts, datetime)
+        assert ts.utcoffset() == timedelta(hours=5, minutes=30)
+
+    def test_datetime_negative_offset(self):
+        tz = timezone(timedelta(hours=-8))
+        dt = datetime(2024, 6, 15, 4, 0, 0, tzinfo=tz)
+        result = decode_properties(encode_properties({"ts": dt}))
+        assert result["ts"] == dt
+        ts = result["ts"]
+        assert isinstance(ts, datetime)
+        assert ts.utcoffset() == timedelta(hours=-8)
+
+    def test_multiple_fields(self):
+        original = {
+            "flag": False,
+            "count": 7,
+            "ratio": 0.5,
+            "label": "test",
+            "created": datetime(2024, 1, 1, tzinfo=UTC),
+        }
+        assert decode_properties(encode_properties(original)) == original
+
+    def test_none_returns_empty(self):
+        assert encode_properties(None) == {}
+        assert decode_properties(None) == {}
+
+    def test_empty_dict_returns_empty(self):
+        assert encode_properties({}) == {}
+        assert decode_properties({}) == {}
+
+
+class TestEncodeFormat:
+    def test_int_format(self):
+        encoded = encode_properties({"x": 10})
+        assert encoded == {"x": {"v": 10, "t": "int"}}
+
+    def test_datetime_stores_utc_and_offset(self):
+        tz = timezone(timedelta(hours=9))
+        dt = datetime(2024, 6, 15, 21, 0, 0, tzinfo=tz)
+        encoded = encode_properties({"ts": dt})
+        entry = encoded["ts"]
+        assert entry["t"] == "datetime"
+        assert entry["tz"] == 9 * 3600
+        assert entry["v"] == dt.astimezone(UTC).isoformat()
+
+
+class TestDecodeErrors:
+    def test_unknown_type_name(self):
+        with pytest.raises(ValueError, match="Unknown property type name"):
+            decode_properties({"x": {"t": "unknown", "v": 1}})
+
+    def test_non_dict_entry(self):
+        with pytest.raises(TypeError, match="Expected dict"):
+            decode_properties({"x": 42})
+
+
+class TestEncodeErrors:
+    def test_unsupported_type(self):
+        with pytest.raises(ValueError, match="Unsupported property value type"):
+            encode_properties(cast(Any, {"x": [1, 2, 3]}))

--- a/packages/server/server_tests/memmachine_server/semantic_memory/storage/in_memory_semantic_storage.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/storage/in_memory_semantic_storage.py
@@ -735,7 +735,7 @@ class InMemorySemanticStorage(SemanticStorage):
         if internal_name in field_mapping:
             return field_mapping[internal_name], False
 
-        return None, False
+        raise ValueError(f"Unknown filter field: {field!r}")
 
     def _apply_vector_filter(
         self,

--- a/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_semantic_storage.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_semantic_storage.py
@@ -887,10 +887,11 @@ async def test_get_feature_set_unknown_filter_column_errors(
     )
 
     # No errors occurs
-    await _collect_feature_set(
-        semantic_storage,
-        filter_expr=_expr("missing_column IN (foo)"),
-    )
+    with pytest.raises(ValueError, match="Unknown filter field"):
+        await _collect_feature_set(
+            semantic_storage,
+            filter_expr=_expr("missing_column IN (foo)"),
+        )
 
 
 @pytest.mark.asyncio
@@ -906,10 +907,10 @@ async def test_delete_feature_set_unknown_filter_column_errors(
         embedding=np.array([1.0], dtype=float),
     )
 
-    # No errors occurs
-    await semantic_storage.delete_feature_set(
-        filter_expr=_expr("missing_column IN (foo)"),
-    )
+    with pytest.raises(ValueError, match="Unknown filter field"):
+        await semantic_storage.delete_feature_set(
+            filter_expr=_expr("missing_column IN (foo)"),
+        )
 
 
 @pytest.mark.asyncio

--- a/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_semantic_storage.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_semantic_storage.py
@@ -886,7 +886,6 @@ async def test_get_feature_set_unknown_filter_column_errors(
         embedding=np.array([1.0], dtype=float),
     )
 
-    # No errors occurs
     with pytest.raises(ValueError, match="Unknown filter field"):
         await _collect_feature_set(
             semantic_storage,

--- a/packages/server/src/memmachine_server/common/episode_store/episode_sqlalchemy_store.py
+++ b/packages/server/src/memmachine_server/common/episode_store/episode_sqlalchemy_store.py
@@ -51,7 +51,10 @@ from memmachine_server.common.filter.filter_parser import (
     demangle_user_metadata_key,
     normalize_filter_field,
 )
-from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
+from memmachine_server.common.filter.sql_filter_util import (
+    FieldEncoding,
+    compile_sql_filter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -290,31 +293,31 @@ class SqlAlchemyEpisodeStore(EpisodeStorage):
     @staticmethod
     def _resolve_episode_field(
         field: str,
-    ) -> tuple[Any, bool] | tuple[None, bool]:
+    ) -> tuple[ColumnElement, FieldEncoding]:
         internal_name, is_user_metadata = normalize_filter_field(field)
         if is_user_metadata:
             key = demangle_user_metadata_key(internal_name)
-            return Episode.json_metadata[key], True
+            return Episode.json_metadata[key], "json"
 
         # Check for system field mappings (case-insensitive)
         normalized = internal_name.lower()
-        field_mapping: dict[str, Any] = {
-            "uid": Episode.id,
-            "id": Episode.id,
-            "session_key": Episode.session_key,
-            "session": Episode.session_key,
-            "producer_id": Episode.producer_id,
-            "producer_role": Episode.producer_role,
-            "produced_for_id": Episode.produced_for_id,
-            "episode_type": Episode.episode_type,
-            "content": Episode.content,
-            "created_at": Episode.created_at,
+        field_mapping: dict[str, ColumnElement] = {
+            "uid": Episode.id.expression,
+            "id": Episode.id.expression,
+            "session_key": Episode.session_key.expression,
+            "session": Episode.session_key.expression,
+            "producer_id": Episode.producer_id.expression,
+            "producer_role": Episode.producer_role.expression,
+            "produced_for_id": Episode.produced_for_id.expression,
+            "episode_type": Episode.episode_type.expression,
+            "content": Episode.content.expression,
+            "created_at": Episode.created_at.expression,
         }
 
         if normalized in field_mapping:
-            return field_mapping[normalized], False
+            return field_mapping[normalized], "column"
 
-        return None, False
+        raise ValueError(f"Unknown filter field: {field!r}")
 
     async def get_episode_messages(
         self,

--- a/packages/server/src/memmachine_server/common/filter/sql_filter_util.py
+++ b/packages/server/src/memmachine_server/common/filter/sql_filter_util.py
@@ -1,12 +1,22 @@
-"""SQLAlchemy utilities for FilterExpr."""
+"""
+Unified SQLAlchemy filter compiler for FilterExpr trees.
 
-import logging
+Supports different field encodings via `FieldEncoding`:
+- `"column"`: direct column comparison, no casting.
+- `"json"`: raw JSON value, cast based on the Python value type.
+- `"properties_json"`: type-tagged JSON (`{"t": …, "v": …}`) supporting PropertyValue.
+"""
+
 from collections.abc import Callable
-from typing import Any
+from datetime import UTC, datetime
+from typing import Literal
 
 from sqlalchemy import ColumnElement, and_, false, or_
 
-from memmachine_server.common.data_types import FilterValue
+from memmachine_server.common.data_types import (
+    PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME,
+    PropertyValue,
+)
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -16,30 +26,26 @@ from memmachine_server.common.filter.filter_parser import (
     Not,
     Or,
 )
+from memmachine_server.common.properties_json import (
+    PROPERTY_TYPE_KEY,
+    PROPERTY_VALUE_KEY,
+)
+from memmachine_server.common.utils import ensure_tz_aware
 
-logger = logging.getLogger(__name__)
+FieldEncoding = Literal["column", "json", "properties_json"]
 
-FieldResolver = Callable[[str], tuple[Any, bool]]
+FieldResolver = Callable[[str], tuple[ColumnElement, FieldEncoding]]
+"""
+Maps a filter field name to a ``(column, kind)`` pair.
 
+Resolvers should call ``.expression`` on ORM ``InstrumentedAttribute``
+values to obtain a ``ColumnElement``.
 
-def _cast_json_column(
-    column: ColumnElement[Any],
-    value: FilterValue,
-) -> ColumnElement[Any]:
-    """Cast a JSON path column to the appropriate SQL type based on *value*.
-
-    Note: datetime values are converted to ISO strings for comparison.
-    """
-    if isinstance(value, bool):
-        return column.as_boolean()
-    if isinstance(value, int):
-        return column.as_integer()
-    if isinstance(value, float):
-        return column.as_float()
-    return column.as_string()
+Raises `ValueError` for unrecognised fields.
+"""
 
 
-_COMPARISON_OPS = {
+_COMPARISON_OPS: dict[str, Callable[[ColumnElement, object], ColumnElement[bool]]] = {
     "=": lambda col, val: col == val,
     "!=": lambda col, val: col != val,
     ">": lambda col, val: col > val,
@@ -49,66 +55,151 @@ _COMPARISON_OPS = {
 }
 
 
-def _compile_leaf(
-    expr: IsNull | In | Comparison,
-    resolve_field: FieldResolver,
-) -> ColumnElement[bool] | None:
-    column, is_json = resolve_field(expr.field)
-    if column is None:
-        logger.warning("Unsupported filter field: %s", expr.field)
-        return None
+def _get_op(op: str) -> Callable[[ColumnElement, object], ColumnElement[bool]]:
+    op_fn = _COMPARISON_OPS.get(op)
+    if op_fn is None:
+        raise ValueError(f"Unsupported operator: {op!r}")
+    return op_fn
 
+
+def _compile_column_leaf(
+    expr: IsNull | In | Comparison,
+    column: ColumnElement,
+) -> ColumnElement[bool]:
     if isinstance(expr, IsNull):
-        if is_json:
-            return column.as_string().is_(None)
         return column.is_(None)
+    if isinstance(expr, In):
+        if not expr.values:
+            return false()
+        return column.in_(expr.values)
+    return _get_op(expr.op)(column, expr.value)
+
+
+def _cast_json_value(
+    column: ColumnElement,
+    value: bool | float | str,
+) -> ColumnElement:
+    """Cast a raw JSON path element based on the Python value type."""
+    if isinstance(value, bool):
+        return column.as_boolean()
+    if isinstance(value, int):
+        return column.as_integer()
+    if isinstance(value, float):
+        return column.as_float()
+    return column.as_string()
+
+
+def _check_json_value(value: PropertyValue) -> bool | int | float | str:
+    """Validate that a filter value is usable with raw JSON fields."""
+    if isinstance(value, datetime):
+        raise TypeError(
+            "datetime filtering requires 'properties_json' fields; "
+            "raw 'json' fields do not support datetime"
+        )
+    return value
+
+
+def _compile_json_leaf(
+    expr: IsNull | In | Comparison,
+    column: ColumnElement,
+) -> ColumnElement[bool]:
+    if isinstance(expr, IsNull):
+        # .as_string() emits ->> instead of JSON_QUOTE(JSON_EXTRACT(...)),
+        # which preserves SQL NULL for missing keys on SQLite.
+        return column.as_string().is_(None)
+    if isinstance(expr, In):
+        if not expr.values:
+            return false()
+        return _cast_json_value(column, _check_json_value(expr.values[0])).in_(
+            expr.values
+        )
+    return _get_op(expr.op)(
+        _cast_json_value(column, _check_json_value(expr.value)), expr.value
+    )
+
+
+def _cast_properties_json_value(
+    value_path: ColumnElement,
+    value: PropertyValue,
+) -> tuple[ColumnElement, object]:
+    """Cast a typed-JSON value path and normalize the comparison value."""
+    if isinstance(value, bool):
+        return value_path.as_boolean(), value
+    if isinstance(value, int):
+        return value_path.as_integer(), value
+    if isinstance(value, float):
+        return value_path.as_float(), value
+    if isinstance(value, datetime):
+        return (
+            value_path.as_string(),
+            ensure_tz_aware(value).astimezone(UTC).isoformat(),
+        )
+    if isinstance(value, str):
+        return value_path.as_string(), value
+    raise TypeError(f"Unsupported property value type: {type(value)!r}")
+
+
+def _compile_properties_json_leaf(
+    expr: IsNull | In | Comparison,
+    column: ColumnElement,
+) -> ColumnElement[bool]:
+    if isinstance(expr, IsNull):
+        return column.as_string().is_(None)
 
     if isinstance(expr, In):
         if not expr.values:
             return false()
-        if is_json:
-            return _cast_json_column(column, expr.values[0]).in_(expr.values)
-        return column.in_(expr.values)
+        first_value = expr.values[0]
+        type_name = PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[type(first_value)]
+        value_path = column[PROPERTY_VALUE_KEY]
+        type_check = column[PROPERTY_TYPE_KEY].as_string() == type_name
+        if isinstance(first_value, int):
+            return and_(type_check, value_path.as_integer().in_(expr.values))
+        return and_(type_check, value_path.as_string().in_(expr.values))
 
-    op_fn = _COMPARISON_OPS.get(expr.op)
-    if op_fn is None:
-        raise ValueError(f"Unsupported operator: {expr.op}")
-
-    if is_json:
-        return op_fn(_cast_json_column(column, expr.value), expr.value)
-    return op_fn(column, expr.value)
+    # Comparison
+    type_name = PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[type(expr.value)]
+    value_path = column[PROPERTY_VALUE_KEY]
+    type_check = column[PROPERTY_TYPE_KEY].as_string() == type_name
+    casted_column, normalized_value = _cast_properties_json_value(
+        value_path, expr.value
+    )
+    return and_(type_check, _get_op(expr.op)(casted_column, normalized_value))
 
 
 def compile_sql_filter(
     expr: FilterExpr,
     resolve_field: FieldResolver,
-) -> ColumnElement[bool] | None:
-    """Compile a FilterExpr tree into an SQLAlchemy boolean expression."""
-    if isinstance(expr, IsNull | In | Comparison):
-        return _compile_leaf(expr, resolve_field)
+) -> ColumnElement[bool]:
+    """
+    Compile a FilterExpr tree into a SQLAlchemy boolean expression.
+
+    The `resolve_field` callback maps each field name to a
+    `(column, FieldEncoding)` pair and raises `ValueError` for unknown fields.
+    """
+    if isinstance(expr, Comparison | In | IsNull):
+        column, kind = resolve_field(expr.field)
+        if kind == "column":
+            return _compile_column_leaf(expr, column)
+        if kind == "json":
+            return _compile_json_leaf(expr, column)
+        if kind == "properties_json":
+            return _compile_properties_json_leaf(expr, column)
+        raise ValueError(f"Unknown field kind: {kind!r}")
 
     if isinstance(expr, And):
-        left = compile_sql_filter(expr.left, resolve_field)
-        right = compile_sql_filter(expr.right, resolve_field)
-        if left is None:
-            return right
-        if right is None:
-            return left
-        return and_(left, right)
+        return and_(
+            compile_sql_filter(expr.left, resolve_field),
+            compile_sql_filter(expr.right, resolve_field),
+        )
 
     if isinstance(expr, Or):
-        left = compile_sql_filter(expr.left, resolve_field)
-        right = compile_sql_filter(expr.right, resolve_field)
-        if left is None:
-            return right
-        if right is None:
-            return left
-        return or_(left, right)
+        return or_(
+            compile_sql_filter(expr.left, resolve_field),
+            compile_sql_filter(expr.right, resolve_field),
+        )
 
     if isinstance(expr, Not):
-        inner = compile_sql_filter(expr.expr, resolve_field)
-        if inner is None:
-            return None
-        return ~inner
+        return ~compile_sql_filter(expr.expr, resolve_field)
 
     raise TypeError(f"Unsupported filter expression type: {type(expr)!r}")

--- a/packages/server/src/memmachine_server/common/properties_json.py
+++ b/packages/server/src/memmachine_server/common/properties_json.py
@@ -1,0 +1,93 @@
+"""
+Type-tagged JSON property encoding and decoding.
+
+Properties are stored in a JSON column as::
+
+    {"field_name": {"t": type_name, "v": value}}
+
+Datetimes additionally include a timezone offset::
+
+    {"field_name": {"t": "datetime", "v": utc_iso_value, "tz": offset_seconds}}
+"""
+
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta, timezone
+from typing import cast
+
+from pydantic import JsonValue
+
+from memmachine_server.common.data_types import (
+    PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE,
+    PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME,
+    PropertyValue,
+)
+from memmachine_server.common.utils import ensure_tz_aware, utc_offset_seconds
+
+PROPERTY_TYPE_KEY = "t"
+PROPERTY_VALUE_KEY = "v"
+PROPERTY_TIMEZONE_OFFSET_KEY = "tz"
+
+
+def encode_properties(
+    properties: Mapping[str, PropertyValue] | None,
+) -> dict[str, dict[str, bool | int | float | str]]:
+    """
+    Encode properties as type-tagged JSON.
+
+    `None` is treated as `{}`.
+    Each property becomes `{"v": value, "t": type_name}`.
+    Datetimes are normalized to UTC and include `{"tz": offset_seconds}`
+    for timezone reconstruction.
+    """
+    if not properties:
+        return {}
+    encoded: dict[str, dict[str, bool | int | float | str]] = {}
+    for key, value in properties.items():
+        type_name = PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME.get(type(value))
+        if type_name is None:
+            raise ValueError(f"Unsupported property value type: {type(value)!r}")
+        if isinstance(value, datetime):
+            aware_value = ensure_tz_aware(value)
+            encoded[key] = {
+                PROPERTY_VALUE_KEY: aware_value.astimezone(UTC).isoformat(),
+                PROPERTY_TYPE_KEY: type_name,
+                PROPERTY_TIMEZONE_OFFSET_KEY: utc_offset_seconds(value),
+            }
+        else:
+            encoded[key] = {
+                PROPERTY_VALUE_KEY: value,
+                PROPERTY_TYPE_KEY: type_name,
+            }
+    return encoded
+
+
+def decode_properties(
+    encoded: Mapping[str, JsonValue] | None,
+) -> dict[str, PropertyValue]:
+    """
+    Decode type-tagged JSON properties back to Python values.
+
+    Returns {} if `encoded` is `None` or empty.
+    Reconstructs the original timezone for datetime values.
+    """
+    if not encoded:
+        return {}
+    properties: dict[str, PropertyValue] = {}
+    for key, entry in encoded.items():
+        if not isinstance(entry, dict):
+            raise TypeError(f"Expected dict for property entry, got {type(entry)!r}")
+        type_name = str(entry[PROPERTY_TYPE_KEY])
+        raw_value = entry[PROPERTY_VALUE_KEY]
+        property_type = PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE.get(type_name)
+        if property_type is None:
+            raise ValueError(f"Unknown property type name: {type_name!r}")
+        if property_type is datetime:
+            utc_dt = datetime.fromisoformat(str(raw_value))
+            tz_offset = entry.get(PROPERTY_TIMEZONE_OFFSET_KEY, 0)
+            original_tz = timezone(timedelta(seconds=int(tz_offset)))
+            properties[key] = ensure_tz_aware(utc_dt).astimezone(original_tz)
+        else:
+            properties[key] = cast(type[bool | int | float | str], property_type)(
+                raw_value
+            )
+    return properties

--- a/packages/server/src/memmachine_server/semantic_memory/storage/neo4j_semantic_storage.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/neo4j_semantic_storage.py
@@ -1161,6 +1161,25 @@ class Neo4jSemanticStorage(SemanticStorage):
             return condition, inner_params
         raise TypeError(f"Unsupported filter expression type: {type(expr)!r}")
 
+    _KNOWN_FIELDS: frozenset[str] = frozenset(
+        {
+            "set_id",
+            "set",
+            "semantic_category_id",
+            "category_name",
+            "category",
+            "tag_id",
+            "tag",
+            "feature",
+            "feature_name",
+            "value",
+            "created_at",
+            "created_at_ts",
+            "updated_at",
+            "updated_at_ts",
+        }
+    )
+
     def _resolve_field_reference(
         self,
         alias: str,
@@ -1174,7 +1193,9 @@ class Neo4jSemanticStorage(SemanticStorage):
             key = field.split(".", 1)[1]
             prop_name = self._metadata_property_name(key)
             return f"{alias}.{prop_name}", None
-        return f"{alias}.{field}", None
+        if field in self._KNOWN_FIELDS:
+            return f"{alias}.{field}", None
+        raise ValueError(f"Unknown filter field: {field!r}")
 
     def _next_filter_param(self) -> str:
         self._filter_param_counter += 1

--- a/packages/server/src/memmachine_server/semantic_memory/storage/sqlalchemy_pgvector_semantic.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/sqlalchemy_pgvector_semantic.py
@@ -32,8 +32,6 @@ from sqlalchemy.engine import Connection, CursorResult
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import (
     DeclarativeBase,
-    InstrumentedAttribute,
-    MappedColumn,
     aliased,
     mapped_column,
 )
@@ -46,7 +44,10 @@ from memmachine_server.common.filter.filter_parser import (
     demangle_user_metadata_key,
     normalize_filter_field,
 )
-from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
+from memmachine_server.common.filter.sql_filter_util import (
+    FieldEncoding,
+    compile_sql_filter,
+)
 from memmachine_server.semantic_memory.semantic_model import SemanticFeature, SetIdT
 from memmachine_server.semantic_memory.storage.storage_base import (
     FeatureIdT,
@@ -649,42 +650,36 @@ class SqlAlchemyPgVectorSemanticStorage(SemanticStorage):
     def _resolve_feature_field_default(
         self,
         field: str,
-    ) -> (
-        tuple[MappedColumn[Any] | InstrumentedAttribute[Any] | ColumnElement[Any], bool]
-        | tuple[None, bool]
-    ):
+    ) -> tuple[ColumnElement, FieldEncoding]:
         return self._resolve_feature_field(Feature, field)
 
     @staticmethod
     def _resolve_feature_field(
         table: type[Feature],
         field: str,
-    ) -> (
-        tuple[MappedColumn[Any] | InstrumentedAttribute[Any] | ColumnElement[Any], bool]
-        | tuple[None, bool]
-    ):
+    ) -> tuple[ColumnElement, FieldEncoding]:
         internal_name, is_user_property = normalize_filter_field(field)
         if is_user_property:
             key = demangle_user_metadata_key(internal_name)
-            return table.json_metadata[key], True
+            return table.json_metadata[key], "json"
 
-        field_mapping = {
-            "set_id": table.set_id,
-            "set": table.set_id,
-            "semantic_category_id": table.semantic_category_id,
-            "category_name": table.semantic_category_id,
-            "category": table.semantic_category_id,
-            "tag_id": table.tag_id,
-            "tag": table.tag_id,
-            "feature": table.feature,
-            "feature_name": table.feature,
-            "value": table.value,
-            "created_at": table.created_at,
-            "updated_at": table.updated_at,
+        field_mapping: dict[str, ColumnElement] = {
+            "set_id": table.set_id.expression,
+            "set": table.set_id.expression,
+            "semantic_category_id": table.semantic_category_id.expression,
+            "category_name": table.semantic_category_id.expression,
+            "category": table.semantic_category_id.expression,
+            "tag_id": table.tag_id.expression,
+            "tag": table.tag_id.expression,
+            "feature": table.feature.expression,
+            "feature_name": table.feature.expression,
+            "value": table.value.expression,
+            "created_at": table.created_at.expression,
+            "updated_at": table.updated_at.expression,
         }
         if internal_name in field_mapping:
-            return field_mapping[internal_name], False
-        return None, False
+            return field_mapping[internal_name], "column"
+        raise ValueError(f"Unknown filter field: {field!r}")
 
     async def _load_feature_citations(
         self,


### PR DESCRIPTION
### Purpose of the change

Needed for SQLAlchemySegmentStore, SQLite VectorStore implementations.

### Description

Made based on #1302 for easier rebasing, but this does not need it.

Add unified, well-tested way to encode/decode properties as SQL JSON to avoid repeated reimplementation.

Consumers of existing behavior are modified to use raw JSON encoding -- they may be moved to properties JSON in the future if appropriate. In particular, existing consumers of existing compile_sql_filter do not handle datetimes (no way of handling type collisions -- the new method uses a discriminated union).

### Type of change

Breaking: filters will no longer ignore unknown keys.

It's confusing and potentially dangerous (especially with more complex filters including NOT, AND, OR) what treating unknown keys as None is supposed to mean. New behavior: If a filter is meant to be sent to multiple memories simultaneously, then all memories must support those fields.

It maybe would be okay if it obeyed SQL 3VL, but there is no case where a filter on one memory's field should affect the filter for another memory.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected