### PR TITLE
chore: bump Node 20 → 24 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch full Git history for SCM versioning
 

--- a/.github/workflows/check-uvlockfile.yml
+++ b/.github/workflows/check-uvlockfile.yml
@@ -20,7 +20,7 @@ jobs:
     # Verifies that uv.lock matches the project configuration; update it before merging if this fails.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,14 +44,14 @@ jobs:
       # Step 1: Checkout source for Release triggers
       - name: Checkout source (Release)
         if: github.event_name == 'release'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       # Step 1: Checkout source for Manual triggers
       - name: Checkout source (Manual)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
@@ -144,14 +144,14 @@ jobs:
       # Step 1: Checkout source for Release triggers
       - name: Checkout source (Release)
         if: github.event_name == 'release'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       # Step 1: Checkout source for Manual triggers
       - name: Checkout source (Manual)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0

--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -29,16 +29,16 @@ jobs:
     strategy:
       fail-fast: false  # Continue running all matrix jobs even if one fails
       matrix:
-        node-version: [20, 22]  # Test against multiple Node.js versions
+        node-version: [22, 24]  # Test against multiple Node.js versions
 
     steps:
       # Step 1: Checkout the repository code
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       # Step 2: Set up Node.js for the current matrix version
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history needed for setuptools-scm versioning
 

--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -40,7 +40,7 @@ jobs:
       # ─────────────────────────────────────
       #
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         id: setup-python

--- a/.github/workflows/openclaw_plugin_publish.yml
+++ b/.github/workflows/openclaw_plugin_publish.yml
@@ -23,7 +23,7 @@ jobs:
         working-directory: ./integrations/openclaw/
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.version) || github.event.release.tag_name }}
 
@@ -49,7 +49,7 @@ jobs:
           '
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org/'

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -25,7 +25,7 @@ jobs:
       
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Create a '/sbom' directory to store the SBOM file in the project root.
       - name: Create SBOM directory

--- a/.github/workflows/sync-platform-openapi.yml
+++ b/.github/workflows/sync-platform-openapi.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 

--- a/.github/workflows/test-python-client-package.yml
+++ b/.github/workflows/test-python-client-package.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test-server-package.yml
+++ b/.github/workflows/test-server-package.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ts-client-publish.yml
+++ b/.github/workflows/ts-client-publish.yml
@@ -22,12 +22,12 @@ jobs:
         working-directory: ./packages/ts-client
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20.19.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Set version from release tag

--- a/.github/workflows/ts-client-test.yml
+++ b/.github/workflows/ts-client-test.yml
@@ -25,12 +25,12 @@ jobs:
         working-directory: ./packages/ts-client
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20.19.x'
+          node-version: '24.x'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
### Purpose of the change

Node.js 20 GitHub Actions are deprecated. This PR updates the minimum Node version to 24.

### Description

GitHub Actions is deprecating Node 20 runners on 2026-06-02. Three workflow files are still pinned to Node 20 and used checkout@v3 / setup-node@v3. Adopt the core of PR #1230 (by @DeoJin): update the matrix and version pins so CI runs on Node 22 and 24. Go further than #1230 on the action versions — jump actions/checkout and actions/setup-node to @v6 (latest) rather than @v4, since @v4 itself runs on Node 20 and would re-trip the same deprecation. @v5 is the floor (defaults to Node 24); @v6 is current.

Audited five additional workflows that carry actions/setup-python@v5 and actions/upload-artifact@v4; those action versions already bundle Node 24 binaries and require no changes.

### Fixes/Closes

Fixes: #1221
Closes: #1230

### Type of change

- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Integration Test

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None
