### PR TITLE
Add LLM-friendly formatting helpers to clients

### DIFF
--- a/packages/client/client_tests/test_format.py
+++ b/packages/client/client_tests/test_format.py
@@ -1,0 +1,261 @@
+"""Unit tests for LLM-friendly memory formatting functions."""
+
+import json
+from datetime import datetime, timezone
+
+from memmachine_common.api.spec import (
+    Episode,
+    EpisodeResponse,
+    EpisodicSearchLongTermMemory,
+    EpisodicSearchResult,
+    EpisodicSearchShortTermMemory,
+    SearchResult,
+    SearchResultContent,
+    SemanticFeature,
+)
+
+from memmachine_client.format import (
+    format_episodes,
+    format_search_result,
+    format_semantic_memories,
+)
+
+
+class TestFormatEpisodes:
+    """Tests for format_episodes."""
+
+    def test_empty(self):
+        assert format_episodes([]) == ""
+
+    def test_single_episode_response(self):
+        ep = EpisodeResponse(
+            uid="1",
+            content="Hello world",
+            producer_id="user_1",
+            producer_role="user",
+            created_at=datetime(2024, 1, 15, 13, 30, tzinfo=timezone.utc),
+        )
+        result = format_episodes([ep])
+        assert (
+            result == '[Monday, January 15, 2024 at 01:30 PM] user_1: "Hello world"\n'
+        )
+
+    def test_multiple_episodes(self):
+        eps = [
+            EpisodeResponse(
+                uid="1",
+                content="First message",
+                producer_id="user_1",
+                producer_role="user",
+                created_at=datetime(2024, 3, 5, 9, 0, tzinfo=timezone.utc),
+            ),
+            EpisodeResponse(
+                uid="2",
+                content="Second message",
+                producer_id="assistant_1",
+                producer_role="assistant",
+                created_at=datetime(2024, 3, 5, 9, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        result = format_episodes(eps)
+        lines = result.strip().split("\n")
+        assert len(lines) == 2
+        assert "user_1" in lines[0]
+        assert "assistant_1" in lines[1]
+
+    def test_episode_without_created_at(self):
+        ep = EpisodeResponse(
+            uid="1",
+            content="No timestamp",
+            producer_id="user_1",
+            producer_role="user",
+            created_at=None,
+        )
+        result = format_episodes([ep])
+        assert result == 'user_1: "No timestamp"\n'
+
+    def test_list_episode_type(self):
+        ep = Episode(
+            uid="1",
+            content="Listed episode",
+            session_key="sess_1",
+            producer_id="user_1",
+            producer_role="user",
+            created_at=datetime(2024, 6, 1, 14, 0, tzinfo=timezone.utc),
+        )
+        result = format_episodes([ep])
+        assert (
+            result == '[Saturday, June 01, 2024 at 02:00 PM] user_1: "Listed episode"\n'
+        )
+
+    def test_content_json_escaped(self):
+        ep = EpisodeResponse(
+            uid="1",
+            content='She said "hello"',
+            producer_id="user_1",
+            producer_role="user",
+            created_at=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+        )
+        result = format_episodes([ep])
+        assert json.dumps('She said "hello"') in result
+
+
+class TestFormatSemanticMemories:
+    """Tests for format_semantic_memories."""
+
+    def test_empty(self):
+        result = format_semantic_memories([])
+        assert result == "{}"
+
+    def test_single_feature(self):
+        feature = SemanticFeature(
+            category="profile",
+            tag="preferences",
+            feature_name="favorite_food",
+            value="pizza",
+        )
+        result = format_semantic_memories([feature])
+        parsed = json.loads(result)
+        assert parsed == {"preferences": {"favorite_food": "pizza"}}
+
+    def test_groups_by_tag(self):
+        features = [
+            SemanticFeature(
+                category="profile",
+                tag="preferences",
+                feature_name="food",
+                value="pizza",
+            ),
+            SemanticFeature(
+                category="profile",
+                tag="preferences",
+                feature_name="color",
+                value="blue",
+            ),
+            SemanticFeature(
+                category="profile",
+                tag="background",
+                feature_name="role",
+                value="engineer",
+            ),
+        ]
+        result = format_semantic_memories(features)
+        parsed = json.loads(result)
+        assert parsed == {
+            "preferences": {"food": "pizza", "color": "blue"},
+            "background": {"role": "engineer"},
+        }
+
+    def test_metadata_excluded(self):
+        feature = SemanticFeature(
+            set_id="set_1",
+            category="profile",
+            tag="info",
+            feature_name="name",
+            value="Alice",
+            metadata=SemanticFeature.Metadata(
+                id="feat_1",
+                citations=["ep_1", "ep_2"],
+                other={"source": "conversation"},
+            ),
+        )
+        result = format_semantic_memories([feature])
+        parsed = json.loads(result)
+        # Only tag/feature_name/value should appear
+        assert parsed == {"info": {"name": "Alice"}}
+        assert "set_id" not in result
+        assert "citations" not in result
+        assert "feat_1" not in result
+
+
+class TestFormatSearchResult:
+    """Tests for format_search_result."""
+
+    def test_empty_result(self):
+        result = SearchResult(
+            status=0,
+            content=SearchResultContent(
+                episodic_memory=None,
+                semantic_memory=None,
+            ),
+        )
+        assert format_search_result(result) == ""
+
+    def test_episodic_only(self):
+        ep = EpisodeResponse(
+            uid="1",
+            content="Hello",
+            producer_id="user_1",
+            producer_role="user",
+            created_at=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+        )
+        result = SearchResult(
+            status=0,
+            content=SearchResultContent(
+                episodic_memory=EpisodicSearchResult(
+                    long_term_memory=EpisodicSearchLongTermMemory(episodes=[ep]),
+                    short_term_memory=EpisodicSearchShortTermMemory(
+                        episodes=[], episode_summary=[]
+                    ),
+                ),
+                semantic_memory=None,
+            ),
+        )
+        formatted = format_search_result(result)
+        assert formatted.startswith("[Episodic Memory]\n")
+        assert "user_1" in formatted
+        assert '"Hello"' in formatted
+        assert "[Semantic Memory]" not in formatted
+
+    def test_semantic_only(self):
+        feature = SemanticFeature(
+            category="profile",
+            tag="prefs",
+            feature_name="food",
+            value="pizza",
+        )
+        result = SearchResult(
+            status=0,
+            content=SearchResultContent(
+                episodic_memory=None,
+                semantic_memory=[feature],
+            ),
+        )
+        formatted = format_search_result(result)
+        assert formatted.startswith("[Semantic Memory]\n")
+        assert "[Episodic Memory]" not in formatted
+        semantic_json = formatted.removeprefix("[Semantic Memory]\n")
+        assert json.loads(semantic_json) == {"prefs": {"food": "pizza"}}
+
+    def test_combined(self):
+        ep = EpisodeResponse(
+            uid="1",
+            content="I like pizza",
+            producer_id="user_1",
+            producer_role="user",
+            created_at=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+        )
+        feature = SemanticFeature(
+            category="profile",
+            tag="prefs",
+            feature_name="food",
+            value="pizza",
+        )
+        result = SearchResult(
+            status=0,
+            content=SearchResultContent(
+                episodic_memory=EpisodicSearchResult(
+                    long_term_memory=EpisodicSearchLongTermMemory(episodes=[ep]),
+                    short_term_memory=EpisodicSearchShortTermMemory(
+                        episodes=[], episode_summary=[]
+                    ),
+                ),
+                semantic_memory=[feature],
+            ),
+        )
+        formatted = format_search_result(result)
+        assert "[Episodic Memory]" in formatted
+        assert "[Semantic Memory]" in formatted
+        assert formatted.index("[Episodic Memory]") < formatted.index(
+            "[Semantic Memory]"
+        )

--- a/packages/client/src/memmachine_client/__init__.py
+++ b/packages/client/src/memmachine_client/__init__.py
@@ -7,7 +7,20 @@ episodic and profile memory systems.
 
 from .client import MemMachineClient
 from .config import Config
+from .format import (
+    format_episodes,
+    format_search_result,
+    format_semantic_memories,
+)
 from .memory import Memory
 from .project import Project
 
-__all__ = ["Config", "MemMachineClient", "Memory", "Project"]
+__all__ = [
+    "Config",
+    "MemMachineClient",
+    "Memory",
+    "Project",
+    "format_episodes",
+    "format_search_result",
+    "format_semantic_memories",
+]

--- a/packages/client/src/memmachine_client/format.py
+++ b/packages/client/src/memmachine_client/format.py
@@ -1,0 +1,101 @@
+"""LLM-friendly formatting for memory search and list results.
+
+These functions mirror the server's internal formatting logic so that
+client-side consumers get the same compact representation the server
+uses when feeding memories into language models.
+
+Episodic format matches ``string_from_episode_context`` in the server.
+Semantic format matches ``_features_to_llm_format`` in the server.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+from memmachine_common.api.spec import (
+    Episode,
+    EpisodeResponse,
+    SearchResult,
+    SemanticFeature,
+)
+
+
+def format_episodes(episodes: Iterable[EpisodeResponse | Episode]) -> str:
+    """Format episodic memories as an LLM-friendly string.
+
+    Each episode is rendered as::
+
+        [Monday, January 01, 2024 at 01:30 PM] producer_id: "content"
+
+    This mirrors the server's ``string_from_episode_context`` output.
+
+    Args:
+        episodes: Episodic memory entries from a search or list result.
+
+    Returns:
+        Newline-terminated formatted string (empty string when *episodes*
+        is empty).
+
+    """
+    result = ""
+    for episode in episodes:
+        if episode.created_at is not None:
+            date_str = episode.created_at.strftime("%A, %B %d, %Y")
+            time_str = episode.created_at.strftime("%I:%M %p")
+            result += f"[{date_str} at {time_str}] {episode.producer_id}: {json.dumps(episode.content)}\n"
+        else:
+            result += f"{episode.producer_id}: {json.dumps(episode.content)}\n"
+    return result
+
+
+def format_semantic_memories(features: Iterable[SemanticFeature]) -> str:
+    """Format semantic memories as a compact JSON string.
+
+    Produces a ``{tag: {feature_name: value}}`` structure, omitting all
+    metadata for context efficiency.  This mirrors the server's
+    ``_features_to_llm_format`` output.
+
+    Args:
+        features: Semantic memory entries from a search or list result.
+
+    Returns:
+        JSON string of the grouped features.
+
+    """
+    structured: dict[str, dict[str, str]] = {}
+    for feature in features:
+        structured.setdefault(feature.tag, {})[feature.feature_name] = feature.value
+    return json.dumps(structured)
+
+
+def format_search_result(result: SearchResult) -> str:
+    """Format a search result as an LLM-friendly string.
+
+    Combines episodic and semantic memories from a
+    :class:`~memmachine_common.api.spec.SearchResult` returned by
+    ``Memory.search()``.
+
+    Args:
+        result: A ``SearchResult`` object.
+
+    Returns:
+        Formatted string combining both memory types.
+
+    """
+    sections: list[str] = []
+
+    if result.content.episodic_memory is not None:
+        episodes = (
+            result.content.episodic_memory.long_term_memory.episodes
+            + result.content.episodic_memory.short_term_memory.episodes
+        )
+        if episodes:
+            sections.append(f"[Episodic Memory]\n{format_episodes(episodes)}")
+
+    if result.content.semantic_memory:
+        sections.append(
+            f"[Semantic Memory]\n{format_semantic_memories(result.content.semantic_memory)}"
+        )
+
+    return "\n".join(sections)

--- a/packages/common/src/memmachine_common/api/spec.py
+++ b/packages/common/src/memmachine_common/api/spec.py
@@ -51,103 +51,55 @@ class ContentType(Enum):
 class EpisodeEntry(BaseModel):
     """Payload used when creating a new episode entry."""
 
-    content: Annotated[
-        str,
-        Field(..., description=SpecDoc.EPISODE_CONTENT),
-    ]
-    producer_id: Annotated[
-        str,
-        Field(..., description=SpecDoc.EPISODE_PRODUCER_ID),
-    ]
-    producer_role: Annotated[
-        str,
-        Field(..., description=SpecDoc.EPISODE_PRODUCER_ROLE),
-    ]
-    produced_for_id: Annotated[
-        str | None,
-        Field(default=None, description=SpecDoc.EPISODE_PRODUCED_FOR_ID),
-    ]
-    episode_type: Annotated[
-        EpisodeType | None,
-        Field(default=None, description=SpecDoc.EPISODE_TYPE),
-    ]
-    metadata: Annotated[
-        dict[str, JsonValue] | None,
-        Field(default=None, description=SpecDoc.EPISODE_METADATA),
-    ]
-    created_at: Annotated[
-        AwareDatetime | None,
-        Field(default=None, description=SpecDoc.EPISODE_CREATED_AT),
-    ]
+    content: str = Field(..., description=SpecDoc.EPISODE_CONTENT)
+    producer_id: str = Field(..., description=SpecDoc.EPISODE_PRODUCER_ID)
+    producer_role: str = Field(..., description=SpecDoc.EPISODE_PRODUCER_ROLE)
+    produced_for_id: str | None = Field(
+        default=None, description=SpecDoc.EPISODE_PRODUCED_FOR_ID
+    )
+    episode_type: EpisodeType | None = Field(
+        default=None, description=SpecDoc.EPISODE_TYPE
+    )
+    metadata: dict[str, JsonValue] | None = Field(
+        default=None, description=SpecDoc.EPISODE_METADATA
+    )
+    created_at: AwareDatetime | None = Field(
+        default=None, description=SpecDoc.EPISODE_CREATED_AT
+    )
 
 
 class EpisodeResponse(EpisodeEntry):
     """Episode data returned in search responses."""
 
-    uid: Annotated[
-        EpisodeIdT,
-        Field(..., description=SpecDoc.EPISODE_UID),
-    ]
-    score: Annotated[
-        float | None,
-        Field(default=None, description=SpecDoc.EPISODE_SCORE),
-    ]
+    uid: EpisodeIdT = Field(..., description=SpecDoc.EPISODE_UID)
+    score: float | None = Field(default=None, description=SpecDoc.EPISODE_SCORE)
 
 
 class Episode(BaseModel):
     """Episode data returned in list responses."""
 
-    uid: Annotated[
-        EpisodeIdT,
-        Field(..., description=SpecDoc.EPISODE_UID),
-    ]
-    content: Annotated[
-        str,
-        Field(..., description=SpecDoc.EPISODE_CONTENT),
-    ]
-    session_key: Annotated[
-        str,
-        Field(..., description=SpecDoc.EPISODE_SESSION_KEY),
-    ]
-    created_at: Annotated[
-        AwareDatetime,
-        Field(..., description=SpecDoc.EPISODE_CREATED_AT),
-    ]
-
-    producer_id: Annotated[
-        str,
-        Field(..., description=SpecDoc.EPISODE_PRODUCER_ID),
-    ]
-    producer_role: Annotated[
-        str,
-        Field(..., description=SpecDoc.EPISODE_PRODUCER_ROLE),
-    ]
-    produced_for_id: Annotated[
-        str | None,
-        Field(default=None, description=SpecDoc.EPISODE_PRODUCED_FOR_ID),
-    ]
-
-    sequence_num: Annotated[
-        int,
-        Field(default=0, description=SpecDoc.EPISODE_SEQUENCE_NUM),
-    ]
-
-    episode_type: Annotated[
-        EpisodeType,
-        Field(default=EpisodeType.MESSAGE, description=SpecDoc.EPISODE_TYPE),
-    ]
-    content_type: Annotated[
-        ContentType,
-        Field(default=ContentType.STRING, description=SpecDoc.EPISODE_CONTENT_TYPE),
-    ]
-    filterable_metadata: Annotated[
-        dict[str, PropertyValue] | None,
-        Field(default=None, description=SpecDoc.EPISODE_FILTERABLE_METADATA),
-    ]
-    metadata: Annotated[
-        dict[str, JsonValue] | None,
-        Field(default=None, description=SpecDoc.EPISODE_METADATA),
-    ]
+    uid: EpisodeIdT = Field(..., description=SpecDoc.EPISODE_UID)
+    content: str = Field(..., description=SpecDoc.EPISODE_CONTENT)
+    session_key: str = Field(..., description=SpecDoc.EPISODE_SESSION_KEY)
+    created_at: AwareDatetime = Field(..., description=SpecDoc.EPISODE_CREATED_AT)
+    producer_id: str = Field(..., description=SpecDoc.EPISODE_PRODUCER_ID)
+    producer_role: str = Field(..., description=SpecDoc.EPISODE_PRODUCER_ROLE)
+    produced_for_id: str | None = Field(
+        default=None, description=SpecDoc.EPISODE_PRODUCED_FOR_ID
+    )
+    sequence_num: int = Field(default=0, description=SpecDoc.EPISODE_SEQUENCE_NUM)
+    episode_type: EpisodeType = Field(
+        default=EpisodeType.MESSAGE, description=SpecDoc.EPISODE_TYPE
+    )
+    content_type: ContentType = Field(
+        default=ContentType.STRING, description=SpecDoc.EPISODE_CONTENT_TYPE
+    )
+    filterable_metadata: dict[str, PropertyValue] | None = Field(
+        default=None, description=SpecDoc.EPISODE_FILTERABLE_METADATA
+    )
+    metadata: dict[str, JsonValue] | None = Field(
+        default=None, description=SpecDoc.EPISODE_METADATA
+    )
 
     def __hash__(self) -> int:
         """Hash an episode by its UID."""
@@ -164,43 +116,24 @@ class SemanticFeature(BaseModel):
     class Metadata(BaseModel):
         """Storage metadata for a semantic feature, including id and citations."""
 
-        citations: Annotated[
-            list[EpisodeIdT] | None,
-            Field(default=None, description=SpecDoc.SEMANTIC_METADATA_CITATIONS),
-        ]
-        id: Annotated[
-            FeatureIdT | None,
-            Field(default=None, description=SpecDoc.SEMANTIC_METADATA_ID),
-        ]
-        other: Annotated[
-            dict[str, Any] | None,
-            Field(default=None, description=SpecDoc.SEMANTIC_METADATA_OTHER),
-        ]
+        citations: list[EpisodeIdT] | None = Field(
+            default=None, description=SpecDoc.SEMANTIC_METADATA_CITATIONS
+        )
+        id: FeatureIdT | None = Field(
+            default=None, description=SpecDoc.SEMANTIC_METADATA_ID
+        )
+        other: dict[str, Any] | None = Field(
+            default=None, description=SpecDoc.SEMANTIC_METADATA_OTHER
+        )
 
-    set_id: Annotated[
-        SetIdT | None,
-        Field(default=None, description=SpecDoc.SEMANTIC_SET_ID),
-    ]
-    category: Annotated[
-        str,
-        Field(..., description=SpecDoc.SEMANTIC_CATEGORY),
-    ]
-    tag: Annotated[
-        str,
-        Field(..., description=SpecDoc.SEMANTIC_TAG),
-    ]
-    feature_name: Annotated[
-        str,
-        Field(..., description=SpecDoc.SEMANTIC_FEATURE_NAME),
-    ]
-    value: Annotated[
-        str,
-        Field(..., description=SpecDoc.SEMANTIC_VALUE),
-    ]
-    metadata: Annotated[
-        Metadata,
-        Field(default_factory=Metadata, description=SpecDoc.SEMANTIC_METADATA),
-    ]
+    set_id: SetIdT | None = Field(default=None, description=SpecDoc.SEMANTIC_SET_ID)
+    category: str = Field(..., description=SpecDoc.SEMANTIC_CATEGORY)
+    tag: str = Field(..., description=SpecDoc.SEMANTIC_TAG)
+    feature_name: str = Field(..., description=SpecDoc.SEMANTIC_FEATURE_NAME)
+    value: str = Field(..., description=SpecDoc.SEMANTIC_VALUE)
+    metadata: Metadata = Field(
+        default_factory=Metadata, description=SpecDoc.SEMANTIC_METADATA
+    )
 
 
 class InvalidNameError(ValueError):

--- a/packages/ts-client/src/memory/format.ts
+++ b/packages/ts-client/src/memory/format.ts
@@ -11,7 +11,20 @@
  * @packageDocumentation
  */
 
-import type { EpisodicMemory, SemanticMemory, SearchMemoriesResult } from './memmachine-memory.types'
+import type { SemanticMemory, SearchMemoriesResult } from './memmachine-memory.types'
+
+/**
+ * Minimal shape required to format an episode.
+ *
+ * Both search-response episodes ({@link EpisodicMemory}) and list-response
+ * episodes ({@link ListEpisodicMemory}) satisfy this shape, so
+ * {@link formatEpisodes} works with episodes from either endpoint.
+ */
+export interface FormattableEpisode {
+  created_at?: string | null
+  producer_id: string
+  content: string
+}
 
 const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'] as const
 const MONTHS = [
@@ -55,16 +68,24 @@ function _formatTime(date: Date): string {
  *
  * This mirrors the server's `string_from_episode_context` output.
  *
+ * Accepts any object with `created_at`, `producer_id`, and `content`,
+ * so both search-response and list-response episodes work without
+ * additional adaptation.
+ *
  * @param episodes - Episodic memory entries from a search or list result.
  * @returns Newline-terminated formatted string (empty string when episodes is empty).
  */
-export function formatEpisodes(episodes: EpisodicMemory[]): string {
+export function formatEpisodes(episodes: FormattableEpisode[]): string {
   let result = ''
   for (const episode of episodes) {
-    const date = new Date(episode.created_at)
-    const dateStr = _formatDate(date)
-    const timeStr = _formatTime(date)
-    result += `[${dateStr} at ${timeStr}] ${episode.producer_id}: ${JSON.stringify(episode.content)}\n`
+    if (episode.created_at) {
+      const date = new Date(episode.created_at)
+      const dateStr = _formatDate(date)
+      const timeStr = _formatTime(date)
+      result += `[${dateStr} at ${timeStr}] ${episode.producer_id}: ${JSON.stringify(episode.content)}\n`
+    } else {
+      result += `${episode.producer_id}: ${JSON.stringify(episode.content)}\n`
+    }
   }
   return result
 }

--- a/packages/ts-client/src/memory/format.ts
+++ b/packages/ts-client/src/memory/format.ts
@@ -1,0 +1,120 @@
+/**
+ * LLM-friendly formatting for memory search and list results.
+ *
+ * These functions mirror the server's internal formatting logic so that
+ * client-side consumers get the same compact representation the server
+ * uses when feeding memories into language models.
+ *
+ * Episodic format matches `string_from_episode_context` on the server.
+ * Semantic format matches `_features_to_llm_format` on the server.
+ *
+ * @packageDocumentation
+ */
+
+import type { EpisodicMemory, SemanticMemory, SearchMemoriesResult } from './memmachine-memory.types'
+
+const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'] as const
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December'
+] as const
+
+function _formatDate(date: Date): string {
+  const day = DAYS[date.getUTCDay()]
+  const month = MONTHS[date.getUTCMonth()]
+  const dd = String(date.getUTCDate()).padStart(2, '0')
+  const year = date.getUTCFullYear()
+  return `${day}, ${month} ${dd}, ${year}`
+}
+
+function _formatTime(date: Date): string {
+  let hours = date.getUTCHours()
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0')
+  const ampm = hours >= 12 ? 'PM' : 'AM'
+  hours = hours % 12 || 12
+  return `${String(hours).padStart(2, '0')}:${minutes} ${ampm}`
+}
+
+/**
+ * Format episodic memories as an LLM-friendly string.
+ *
+ * Each episode is rendered as:
+ * ```
+ * [Monday, January 01, 2024 at 01:30 PM] producer_id: "content"
+ * ```
+ *
+ * This mirrors the server's `string_from_episode_context` output.
+ *
+ * @param episodes - Episodic memory entries from a search or list result.
+ * @returns Newline-terminated formatted string (empty string when episodes is empty).
+ */
+export function formatEpisodes(episodes: EpisodicMemory[]): string {
+  let result = ''
+  for (const episode of episodes) {
+    const date = new Date(episode.created_at)
+    const dateStr = _formatDate(date)
+    const timeStr = _formatTime(date)
+    result += `[${dateStr} at ${timeStr}] ${episode.producer_id}: ${JSON.stringify(episode.content)}\n`
+  }
+  return result
+}
+
+/**
+ * Format semantic memories as a compact JSON string.
+ *
+ * Produces a `{tag: {feature_name: value}}` structure, omitting all
+ * metadata for context efficiency. This mirrors the server's
+ * `_features_to_llm_format` output.
+ *
+ * @param features - Semantic memory entries from a search or list result.
+ * @returns JSON string of the grouped features.
+ */
+export function formatSemanticMemories(features: SemanticMemory[]): string {
+  const structured: Record<string, Record<string, string>> = {}
+  for (const feature of features) {
+    if (!(feature.tag in structured)) {
+      structured[feature.tag] = {}
+    }
+    structured[feature.tag]![feature.feature_name] = feature.value
+  }
+  return JSON.stringify(structured)
+}
+
+/**
+ * Format a search result as an LLM-friendly string.
+ *
+ * Combines episodic and semantic memories from a {@link SearchMemoriesResult}
+ * returned by `MemMachineMemory.search()`.
+ *
+ * @param result - A `SearchMemoriesResult` object.
+ * @returns Formatted string combining both memory types.
+ */
+export function formatSearchResult(result: SearchMemoriesResult): string {
+  const sections: string[] = []
+
+  if (result.content.episodic_memory) {
+    const episodes = [
+      ...result.content.episodic_memory.long_term_memory.episodes,
+      ...result.content.episodic_memory.short_term_memory.episodes
+    ]
+    if (episodes.length > 0) {
+      sections.push(`[Episodic Memory]\n${formatEpisodes(episodes)}`)
+    }
+  }
+
+  if (result.content.semantic_memory && result.content.semantic_memory.length > 0) {
+    sections.push(`[Semantic Memory]\n${formatSemanticMemories(result.content.semantic_memory)}`)
+  }
+
+  return sections.join('\n')
+}

--- a/packages/ts-client/src/memory/index.ts
+++ b/packages/ts-client/src/memory/index.ts
@@ -5,6 +5,7 @@
  * @module memmachine-memory
  */
 export { MemMachineMemory } from './memmachine-memory'
+export { formatEpisodes, formatSemanticMemories, formatSearchResult } from './format'
 
 export type {
   MemoryType,
@@ -16,5 +17,6 @@ export type {
   AddMemoryResult,
   SearchMemoriesOptions,
   SearchMemoriesResult,
-  ListMemoriesOptions
+  ListMemoriesOptions,
+  ListMemoriesResult,
 } from './memmachine-memory.types'

--- a/packages/ts-client/src/memory/index.ts
+++ b/packages/ts-client/src/memory/index.ts
@@ -6,10 +6,12 @@
  */
 export { MemMachineMemory } from './memmachine-memory'
 export { formatEpisodes, formatSemanticMemories, formatSearchResult } from './format'
+export type { FormattableEpisode } from './format'
 
 export type {
   MemoryType,
   EpisodicMemory,
+  ListEpisodicMemory,
   SemanticMemory,
   MemoryContext,
   MemoryProducerRole,

--- a/packages/ts-client/src/memory/memmachine-memory.ts
+++ b/packages/ts-client/src/memory/memmachine-memory.ts
@@ -229,7 +229,7 @@ export class MemMachineMemory {
    * Implements the logic to list memories within MemMachine.
    *
    * @param options - Additional options for listing memories.
-   * @returns A promise that resolves to the search results.
+   * @returns A promise that resolves to the list results.
    * @throws {@link MemMachineAPIError} if the API request fails.
    */
   private async _listMemories(options?: ListMemoriesOptions): Promise<ListMemoriesResult> {

--- a/packages/ts-client/src/memory/memmachine-memory.ts
+++ b/packages/ts-client/src/memory/memmachine-memory.ts
@@ -9,7 +9,8 @@ import type {
   SearchMemoriesOptions,
   SearchMemoriesResult,
   AddMemoryResult,
-  ListMemoriesOptions
+  ListMemoriesOptions,
+  ListMemoriesResult
 } from './memmachine-memory.types'
 
 /**
@@ -102,7 +103,7 @@ export class MemMachineMemory {
    * @returns A promise that resolves to the search results.
    * @throws {@link MemMachineAPIError} if the API request fails.
    */
-  list(options?: ListMemoriesOptions): Promise<SearchMemoriesResult> {
+  list(options?: ListMemoriesOptions): Promise<ListMemoriesResult> {
     return this._listMemories(options)
   }
 
@@ -231,7 +232,7 @@ export class MemMachineMemory {
    * @returns A promise that resolves to the search results.
    * @throws {@link MemMachineAPIError} if the API request fails.
    */
-  private async _listMemories(options?: ListMemoriesOptions): Promise<SearchMemoriesResult> {
+  private async _listMemories(options?: ListMemoriesOptions): Promise<ListMemoriesResult> {
     const { page_size = 10, page_num = 0, filter = '', type = 'episodic' } = options ?? {}
 
     const payload = {

--- a/packages/ts-client/src/memory/memmachine-memory.ts
+++ b/packages/ts-client/src/memory/memmachine-memory.ts
@@ -100,7 +100,7 @@ export class MemMachineMemory {
    * Lists memories within MemMachine for the current project.
    *
    * @param options - Additional options for listing memories.
-   * @returns A promise that resolves to the search results.
+   * @returns A promise that resolves to the list results.
    * @throws {@link MemMachineAPIError} if the API request fails.
    */
   list(options?: ListMemoriesOptions): Promise<ListMemoriesResult> {

--- a/packages/ts-client/src/memory/memmachine-memory.types.ts
+++ b/packages/ts-client/src/memory/memmachine-memory.types.ts
@@ -154,6 +154,24 @@ export interface SearchMemoriesResult {
 }
 
 /**
+ * Represents the result of listing memories in MemMachine.
+ *
+ * Unlike {@link SearchMemoriesResult}, list results contain flat arrays
+ * of episodes and semantic memories rather than a nested long-term /
+ * short-term structure.
+ *
+ * @property status - Status code of the list operation result.
+ * @property content - Content of the list result, including episodic and semantic memories.
+ */
+export interface ListMemoriesResult {
+  status: number
+  content: {
+    episodic_memory?: EpisodicMemory[]
+    semantic_memory?: SemanticMemory[]
+  }
+}
+
+/**
  * Options for listing memories in MemMachine.
  *
  * @property page_size - Number of memories per page (optional).

--- a/packages/ts-client/src/memory/memmachine-memory.types.ts
+++ b/packages/ts-client/src/memory/memmachine-memory.types.ts
@@ -18,12 +18,12 @@ export type MemoryType = 'episodic' | 'semantic'
 export type MemoryProducerRole = 'user' | 'assistant' | 'system'
 
 /**
- * Represents an episodic memory entry in MemMachine.
+ * Represents an episodic memory entry returned by search.
  *
  * @property uid - Unique identifier for the memory entry.
- * @property score - Relevance score of the memory entry.
+ * @property score - Relevance score of the memory entry (may be null).
  * @property content - Content of the memory entry.
- * @property created_at - Timestamp when the memory entry was created.
+ * @property created_at - Timestamp when the memory entry was created (may be null).
  * @property producer_id - ID of the entity that produced the memory entry.
  * @property producer_role - Role of the producer.
  * @property produced_for_id - ID of the entity for whom the memory was produced.
@@ -32,16 +32,53 @@ export type MemoryProducerRole = 'user' | 'assistant' | 'system'
  */
 export interface EpisodicMemory {
   uid: string
-  score: number
+  score?: number | null
   content: string
+  created_at?: string | null
+
+  producer_id: string
+  producer_role: string
+  produced_for_id?: string | null
+
+  episode_type?: string | null
+  metadata?: Record<string, unknown> | null
+}
+
+/**
+ * Represents an episodic memory entry returned by list.
+ *
+ * Unlike {@link EpisodicMemory} (the search-response shape), list
+ * responses include storage fields like `session_key` and `sequence_num`
+ * but do not carry a relevance `score`.
+ *
+ * @property uid - Unique identifier for the memory entry.
+ * @property content - Content of the memory entry.
+ * @property session_key - Key of the session that owns the episode.
+ * @property created_at - Timestamp when the memory entry was created.
+ * @property producer_id - ID of the entity that produced the memory entry.
+ * @property producer_role - Role of the producer.
+ * @property produced_for_id - ID of the entity for whom the memory was produced.
+ * @property sequence_num - Monotonic ordering within the session.
+ * @property episode_type - Type of episode associated with the memory entry.
+ * @property content_type - Storage content type (e.g. "string").
+ * @property filterable_metadata - Indexed metadata usable as filters.
+ * @property metadata - Additional metadata associated with the memory entry.
+ */
+export interface ListEpisodicMemory {
+  uid: string
+  content: string
+  session_key: string
   created_at: string
 
   producer_id: string
   producer_role: string
-  produced_for_id?: string
+  produced_for_id?: string | null
 
-  episode_type: string
-  metadata?: Record<string, unknown>
+  sequence_num?: number
+  episode_type?: string
+  content_type?: string
+  filterable_metadata?: Record<string, unknown> | null
+  metadata?: Record<string, unknown> | null
 }
 
 /**
@@ -134,13 +171,17 @@ export interface SearchMemoriesOptions {
 /**
  * Represents the result of searching memories in MemMachine.
  *
+ * Both `episodic_memory` and `semantic_memory` may be omitted or null
+ * when the corresponding memory type was not requested or produced no
+ * results — the server uses `response_model_exclude_none`.
+ *
  * @property status - Status code of the search operation result.
  * @property content - Content of the search result, including episodic and semantic memories.
  */
 export interface SearchMemoriesResult {
   status: number
   content: {
-    episodic_memory: {
+    episodic_memory?: {
       long_term_memory: {
         episodes: EpisodicMemory[]
       }
@@ -148,8 +189,8 @@ export interface SearchMemoriesResult {
         episodes: EpisodicMemory[]
         episode_summary: string[]
       }
-    }
-    semantic_memory: SemanticMemory[]
+    } | null
+    semantic_memory?: SemanticMemory[] | null
   }
 }
 
@@ -166,8 +207,8 @@ export interface SearchMemoriesResult {
 export interface ListMemoriesResult {
   status: number
   content: {
-    episodic_memory?: EpisodicMemory[]
-    semantic_memory?: SemanticMemory[]
+    episodic_memory?: ListEpisodicMemory[] | null
+    semantic_memory?: SemanticMemory[] | null
   }
 }
 

--- a/packages/ts-client/tests/format.spec.ts
+++ b/packages/ts-client/tests/format.spec.ts
@@ -1,0 +1,248 @@
+import { formatEpisodes, formatSemanticMemories, formatSearchResult } from '@/memory/format'
+import type { EpisodicMemory, SemanticMemory, SearchMemoriesResult } from '@/memory/memmachine-memory.types'
+
+describe('formatEpisodes', () => {
+  it('returns empty string for empty array', () => {
+    expect(formatEpisodes([])).toBe('')
+  })
+
+  it('formats a single episode', () => {
+    const episode: EpisodicMemory = {
+      uid: '1',
+      score: 0.9,
+      content: 'Hello world',
+      created_at: '2024-01-15T13:30:00.000Z',
+      producer_id: 'user_1',
+      producer_role: 'user',
+      episode_type: 'message'
+    }
+    const result = formatEpisodes([episode])
+    expect(result).toBe('[Monday, January 15, 2024 at 01:30 PM] user_1: "Hello world"\n')
+  })
+
+  it('formats multiple episodes', () => {
+    const episodes: EpisodicMemory[] = [
+      {
+        uid: '1',
+        score: 0.9,
+        content: 'First message',
+        created_at: '2024-03-05T09:00:00.000Z',
+        producer_id: 'user_1',
+        producer_role: 'user',
+        episode_type: 'message'
+      },
+      {
+        uid: '2',
+        score: 0.8,
+        content: 'Second message',
+        created_at: '2024-03-05T09:01:00.000Z',
+        producer_id: 'assistant_1',
+        producer_role: 'assistant',
+        episode_type: 'message'
+      }
+    ]
+    const result = formatEpisodes(episodes)
+    const lines = result.trim().split('\n')
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toContain('user_1')
+    expect(lines[1]).toContain('assistant_1')
+  })
+
+  it('JSON-escapes content', () => {
+    const episode: EpisodicMemory = {
+      uid: '1',
+      score: 0.9,
+      content: 'She said "hello"',
+      created_at: '2024-01-01T00:00:00.000Z',
+      producer_id: 'user_1',
+      producer_role: 'user',
+      episode_type: 'message'
+    }
+    const result = formatEpisodes([episode])
+    expect(result).toContain(JSON.stringify('She said "hello"'))
+  })
+})
+
+describe('formatSemanticMemories', () => {
+  it('returns empty object for empty array', () => {
+    expect(formatSemanticMemories([])).toBe('{}')
+  })
+
+  it('formats a single feature', () => {
+    const feature: SemanticMemory = {
+      set_id: 'set_1',
+      category: 'profile',
+      tag: 'preferences',
+      feature_name: 'favorite_food',
+      value: 'pizza',
+      metadata: {}
+    }
+    const result = formatSemanticMemories([feature])
+    expect(JSON.parse(result)).toEqual({ preferences: { favorite_food: 'pizza' } })
+  })
+
+  it('groups features by tag', () => {
+    const features: SemanticMemory[] = [
+      {
+        set_id: 'set_1',
+        category: 'profile',
+        tag: 'preferences',
+        feature_name: 'food',
+        value: 'pizza',
+        metadata: {}
+      },
+      {
+        set_id: 'set_1',
+        category: 'profile',
+        tag: 'preferences',
+        feature_name: 'color',
+        value: 'blue',
+        metadata: {}
+      },
+      {
+        set_id: 'set_1',
+        category: 'profile',
+        tag: 'background',
+        feature_name: 'role',
+        value: 'engineer',
+        metadata: {}
+      }
+    ]
+    const result = formatSemanticMemories(features)
+    expect(JSON.parse(result)).toEqual({
+      preferences: { food: 'pizza', color: 'blue' },
+      background: { role: 'engineer' }
+    })
+  })
+
+  it('excludes metadata', () => {
+    const feature: SemanticMemory = {
+      set_id: 'set_1',
+      category: 'profile',
+      tag: 'info',
+      feature_name: 'name',
+      value: 'Alice',
+      metadata: {
+        id: 'feat_1',
+        citations: ['ep_1', 'ep_2'],
+        other: { source: 'conversation' }
+      }
+    }
+    const result = formatSemanticMemories([feature])
+    expect(JSON.parse(result)).toEqual({ info: { name: 'Alice' } })
+    expect(result).not.toContain('set_id')
+    expect(result).not.toContain('citations')
+    expect(result).not.toContain('feat_1')
+  })
+})
+
+describe('formatSearchResult', () => {
+  it('returns empty string for empty result', () => {
+    const result: SearchMemoriesResult = {
+      status: 0,
+      content: {
+        episodic_memory: {
+          long_term_memory: { episodes: [] },
+          short_term_memory: { episodes: [], episode_summary: [] }
+        },
+        semantic_memory: []
+      }
+    }
+    expect(formatSearchResult(result)).toBe('')
+  })
+
+  it('formats episodic only', () => {
+    const result: SearchMemoriesResult = {
+      status: 0,
+      content: {
+        episodic_memory: {
+          long_term_memory: {
+            episodes: [
+              {
+                uid: '1',
+                score: 0.9,
+                content: 'Hello',
+                created_at: '2024-01-01T12:00:00.000Z',
+                producer_id: 'user_1',
+                producer_role: 'user',
+                episode_type: 'message'
+              }
+            ]
+          },
+          short_term_memory: { episodes: [], episode_summary: [] }
+        },
+        semantic_memory: []
+      }
+    }
+    const formatted = formatSearchResult(result)
+    expect(formatted).toMatch(/^\[Episodic Memory\]\n/)
+    expect(formatted).toContain('user_1')
+    expect(formatted).toContain('"Hello"')
+    expect(formatted).not.toContain('[Semantic Memory]')
+  })
+
+  it('formats semantic only', () => {
+    const result: SearchMemoriesResult = {
+      status: 0,
+      content: {
+        episodic_memory: {
+          long_term_memory: { episodes: [] },
+          short_term_memory: { episodes: [], episode_summary: [] }
+        },
+        semantic_memory: [
+          {
+            set_id: 'set_1',
+            category: 'profile',
+            tag: 'prefs',
+            feature_name: 'food',
+            value: 'pizza',
+            metadata: {}
+          }
+        ]
+      }
+    }
+    const formatted = formatSearchResult(result)
+    expect(formatted).toMatch(/^\[Semantic Memory\]\n/)
+    expect(formatted).not.toContain('[Episodic Memory]')
+    const semanticJson = formatted.replace('[Semantic Memory]\n', '')
+    expect(JSON.parse(semanticJson)).toEqual({ prefs: { food: 'pizza' } })
+  })
+
+  it('formats combined result', () => {
+    const result: SearchMemoriesResult = {
+      status: 0,
+      content: {
+        episodic_memory: {
+          long_term_memory: {
+            episodes: [
+              {
+                uid: '1',
+                score: 0.9,
+                content: 'I like pizza',
+                created_at: '2024-01-01T12:00:00.000Z',
+                producer_id: 'user_1',
+                producer_role: 'user',
+                episode_type: 'message'
+              }
+            ]
+          },
+          short_term_memory: { episodes: [], episode_summary: [] }
+        },
+        semantic_memory: [
+          {
+            set_id: 'set_1',
+            category: 'profile',
+            tag: 'prefs',
+            feature_name: 'food',
+            value: 'pizza',
+            metadata: {}
+          }
+        ]
+      }
+    }
+    const formatted = formatSearchResult(result)
+    expect(formatted).toContain('[Episodic Memory]')
+    expect(formatted).toContain('[Semantic Memory]')
+    expect(formatted.indexOf('[Episodic Memory]')).toBeLessThan(formatted.indexOf('[Semantic Memory]'))
+  })
+})

--- a/packages/ts-client/tests/format.spec.ts
+++ b/packages/ts-client/tests/format.spec.ts
@@ -1,5 +1,10 @@
 import { formatEpisodes, formatSemanticMemories, formatSearchResult } from '@/memory/format'
-import type { EpisodicMemory, SemanticMemory, SearchMemoriesResult } from '@/memory/memmachine-memory.types'
+import type {
+  EpisodicMemory,
+  ListEpisodicMemory,
+  SemanticMemory,
+  SearchMemoriesResult
+} from '@/memory/memmachine-memory.types'
 
 describe('formatEpisodes', () => {
   it('returns empty string for empty array', () => {
@@ -60,6 +65,35 @@ describe('formatEpisodes', () => {
     }
     const result = formatEpisodes([episode])
     expect(result).toContain(JSON.stringify('She said "hello"'))
+  })
+
+  it('accepts list-shaped episodes (no score, adds session_key)', () => {
+    const episode: ListEpisodicMemory = {
+      uid: '1',
+      content: 'Listed item',
+      session_key: 'sess_1',
+      created_at: '2024-02-14T10:30:00.000Z',
+      producer_id: 'user_1',
+      producer_role: 'user',
+      sequence_num: 0,
+      episode_type: 'message'
+    }
+    const result = formatEpisodes([episode])
+    expect(result).toBe('[Wednesday, February 14, 2024 at 10:30 AM] user_1: "Listed item"\n')
+  })
+
+  it('omits timestamp prefix when created_at is missing', () => {
+    const result = formatEpisodes([
+      { content: 'No timestamp', producer_id: 'user_1' }
+    ])
+    expect(result).toBe('user_1: "No timestamp"\n')
+  })
+
+  it('omits timestamp prefix when created_at is null', () => {
+    const result = formatEpisodes([
+      { content: 'Null ts', producer_id: 'user_1', created_at: null }
+    ])
+    expect(result).toBe('user_1: "Null ts"\n')
   })
 })
 
@@ -206,6 +240,73 @@ describe('formatSearchResult', () => {
     expect(formatted).not.toContain('[Episodic Memory]')
     const semanticJson = formatted.replace('[Semantic Memory]\n', '')
     expect(JSON.parse(semanticJson)).toEqual({ prefs: { food: 'pizza' } })
+  })
+
+  it('returns empty string when both fields are undefined', () => {
+    const result: SearchMemoriesResult = {
+      status: 0,
+      content: {}
+    }
+    expect(formatSearchResult(result)).toBe('')
+  })
+
+  it('returns empty string when both fields are null', () => {
+    const result: SearchMemoriesResult = {
+      status: 0,
+      content: {
+        episodic_memory: null,
+        semantic_memory: null
+      }
+    }
+    expect(formatSearchResult(result)).toBe('')
+  })
+
+  it('handles episodic_memory undefined with semantic present', () => {
+    const result: SearchMemoriesResult = {
+      status: 0,
+      content: {
+        semantic_memory: [
+          {
+            set_id: 'set_1',
+            category: 'profile',
+            tag: 'prefs',
+            feature_name: 'food',
+            value: 'pizza',
+            metadata: {}
+          }
+        ]
+      }
+    }
+    const formatted = formatSearchResult(result)
+    expect(formatted).toMatch(/^\[Semantic Memory\]\n/)
+    expect(formatted).not.toContain('[Episodic Memory]')
+  })
+
+  it('handles semantic_memory undefined with episodic present', () => {
+    const result: SearchMemoriesResult = {
+      status: 0,
+      content: {
+        episodic_memory: {
+          long_term_memory: {
+            episodes: [
+              {
+                uid: '1',
+                score: 0.9,
+                content: 'Hello',
+                created_at: '2024-01-01T12:00:00.000Z',
+                producer_id: 'user_1',
+                producer_role: 'user',
+                episode_type: 'message'
+              }
+            ]
+          },
+          short_term_memory: { episodes: [], episode_summary: [] }
+        }
+      }
+    }
+    const formatted = formatSearchResult(result)
+    expect(formatted).toMatch(/^\[Episodic Memory\]\n/)
+    expect(formatted).not.toContain('[Semantic Memory]')
   })
 
   it('formats combined result', () => {


### PR DESCRIPTION
### Purpose of the change

Both clients currently have no way of formatting memories in LLM-friendly/context-efficient format.

### Description

Based on the logic of server's string_from_episode_context and internal formatting for semantic memories, add functions to do the same thing in clients.

Written entirely by Claude Code.

### Fixes/Closes

Addresses client/server form of #1278, but does not solve for MCP, which needs a redesign.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [ ] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected