### PR TITLE
feat: add Apache AGE as an alternative graph backend

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,6 +16,13 @@ on:
 env:
   # Docker image name to publish
   IMAGE_NAME: memmachine/memmachine
+  # AGE + pgvector companion image (referenced by docker-compose.yml and the
+  # helm chart when ``episodicBackend=age``).
+  AGE_IMAGE_NAME: memmachine/postgres-age
+  # The AGE image version tracks the apache/age base tag it layers pgvector
+  # onto, not the MemMachine release cadence. Bump when updating the base in
+  # deployments/docker/postgres-age/Dockerfile.
+  AGE_IMAGE_TAG: pg16-1.6.0
 
 permissions:
   # Only need read access to repository contents for this workflow
@@ -220,3 +227,56 @@ jobs:
       # Step 7: Show the digest of the built GPU image (useful for traceability)
       - name: Show GPU image digest
         run: echo "GPU digest - ${{ steps.build_gpu.outputs.digest }}"
+
+  build-postgres-age:
+    name: Build and Push Postgres+AGE Image
+    # Independent of the MemMachine app build — AGE_IMAGE_TAG is pinned to
+    # the apache/age base version, not the MemMachine release. Runs in
+    # parallel with build-cpu (no ``needs:``) because it shares no cache.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source (Release)
+        if: github.event_name == 'release'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Checkout source (Manual)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_API_KEY }}
+
+      - name: Build and push Postgres+AGE image
+        id: build_age
+        uses: docker/build-push-action@v6
+        with:
+          context: ./deployments/docker/postgres-age
+          file: ./deployments/docker/postgres-age/Dockerfile
+          push: true
+          tags: ${{ env.AGE_IMAGE_NAME }}:${{ env.AGE_IMAGE_TAG }}
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}
+          # linux/amd64 only: the apache/age base image has historically not
+          # published arm64 variants consistently, so a multi-arch build can
+          # fail at "apt-get update" inside the arm64 emulation layer. Add
+          # linux/arm64 back once we confirm the pinned base tag ships it.
+          platforms: linux/amd64
+          cache-from: type=gha,scope=build-postgres-age
+          cache-to: type=gha,mode=max,scope=build-postgres-age
+
+      - name: Show Postgres+AGE image digest
+        run: echo "AGE digest - ${{ steps.build_age.outputs.digest }}"

--- a/DOCKER_COMPOSE_README.md
+++ b/DOCKER_COMPOSE_README.md
@@ -133,6 +133,58 @@ docker-compose down -v
 - **Neo4j** (ports 7474, 7687): Episodic memory with vector similarity
 - **MemMachine** (port 8080): Main API server (uses pre-built `memmachine/memmachine` image)
 
+### Apache AGE: single-Postgres alternative to Neo4j
+
+MemMachine can run against Apache AGE (openCypher over PostgreSQL, Apache-2.0) instead of Neo4j. AGE's image ships both the ``age`` and ``vector`` extensions, so one Postgres instance backs both the graph store and semantic memory — the same way the helm chart's ``episodicBackend=age`` mode does.
+
+**Option 1 (recommended): full AGE stack via `docker-compose.age.yml`**
+
+Mirrors the helm single-stack experience. Use this file instead of ``docker-compose.yml`` (not alongside it — both define a ``memmachine`` service).
+
+```bash
+# 1. Copy the AGE sample config and edit it (set API key; change
+#    host from ``localhost`` to ``postgres-age`` so MemMachine resolves
+#    the service name over the compose network).
+cp sample_configs/episodic_memory_config.age.sample configuration.yml
+
+# 2. Bring the stack up — one database, one command.
+docker compose -f docker-compose.age.yml up
+```
+
+**Option 2: AGE container + locally-installed server**
+
+If you'd rather run the server outside Docker, start just the AGE service from the base file and point a pip-installed MemMachine at it.
+
+```bash
+# 1. Start just the AGE-enabled Postgres from the base compose file.
+docker compose --profile age up postgres-age
+
+# 2. Install the server and point it at postgres-age on localhost.
+pip install memmachine
+cp sample_configs/episodic_memory_config.age.sample configuration.yml
+# Edit configuration.yml: keep host: localhost, set port to ${AGE_PORT:-5433},
+# and replace placeholders with your API key / password.
+memmachine-server --config configuration.yml
+```
+
+Both options use the same config shape:
+
+```yaml
+resources:
+  databases:
+    my_storage_id:
+      provider: age
+      config:
+        host: postgres-age     # or localhost for Option 2
+        port: 5432             # or ${AGE_PORT:-5433} for Option 2
+        user: ${AGE_USER:-memmachine}
+        password: ${AGE_PASSWORD:-memmachine_password}
+        db_name: ${AGE_DB:-memmachine}
+        graph_name: mem_graph
+```
+
+See ``sample_configs/episodic_memory_config.age.sample`` for a complete example including the pgvector-backed semantic-memory configuration that rides on the same Postgres.
+
 ## Configuration
 
 Key files:

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ See the [MCP documentation](https://docs.memmachine.ai/integrations/mcp) for set
 
 - **Multiple Memory Types**: Working (short-term), Episodic (long-term conversational), and Profile (user facts) memory
 - **Developer-Friendly APIs**: Python SDK, RESTful API, TypeScript SDK, and MCP server interfaces
-- **Flexible Storage**: Graph database (Neo4j) for episodic memory, SQL for profiles
+- **Flexible Storage**: Graph database (Neo4j, NebulaGraph, or Apache AGE) for episodic memory, SQL for profiles
 - **LLM Agnostic**: Works with OpenAI, Anthropic, Bedrock, Ollama, and any LLM provider
 - **Self-Hosted or Cloud**: Run locally, in Docker, or use our managed service
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -6,7 +6,7 @@ This guide helps AI coding assistants (like Cursor, Claude Code, Codex, etc.) un
 
 MemMachine provides two types of memory:
 
-- **Episodic Memory**: Stores conversational episodes (messages, interactions) in a graph database (Neo4j). Supports both short-term (recent context) and long-term (summarized) storage.
+- **Episodic Memory**: Stores conversational episodes (messages, interactions) in a graph database. Supported backends are Neo4j, NebulaGraph, and Apache AGE (openCypher over PostgreSQL). Supports both short-term (recent context) and long-term (summarized) storage.
 - **Semantic Memory**: User-specific facts, preferences, and knowledge extracted from conversations. Uses vector embeddings for semantic search and is stored in PostgreSQL.
 
 ## Installation

--- a/deployments/docker/postgres-age/Dockerfile
+++ b/deployments/docker/postgres-age/Dockerfile
@@ -1,0 +1,13 @@
+# Apache AGE + pgvector in a single PostgreSQL image.
+#
+# The upstream ``apache/age`` images only bundle the AGE extension. MemMachine's
+# ``vector_graph_store`` with ``provider: age`` also needs pgvector for the
+# similarity side tables, so this Dockerfile apt-installs
+# ``postgresql-16-pgvector`` on top of the official AGE image. The base is
+# pinned to a specific release tag to keep builds reproducible.
+ARG AGE_BASE=apache/age:release_PG16_1.6.0
+FROM ${AGE_BASE}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-16-pgvector \
+    && rm -rf /var/lib/apt/lists/*

--- a/deployments/helm/Chart.yaml
+++ b/deployments/helm/Chart.yaml
@@ -5,7 +5,7 @@
 # container image version changes.
 apiVersion: v2
 name: memmachine
-description: A Helm chart for deploying memmachine, Neo4j, and Postgres
+description: A Helm chart for deploying memmachine with Neo4j or Apache AGE and Postgres
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "v0.2.6"

--- a/deployments/helm/README.md
+++ b/deployments/helm/README.md
@@ -1,6 +1,21 @@
 # MemMachine Helm Chart
 
-Deploys MemMachine with optional in-cluster PostgreSQL (pgvector) and Neo4j. Both databases can be replaced with external instances via `postgres.enabled=false` / `neo4j.enabled=false`.
+Deploys MemMachine with optional in-cluster PostgreSQL (pgvector), Neo4j, and Apache AGE (openCypher over PostgreSQL). Any of the three databases can be replaced with external instances via `postgres.enabled=false` / `neo4j.enabled=false` / `postgresAge.enabled=false`.
+
+### Choosing an episodic backend
+
+`episodicBackend` (top-level, values: `neo4j` | `age`, default `neo4j`) picks which graph backend MemMachine connects to. This is **orthogonal** to the per-backend `*.enabled` flags, which control whether the chart deploys that backend in-cluster:
+
+| episodicBackend | neo4j.enabled | postgresAge.enabled | Effect |
+|-----------------|---------------|---------------------|--------|
+| `neo4j`         | `true`        | `false`             | Default. In-cluster Neo4j + in-cluster pgvector Postgres. |
+| `neo4j`         | `false`       | `false`             | External Neo4j (override `neo4j.host`) + in-cluster or external Postgres. |
+| `age`           | `false`       | `true`              | Apache-2.0, single-Postgres stack: in-cluster AGE-enabled Postgres backs both the graph store and semantic memory. The standalone pgvector `postgres` Deployment is **automatically skipped**. |
+| `age`           | `false`       | `false`             | External AGE-enabled Postgres (override `postgresAge.host`, set `postgresAge.password`). |
+
+In AGE mode, `postgres.enabled` is ignored: the postgres-age image bakes in both `age` and `vector`, so the chart collapses semantic memory, session_manager, episode_store, and config_database onto the same Postgres that holds the graph. One database service for the whole stack.
+
+For an Apache-2.0-licensed stack, set `episodicBackend=age`, `postgresAge.enabled=true`, and `neo4j.enabled=false`; the chart renders `db_age` (provider `age`) into the generated `configuration.yml`, skips the standalone `postgres` Deployment, and swaps the `wait-for-neo4j` init container for `wait-for-postgres-age`.
 
 ## Chart Info
 

--- a/deployments/helm/templates/memmachine-configmaps.yaml
+++ b/deployments/helm/templates/memmachine-configmaps.yaml
@@ -1,3 +1,6 @@
+{{- if not (has .Values.episodicBackend (list "neo4j" "age")) -}}
+{{ fail (printf "episodicBackend must be one of: neo4j, age (got %q)" .Values.episodicBackend) }}
+{{- end -}}
 # memmachine-configmaps.yaml
 # Defines two ConfigMaps for the MemMachine application:
 #
@@ -31,7 +34,11 @@ data:
       long_term_memory:
         embedder: default_embedder
         reranker: my_reranker_id
+        {{- if eq .Values.episodicBackend "age" }}
+        vector_graph_store: db_age
+        {{- else }}
         vector_graph_store: db_neo4j
+        {{- end }}
       short_term_memory:
         llm_model: default_model
         message_capacity: 500
@@ -54,6 +61,23 @@ data:
         db_postgres:
           provider: postgres
           config:
+            {{- if eq .Values.episodicBackend "age" }}
+            # Single-Postgres stack: semantic memory, session_manager,
+            # episode_store, and config_database all ride on the same
+            # AGE-enabled Postgres as the graph store. postgresAge.image
+            # ships both ``age`` and ``vector`` extensions, so pgvector is
+            # available for semantic memory without a separate instance.
+            host: {{ .Values.postgresAge.host }}
+            port: {{ .Values.postgresAge.port }}
+            user: {{ .Values.postgresAge.user }}
+            password: $POSTGRES_PASSWORD
+            db_name: {{ .Values.postgresAge.database }}
+            pool_size: {{ .Values.postgresAge.pool_size }}
+            max_overflow: {{ .Values.postgresAge.max_overflow }}
+            pool_timeout: {{ .Values.postgresAge.pool_timeout }}
+            pool_recycle: {{ .Values.postgresAge.pool_recycle }}
+            pool_pre_ping: {{ .Values.postgresAge.pool_pre_ping }}
+            {{- else }}
             host: {{ .Values.postgres.host }}
             port: {{ .Values.postgres.port }}
             user: {{ .Values.postgres.user }}
@@ -64,6 +88,8 @@ data:
             pool_timeout: {{ .Values.postgres.pool_timeout }}
             pool_recycle: {{ .Values.postgres.pool_recycle }}
             pool_pre_ping: {{ .Values.postgres.pool_pre_ping }}
+            {{- end }}
+        {{- if eq .Values.episodicBackend "neo4j" }}
         db_neo4j:
           provider: neo4j
           config:
@@ -78,6 +104,30 @@ data:
             {{- if ne .Values.neo4j.pool.liveness_check_timeout nil }}
             liveness_check_timeout: {{ .Values.neo4j.pool.liveness_check_timeout }}
             {{- end }}
+        {{- end }}
+        {{- if eq .Values.episodicBackend "age" }}
+        db_age:
+          provider: age
+          config:
+            host: {{ .Values.postgresAge.host }}
+            port: {{ .Values.postgresAge.port }}
+            user: {{ .Values.postgresAge.user }}
+            # db_postgres and db_age point at the same Postgres in AGE mode,
+            # so both resolve ``$POSTGRES_PASSWORD`` (sourced from
+            # postgres-age-secret when episodicBackend=age).
+            password: $POSTGRES_PASSWORD
+            db_name: {{ .Values.postgresAge.database }}
+            graph_name: {{ .Values.postgresAge.graph_name }}
+            range_index_creation_threshold: {{ .Values.postgresAge.range_index_creation_threshold }}
+            vector_index_creation_threshold: {{ .Values.postgresAge.vector_index_creation_threshold }}
+            hnsw_m: {{ .Values.postgresAge.hnsw_m }}
+            hnsw_ef_construction: {{ .Values.postgresAge.hnsw_ef_construction }}
+            pool_size: {{ .Values.postgresAge.pool_size }}
+            max_overflow: {{ .Values.postgresAge.max_overflow }}
+            pool_timeout: {{ .Values.postgresAge.pool_timeout }}
+            pool_recycle: {{ .Values.postgresAge.pool_recycle }}
+            pool_pre_ping: {{ .Values.postgresAge.pool_pre_ping }}
+        {{- end }}
       embedders:
         default_embedder:
           provider: "{{ .Values.memmachine.embedder.provider }}"
@@ -112,10 +162,17 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   .env: |
+    {{- if eq .Values.episodicBackend "age" }}
+    POSTGRES_HOST={{ .Values.postgresAge.host }}
+    POSTGRES_PORT={{ .Values.postgresAge.port }}
+    POSTGRES_USER={{ .Values.postgresAge.user }}
+    POSTGRES_DB={{ .Values.postgresAge.database }}
+    {{- else }}
     POSTGRES_HOST={{ .Values.postgres.host }}
     POSTGRES_PORT={{ .Values.postgres.port }}
     POSTGRES_USER={{ .Values.postgres.user }}
     POSTGRES_DB={{ .Values.postgres.database }}
+    {{- end }}
     MCP_BASE_URL={{ .Values.memmachine.config.baseUrl }}
     GATEWAY_URL={{ .Values.memmachine.config.gatewayUrl }}
     FAST_MCP_LOG_LEVEL={{ .Values.memmachine.config.loggingLevel }}

--- a/deployments/helm/templates/memmachine-deployment.yaml
+++ b/deployments/helm/templates/memmachine-deployment.yaml
@@ -22,13 +22,21 @@ spec:
         app: memmachine
     spec:
       initContainers:
+        {{- if eq .Values.episodicBackend "age" }}
+        # Single-Postgres stack: wait for the AGE-enabled Postgres only.
+        # The standalone ``postgres`` Deployment is skipped in AGE mode
+        # because postgresAge.image ships both ``age`` and ``vector``.
+        - name: wait-for-postgres
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -zv {{ .Values.postgresAge.host }} {{ .Values.postgresAge.port }}; do echo waiting for postgres-age; sleep 2; done']
+        {{- else }}
         - name: wait-for-postgres
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -zv {{ .Values.postgres.host }} {{ .Values.postgres.port }}; do echo waiting for postgres; sleep 2; done']
-
         - name: wait-for-neo4j
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -zv {{ .Values.neo4j.host }} {{ .Values.neo4j.port }}; do echo waiting for neo4j; sleep 2; done']
+        {{- end }}
 
       containers:
         - name: memmachine
@@ -60,11 +68,20 @@ spec:
                 secretKeyRef:
                   name: memmachine-secrets
                   key: OPENAI_API_KEY
+            # POSTGRES_PASSWORD is the sole Postgres credential env var.
+            # In AGE mode it comes from postgres-age-secret (the only
+            # Postgres MemMachine talks to); in Neo4j mode it comes from
+            # postgres-secret (the pgvector instance for semantic memory).
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{- if eq .Values.episodicBackend "age" }}
+                  name: postgres-age-secret
+                  {{- else }}
                   name: postgres-secret
+                  {{- end }}
                   key: POSTGRES_PASSWORD
+            {{- if eq .Values.episodicBackend "neo4j" }}
             - name: NEO4J_USER
               valueFrom:
                 secretKeyRef:
@@ -75,6 +92,7 @@ spec:
                 secretKeyRef:
                   name: neo4j-secret
                   key: NEO4J_PASSWORD
+            {{- end }}
             - name: LOG_FILE
               value: "/app/data/memmachine.log"
             - name: MEMORY_CONFIG

--- a/deployments/helm/templates/postgres-age-deployment.yaml
+++ b/deployments/helm/templates/postgres-age-deployment.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.postgresAge.enabled }}
+# postgres-age-deployment.yaml
+# Deploys an Apache AGE-enabled PostgreSQL instance (openCypher over Postgres
+# with pgvector), suitable as an Apache-2.0-licensed alternative to Neo4j for
+# episodic memory storage.
+#
+# The referenced image (.Values.postgresAge.image) must ship BOTH the ``age``
+# and ``vector`` extensions. The upstream apache/age image only ships AGE, so
+# operators should build the combined image from
+# deployments/docker/postgres-age/ and push it to their registry before
+# enabling this deployment.
+#
+# postgresAge.enabled controls only whether this in-cluster Deployment (plus
+# its Service/PVC) renders. Pointing MemMachine at AGE is a separate,
+# orthogonal decision controlled by the top-level ``episodicBackend`` value
+# (``neo4j`` | ``age``) — see the chart README. Typical in-cluster AGE stack:
+# ``episodicBackend=age`` + ``postgresAge.enabled=true`` + ``neo4j.enabled=false``.
+# Side tables for vector similarity are created in the ``public`` schema of
+# the same database, keyed by vertex uid. Data is persisted to
+# postgres-age-pvc at /var/lib/postgresql/data.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: memmachine-postgres-age
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: memmachine-postgres-age
+  template:
+    metadata:
+      labels:
+        app: memmachine-postgres-age
+    spec:
+      containers:
+        - name: postgres-age
+          image: {{ .Values.postgresAge.image }}
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresAge.database }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresAge.user }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-age-secret
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_INITDB_ARGS
+              value: "--encoding=UTF-8 --lc-collate=C --lc-ctype=C"
+          resources:
+            {{- toYaml .Values.postgresAge.resources | nindent 12 }}
+          livenessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresAge.user }}
+                - -d
+                - {{ .Values.postgresAge.database }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          volumeMounts:
+            - name: postgres-age-storage
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgres-age-storage
+          persistentVolumeClaim:
+            claimName: postgres-age-pvc
+{{- end }}

--- a/deployments/helm/templates/postgres-age-service.yaml
+++ b/deployments/helm/templates/postgres-age-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgresAge.enabled }}
+# postgres-age-service.yaml
+# ClusterIP Service for internal access to the AGE-enabled PostgreSQL on
+# port 5432. DNS inside the cluster:
+#   memmachine-postgres-age.<namespace>.svc.cluster.local
+# Point the MemMachine AgeConf at host: memmachine-postgres-age to use this
+# as the episodic-memory backend.
+apiVersion: v1
+kind: Service
+metadata:
+  name: memmachine-postgres-age
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: memmachine-postgres-age
+  ports:
+    - port: 5432
+      targetPort: 5432
+{{- end }}

--- a/deployments/helm/templates/postgres-deployment.yaml
+++ b/deployments/helm/templates/postgres-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.postgres.enabled }}
+{{- if and .Values.postgres.enabled (ne .Values.episodicBackend "age") }}
 # postgres-deployment.yaml
 # Deploys PostgreSQL with the pgvector extension (1 replica).
 # Used by MemMachine for: episode storage, semantic memory, profile/config data,
@@ -6,6 +6,11 @@
 # from the postgres-secret Secret. The database is initialized with UTF-8
 # encoding and C locale via POSTGRES_INITDB_ARGS.
 # Data is persisted to the postgres-pvc PVC at /var/lib/postgresql/data.
+#
+# In AGE mode (``episodicBackend=age``) this deployment is skipped: the
+# postgres-age image already ships the ``vector`` extension, so semantic
+# memory rides on the same Postgres as the graph store — one database
+# service for the whole stack.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deployments/helm/templates/postgres-service.yaml
+++ b/deployments/helm/templates/postgres-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.postgres.enabled }}
+{{- if and .Values.postgres.enabled (ne .Values.episodicBackend "age") }}
 # postgres-service.yaml
 # ClusterIP Service for internal access to PostgreSQL on port 5432.
 # DNS inside the cluster: memmachine-postgres.<namespace>.svc.cluster.local

--- a/deployments/helm/templates/pvc.yaml
+++ b/deployments/helm/templates/pvc.yaml
@@ -21,12 +21,27 @@ spec:
       storage: {{ .Values.pvcSize }}
   storageClassName: {{ .Values.storageClass }}
 {{- end }}
-{{- if .Values.postgres.enabled }}
+{{- if and .Values.postgres.enabled (ne .Values.episodicBackend "age") }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: postgres-pvc
+  namespace: {{ $namespace }}
+spec:
+  accessModes:
+    - {{ .Values.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.pvcSize }}
+  storageClassName: {{ .Values.storageClass }}
+{{- end }}
+{{- if .Values.postgresAge.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-age-pvc
   namespace: {{ $namespace }}
 spec:
   accessModes:

--- a/deployments/helm/templates/secrets.yaml
+++ b/deployments/helm/templates/secrets.yaml
@@ -47,3 +47,24 @@ stringData:
   NEO4J_USER: {{ .Values.neo4j.user }}
   NEO4J_PASSWORD: {{ .Values.neo4j.password }}
   NEO4J_AUTH: {{ .Values.neo4j.user }}/{{ .Values.neo4j.password }}
+{{- if or .Values.postgresAge.enabled (eq .Values.episodicBackend "age") }}
+---
+# postgres-age-secret
+# Holds PostgreSQL credentials for the AGE-enabled instance. Consumed by the
+# in-cluster postgres-age Deployment (when postgresAge.enabled=true) and by
+# the MemMachine Deployment (when episodicBackend=age, regardless of whether
+# AGE is in-cluster or external — parallel to how neo4j-secret renders
+# unconditionally).
+#
+# Key is ``POSTGRES_PASSWORD`` (not ``POSTGRES_AGE_PASSWORD``) so the
+# MemMachine Deployment can source the same env var name from either this
+# secret or postgres-secret depending on episodicBackend.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-age-secret
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: {{ .Values.postgresAge.password }}
+{{- end }}

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -16,6 +16,14 @@ storageClass: nfs-client
 accessMode: ReadWriteMany
 pvcSize: 5Gi
 
+# Which graph backend MemMachine connects to for episodic memory. Orthogonal
+# to the per-backend ``.enabled`` flags below: those control whether the chart
+# deploys that backend in-cluster, while this picks which one the app talks
+# to. "neo4j" (default) + neo4j.enabled=false means use an external Neo4j;
+# "age" + postgresAge.enabled=false means use an external AGE-enabled
+# Postgres.
+episodicBackend: neo4j  # one of: neo4j | age
+
 neo4j:
   enabled: true              # false = skip in-cluster Deployment/Service/PVC, use external host
   host: memmachine-neo4j     # internal service name (default); override when enabled: false
@@ -41,14 +49,64 @@ neo4j:
     max_connection_lifetime: 3600        # driver default (1 hour); lower for AuraDB (e.g. 3000)
     # liveness_check_timeout: ~          # driver default (disabled); set to 0 to always check
 
+# Standalone PostgreSQL (pgvector) for semantic memory, session_manager,
+# episode_store, and config_database. When ``episodicBackend: age`` is set,
+# this Deployment/Service/PVC is skipped: the postgres-age image ships
+# ``vector`` too, so all relational workloads ride on the AGE-enabled
+# instance instead (the "single-Postgres stack" story).
 postgres:
-  enabled: true              # false = skip in-cluster Deployment/Service/PVC, use external host
+  enabled: true              # false = skip in-cluster Deployment/Service/PVC, use external host (ignored in AGE mode)
   host: memmachine-postgres  # internal service name (default); override when enabled: false
   port: 5432                 # default Postgres port; override if external uses different port
   image: pgvector/pgvector:pg16
   user: memmachine
   password: memverge   # dev default; override in production
   database: memmachine
+  pool_size: 5
+  max_overflow: 10
+  pool_timeout: 30      # SQLAlchemy default (seconds to wait for a connection)
+  pool_recycle: -1      # SQLAlchemy default (disabled; set to e.g. 3000 for idle-timeout avoidance)
+  pool_pre_ping: false  # SQLAlchemy default; set to true to test connections before checkout
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      memory: 2Gi
+
+# Apache AGE: PostgreSQL extension adding openCypher support. When enabled,
+# this chart deploys a second PostgreSQL instance that ships with the ``age``
+# and ``vector`` extensions installed, suitable for use as the MemMachine
+# vector_graph_store via ``provider: age`` in configuration.yml. Users who
+# want to stand up an AGE-only stack should set ``neo4j.enabled: false`` and
+# point the episodic configuration at ``memmachine-postgres-age``.
+#
+# The referenced image must ship BOTH ``age`` and ``vector`` extensions. The
+# upstream ``apache/age`` images bundle only AGE, so operators are expected to
+# build and push a combined image from ``deployments/docker/postgres-age/``
+# and set ``postgresAge.image`` to its registry path. Example::
+#
+#   docker build -t my-registry/postgres-age:pg16-1.6.0 \
+#       deployments/docker/postgres-age
+#   docker push my-registry/postgres-age:pg16-1.6.0
+postgresAge:
+  enabled: false                       # opt-in; leave false for Neo4j-default installs
+  host: memmachine-postgres-age        # internal service name when enabled: true
+  port: 5432
+  # Override to point at your built+pushed image (see note above). The default
+  # value is a placeholder: it will ImagePullBackOff unless you build and
+  # push the image under this name, or override with your own path.
+  image: memmachine/postgres-age:pg16-1.6.0
+  user: memmachine
+  password: CHANGE_ME                  # dev placeholder; MUST override in production
+  database: memmachine
+  graph_name: mem_graph
+  range_index_creation_threshold: 10000
+  vector_index_creation_threshold: 10000
+  hnsw_m: 16
+  hnsw_ef_construction: 64
+  # SQLAlchemy connection-pool tuning. Applies to both db_age (AgeConf) and
+  # db_postgres (SqlAlchemyConf) in AGE mode, since both share this Postgres.
   pool_size: 5
   max_overflow: 10
   pool_timeout: 30      # SQLAlchemy default (seconds to wait for a connection)

--- a/docker-compose.age.yml
+++ b/docker-compose.age.yml
@@ -1,0 +1,106 @@
+# docker-compose.age.yml
+# Apache-2.0, single-Postgres MemMachine stack.
+#
+# Use this file *instead of* ``docker-compose.yml`` (not in addition to it)
+# when you want to run MemMachine against Apache AGE rather than Neo4j.
+# This deploys exactly one database service — an AGE-enabled Postgres that
+# ships ``age`` + ``vector`` — and wires MemMachine to use it for both the
+# graph store (via provider: age) and semantic memory (via pgvector), the
+# same way the helm chart's ``episodicBackend=age`` mode does.
+#
+# Usage:
+#
+#   # 1. Copy the sample config and edit it (set API key, adjust host to
+#   #    ``postgres-age`` so MemMachine resolves the service over the
+#   #    compose network rather than localhost).
+#   cp sample_configs/episodic_memory_config.age.sample configuration.yml
+#
+#   # 2. Bring the stack up.
+#   docker compose -f docker-compose.age.yml up
+#
+# The base ``docker-compose.yml`` (Neo4j-backed stack) is untouched and still
+# the default ``docker compose up`` experience. Pick whichever file matches
+# the backend you want — running both files simultaneously isn't supported
+# because both define a ``memmachine`` service.
+
+services:
+  # Apache AGE-enabled PostgreSQL. Ships both the ``age`` extension (for the
+  # MemMachine vector_graph_store) and the ``vector`` extension (for
+  # pgvector-backed semantic memory) in one Postgres process.
+  postgres-age:
+    image: ${AGE_IMAGE:-memmachine/postgres-age:pg16-1.6.0}
+    build:
+      context: ./deployments/docker/postgres-age
+    container_name: memmachine-postgres-age
+    restart: unless-stopped
+    ports:
+      - "${AGE_PORT:-5432}:5432"
+    environment:
+      POSTGRES_DB: ${AGE_DB:-memmachine}
+      POSTGRES_USER: ${AGE_USER:-memmachine}
+      POSTGRES_PASSWORD: ${AGE_PASSWORD:-memmachine_password}
+      POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --lc-collate=C --lc-ctype=C"
+    volumes:
+      - postgres_age_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${AGE_USER:-memmachine} -d ${AGE_DB:-memmachine}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - memmachine-network
+
+  memmachine:
+    image: ${MEMMACHINE_IMAGE:-memmachine/memmachine}
+    pull_policy: ${PULL_POLICY:-always}
+    container_name: memmachine-app
+    restart: unless-stopped
+    ports:
+      - "${MEMORY_SERVER_PORT:-8080}:8080"
+    environment:
+      # POSTGRES_* point at the AGE instance. Alembic pgvector migrations
+      # read these at startup; the app's own db_postgres / db_age entries
+      # resolve ``password: $POSTGRES_PASSWORD`` against the same value so
+      # both relational and graph workloads land on one Postgres.
+      POSTGRES_HOST: postgres-age
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${AGE_USER:-memmachine}
+      POSTGRES_PASSWORD: ${AGE_PASSWORD:-memmachine_password}
+      POSTGRES_DB: ${AGE_DB:-memmachine}
+
+      MEMORY_CONFIG: ${MEMORY_CONFIG:-/app/configuration.yml}
+      MCP_BASE_URL: ${MCP_BASE_URL:-http://memmachine:8080}
+      GATEWAY_URL: ${GATEWAY_URL:-http://localhost:8080}
+      FAST_MCP_LOG_LEVEL: ${FAST_MCP_LOG_LEVEL:-INFO}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      MEMMACHINE_WORKERS: ${MEMMACHINE_WORKERS:-1}
+      MEMMACHINE_CONFIG_API: ${MEMMACHINE_CONFIG_API:-}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      HOST: 0.0.0.0
+    volumes:
+      - ./configuration.yml:/app/configuration.yml:rw,Z
+      - memmachine_logs:/tmp/memory_logs
+    depends_on:
+      postgres-age:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://localhost:8080/api/v2/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    networks:
+      - memmachine-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+volumes:
+  postgres_age_data:
+    driver: local
+  memmachine_logs:
+    driver: local
+
+networks:
+  memmachine-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,48 @@ services:
     networks:
       - memmachine-network
 
+  # Apache AGE: PostgreSQL + openCypher + pgvector in a single container.
+  #
+  # Opt-in via the ``age`` profile. Intended for the "run postgres-age
+  # alongside a locally-installed memmachine-server" workflow (Option 2 in
+  # DOCKER_COMPOSE_README). For a full in-compose AGE stack where
+  # MemMachine itself runs against AGE rather than Neo4j, use the separate
+  # ``docker-compose.age.yml`` file instead — it's self-contained and
+  # mirrors the helm chart's ``episodicBackend=age`` single-Postgres
+  # behavior.
+  #
+  # The profile deliberately does not pull in ``memmachine`` so that the
+  # default ``docker compose up`` flow continues to work unchanged for
+  # Neo4j users.
+  postgres-age:
+    # apache/age only ships the AGE extension, so we layer pgvector on top
+    # via a local Dockerfile. ``docker compose --profile age build`` produces
+    # the image; operators who prefer a pre-built image can override
+    # ``AGE_IMAGE`` and skip the build.
+    image: ${AGE_IMAGE:-memmachine/postgres-age:pg16-1.6.0}
+    build:
+      context: ./deployments/docker/postgres-age
+    container_name: memmachine-postgres-age
+    restart: unless-stopped
+    profiles:
+      - age
+    ports:
+      - "${AGE_PORT:-5433}:5432"
+    environment:
+      POSTGRES_DB: ${AGE_DB:-memmachine}
+      POSTGRES_USER: ${AGE_USER:-memmachine}
+      POSTGRES_PASSWORD: ${AGE_PASSWORD:-memmachine_password}
+    volumes:
+      - postgres_age_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${AGE_USER:-memmachine} -d ${AGE_DB:-memmachine}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - memmachine-network
+
   # MemMachine application
   memmachine:
     image: ${MEMMACHINE_IMAGE:-memmachine/memmachine}
@@ -118,6 +160,8 @@ services:
 
 volumes:
   postgres_data:
+    driver: local
+  postgres_age_data:
     driver: local
   neo4j_data:
     driver: local

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
@@ -6,6 +6,7 @@ from pydantic import SecretStr
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from memmachine_server.common.configuration.database_conf import (
+    AgeConf,
     DatabasesConf,
     Neo4jConf,
     SqlAlchemyConf,
@@ -41,6 +42,7 @@ def mock_conf():
     }
     conf.sqlite_confs = {}
     conf.nebula_graph_confs = {}
+    conf.age_confs = {}
     return conf
 
 
@@ -90,6 +92,7 @@ async def test_build_and_validate_sqlite():
     conf = MagicMock(spec=DatabasesConf)
     conf.neo4j_confs = {}
     conf.nebula_graph_confs = {}
+    conf.age_confs = {}
     conf.relational_db_confs = {
         "sqlite1": SqlAlchemyConf(
             dialect="sqlite",
@@ -136,6 +139,7 @@ async def test_neo4j_pool_lifecycle_kwargs():
     conf.neo4j_confs = {"neo1": neo4j_conf}
     conf.relational_db_confs = {}
     conf.nebula_graph_confs = {}
+    conf.age_confs = {}
 
     mock_driver = MagicMock()
     mock_driver.close = AsyncMock()
@@ -204,6 +208,7 @@ async def test_neo4j_pool_lifecycle_kwargs_none_omitted():
     conf.neo4j_confs = {"neo1": neo4j_conf}
     conf.relational_db_confs = {}
     conf.nebula_graph_confs = {}
+    conf.age_confs = {}
 
     mock_driver = MagicMock()
     mock_driver.close = AsyncMock()
@@ -254,3 +259,187 @@ async def test_sqlalchemy_pool_lifecycle_kwargs_none_omitted():
     assert "pool_timeout" not in call_kwargs
     assert "pool_recycle" not in call_kwargs
     assert "pool_pre_ping" not in call_kwargs
+
+
+def _age_conf(**overrides: Any) -> AgeConf:
+    defaults: dict[str, Any] = {
+        "host": "localhost",
+        "port": 5432,
+        "user": "postgres",
+        "password": SecretStr("pw"),
+        "db_name": "memmachine",
+        "graph_name": "mem_graph",
+    }
+    defaults.update(overrides)
+    return AgeConf(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_build_age(mock_conf):
+    """AGE engine + graph store are both created and registered under the conf name."""
+    mock_conf.age_confs = {"age1": _age_conf()}
+    mock_engine = MagicMock(spec=AsyncEngine)
+    mock_engine.sync_engine = MagicMock()
+
+    with (
+        patch(
+            "memmachine_server.common.resource_manager.database_manager.create_async_engine",
+            return_value=mock_engine,
+        ),
+        patch(
+            "memmachine_server.common.resource_manager.database_manager._register_age_connect_hook",
+        ),
+        patch(
+            "memmachine_server.common.resource_manager.database_manager.AgeVectorGraphStore",
+        ) as mock_store_cls,
+    ):
+        builder = DatabaseManager(mock_conf)
+        await builder.async_get_age_engine("age1")
+
+    assert builder.age_engines["age1"] is mock_engine
+    assert builder.graph_stores["age1"] is mock_store_cls.return_value
+
+
+@pytest.mark.asyncio
+async def test_age_pool_lifecycle_kwargs_forwarded():
+    """pool_size, max_overflow, pool_timeout, pool_recycle, pool_pre_ping are forwarded."""
+    conf = MagicMock(spec=DatabasesConf)
+    conf.neo4j_confs = {}
+    conf.relational_db_confs = {}
+    conf.nebula_graph_confs = {}
+    conf.age_confs = {
+        "age1": _age_conf(
+            pool_size=7,
+            max_overflow=3,
+            pool_timeout=45,
+            pool_recycle=1800,
+            pool_pre_ping=True,
+        )
+    }
+
+    mock_engine = MagicMock(spec=AsyncEngine)
+    mock_engine.sync_engine = MagicMock()
+
+    with (
+        patch(
+            "memmachine_server.common.resource_manager.database_manager.create_async_engine",
+            return_value=mock_engine,
+        ) as mock_create,
+        patch(
+            "memmachine_server.common.resource_manager.database_manager._register_age_connect_hook",
+        ),
+        patch(
+            "memmachine_server.common.resource_manager.database_manager.AgeVectorGraphStore",
+        ),
+    ):
+        builder = DatabaseManager(conf)
+        await builder.async_get_age_engine("age1")
+
+    call_kwargs = mock_create.call_args.kwargs
+    assert call_kwargs["pool_size"] == 7
+    assert call_kwargs["max_overflow"] == 3
+    assert call_kwargs["pool_timeout"] == 45
+    assert call_kwargs["pool_recycle"] == 1800
+    assert call_kwargs["pool_pre_ping"] is True
+
+
+@pytest.mark.asyncio
+async def test_age_pool_lifecycle_kwargs_none_omitted():
+    """When pool knobs are None, they are not forwarded to create_async_engine."""
+    conf = MagicMock(spec=DatabasesConf)
+    conf.neo4j_confs = {}
+    conf.relational_db_confs = {}
+    conf.nebula_graph_confs = {}
+    conf.age_confs = {"age1": _age_conf()}
+
+    mock_engine = MagicMock(spec=AsyncEngine)
+    mock_engine.sync_engine = MagicMock()
+
+    with (
+        patch(
+            "memmachine_server.common.resource_manager.database_manager.create_async_engine",
+            return_value=mock_engine,
+        ) as mock_create,
+        patch(
+            "memmachine_server.common.resource_manager.database_manager._register_age_connect_hook",
+        ),
+        patch(
+            "memmachine_server.common.resource_manager.database_manager.AgeVectorGraphStore",
+        ),
+    ):
+        builder = DatabaseManager(conf)
+        await builder.async_get_age_engine("age1")
+
+    call_kwargs = mock_create.call_args.kwargs
+    for key in (
+        "pool_size",
+        "max_overflow",
+        "pool_timeout",
+        "pool_recycle",
+        "pool_pre_ping",
+    ):
+        assert key not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_age_graph_store_params_forwarded():
+    """Index thresholds and HNSW knobs from AgeConf reach AgeVectorGraphStoreParams."""
+    conf = MagicMock(spec=DatabasesConf)
+    conf.neo4j_confs = {}
+    conf.relational_db_confs = {}
+    conf.nebula_graph_confs = {}
+    conf.age_confs = {
+        "age1": _age_conf(
+            range_index_creation_threshold=500,
+            vector_index_creation_threshold=1000,
+            hnsw_m=24,
+            hnsw_ef_construction=96,
+        )
+    }
+
+    mock_engine = MagicMock(spec=AsyncEngine)
+    mock_engine.sync_engine = MagicMock()
+
+    with (
+        patch(
+            "memmachine_server.common.resource_manager.database_manager.create_async_engine",
+            return_value=mock_engine,
+        ),
+        patch(
+            "memmachine_server.common.resource_manager.database_manager._register_age_connect_hook",
+        ),
+        patch(
+            "memmachine_server.common.resource_manager.database_manager.AgeVectorGraphStore",
+        ),
+        patch(
+            "memmachine_server.common.resource_manager.database_manager.AgeVectorGraphStoreParams",
+        ) as mock_params,
+    ):
+        builder = DatabaseManager(conf)
+        await builder.async_get_age_engine("age1")
+
+    params_kwargs = mock_params.call_args.kwargs
+    assert params_kwargs["graph_name"] == "mem_graph"
+    assert params_kwargs["range_index_creation_threshold"] == 500
+    assert params_kwargs["vector_index_creation_threshold"] == 1000
+    assert params_kwargs["hnsw_m"] == 24
+    assert params_kwargs["hnsw_ef_construction"] == 96
+
+
+@pytest.mark.asyncio
+async def test_validate_age_engine_passes():
+    """validate_age_engine completes silently when SELECT 1 returns the expected row."""
+    mock_engine = MagicMock(spec=AsyncEngine)
+    mock_engine.dispose = AsyncMock()
+
+    mock_result = MagicMock()
+    mock_result.fetchone.return_value = (1,)
+
+    mock_conn = AsyncMock()
+    mock_conn.execute.return_value = mock_result
+
+    mock_engine.connect.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_engine.connect.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    await DatabaseManager.validate_age_engine("age1", cast(AsyncEngine, mock_engine))
+    mock_engine.dispose.assert_not_awaited()

--- a/packages/server/server_tests/memmachine_server/common/test_age_utils.py
+++ b/packages/server/server_tests/memmachine_server/common/test_age_utils.py
@@ -1,0 +1,330 @@
+"""Unit tests for age_utils.
+
+These tests run without Docker or any database. They exercise only the pure
+helpers (sanitization, agtype parsing, parameter encoding, Cypher wrapping).
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any, cast
+
+import pytest
+
+from memmachine_server.common.age_utils import (
+    AgeEdge,
+    AgePath,
+    AgeVertex,
+    AgtypeParseError,
+    age_value_from_python,
+    age_value_to_python,
+    build_cypher_call,
+    desanitize_identifier,
+    encode_agtype_params,
+    parse_agtype,
+    render_comparison,
+    sanitize_identifier,
+    validate_graph_name,
+)
+
+# ---------------------------------------------------------------------------
+# Identifier sanitization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "normal_name",
+        "123",
+        ")(*&^%$#@!",
+        "😀",
+        "𰻝",
+        " \t\n",
+        "",
+        "with spaces",
+        "snake_case_name",
+    ],
+)
+def test_sanitize_identifier_round_trip(name):
+    sanitized = sanitize_identifier(name)
+    assert sanitized.startswith("SANITIZED_")
+    assert sanitized[0].isalpha()
+    assert all(c.isalnum() or c == "_" for c in sanitized)
+    assert desanitize_identifier(sanitized) == name
+
+
+def test_sanitize_identifier_distinct_for_distinct_inputs():
+    seen = set()
+    for value in ["alpha", "ALPHA", "alpha ", " alpha", "alpha!", "alpha?"]:
+        sanitized = sanitize_identifier(value)
+        assert sanitized not in seen
+        seen.add(sanitized)
+
+
+# ---------------------------------------------------------------------------
+# Graph-name validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "good",
+    ["mem_graph", "g1", "_underscore", "ABCxyz123", "a" * 63],
+)
+def test_validate_graph_name_accepts_valid(good):
+    assert validate_graph_name(good) == good
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "1leading_digit",
+        "has space",
+        "has-dash",
+        "ends_with_quote'",
+        "a" * 64,
+        "DROP TABLE x; --",
+        "has;semicolon",
+    ],
+)
+def test_validate_graph_name_rejects_invalid(bad):
+    with pytest.raises(ValueError, match="Invalid AGE graph name"):
+        validate_graph_name(bad)
+
+
+# ---------------------------------------------------------------------------
+# Cypher call wrapping
+# ---------------------------------------------------------------------------
+
+
+def test_build_cypher_call_no_params():
+    sql = build_cypher_call("mem_graph", "MATCH (n) RETURN n", returns=("n",))
+    assert "cypher('mem_graph', $cypher_body$MATCH (n) RETURN n$cypher_body$)" in sql
+    assert sql.endswith("AS (n agtype)")
+
+
+def test_build_cypher_call_with_params():
+    sql = build_cypher_call(
+        "mem_graph",
+        "MATCH (n) WHERE n.uid = $uid RETURN n",
+        returns=("n",),
+        has_params=True,
+    )
+    assert "$1::agtype" in sql
+    assert "$cypher_body$" in sql
+    assert "MATCH (n) WHERE n.uid = $uid RETURN n" in sql
+
+
+def test_build_cypher_call_multiple_returns():
+    sql = build_cypher_call(
+        "mem_graph",
+        "MATCH (n) RETURN n, count(n)",
+        returns=("n", "c"),
+    )
+    assert "AS (n agtype, c agtype)" in sql
+
+
+def test_build_cypher_call_rejects_invalid_graph_name():
+    with pytest.raises(ValueError, match="Invalid AGE graph name"):
+        build_cypher_call("bad name", "RETURN 1", returns=("v",))
+
+
+def test_build_cypher_call_rejects_returns_empty():
+    with pytest.raises(ValueError, match="at least one return column"):
+        build_cypher_call("mem_graph", "RETURN 1", returns=())
+
+
+def test_build_cypher_call_rejects_collision_with_delimiter():
+    with pytest.raises(ValueError, match="reserved dollar-quoted delimiter"):
+        build_cypher_call(
+            "mem_graph",
+            "MATCH (n) RETURN $cypher_body$ as v",
+            returns=("v",),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parameter encoding
+# ---------------------------------------------------------------------------
+
+
+def test_encode_agtype_params_none():
+    assert encode_agtype_params(None) == "{}"
+
+
+def test_encode_agtype_params_primitives():
+    out = encode_agtype_params({"name": "abc", "n": 5, "ok": True})
+    # JSON keys remain quoted; ordering follows dict insertion.
+    assert '"name":"abc"' in out
+    assert '"n":5' in out
+    assert '"ok":true' in out
+
+
+def test_encode_agtype_params_datetime_to_iso_utc():
+    dt = datetime(2024, 6, 15, 12, 30, 0, tzinfo=UTC)
+    out = encode_agtype_params({"when": dt})
+    assert '"when":"2024-06-15T12:30:00+00:00"' in out
+
+
+def test_encode_agtype_params_datetime_naive_treated_as_utc():
+    dt = datetime(2024, 6, 15, 12, 30, 0)  # noqa: DTZ001  (intentional)
+    out = encode_agtype_params({"when": dt})
+    # Naive becomes UTC-aware; rendered as +00:00 offset.
+    assert "2024-06-15T12:30:00+00:00" in out
+
+
+def test_encode_agtype_params_datetime_normalized_to_utc():
+    pst = timezone(timedelta(hours=-8))
+    dt = datetime(2024, 6, 15, 4, 30, 0, tzinfo=pst)
+    out = encode_agtype_params({"when": dt})
+    assert "2024-06-15T12:30:00+00:00" in out
+
+
+def test_encode_agtype_params_nested():
+    payload = {"props": {"a": 1, "b": [1, 2, 3]}}
+    out = encode_agtype_params(payload)
+    assert '"props":{"a":1,"b":[1,2,3]}' in out
+
+
+# ---------------------------------------------------------------------------
+# agtype parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_agtype_primitives():
+    assert parse_agtype("null") is None
+    assert parse_agtype("true") is True
+    assert parse_agtype("false") is False
+    assert parse_agtype("42") == 42
+    assert parse_agtype("-7") == -7
+    assert parse_agtype("3.14") == 3.14
+    assert parse_agtype("-1.5e2") == -150.0
+
+
+def test_parse_agtype_strings_with_escapes():
+    assert parse_agtype('"hello"') == "hello"
+    assert parse_agtype(r'"with \"quotes\""') == 'with "quotes"'
+    assert parse_agtype(r'"\n\t\\"') == "\n\t\\"
+    assert parse_agtype(r'"\u0041"') == "A"
+
+
+def test_parse_agtype_arrays_and_objects():
+    assert parse_agtype("[]") == []
+    assert parse_agtype("[1, 2, 3]") == [1, 2, 3]
+    assert parse_agtype('{"a": 1, "b": "two"}') == {"a": 1, "b": "two"}
+
+
+def test_parse_agtype_vertex():
+    raw = '{"id": 844424930131969, "label": "Entity", "properties": {"uid": "abc"}}::vertex'
+    vertex = parse_agtype(raw)
+    assert isinstance(vertex, AgeVertex)
+    assert vertex.id == 844424930131969
+    assert vertex.label == "Entity"
+    assert vertex.properties == {"uid": "abc"}
+
+
+def test_parse_agtype_edge():
+    raw = (
+        '{"id": 1, "label": "REL", "start_id": 2, "end_id": 3, '
+        '"properties": {"weight": 0.5}}::edge'
+    )
+    edge = parse_agtype(raw)
+    assert isinstance(edge, AgeEdge)
+    assert edge.id == 1
+    assert edge.label == "REL"
+    assert edge.start_id == 2
+    assert edge.end_id == 3
+    assert edge.properties == {"weight": 0.5}
+
+
+def test_parse_agtype_path():
+    raw = "[1, 2, 3]::path"
+    path = parse_agtype(raw)
+    assert isinstance(path, AgePath)
+    assert path.elements == (1, 2, 3)
+
+
+def test_parse_agtype_handles_whitespace_and_none():
+    assert parse_agtype(None) is None
+    assert parse_agtype("  null  ") is None
+    assert parse_agtype('  "padded"  ') == "padded"
+
+
+def test_parse_agtype_bytes_input():
+    assert parse_agtype(b'"hello"') == "hello"
+
+
+def test_parse_agtype_rejects_trailing_data():
+    with pytest.raises(AgtypeParseError):
+        parse_agtype("123 garbage")
+
+
+def test_parse_agtype_rejects_unterminated_string():
+    with pytest.raises(AgtypeParseError):
+        parse_agtype('"open')
+
+
+def test_parse_agtype_rejects_unknown_token():
+    with pytest.raises(AgtypeParseError):
+        parse_agtype("undefined")
+
+
+# ---------------------------------------------------------------------------
+# Value round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_age_value_round_trip_for_datetime_utc():
+    original = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+    encoded = age_value_from_python(original)
+    assert isinstance(encoded, str)
+    decoded = age_value_to_python(encoded)
+    assert decoded == original
+
+
+def test_age_value_round_trip_for_naive_datetime():
+    original = datetime(2024, 1, 2, 3, 4, 5)  # noqa: DTZ001  (intentional)
+    encoded = age_value_from_python(original)
+    decoded = age_value_to_python(encoded)
+    assert decoded.tzinfo is not None
+    # Naive datetimes are interpreted as UTC.
+    assert decoded == original.replace(tzinfo=UTC)
+
+
+def test_age_value_round_trip_for_lists():
+    original = [datetime(2024, 1, 1, tzinfo=UTC), "x", 5]
+    encoded = age_value_from_python(original)
+    decoded = age_value_to_python(encoded)
+    assert decoded[0] == original[0]
+    assert decoded[1] == "x"
+    assert decoded[2] == 5
+
+
+def test_age_value_to_python_returns_string_when_not_iso():
+    assert age_value_to_python("hello") == "hello"
+    assert age_value_to_python("2024") == "2024"
+
+
+# ---------------------------------------------------------------------------
+# render_comparison
+# ---------------------------------------------------------------------------
+
+
+def test_render_comparison_basic():
+    assert render_comparison("n.x", "=", "$p1", value=5) == "n.x = $p1"
+    assert render_comparison("n.x", "!=", "$p1", value=5) == "n.x <> $p1"
+    assert render_comparison("n.x", ">=", "$p1", value=5) == "n.x >= $p1"
+
+
+def test_render_comparison_datetime_string_compare():
+    dt = datetime(2024, 6, 15, tzinfo=UTC)
+    # AGE stores datetimes as ISO-8601 UTC strings, so comparison is plain.
+    rendered = render_comparison("n.t", ">", "$p1", value=dt)
+    assert rendered == "n.t > $p1"
+
+
+def test_render_comparison_rejects_list_value():
+    with pytest.raises(TypeError, match="comparison cannot accept list"):
+        # Intentionally passing a list here to exercise the defensive
+        # guard in render_comparison, which normally takes a scalar
+        # PropertyValue. Cast to Any so ty doesn't complain.
+        render_comparison("n.x", "=", "$p1", value=cast(Any, [1, 2, 3]))

--- a/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_age_vector_graph_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_age_vector_graph_store.py
@@ -1,0 +1,910 @@
+"""Integration tests for ``AgeVectorGraphStore``.
+
+Requires Docker. The fixtures launch an ``apache/age`` container with the
+``age`` and ``vector`` extensions preinstalled and exercise the store end-to-
+end against a real PostgreSQL instance. Tests are marked ``integration`` so
+the default ``pytest`` invocation skips them.
+"""
+
+import socket
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import URL
+from sqlalchemy.ext.asyncio import create_async_engine
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.image import DockerImage
+from testcontainers.core.waiting_utils import wait_for_logs
+
+from memmachine_server.common.age_utils import setup_age_sync_connection
+from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.filter.filter_parser import (
+    And as FilterAnd,
+)
+from memmachine_server.common.filter.filter_parser import (
+    Comparison as FilterComparison,
+)
+from memmachine_server.common.filter.filter_parser import (
+    In as FilterIn,
+)
+from memmachine_server.common.filter.filter_parser import (
+    IsNull as FilterIsNull,
+)
+from memmachine_server.common.filter.filter_parser import (
+    Not as FilterNot,
+)
+from memmachine_server.common.filter.filter_parser import (
+    Or as FilterOr,
+)
+from memmachine_server.common.metrics_factory.prometheus_metrics_factory import (
+    PrometheusMetricsFactory,
+)
+from memmachine_server.common.vector_graph_store.age_vector_graph_store import (
+    DEFAULT_GRAPH_NAME,
+    AgeVectorGraphStore,
+    AgeVectorGraphStoreParams,
+)
+from memmachine_server.common.vector_graph_store.data_types import (
+    Edge,
+    Node,
+)
+from server_tests.memmachine_server.conftest import is_docker_available
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def metrics_factory():
+    return PrometheusMetricsFactory()
+
+
+_POSTGRES_AGE_DOCKERFILE_DIR = (
+    Path(__file__).resolve().parents[6] / "deployments" / "docker" / "postgres-age"
+)
+
+
+@pytest.fixture(scope="module")
+def age_connection_info():
+    if not is_docker_available():
+        pytest.skip("Docker is not available")
+
+    # Build the AGE + pgvector image from the same Dockerfile the production
+    # docker-compose / helm stack uses, so the test environment matches prod
+    # and we avoid a per-run ``apt-get install postgresql-16-pgvector`` inside
+    # a stock apache/age container.
+    if not _POSTGRES_AGE_DOCKERFILE_DIR.is_dir():
+        pytest.skip(
+            f"postgres-age Dockerfile dir not found at {_POSTGRES_AGE_DOCKERFILE_DIR}"
+        )
+
+    user = "postgres"
+    password = "postgres"
+    dbname = "memmachine_test"
+
+    with DockerImage(
+        path=str(_POSTGRES_AGE_DOCKERFILE_DIR),
+        tag="memmachine-test/postgres-age:pg16-1.6.0",
+    ) as image:
+        container = (
+            DockerContainer(str(image))
+            .with_exposed_ports(5432)
+            .with_env("POSTGRES_USER", user)
+            .with_env("POSTGRES_PASSWORD", password)
+            .with_env("POSTGRES_DB", dbname)
+        )
+        container.start()
+        try:
+            wait_for_logs(
+                container,
+                "database system is ready to accept connections",
+                timeout=60,
+            )
+
+            host = container.get_container_host_ip()
+            port = int(container.get_exposed_port(5432))
+
+            # Postgres typically restarts once during init (pg_ctl reload
+            # after template setup). Poll the exposed port until it accepts
+            # TCP connections so tests don't race the re-listen.
+            deadline = time.monotonic() + 30.0
+            last_err: OSError | None = None
+            while time.monotonic() < deadline:
+                try:
+                    with socket.create_connection((host, port), timeout=1):
+                        break
+                except OSError as err:
+                    last_err = err
+                    time.sleep(0.25)
+            else:
+                raise RuntimeError(
+                    f"Postgres/AGE container never became reachable on {host}:{port}"
+                ) from last_err
+
+            yield {
+                "host": host,
+                "port": port,
+                "user": user,
+                "password": password,
+                "db_name": dbname,
+            }
+        finally:
+            container.stop()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def age_engine(age_connection_info):
+    url = URL.create(
+        "postgresql+asyncpg",
+        username=age_connection_info["user"],
+        password=age_connection_info["password"],
+        host=age_connection_info["host"],
+        port=age_connection_info["port"],
+        database=age_connection_info["db_name"],
+    )
+    engine = create_async_engine(url, pool_pre_ping=True)
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _on_connect(dbapi_connection, _connection_record):
+        setup_age_sync_connection(dbapi_connection)
+
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture(scope="module")
+def vector_graph_store(age_engine, metrics_factory):
+    return AgeVectorGraphStore(
+        AgeVectorGraphStoreParams(
+            engine=age_engine,
+            graph_name=DEFAULT_GRAPH_NAME,
+            force_exact_similarity_search=True,
+            metrics_factory=metrics_factory,
+        ),
+    )
+
+
+@pytest.fixture(scope="module")
+def vector_graph_store_ann(age_engine):
+    return AgeVectorGraphStore(
+        AgeVectorGraphStoreParams(
+            engine=age_engine,
+            graph_name=DEFAULT_GRAPH_NAME,
+            force_exact_similarity_search=False,
+            filtered_similarity_search_fudge_factor=2,
+            exact_similarity_search_fallback_threshold=0.5,
+            range_index_creation_threshold=0,
+            vector_index_creation_threshold=0,
+        ),
+    )
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def db_cleanup(age_engine, vector_graph_store):
+    # Drop and recreate the AGE graph between tests to clear all labels,
+    # vertices, edges, and side tables tied to the previous run.
+    await vector_graph_store.delete_all_data()
+    async with age_engine.begin() as conn:
+        # Drop every pgvector side table belonging to the test graph. Side
+        # tables live in ``public`` and are prefixed with the graph name.
+        result = await conn.exec_driver_sql(
+            "SELECT tablename FROM pg_tables "
+            "WHERE schemaname = 'public' AND tablename LIKE $1 ESCAPE '\\'",
+            (f"{DEFAULT_GRAPH_NAME}\\_emb\\_%",),
+        )
+        side_tables = [row[0] for row in result]
+        for table in side_tables:
+            await conn.exec_driver_sql(f'DROP TABLE IF EXISTS public."{table}"')
+    # Reset in-memory caches so counts and index-state don't bleed across tests.
+    vector_graph_store._reset_in_memory_caches()
+    yield
+
+
+async def _count_vertices(engine) -> int:
+    async with engine.connect() as conn:
+        result = await conn.exec_driver_sql(
+            (
+                f"SELECT * FROM cypher('{DEFAULT_GRAPH_NAME}', "
+                "$cypher_body$MATCH (n) RETURN count(n)$cypher_body$"
+                ") AS (c agtype)"
+            ),
+        )
+        row = result.first()
+    if row is None:
+        return 0
+    return int(str(row[0]))
+
+
+async def _count_edges(engine) -> int:
+    async with engine.connect() as conn:
+        result = await conn.exec_driver_sql(
+            (
+                f"SELECT * FROM cypher('{DEFAULT_GRAPH_NAME}', "
+                "$cypher_body$MATCH ()-[r]->() "
+                "RETURN count(r)$cypher_body$"
+                ") AS (c agtype)"
+            ),
+        )
+        row = result.first()
+    if row is None:
+        return 0
+    return int(str(row[0]))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_nodes(age_engine, vector_graph_store):
+    assert await _count_vertices(age_engine) == 0
+
+    await vector_graph_store.add_nodes(collection="Entity", nodes=[])
+    assert await _count_vertices(age_engine) == 0
+
+    nodes = [
+        Node(uid=str(uuid4()), properties={"name": "Node1"}),
+        Node(uid=str(uuid4()), properties={"name": "Node2"}),
+        Node(
+            uid=str(uuid4()),
+            properties={
+                "name": "Node3",
+                "time": datetime.now(tz=UTC),
+                "none_value": None,
+            },
+            embeddings={
+                "embedding_name": (
+                    [0.1, 0.2, 0.3],
+                    SimilarityMetric.COSINE,
+                ),
+            },
+        ),
+    ]
+
+    await vector_graph_store.add_nodes(collection="Entity", nodes=nodes)
+    assert await _count_vertices(age_engine) == len(nodes)
+
+
+@pytest.mark.asyncio
+async def test_add_edges(age_engine, vector_graph_store):
+    node1_uid = str(uuid4())
+    node2_uid = str(uuid4())
+    node3_uid = str(uuid4())
+
+    nodes = [
+        Node(uid=node1_uid, properties={"name": "Node1"}),
+        Node(uid=node2_uid, properties={"name": "Node2"}),
+        Node(
+            uid=node3_uid,
+            properties={"name": "Node3"},
+            embeddings={
+                "embedding_name": (
+                    [0.1, 0.2, 0.3],
+                    SimilarityMetric.COSINE,
+                ),
+            },
+        ),
+    ]
+    await vector_graph_store.add_nodes(collection="Entity", nodes=nodes)
+    assert await _count_edges(age_engine) == 0
+
+    await vector_graph_store.add_edges(
+        relation="RELATED_TO",
+        source_collection="Entity",
+        target_collection="Entity",
+        edges=[],
+    )
+    assert await _count_edges(age_engine) == 0
+
+    related = [
+        Edge(
+            uid=str(uuid4()),
+            source_uid=node1_uid,
+            target_uid=node2_uid,
+            properties={"description": "Node1 to Node2"},
+        ),
+        Edge(
+            uid=str(uuid4()),
+            source_uid=node2_uid,
+            target_uid=node1_uid,
+            properties={"description": "Node2 to Node1"},
+        ),
+        Edge(
+            uid=str(uuid4()),
+            source_uid=node1_uid,
+            target_uid=node3_uid,
+            properties={"description": "Node1 to Node3"},
+            embeddings={
+                "embedding_name": (
+                    [0.4, 0.5, 0.6],
+                    SimilarityMetric.DOT,
+                ),
+            },
+        ),
+    ]
+
+    is_edges = [
+        Edge(
+            uid=str(uuid4()),
+            source_uid=node1_uid,
+            target_uid=node1_uid,
+            properties={"description": "Node1 loop"},
+        ),
+        Edge(
+            uid=str(uuid4()),
+            source_uid=node2_uid,
+            target_uid=node2_uid,
+            properties={"description": "Node2 loop"},
+        ),
+    ]
+
+    await vector_graph_store.add_edges(
+        relation="RELATED_TO",
+        source_collection="Entity",
+        target_collection="Entity",
+        edges=related,
+    )
+    await vector_graph_store.add_edges(
+        relation="IS",
+        source_collection="Entity",
+        target_collection="Entity",
+        edges=is_edges,
+    )
+
+    assert await _count_edges(age_engine) == 5
+
+
+@pytest.mark.asyncio
+async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
+    nodes = [
+        Node(
+            uid=str(uuid4()),
+            properties={"name": "Node1"},
+            embeddings={
+                "embedding1": ([1000.0, 0.0], SimilarityMetric.COSINE),
+                "embedding2": ([1000.0, 0.0], SimilarityMetric.EUCLIDEAN),
+            },
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={"name": "Node2", "include?": "yes"},
+            embeddings={
+                "embedding1": ([10.0, 10.0], SimilarityMetric.COSINE),
+                "embedding2": ([10.0, 10.0], SimilarityMetric.EUCLIDEAN),
+            },
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={"name": "Node3", "include?": "no"},
+            embeddings={
+                "embedding1": ([-100.0, 0.0], SimilarityMetric.COSINE),
+                "embedding2": ([-100.0, 0.0], SimilarityMetric.EUCLIDEAN),
+            },
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={"name": "Node4", "include?": "no"},
+            embeddings={
+                "embedding1": ([-100.0, -1.0], SimilarityMetric.COSINE),
+                "embedding2": ([-100.0, -1.0], SimilarityMetric.EUCLIDEAN),
+            },
+        ),
+    ]
+    await vector_graph_store.add_nodes(collection="Entity", nodes=nodes)
+
+    # Exact search (force_exact_similarity_search=True)
+    results = await vector_graph_store.search_similar_nodes(
+        collection="Entity",
+        query_embedding=[1.0, 0.0],
+        embedding_name="embedding1",
+        similarity_metric=SimilarityMetric.COSINE,
+        limit=3,
+    )
+    assert len(results) == 3
+    assert results[0].properties["name"] == "Node1"
+
+    # Exact search with property filter should isolate Node2.
+    results = await vector_graph_store.search_similar_nodes(
+        collection="Entity",
+        query_embedding=[1.0, 0.0],
+        embedding_name="embedding1",
+        similarity_metric=SimilarityMetric.COSINE,
+        limit=3,
+        property_filter=FilterComparison(
+            field="include?",
+            op="=",
+            value="yes",
+        ),
+    )
+    assert len(results) == 1
+    assert results[0].properties["name"] == "Node2"
+
+    # Filter with OR + IS NULL pulls in Node1.
+    results = await vector_graph_store.search_similar_nodes(
+        collection="Entity",
+        query_embedding=[1.0, 0.0],
+        embedding_name="embedding1",
+        similarity_metric=SimilarityMetric.COSINE,
+        limit=3,
+        property_filter=FilterOr(
+            left=FilterComparison(field="include?", op="=", value="yes"),
+            right=FilterIsNull(field="include?"),
+        ),
+    )
+    assert len(results) == 2
+    assert results[0].properties["name"] == "Node1"
+
+    # EUCLIDEAN picks Node2 (closest to [1.0, 0.0]).
+    results = await vector_graph_store.search_similar_nodes(
+        collection="Entity",
+        query_embedding=[1.0, 0.0],
+        embedding_name="embedding2",
+        similarity_metric=SimilarityMetric.EUCLIDEAN,
+        limit=3,
+    )
+    assert results[0].properties["name"] == "Node2"
+
+    # ANN path returns something; index may still be warming.
+    results = await vector_graph_store_ann.search_similar_nodes(
+        collection="Entity",
+        query_embedding=[1.0, 0.0],
+        embedding_name="embedding1",
+        similarity_metric=SimilarityMetric.COSINE,
+        limit=3,
+    )
+    assert 0 < len(results) <= 3
+
+
+@pytest.mark.asyncio
+async def test_search_related_nodes(vector_graph_store):
+    node1_uid = str(uuid4())
+    node2_uid = str(uuid4())
+    node3_uid = str(uuid4())
+    node4_uid = str(uuid4())
+
+    nodes = [
+        Node(uid=node1_uid, properties={"name": "Node1"}),
+        Node(
+            uid=node2_uid,
+            properties={"name": "Node2", "extra!": "something"},
+        ),
+        Node(uid=node3_uid, properties={"name": "Node3", "marker?": "A"}),
+        Node(uid=node4_uid, properties={"name": "Node4", "marker?": "B"}),
+    ]
+    await vector_graph_store.add_nodes(collection="Entity", nodes=nodes)
+
+    related_edges = [
+        Edge(
+            uid=str(uuid4()),
+            source_uid=node1_uid,
+            target_uid=node2_uid,
+            properties={"description": "Node1 to Node2"},
+        ),
+        Edge(
+            uid=str(uuid4()),
+            source_uid=node2_uid,
+            target_uid=node1_uid,
+            properties={"description": "Node2 to Node1"},
+        ),
+        Edge(
+            uid=str(uuid4()),
+            source_uid=node3_uid,
+            target_uid=node2_uid,
+            properties={"description": "Node3 to Node2", "extra": 1},
+        ),
+        Edge(
+            uid=str(uuid4()),
+            source_uid=node3_uid,
+            target_uid=node4_uid,
+            properties={"description": "Node3 to Node4", "extra": 2},
+        ),
+    ]
+    await vector_graph_store.add_edges(
+        relation="RELATED_TO",
+        source_collection="Entity",
+        target_collection="Entity",
+        edges=related_edges,
+    )
+
+    # Self-loops so the undirected match from node1/node2/node3 also returns
+    # the queried node itself — mirrors the Neo4j backend's test fixture so
+    # assertions stay aligned across backends.
+    self_loops = [
+        Edge(
+            uid=str(uuid4()),
+            source_uid=node1_uid,
+            target_uid=node1_uid,
+            properties={"description": "Node1 loop"},
+        ),
+        Edge(
+            uid=str(uuid4()),
+            source_uid=node2_uid,
+            target_uid=node2_uid,
+            properties={"description": "Node2 loop"},
+        ),
+        Edge(
+            uid=str(uuid4()),
+            source_uid=node3_uid,
+            target_uid=node3_uid,
+            properties={"description": "Node3 loop"},
+        ),
+    ]
+    await vector_graph_store.add_edges(
+        relation="RELATED_TO",
+        source_collection="Entity",
+        target_collection="Entity",
+        edges=self_loops,
+    )
+
+    results = await vector_graph_store.search_related_nodes(
+        relation="RELATED_TO",
+        other_collection="Entity",
+        this_collection="Entity",
+        this_node_uid=node1_uid,
+    )
+    names = {r.properties["name"] for r in results}
+    assert names == {"Node1", "Node2"}
+
+    results = await vector_graph_store.search_related_nodes(
+        relation="RELATED_TO",
+        other_collection="Entity",
+        this_collection="Entity",
+        this_node_uid=node1_uid,
+        node_property_filter=FilterComparison(
+            field="extra!", op="=", value="something"
+        ),
+    )
+    assert len(results) == 1
+    assert results[0].properties["name"] == "Node2"
+
+    results = await vector_graph_store.search_related_nodes(
+        relation="RELATED_TO",
+        other_collection="Entity",
+        this_collection="Entity",
+        this_node_uid=node3_uid,
+        edge_property_filter=FilterComparison(field="extra", op="=", value=1),
+    )
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_directional_nodes(vector_graph_store):
+    now = datetime.now(tz=UTC)
+    delta = timedelta(days=1)
+
+    nodes = [
+        Node(
+            uid=str(uuid4()),
+            properties={"name": "Event1", "timestamp": now},
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={
+                "name": "Event2",
+                "timestamp": now + delta,
+                "include?": "yes",
+            },
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={"name": "Event3", "timestamp": now + 2 * delta},
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={
+                "name": "Event4",
+                "timestamp": now + 3 * delta,
+                "include?": "yes",
+            },
+        ),
+    ]
+    await vector_graph_store.add_nodes(collection="Event", nodes=nodes)
+
+    results = await vector_graph_store.search_directional_nodes(
+        collection="Event",
+        by_properties=["timestamp"],
+        starting_at=[now + delta],
+        order_ascending=[True],
+        include_equal_start=True,
+        limit=2,
+    )
+    assert len(results) == 2
+    assert results[0].properties["name"] == "Event2"
+    assert results[1].properties["name"] == "Event3"
+
+    # TZ-aware comparison across zones.
+    result_ts = (
+        results[0].properties["timestamp"].astimezone(ZoneInfo("America/Los_Angeles"))
+    )
+    results = await vector_graph_store.search_directional_nodes(
+        collection="Event",
+        by_properties=["timestamp"],
+        starting_at=[result_ts],
+        order_ascending=[False],
+        include_equal_start=False,
+        limit=1,
+    )
+    assert len(results) == 1
+    assert results[0].properties["name"] != "Event2"
+
+    # Filter-augmented directional search.
+    results = await vector_graph_store.search_directional_nodes(
+        collection="Event",
+        by_properties=["timestamp"],
+        starting_at=[now + delta],
+        order_ascending=[True],
+        include_equal_start=True,
+        limit=2,
+        property_filter=FilterComparison(field="include?", op="=", value="yes"),
+    )
+    assert len(results) == 2
+    assert results[0].properties["name"] == "Event2"
+    assert results[1].properties["name"] == "Event4"
+
+    # Null starting value behaves as "no lower bound".
+    results = await vector_graph_store.search_directional_nodes(
+        collection="Event",
+        by_properties=["timestamp"],
+        starting_at=[None],
+        order_ascending=[False],
+        limit=2,
+    )
+    assert len(results) == 2
+    assert results[0].properties["name"] == "Event4"
+    assert results[1].properties["name"] == "Event3"
+
+
+@pytest.mark.asyncio
+async def test_search_matching_nodes(vector_graph_store):
+    people = [
+        Node(
+            uid=str(uuid4()),
+            properties={
+                "name": "Alice",
+                "age!with$pecialchars": 30,
+                "city": "San Francisco",
+                "title": "Engineer",
+            },
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={
+                "name": "Bob",
+                "age!with$pecialchars": 25,
+                "city": "Los Angeles",
+                "title": "Designer",
+            },
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={"name": "Charlie", "city": "New York"},
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={
+                "name": "David",
+                "age!with$pecialchars": 30,
+                "city": "New York",
+                "none_value": None,
+            },
+        ),
+    ]
+    robots = [
+        Node(uid=str(uuid4()), properties={"name": "Eve", "city": "Axiom"}),
+    ]
+    await vector_graph_store.add_nodes(collection="Person", nodes=people)
+    await vector_graph_store.add_nodes(collection="Robot", nodes=robots)
+
+    assert len(await vector_graph_store.search_matching_nodes(collection="Person")) == 4
+    assert len(await vector_graph_store.search_matching_nodes(collection="Robot")) == 1
+
+    # IS NULL on a field nobody has -> everyone matches.
+    results = await vector_graph_store.search_matching_nodes(
+        collection="Robot",
+        property_filter=FilterIsNull(field="none_value"),
+    )
+    assert len(results) == 1
+
+    results = await vector_graph_store.search_matching_nodes(
+        collection="Person",
+        property_filter=FilterComparison(field="city", op="=", value="New York"),
+    )
+    assert len(results) == 2
+
+    results = await vector_graph_store.search_matching_nodes(
+        collection="Person",
+        property_filter=FilterAnd(
+            left=FilterComparison(field="city", op="=", value="New York"),
+            right=FilterComparison(field="age!with$pecialchars", op="=", value=30),
+        ),
+    )
+    assert len(results) == 1
+
+    # OR with IS NULL includes those missing the property.
+    results = await vector_graph_store.search_matching_nodes(
+        collection="Person",
+        property_filter=FilterOr(
+            left=FilterComparison(field="title", op="=", value="Engineer"),
+            right=FilterIsNull(field="title"),
+        ),
+    )
+    assert len(results) == 3  # Alice + Charlie + David
+
+    # Inequality comparisons.
+    results = await vector_graph_store.search_matching_nodes(
+        collection="Person",
+        property_filter=FilterComparison(
+            field="age!with$pecialchars", op=">", value=25
+        ),
+    )
+    assert len(results) == 2
+
+    # IN list.
+    results = await vector_graph_store.search_matching_nodes(
+        collection="Person",
+        property_filter=FilterIn(field="city", values=["San Francisco", "Los Angeles"]),
+    )
+    assert len(results) == 2
+
+    # NOT.
+    results = await vector_graph_store.search_matching_nodes(
+        collection="Person",
+        property_filter=FilterNot(
+            expr=FilterComparison(field="city", op="=", value="New York"),
+        ),
+    )
+    assert len(results) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_nodes(vector_graph_store):
+    nodes = [
+        Node(
+            uid=str(uuid4()),
+            properties={"name": "Node1", "time": datetime.now(tz=UTC)},
+        ),
+        Node(uid=str(uuid4()), properties={"name": "Node2"}),
+        Node(uid=str(uuid4()), properties={"name": "Node3"}),
+    ]
+    await vector_graph_store.add_nodes(collection="Entity", nodes=nodes)
+
+    fetched = await vector_graph_store.get_nodes(
+        collection="Entity",
+        node_uids=[n.uid for n in nodes],
+    )
+    assert len(fetched) == 3
+    assert {n.uid for n in fetched} == {n.uid for n in nodes}
+
+    # Partial match — requesting one real + one nonexistent uid.
+    fetched = await vector_graph_store.get_nodes(
+        collection="Entity",
+        node_uids=[nodes[0].uid, str(uuid4())],
+    )
+    assert len(fetched) == 1
+    assert fetched[0].uid == nodes[0].uid
+
+
+@pytest.mark.asyncio
+async def test_delete_nodes(age_engine, vector_graph_store):
+    nodes = [Node(uid=str(uuid4())) for _ in range(6)]
+    await vector_graph_store.add_nodes(collection="Entity", nodes=nodes)
+    assert await _count_vertices(age_engine) == 6
+
+    # Deleting from a non-existent collection is a no-op.
+    await vector_graph_store.delete_nodes(
+        collection="Bad", node_uids=[n.uid for n in nodes[:3]]
+    )
+    assert await _count_vertices(age_engine) == 6
+
+    await vector_graph_store.delete_nodes(
+        collection="Entity", node_uids=[n.uid for n in nodes[:3]]
+    )
+    assert await _count_vertices(age_engine) == 3
+
+
+@pytest.mark.asyncio
+async def test_delete_all_data(age_engine, vector_graph_store):
+    nodes = [Node(uid=str(uuid4())) for _ in range(6)]
+    await vector_graph_store.add_nodes(collection="Entity", nodes=nodes)
+    assert await _count_vertices(age_engine) == 6
+
+    await vector_graph_store.delete_all_data()
+    assert await _count_vertices(age_engine) == 0
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_preserves_embeddings(vector_graph_store):
+    original = Node(
+        uid=str(uuid4()),
+        properties={"name": "Roundtrip"},
+        embeddings={
+            "default": ([0.1, 0.2, 0.3], SimilarityMetric.COSINE),
+        },
+    )
+    await vector_graph_store.add_nodes(collection="Entity", nodes=[original])
+    [fetched] = await vector_graph_store.get_nodes(
+        collection="Entity",
+        node_uids=[original.uid],
+    )
+    assert fetched.uid == original.uid
+    assert fetched.properties == original.properties
+    assert set(fetched.embeddings.keys()) == {"default"}
+    stored_embedding, stored_metric = fetched.embeddings["default"]
+    assert stored_metric is SimilarityMetric.COSINE
+    assert len(stored_embedding) == 3
+    # pgvector may renormalize float precision; accept small epsilon.
+    for actual, expected in zip(stored_embedding, [0.1, 0.2, 0.3], strict=True):
+        assert abs(actual - expected) < 1e-5
+
+
+@pytest.mark.asyncio
+async def test_edge_embedding_persisted_in_side_table(age_engine, vector_graph_store):
+    """Edges with embeddings populate their own pgvector side table.
+
+    The public API surface doesn't expose per-edge vector search, but the
+    side-table plumbing still runs and is what ``delete_all_data`` /
+    ``delete_nodes`` rely on, so we verify the rows are written.
+    """
+    source_uid = str(uuid4())
+    target_uid = str(uuid4())
+    edge_uid = str(uuid4())
+    await vector_graph_store.add_nodes(
+        collection="Entity",
+        nodes=[
+            Node(uid=source_uid, properties={"name": "Source"}),
+            Node(uid=target_uid, properties={"name": "Target"}),
+        ],
+    )
+    await vector_graph_store.add_edges(
+        relation="RELATED_TO",
+        source_collection="Entity",
+        target_collection="Entity",
+        edges=[
+            Edge(
+                uid=edge_uid,
+                source_uid=source_uid,
+                target_uid=target_uid,
+                properties={"kind": "witness"},
+                embeddings={
+                    "default": (
+                        [0.4, 0.5, 0.6],
+                        SimilarityMetric.EUCLIDEAN,
+                    ),
+                },
+            ),
+        ],
+    )
+
+    # Confirm the edge side table exists and contains our one row. Side-table
+    # names are hashed to stay within Postgres' 63-byte identifier limit, so
+    # we resolve them through the registry rather than scanning pg_tables by
+    # prefix.
+    async with age_engine.begin() as conn:
+        result = await conn.exec_driver_sql(
+            "SELECT table_name FROM public.\"{registry}\" WHERE kind = 'edge'".format(
+                registry=f"{DEFAULT_GRAPH_NAME}_emb_registry"
+            ),
+        )
+        edge_tables = [row[0] for row in result]
+        assert len(edge_tables) == 1, (
+            f"expected exactly one edge side table, got {edge_tables}"
+        )
+        [table] = edge_tables
+        count_result = await conn.exec_driver_sql(
+            f'SELECT COUNT(*) FROM public."{table}" WHERE edge_uid = $1',
+            (edge_uid,),
+        )
+        count_row = count_result.first()
+    assert count_row is not None
+    assert count_row[0] == 1

--- a/packages/server/server_tests/memmachine_server/installation/test_configuration_wizard.py
+++ b/packages/server/server_tests/memmachine_server/installation/test_configuration_wizard.py
@@ -211,3 +211,60 @@ def test_un_provided_neo4j(mock_input, conf_args):
     assert neo4j_conf.user == "neo4j"
     assert neo4j_conf.password.get_secret_value() == "password"
     assert len(db_conf.relational_db_confs) == 1
+
+
+@patch("builtins.input")
+def test_age_backend(mock_input, conf_args):
+    """AGE interactive mode collects six connection fields and emits paired confs.
+
+    The generated config registers an AgeConf for the graph store and a
+    companion SqlAlchemyConf at the same Postgres instance so semantic
+    memory's pgvector store rides along — the single-Postgres promise.
+    """
+    conf_args.graph_backend = "age"
+    mock_input.side_effect = [
+        "age.example.com",  # host
+        "5500",  # port
+        "mm_user",  # user
+        "mm_password",  # password
+        "mm_db",  # db_name
+        "mem_g",  # graph_name
+    ]
+    conf = ConfigurationWizard(conf_args)
+    db_conf = conf.database_conf
+
+    # AGE graph store registered, Neo4j absent.
+    assert len(db_conf.neo4j_confs) == 0
+    assert len(db_conf.age_confs) == 1
+    age_conf = db_conf.age_confs[ConfigurationWizard.AGE_DB_ID]
+    assert age_conf.host == "age.example.com"
+    assert age_conf.port == 5500
+    assert age_conf.user == "mm_user"
+    assert age_conf.password.get_secret_value() == "mm_password"
+    assert age_conf.db_name == "mm_db"
+    assert age_conf.graph_name == "mem_g"
+
+    # Companion SqlAlchemyConf targets the same Postgres instance.
+    assert ConfigurationWizard.AGE_POSTGRES_DB_ID in db_conf.relational_db_confs
+    pg_conf = db_conf.relational_db_confs[ConfigurationWizard.AGE_POSTGRES_DB_ID]
+    assert pg_conf.dialect == "postgresql"
+    assert pg_conf.host == age_conf.host
+    assert pg_conf.port == age_conf.port
+    assert pg_conf.db_name == age_conf.db_name
+
+    # Long-term memory points at the AGE graph store; semantic memory
+    # rides on the companion SqlAlchemyConf.
+    assert (
+        conf.long_term_memory_conf.vector_graph_store
+        == ConfigurationWizard.AGE_DB_ID
+    )
+    assert (
+        conf.semantic_manager_conf.database
+        == ConfigurationWizard.AGE_POSTGRES_DB_ID
+    )
+
+
+def test_invalid_graph_backend_rejected(conf_args):
+    conf_args.graph_backend = "foobar"
+    with pytest.raises(ValueError, match="graph_backend"):
+        ConfigurationWizard(conf_args)

--- a/packages/server/server_tests/memmachine_server/installation/test_memmachine_configure.py
+++ b/packages/server/server_tests/memmachine_server/installation/test_memmachine_configure.py
@@ -102,6 +102,7 @@ class MockWindowsEnvironment(WindowsEnvironment):
 @patch("builtins.input")
 def test_install_in_windows(mock_input, mock_wizard):
     mock_input.side_effect = [
+        "",  # graph backend → neo4j (default)
         "y",  # Confirm installation
     ]
     environment = MockWindowsEnvironment()
@@ -118,6 +119,7 @@ def test_install_in_windows(mock_input, mock_wizard):
 @patch("builtins.input")
 def test_install_in_windows_default_dir(mock_input, monkeypatch, mock_wizard):
     mock_input.side_effect = [
+        "",  # graph backend → neo4j (default)
         "y",  # Confirm installation
         "",  # Use default install directory
     ]
@@ -141,6 +143,7 @@ def test_install_in_windows_default_dir(mock_input, monkeypatch, mock_wizard):
 @patch("builtins.input")
 def test_use_custom_neo4j(mock_input, mock_wizard):
     mock_input.side_effect = [
+        "",  # graph backend → neo4j (default)
         "n",  # do not install neo4j
     ]
     environment = MockWindowsEnvironment()
@@ -149,7 +152,11 @@ def test_use_custom_neo4j(mock_input, mock_wizard):
     assert not environment.neo4j_installed
 
 
-def test_install_in_windows_neo4j_preinstalled(mock_wizard):
+@patch("builtins.input")
+def test_install_in_windows_neo4j_preinstalled(mock_input, mock_wizard):
+    mock_input.side_effect = [
+        "",  # graph backend → neo4j (default)
+    ]
     environment = MockWindowsEnvironment()
     installer = WindowsInstaller(environment)
     environment.neo4j_preinstalled = True
@@ -183,6 +190,7 @@ class MockMacOSEnvironment(MacosEnvironment):
 @patch("platform.machine")
 def test_install_in_macos(mock_machine, mock_input, mock_wizard):
     mock_input.side_effect = [
+        "",  # graph backend → neo4j (default)
         "y",  # Confirm installation
     ]
     mock_machine.return_value = "arm64"
@@ -199,6 +207,7 @@ def test_install_in_macos(mock_machine, mock_input, mock_wizard):
 @patch("platform.machine")
 def test_install_in_macos_x64(mock_machine, mock_input, mock_wizard):
     mock_input.side_effect = [
+        "",  # graph backend → neo4j (default)
         "y",  # Confirm installation
     ]
     mock_machine.return_value = "x86_64"
@@ -211,7 +220,11 @@ def test_install_in_macos_x64(mock_machine, mock_input, mock_wizard):
     assert Path("~/.config/memmachine/cfg.yml").expanduser().exists()
 
 
-def test_install_in_macos_neo4j_preinstalled(mock_wizard):
+@patch("builtins.input")
+def test_install_in_macos_neo4j_preinstalled(mock_input, mock_wizard):
+    mock_input.side_effect = [
+        "",  # graph backend → neo4j (default)
+    ]
     environment = MockMacOSEnvironment()
     environment.neo4j_preinstalled = True
     installer = MacosInstaller(environment)
@@ -242,6 +255,7 @@ class MockLinuxEnvironment(LinuxEnvironment):
 @patch("builtins.input")
 def test_install_in_linux(mock_input, mock_wizard):
     mock_input.side_effect = [
+        "",  # graph backend → neo4j (default)
         "y",  # Confirm installation
     ]
     environment = MockLinuxEnvironment()

--- a/packages/server/src/memmachine_server/common/age_utils.py
+++ b/packages/server/src/memmachine_server/common/age_utils.py
@@ -1,0 +1,531 @@
+# ruff: noqa: ANN401
+"""Helpers for working with Apache AGE values, Cypher wrapping, and connections.
+
+Apache AGE is a PostgreSQL extension that adds openCypher support. It uses its
+own custom type (``agtype``) for vertices, edges, paths, maps, lists, and
+primitive values. Cypher statements must be wrapped in a SQL ``cypher()`` call,
+so this module provides the small set of primitives needed by
+``AgeVectorGraphStore`` to build and execute queries.
+
+The utilities here are intentionally narrow in scope: they cover the subset of
+``agtype`` that MemMachine persists (primitives, lists, maps, vertices, edges),
+the exact Cypher-wrapping shape that AGE requires, and the per-connection
+extension setup that every pooled connection must run.
+
+``ANN401`` is disabled module-wide: the agtype parser, parameter encoder, and
+SQLAlchemy DB-API adapter all operate on genuinely-polymorphic values, and
+replacing ``Any`` with wide unions would obscure the point of each helper.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from memmachine_server.common.data_types import PropertyValue
+
+__all__ = [
+    "AgeEdge",
+    "AgePath",
+    "AgeVertex",
+    "AgtypeParseError",
+    "age_value_from_python",
+    "age_value_to_python",
+    "build_cypher_call",
+    "encode_agtype_params",
+    "parse_agtype",
+    "render_comparison",
+    "sanitize_identifier",
+    "setup_age_sync_connection",
+    "validate_graph_name",
+]
+
+
+# AGE graph names become PostgreSQL schema names, so they must be valid
+# identifiers. We apply a strict safelist to avoid any need for quoting.
+_GRAPH_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+
+# Sanitized identifiers for labels and properties use a fixed prefix followed by
+# only ASCII letters, digits, and underscores. This mirrors the Neo4j backend's
+# approach so that encoded names remain deterministic across implementations.
+_SANITIZE_PREFIX = "SANITIZED_"
+
+
+class AgtypeParseError(ValueError):
+    """Raised when an ``agtype`` text value cannot be decoded."""
+
+
+@dataclass(frozen=True)
+class AgeVertex:
+    """Decoded representation of an AGE vertex (``{...}::vertex``)."""
+
+    id: int
+    label: str
+    properties: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AgeEdge:
+    """Decoded representation of an AGE edge (``{...}::edge``)."""
+
+    id: int
+    label: str
+    start_id: int
+    end_id: int
+    properties: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AgePath:
+    """Decoded representation of an AGE path (alternating vertices and edges)."""
+
+    elements: tuple[AgeVertex | AgeEdge, ...]
+
+
+def validate_graph_name(name: str) -> str:
+    """Validate that ``name`` is safe to interpolate as an AGE graph name.
+
+    AGE graph names cannot be parameterized in the ``cypher()`` SQL call, so
+    they are interpolated directly. This check guarantees the value is a
+    conservative identifier (letters, digits, underscores) and rejects anything
+    that could break out of the surrounding single-quoted string.
+    """
+    if not _GRAPH_NAME_RE.fullmatch(name):
+        raise ValueError(
+            f"Invalid AGE graph name '{name}': must match {_GRAPH_NAME_RE.pattern}"
+        )
+    return name
+
+
+def sanitize_identifier(name: str) -> str:
+    """Return a deterministic identifier safe for use as a Cypher label or key.
+
+    Non-alphanumeric characters are escaped as ``_u<codepoint_hex>_`` so the
+    resulting identifier always starts with a letter, contains only ASCII
+    letters, digits, and underscores, and can be losslessly reversed by
+    :func:`desanitize_identifier`.
+    """
+    return _SANITIZE_PREFIX + "".join(
+        c if c.isalnum() else f"_u{ord(c):x}_" for c in name
+    )
+
+
+def desanitize_identifier(sanitized_name: str) -> str:
+    """Reverse :func:`sanitize_identifier`."""
+    return re.sub(
+        r"_u([0-9a-fA-F]+)_",
+        lambda match: chr(int(match[1], 16)),
+        sanitized_name.removeprefix(_SANITIZE_PREFIX),
+    )
+
+
+def age_value_from_python(value: Any) -> Any:
+    """Convert a Python property value into something JSON/agtype-encodable.
+
+    ``datetime`` values are normalized to UTC and emitted as ISO-8601 strings
+    so that lexical and chronological ordering coincide. Lists recurse. All
+    other primitives pass through unchanged. Accepts ``Any`` because callers
+    pass through free-form values (embedding lists, filter literals, mixed
+    map values) and the function is intentionally polymorphic.
+    """
+    if isinstance(value, _dt.datetime):
+        tzinfo = value.tzinfo
+        if tzinfo is None:
+            value = value.replace(tzinfo=_dt.UTC)
+        return value.astimezone(_dt.UTC).isoformat()
+    if isinstance(value, list):
+        return [age_value_from_python(item) for item in value]
+    return value
+
+
+def age_value_to_python(value: Any) -> Any:
+    """Inverse of :func:`age_value_from_python` for values read from AGE.
+
+    Strings that look like ISO-8601 datetimes are parsed back into aware
+    ``datetime`` objects; other values are returned as-is.
+    """
+    if isinstance(value, str) and _looks_like_iso_datetime(value):
+        try:
+            parsed = _dt.datetime.fromisoformat(value)
+        except ValueError:
+            return value
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=_dt.UTC)
+        return parsed
+    if isinstance(value, list):
+        return [age_value_to_python(item) for item in value]
+    return value
+
+
+_ISO_DATETIME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?"
+    r"(?:[Zz]|[+-]\d{2}:?\d{2})?$"
+)
+
+
+def _looks_like_iso_datetime(value: str) -> bool:
+    return bool(_ISO_DATETIME_RE.match(value))
+
+
+def encode_agtype_params(params: Mapping[str, Any] | None) -> str:
+    """JSON-encode a parameter map so it can be bound as an ``agtype`` argument.
+
+    Cypher parameters are passed to ``cypher()`` as a single ``agtype`` value.
+    ``agtype`` accepts JSON object literals for map parameters, so we emit
+    standard JSON. Datetime values are normalized to ISO-8601 UTC strings via
+    :func:`age_value_from_python`.
+
+    ``allow_nan=True`` is deliberate: Python's ``json`` emits ``NaN``,
+    ``Infinity``, and ``-Infinity`` for non-finite floats, and :func:`parse_agtype`
+    accepts the same spellings, so the round trip stays symmetric.
+    """
+    if params is None:
+        return "{}"
+    prepared = {key: _prepare_for_json(value) for key, value in params.items()}
+    return json.dumps(prepared, allow_nan=True, separators=(",", ":"))
+
+
+def _prepare_for_json(value: Any) -> Any:
+    if isinstance(value, _dt.datetime):
+        return age_value_from_python(value)
+    if isinstance(value, list):
+        return [_prepare_for_json(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _prepare_for_json(item) for key, item in value.items()}
+    return value
+
+
+# Dollar-quoted delimiter used to wrap the Cypher body. Distinct from the empty
+# ``$$`` delimiter so that doubled dollar signs cannot accidentally terminate
+# the string literal from inside the Cypher text.
+_CYPHER_DOLLAR_TAG = "$cypher_body$"
+
+
+def build_cypher_call(
+    graph_name: str,
+    cypher_body: str,
+    *,
+    returns: Iterable[str] = ("v",),
+    has_params: bool = False,
+) -> str:
+    """Build the ``SELECT ... FROM cypher(...)`` wrapper that AGE requires.
+
+    Args:
+        graph_name: The AGE graph name. Must pass :func:`validate_graph_name`.
+        cypher_body: The Cypher statement to execute.
+        returns: Names of the returned columns; each is typed as ``agtype``.
+        has_params: Whether the caller binds a parameter map as ``$1``.
+
+    Returns:
+        A SQL statement that can be executed via SQLAlchemy or asyncpg.
+    """
+    validate_graph_name(graph_name)
+    if _CYPHER_DOLLAR_TAG in cypher_body:
+        raise ValueError(
+            "Cypher body contains the reserved dollar-quoted delimiter; "
+            "either escape or rename the delimiter in the source statement."
+        )
+
+    return_columns = ", ".join(f"{name} agtype" for name in returns)
+    if not return_columns:
+        raise ValueError("at least one return column is required")
+
+    params_slot = ", $1::agtype" if has_params else ""
+    return (
+        f"SELECT * FROM cypher('{graph_name}', "
+        f"{_CYPHER_DOLLAR_TAG}{cypher_body}{_CYPHER_DOLLAR_TAG}"
+        f"{params_slot}"
+        f") AS ({return_columns})"
+    )
+
+
+def setup_age_sync_connection(dbapi_connection: Any) -> None:
+    """Run the per-session setup required for AGE on a DB-API connection.
+
+    Designed to be registered on a SQLAlchemy engine's ``connect`` event so the
+    extension is loaded and the search path is set before any Cypher query
+    runs. The caller supplies the raw DB-API connection; this function opens
+    and closes its own cursor.
+
+    The AGE extension must be installed (via ``CREATE EXTENSION age``) before
+    ``LOAD 'age'`` can succeed. On the very first connection to a fresh
+    database, the extension has not yet been installed, so we probe
+    ``pg_extension`` first and skip the LOAD in that case — the later
+    ``_ensure_graph_initialized`` step runs ``CREATE EXTENSION`` explicitly,
+    and subsequent pooled connections see the extension and load it normally.
+    """
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute("SELECT 1 FROM pg_extension WHERE extname = 'age'")
+        has_age = cursor.fetchone() is not None
+        if has_age:
+            cursor.execute("LOAD 'age'")
+        cursor.execute('SET search_path = ag_catalog, "$user", public')
+    finally:
+        cursor.close()
+
+
+# ---------------------------------------------------------------------------
+# agtype parsing
+# ---------------------------------------------------------------------------
+
+_AGTYPE_SUFFIXES = ("::vertex", "::edge", "::path", "::numeric")
+
+
+def parse_agtype(text: str | bytes | None) -> Any:
+    """Parse an ``agtype`` text value into native Python data.
+
+    The parser accepts the JSON grammar extended with the ``::vertex``,
+    ``::edge``, ``::path``, and ``::numeric`` type annotations that AGE emits
+    on its custom types. Vertex and edge objects are returned as
+    :class:`AgeVertex` / :class:`AgeEdge` instances; paths as :class:`AgePath`.
+    """
+    if text is None:
+        return None
+    if isinstance(text, bytes):
+        text = text.decode("utf-8")
+    parser = _AgtypeParser(text)
+    value = parser.parse_value()
+    parser.skip_ws()
+    if not parser.at_end():
+        raise AgtypeParseError(
+            f"unexpected trailing data at position {parser.pos}: {text!r}"
+        )
+    return value
+
+
+class _AgtypeParser:
+    """Minimal recursive-descent parser for the ``agtype`` text grammar."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.pos = 0
+
+    def at_end(self) -> bool:
+        return self.pos >= len(self.text)
+
+    def skip_ws(self) -> None:
+        while self.pos < len(self.text) and self.text[self.pos].isspace():
+            self.pos += 1
+
+    def _peek(self) -> str:
+        if self.pos >= len(self.text):
+            raise AgtypeParseError("unexpected end of input")
+        return self.text[self.pos]
+
+    def _consume(self, literal: str) -> bool:
+        if self.text.startswith(literal, self.pos):
+            self.pos += len(literal)
+            return True
+        return False
+
+    def _require(self, literal: str) -> None:
+        if not self._consume(literal):
+            raise AgtypeParseError(f"expected {literal!r} at position {self.pos}")
+
+    def parse_value(self) -> Any:
+        self.skip_ws()
+        value = self._parse_raw_value()
+        self.skip_ws()
+        value = self._maybe_apply_suffix(value)
+        return value
+
+    def _maybe_apply_suffix(self, value: Any) -> Any:
+        for suffix in _AGTYPE_SUFFIXES:
+            if self._consume(suffix):
+                return _coerce_typed_value(suffix, value)
+        return value
+
+    def _parse_raw_value(self) -> Any:  # noqa: C901
+        if self.at_end():
+            raise AgtypeParseError("unexpected end of input")
+        ch = self._peek()
+        if ch == "{":
+            return self._parse_object()
+        if ch == "[":
+            return self._parse_array()
+        if ch == '"':
+            return self._parse_string()
+        if ch == "-" or ch.isdigit():
+            return self._parse_number()
+        if self._consume("true"):
+            return True
+        if self._consume("false"):
+            return False
+        if self._consume("null"):
+            return None
+        # Non-JSON numeric literals that AGE may emit.
+        for token, replacement in (
+            ("NaN", float("nan")),
+            ("Infinity", float("inf")),
+            ("-Infinity", float("-inf")),
+        ):
+            if self._consume(token):
+                return replacement
+        raise AgtypeParseError(f"unexpected character {ch!r} at position {self.pos}")
+
+    def _parse_object(self) -> dict[str, Any]:
+        self._require("{")
+        self.skip_ws()
+        result: dict[str, Any] = {}
+        if self._consume("}"):
+            return result
+        while True:
+            self.skip_ws()
+            key = self._parse_string()
+            self.skip_ws()
+            self._require(":")
+            value = self.parse_value()
+            result[key] = value
+            self.skip_ws()
+            if self._consume(","):
+                continue
+            self._require("}")
+            return result
+
+    def _parse_array(self) -> list[Any]:
+        self._require("[")
+        self.skip_ws()
+        result: list[Any] = []
+        if self._consume("]"):
+            return result
+        while True:
+            value = self.parse_value()
+            result.append(value)
+            self.skip_ws()
+            if self._consume(","):
+                continue
+            self._require("]")
+            return result
+
+    def _parse_string(self) -> str:
+        self._require('"')
+        chars: list[str] = []
+        while True:
+            if self.at_end():
+                raise AgtypeParseError("unterminated string literal")
+            ch = self.text[self.pos]
+            self.pos += 1
+            if ch == '"':
+                return "".join(chars)
+            if ch == "\\":
+                chars.append(self._parse_string_escape())
+                continue
+            chars.append(ch)
+
+    def _parse_string_escape(self) -> str:  # noqa: C901
+        if self.at_end():
+            raise AgtypeParseError("unterminated escape sequence")
+        ch = self.text[self.pos]
+        self.pos += 1
+        if ch == '"':
+            return '"'
+        if ch == "\\":
+            return "\\"
+        if ch == "/":
+            return "/"
+        if ch == "b":
+            return "\b"
+        if ch == "f":
+            return "\f"
+        if ch == "n":
+            return "\n"
+        if ch == "r":
+            return "\r"
+        if ch == "t":
+            return "\t"
+        if ch == "u":
+            if self.pos + 4 > len(self.text):
+                raise AgtypeParseError("truncated unicode escape")
+            hex_value = self.text[self.pos : self.pos + 4]
+            self.pos += 4
+            try:
+                return chr(int(hex_value, 16))
+            except ValueError as err:
+                raise AgtypeParseError(
+                    f"invalid unicode escape \\u{hex_value}"
+                ) from err
+        raise AgtypeParseError(f"invalid escape character \\{ch}")
+
+    def _parse_number(self) -> int | float:
+        start = self.pos
+        if self._consume("-"):
+            pass
+        while self.pos < len(self.text) and self.text[self.pos].isdigit():
+            self.pos += 1
+        is_float = False
+        if self.pos < len(self.text) and self.text[self.pos] == ".":
+            is_float = True
+            self.pos += 1
+            while self.pos < len(self.text) and self.text[self.pos].isdigit():
+                self.pos += 1
+        if self.pos < len(self.text) and self.text[self.pos] in "eE":
+            is_float = True
+            self.pos += 1
+            if self.pos < len(self.text) and self.text[self.pos] in "+-":
+                self.pos += 1
+            while self.pos < len(self.text) and self.text[self.pos].isdigit():
+                self.pos += 1
+        literal = self.text[start : self.pos]
+        try:
+            return float(literal) if is_float else int(literal)
+        except ValueError as err:
+            raise AgtypeParseError(f"invalid number literal {literal!r}") from err
+
+
+def _coerce_typed_value(suffix: str, value: Any) -> Any:
+    if suffix == "::vertex":
+        if not isinstance(value, dict):
+            raise AgtypeParseError("expected object before ::vertex annotation")
+        return AgeVertex(
+            id=int(value.get("id", 0)),
+            label=str(value.get("label", "")),
+            properties=dict(value.get("properties", {})),
+        )
+    if suffix == "::edge":
+        if not isinstance(value, dict):
+            raise AgtypeParseError("expected object before ::edge annotation")
+        return AgeEdge(
+            id=int(value.get("id", 0)),
+            label=str(value.get("label", "")),
+            start_id=int(value.get("start_id", 0)),
+            end_id=int(value.get("end_id", 0)),
+            properties=dict(value.get("properties", {})),
+        )
+    if suffix == "::path":
+        if not isinstance(value, list):
+            raise AgtypeParseError("expected array before ::path annotation")
+        return AgePath(elements=tuple(value))
+    if suffix == "::numeric":
+        # ``::numeric`` keeps arbitrary-precision decimals as their string form;
+        # we defer to the caller to interpret it rather than losing precision.
+        return value
+    raise AgtypeParseError(f"unknown agtype suffix {suffix!r}")
+
+
+# ---------------------------------------------------------------------------
+# Comparison rendering
+# ---------------------------------------------------------------------------
+
+
+def render_comparison(
+    left: str,
+    op: str,
+    right: str,
+    value: PropertyValue,
+) -> str:
+    """Render a Cypher comparison clause for a property value.
+
+    AGE stores datetimes as ISO-8601 strings, so lexical and chronological
+    ordering coincide and a plain operator is sufficient. The ``!=`` form is
+    normalized to ``<>`` to match the Cypher grammar used elsewhere.
+    """
+    if op == "!=":
+        op = "<>"
+    if isinstance(value, list):
+        raise TypeError(f"'{op}' comparison cannot accept list values")
+    return f"{left} {op} {right}"

--- a/packages/server/src/memmachine_server/common/configuration/database_conf.py
+++ b/packages/server/src/memmachine_server/common/configuration/database_conf.py
@@ -5,6 +5,7 @@ from typing import ClassVar, Self
 
 import yaml
 from pydantic import BaseModel, Field, SecretStr, model_validator
+from sqlalchemy.engine import URL
 
 from memmachine_server.common.configuration.mixin_confs import (
     PasswordMixin,
@@ -85,6 +86,119 @@ class Neo4jConf(YamlSerializableMixin, PasswordMixin):
         if "neo4j+s://" in self.host:
             return self.host
         return f"bolt://{self.host}:{self.port}"
+
+
+class AgeConf(YamlSerializableMixin, PasswordMixin):
+    """Configuration options for an Apache AGE (PostgreSQL) instance.
+
+    AGE is a PostgreSQL extension, so connections reuse the standard SQLAlchemy
+    + asyncpg stack. Vector similarity search is delegated to pgvector side
+    tables, so the same database must also have the ``vector`` extension
+    available (already required for ``SqlAlchemyPgVectorSemanticStorage``).
+    """
+
+    host: str = Field(default="localhost", description="PostgreSQL host")
+    port: int = Field(default=5432, description="PostgreSQL port")
+    user: str = Field(default="postgres", description="PostgreSQL username")
+    password: SecretStr = Field(
+        default=SecretStr("postgres_password"),
+        description=(
+            "Password for the PostgreSQL user. "
+            "You may reference an environment variable using `$ENV` or `${ENV}` "
+            "syntax (for example, `$AGE_PASSWORD`)."
+        ),
+    )
+    db_name: str = Field(default="postgres", description="Database name")
+    graph_name: str = Field(
+        default="mem_graph",
+        description=(
+            "AGE graph name. Becomes the PostgreSQL schema that holds the "
+            "AGE catalog tables, and is used as the prefix for the pgvector "
+            "side tables. Must be a valid PostgreSQL identifier."
+        ),
+    )
+
+    # Search behavior — mirrors Neo4jConf for consistency across backends.
+    force_exact_similarity_search: bool = Field(
+        default=False,
+        description="Whether to force exact similarity search instead of ANN",
+    )
+    range_index_creation_threshold: int | None = Field(
+        default=None,
+        description=(
+            "Minimum number of entities in a collection or relationship "
+            "before AGE automatically creates a B-tree property index."
+        ),
+    )
+    vector_index_creation_threshold: int | None = Field(
+        default=None,
+        description=(
+            "Minimum number of entities in a collection or relationship "
+            "before pgvector automatically creates an HNSW vector index."
+        ),
+    )
+
+    # pgvector HNSW tuning
+    hnsw_m: int = Field(
+        default=16,
+        description=(
+            "pgvector HNSW 'm' parameter (max neighbors per layer). "
+            "Higher values trade memory for recall."
+        ),
+        gt=0,
+    )
+    hnsw_ef_construction: int = Field(
+        default=64,
+        description=(
+            "pgvector HNSW 'ef_construction' parameter (build quality). "
+            "Higher values trade build time for index quality."
+        ),
+        gt=0,
+    )
+
+    # SQLAlchemy connection pool tuning (mirrors SqlAlchemyConf knobs).
+    pool_size: int | None = Field(
+        default=None,
+        description=("Number of persistent connections to maintain in the pool."),
+    )
+    max_overflow: int | None = Field(
+        default=None,
+        description=(
+            "Maximum number of temporary connections allowed above pool_size."
+        ),
+    )
+    pool_timeout: int | None = Field(
+        default=None,
+        description=(
+            "Maximum time in seconds to wait for a connection from the pool. "
+            "Internal default is 30."
+        ),
+    )
+    pool_recycle: int | None = Field(
+        default=None,
+        description=("Maximum age of a connection in seconds before it is recycled."),
+    )
+    pool_pre_ping: bool | None = Field(
+        default=None,
+        description=("When True, test each connection for liveness before checkout."),
+    )
+
+    @property
+    def uri(self) -> str:
+        """Construct the SQLAlchemy/asyncpg URI for this AGE deployment.
+
+        Uses :func:`sqlalchemy.engine.URL.create` so special characters in
+        the password (``@``, ``:``, ``/``, ``#``, etc.) are correctly
+        percent-encoded rather than breaking the DSN.
+        """
+        return URL.create(
+            "postgresql+asyncpg",
+            username=self.user,
+            password=self.password.get_secret_value(),
+            host=self.host,
+            port=self.port,
+            database=self.db_name,
+        ).render_as_string(hide_password=False)
 
 
 class NebulaGraphConf(YamlSerializableMixin, PasswordMixin):
@@ -333,7 +447,9 @@ class SupportedDB(StrEnum):
     """Supported database providers."""
 
     # <-- Add these annotations so mypy knows these attributes exist
-    conf_cls: type[Neo4jConf] | type[SqlAlchemyConf] | type[NebulaGraphConf]
+    conf_cls: (
+        type[Neo4jConf] | type[SqlAlchemyConf] | type[NebulaGraphConf] | type[AgeConf]
+    )
     dialect: str | None
     driver: str | None
 
@@ -341,11 +457,17 @@ class SupportedDB(StrEnum):
     POSTGRES = ("postgres", SqlAlchemyConf, "postgresql", "asyncpg")
     SQLITE = ("sqlite", SqlAlchemyConf, "sqlite", "aiosqlite")
     NEBULA_GRAPH = ("nebula_graph", NebulaGraphConf, None, None)
+    AGE = ("age", AgeConf, None, None)
 
     def __new__(
         cls,
         value: str,
-        conf_cls: type[Neo4jConf] | type[SqlAlchemyConf] | type[NebulaGraphConf],
+        conf_cls: (
+            type[Neo4jConf]
+            | type[SqlAlchemyConf]
+            | type[NebulaGraphConf]
+            | type[AgeConf]
+        ),
         dialect: str | None,
         driver: str | None,
     ) -> Self:
@@ -366,10 +488,14 @@ class SupportedDB(StrEnum):
             f"Unsupported provider '{provider}'. Supported providers are: {valid}"
         )
 
-    def build_config(self, conf: dict) -> Neo4jConf | SqlAlchemyConf | NebulaGraphConf:
+    def build_config(
+        self, conf: dict
+    ) -> Neo4jConf | SqlAlchemyConf | NebulaGraphConf | AgeConf:
         if self is SupportedDB.NEO4J:
             return self.conf_cls(**conf)
         if self is SupportedDB.NEBULA_GRAPH:
+            return self.conf_cls(**conf)
+        if self is SupportedDB.AGE:
             return self.conf_cls(**conf)
         # Relational DBs (PostgreSQL, SQLite)
         if self.dialect is None or self.driver is None:
@@ -388,6 +514,10 @@ class SupportedDB(StrEnum):
     def is_nebula_graph(self) -> bool:
         return self is SupportedDB.NEBULA_GRAPH
 
+    @property
+    def is_age(self) -> bool:
+        return self is SupportedDB.AGE
+
 
 class DatabasesConf(BaseModel):
     """Top-level storage configuration mapping identifiers to backends."""
@@ -395,6 +525,7 @@ class DatabasesConf(BaseModel):
     neo4j_confs: dict[str, Neo4jConf] = {}
     relational_db_confs: dict[str, SqlAlchemyConf] = {}
     nebula_graph_confs: dict[str, NebulaGraphConf] = {}
+    age_confs: dict[str, AgeConf] = {}
 
     PROVIDER_KEY: ClassVar[str] = "provider"
     CONFIG_KEY: ClassVar[str] = "config"
@@ -404,6 +535,7 @@ class DatabasesConf(BaseModel):
     POSTGRESQL: ClassVar[str] = "postgresql"
     SQLITE: ClassVar[str] = "sqlite"
     NEBULA_GRAPH: ClassVar[str] = "nebula_graph"
+    AGE: ClassVar[str] = "age"
     DIALECT: ClassVar[str] = "dialect"
 
     def to_yaml_dict(self) -> dict:
@@ -437,6 +569,12 @@ class DatabasesConf(BaseModel):
                 self.CONFIG_KEY: conf.to_yaml_dict(),
             }
 
+        for database_id, conf in self.age_confs.items():
+            databases[database_id] = {
+                self.PROVIDER_KEY: self.AGE,
+                self.CONFIG_KEY: conf.to_yaml_dict(),
+            }
+
         return databases
 
     def to_yaml(self) -> str:
@@ -453,6 +591,7 @@ class DatabasesConf(BaseModel):
         neo4j_dict = {}
         relational_db_dict = {}
         nebula_graph_dict = {}
+        age_dict = {}
 
         for database_id, resource_definition in databases.items():
             provider_str = resource_definition.get(cls.PROVIDER_KEY)
@@ -465,6 +604,8 @@ class DatabasesConf(BaseModel):
                 neo4j_dict[database_id] = config_obj
             elif provider.is_nebula_graph:
                 nebula_graph_dict[database_id] = config_obj
+            elif provider.is_age:
+                age_dict[database_id] = config_obj
             else:
                 relational_db_dict[database_id] = config_obj
 
@@ -472,4 +613,5 @@ class DatabasesConf(BaseModel):
             neo4j_confs=neo4j_dict,
             relational_db_confs=relational_db_dict,
             nebula_graph_confs=nebula_graph_dict,
+            age_confs=age_dict,
         )

--- a/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
@@ -1,4 +1,4 @@
-"""Manage database engines for SQL, Neo4j, and NebulaGraph backends."""
+"""Manage database engines for SQL, Neo4j, NebulaGraph, and Apache AGE backends."""
 
 import asyncio
 import logging
@@ -6,10 +6,12 @@ from asyncio import Lock
 from typing import TYPE_CHECKING, Any, Self
 
 from neo4j import AsyncDriver, AsyncGraphDatabase
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
+from memmachine_server.common.age_utils import setup_age_sync_connection
 from memmachine_server.common.configuration.database_conf import (
+    AgeConf,
     DatabasesConf,
     Neo4jConf,
 )
@@ -18,6 +20,10 @@ from memmachine_server.common.errors import (
     SQLConfigurationError,
 )
 from memmachine_server.common.vector_graph_store import VectorGraphStore
+from memmachine_server.common.vector_graph_store.age_vector_graph_store import (
+    AgeVectorGraphStore,
+    AgeVectorGraphStoreParams,
+)
 from memmachine_server.common.vector_graph_store.neo4j_vector_graph_store import (
     Neo4jVectorGraphStore,
     Neo4jVectorGraphStoreParams,
@@ -45,11 +51,13 @@ class DatabaseManager:
         # is only imported under TYPE_CHECKING and doesn't exist at runtime.
         # Type checkers see it, but runtime treats it as a string literal.
         self.nebula_clients: dict[str, NebulaAsyncClient] = {}
+        self.age_engines: dict[str, AsyncEngine] = {}
 
         self._lock = Lock()
         self._neo4j_locks: dict[str, Lock] = {}
         self._sql_locks: dict[str, Lock] = {}
         self._nebula_locks: dict[str, Lock] = {}
+        self._age_locks: dict[str, Lock] = {}
 
     async def build_all(self, validate: bool = False) -> Self:
         """Optionally eagerly initialize all backends."""
@@ -65,8 +73,12 @@ class DatabaseManager:
             self.async_get_nebula_client(name, validate=validate)
             for name in self.conf.nebula_graph_confs
         ]
+        age_tasks = [
+            self.async_get_age_engine(name, validate=validate)
+            for name in self.conf.age_confs
+        ]
         # Lazy build will occur in get_* calls, but build_all can trigger them
-        tasks = neo4j_tasks + relation_db_tasks + nebula_tasks
+        tasks = neo4j_tasks + relation_db_tasks + nebula_tasks + age_tasks
         await asyncio.gather(*tasks)
 
         if validate:
@@ -74,6 +86,7 @@ class DatabaseManager:
                 self._validate_neo4j_drivers(),
                 self._validate_sql_engines(),
                 self._validate_nebula_clients(),
+                self._validate_age_engines(),
             )
 
         return self
@@ -88,14 +101,18 @@ class DatabaseManager:
                 tasks.append(self._close_async_engine(name, engine))
             for name, client in self.nebula_clients.items():
                 tasks.append(self._close_nebula_client(name, client))
+            for name, engine in self.age_engines.items():
+                tasks.append(self._close_async_engine(name, engine))
             await asyncio.gather(*tasks)
             self.graph_stores.clear()
             self.neo4j_drivers.clear()
             self.sql_engines.clear()
             self.nebula_clients.clear()
+            self.age_engines.clear()
             self._neo4j_locks.clear()
             self._sql_locks.clear()
             self._nebula_locks.clear()
+            self._age_locks.clear()
 
     @staticmethod
     async def _close_async_driver(name: str, driver: AsyncDriver) -> None:
@@ -185,7 +202,7 @@ class DatabaseManager:
         return asyncio.run(self.async_get_neo4j_driver(name, validate=True))
 
     async def get_vector_graph_store(self, name: str) -> VectorGraphStore:
-        """Return a vector graph store, auto-detecting Neo4j or NebulaGraph backend."""
+        """Return a vector graph store, auto-detecting the configured backend."""
         # Check if it's a Neo4j configuration
         if name in self.conf.neo4j_confs:
             await self.async_get_neo4j_driver(name, validate=True)
@@ -196,9 +213,15 @@ class DatabaseManager:
             await self.async_get_nebula_client(name, validate=True)
             return self.graph_stores[name]
 
-        # Not found in either
+        # Check if it's an Apache AGE configuration
+        if name in self.conf.age_confs:
+            await self.async_get_age_engine(name, validate=True)
+            return self.graph_stores[name]
+
+        # Not found in any
         raise ValueError(
-            f"VectorGraphStore '{name}' not found in neo4j_confs or nebula_graph_confs"
+            f"VectorGraphStore '{name}' not found in neo4j_confs, "
+            "nebula_graph_confs, or age_confs"
         )
 
     @staticmethod
@@ -470,3 +493,117 @@ class DatabaseManager:
         """Validate connectivity to each NebulaGraph instance."""
         for name, client in self.nebula_clients.items():
             await self.validate_nebula_client(name, client)
+
+    # --- Apache AGE ---
+
+    async def async_get_age_engine(
+        self, name: str, validate: bool = False
+    ) -> AsyncEngine:
+        """Return an AGE-enabled SQLAlchemy engine, creating it if necessary."""
+        if name not in self._age_locks:
+            async with self._lock:
+                self._age_locks.setdefault(name, Lock())
+
+        async with self._age_locks[name]:
+            if name in self.age_engines:
+                return self.age_engines[name]
+
+            conf = self.conf.age_confs.get(name)
+            if not conf:
+                raise ValueError(f"AGE config '{name}' not found.")
+
+            engine = self._build_age_engine(conf)
+
+            if validate:
+                await self.validate_age_engine(name, engine)
+
+            self.age_engines[name] = engine
+
+            params_kwargs: dict[str, Any] = {
+                "engine": engine,
+                "graph_name": conf.graph_name,
+                "force_exact_similarity_search": conf.force_exact_similarity_search,
+                "range_index_hierarchies": [["uid"], ["timestamp", "uid"]],
+                "hnsw_m": conf.hnsw_m,
+                "hnsw_ef_construction": conf.hnsw_ef_construction,
+            }
+            if conf.range_index_creation_threshold is not None:
+                params_kwargs["range_index_creation_threshold"] = (
+                    conf.range_index_creation_threshold
+                )
+            if conf.vector_index_creation_threshold is not None:
+                params_kwargs["vector_index_creation_threshold"] = (
+                    conf.vector_index_creation_threshold
+                )
+
+            params = AgeVectorGraphStoreParams(**params_kwargs)
+            self.graph_stores[name] = AgeVectorGraphStore(params)
+            return engine
+
+    @staticmethod
+    def _build_age_engine(conf: AgeConf) -> AsyncEngine:
+        """Build an async SQLAlchemy engine and wire the per-connection setup."""
+        engine_kwargs: dict[str, bool | int] = {
+            "echo": False,
+            "future": True,
+        }
+        if conf.pool_size is not None:
+            engine_kwargs["pool_size"] = conf.pool_size
+        if conf.max_overflow is not None:
+            engine_kwargs["max_overflow"] = conf.max_overflow
+        if conf.pool_timeout is not None:
+            engine_kwargs["pool_timeout"] = conf.pool_timeout
+        if conf.pool_recycle is not None:
+            engine_kwargs["pool_recycle"] = conf.pool_recycle
+        if conf.pool_pre_ping is not None:
+            engine_kwargs["pool_pre_ping"] = conf.pool_pre_ping
+
+        engine = create_async_engine(conf.uri, **engine_kwargs)
+        _register_age_connect_hook(engine)
+        return engine
+
+    @staticmethod
+    async def validate_age_engine(name: str, engine: AsyncEngine) -> None:
+        """Validate connectivity for an AGE engine."""
+        try:
+            logger.info("Validating AGE engine '%s'", name)
+            async with engine.connect() as conn:
+                result = await conn.execute(text("SELECT 1 AS ok"))
+                row = result.fetchone()
+        except Exception as e:
+            await engine.dispose()
+            raise SQLConfigurationError(
+                f"AGE config '{name}' failed verification: {e}",
+            ) from e
+
+        if not row or row[0] != 1:
+            await engine.dispose()
+            raise SQLConfigurationError(
+                f"Verification failed for AGE config '{name}'",
+            )
+        logger.info("AGE engine '%s' validated successfully", name)
+
+    async def _validate_age_engines(self) -> None:
+        """Validate connectivity for each AGE engine."""
+        for name, engine in self.age_engines.items():
+            await self.validate_age_engine(name, engine)
+
+
+def _register_age_connect_hook(engine: AsyncEngine) -> None:
+    """Wire per-connection AGE setup onto a SQLAlchemy async engine.
+
+    Extracted as a module-level function so tests can patch this seam
+    directly instead of patching ``sqlalchemy.event.listens_for``, which
+    couples the test to internal SQLAlchemy plumbing.
+
+    AGE's session state (extension load, search_path) is per-connection, so
+    every newly created physical connection must run the setup before any
+    Cypher query.
+    """
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _on_connect(
+        dbapi_connection: Any,  # noqa: ANN401
+        connection_record: Any,  # noqa: ANN401, ARG001
+    ) -> None:
+        setup_age_sync_connection(dbapi_connection)

--- a/packages/server/src/memmachine_server/common/vector_graph_store/age_vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/age_vector_graph_store.py
@@ -1,0 +1,1900 @@
+"""Apache AGE-backed vector graph store implementation.
+
+Apache AGE is a PostgreSQL extension that adds openCypher support on top of
+relational storage. Because AGE does not provide a native vector index, this
+implementation stores graph structure and scalar properties inside AGE and
+delegates vector similarity search to a pgvector-indexed side table that is
+keyed by vertex or edge uid. A single PostgreSQL instance therefore provides
+both the graph backend and (via ``SqlAlchemyPgVectorSemanticStorage``) the
+semantic backend under permissive, Apache-2.0-compatible licensing.
+"""
+
+import asyncio
+import hashlib
+import logging
+from collections.abc import Awaitable, Iterable, Mapping
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, InstanceOf
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
+
+from memmachine_server.common.age_utils import (
+    AgeVertex,
+    age_value_from_python,
+    age_value_to_python,
+    build_cypher_call,
+    desanitize_identifier,
+    encode_agtype_params,
+    parse_agtype,
+    render_comparison,
+    sanitize_identifier,
+    validate_graph_name,
+)
+from memmachine_server.common.data_types import (
+    OrderedValue,
+    SimilarityMetric,
+)
+from memmachine_server.common.filter.filter_parser import (
+    And as FilterAnd,
+)
+from memmachine_server.common.filter.filter_parser import (
+    Comparison as FilterComparison,
+)
+from memmachine_server.common.filter.filter_parser import (
+    FilterExpr,
+)
+from memmachine_server.common.filter.filter_parser import (
+    In as FilterIn,
+)
+from memmachine_server.common.filter.filter_parser import (
+    IsNull as FilterIsNull,
+)
+from memmachine_server.common.filter.filter_parser import (
+    Not as FilterNot,
+)
+from memmachine_server.common.filter.filter_parser import (
+    Or as FilterOr,
+)
+from memmachine_server.common.metrics_factory import MetricsFactory, OperationTracker
+from memmachine_server.common.utils import async_locked
+
+from .data_types import (
+    Edge,
+    EntityType,
+    Node,
+    PropertyValue,
+    demangle_embedding_name,
+    demangle_property_name,
+    is_mangled_embedding_name,
+    is_mangled_property_name,
+    mangle_embedding_name,
+    mangle_property_name,
+)
+from .vector_graph_store import VectorGraphStore
+
+logger = logging.getLogger(__name__)
+
+# Default AGE graph name. AGE creates a schema of this name plus a pair of
+# catalog tables; the side tables for vector storage are prefixed with it.
+DEFAULT_GRAPH_NAME = "mem_graph"
+
+# Upper bound for vector dimensionality. pgvector caps ``vector`` columns at
+# 16000 dimensions, which we surface directly here rather than inheriting
+# Neo4j's tighter 4096 cap — users who pick AGE specifically because they
+# want the pgvector ceiling shouldn't be artificially limited.
+_MAX_VECTOR_DIMENSIONS = 16000
+
+# Postgres caps identifier length at 63 bytes (NAMEDATALEN - 1). Side-table
+# names are derived from a sha1 digest so they always fit, but the
+# (collection_label, embedding_name) mapping must still be recoverable for
+# cleanup and hydration. A per-graph registry table holds that mapping.
+_SIDE_TABLE_REGISTRY_SUFFIX = "_emb_registry"
+
+
+class AgeVectorGraphStoreParams(BaseModel):
+    """Parameters for :class:`AgeVectorGraphStore`.
+
+    Attributes:
+        engine: Async SQLAlchemy engine pointing at a PostgreSQL database with
+            the ``age`` and ``vector`` extensions available.
+        graph_name: AGE graph name. Used as the PostgreSQL schema name for the
+            AGE catalog and as a prefix for the pgvector side tables.
+        force_exact_similarity_search: Skip the pgvector HNSW index and always
+            perform an exact KNN scan (useful for small collections or tests).
+        filtered_similarity_search_fudge_factor: Multiplier applied to the
+            search limit when a property filter is combined with ANN search, to
+            compensate for the index returning unfiltered neighbors.
+        exact_similarity_search_fallback_threshold: If an ANN-plus-filter
+            search returns fewer than ``threshold * limit`` rows, fall back to
+            an exact scan that applies the filter in SQL.
+        range_index_hierarchies: List of property name hierarchies for which to
+            create composite B-tree indexes on the AGE vertex/edge tables.
+        range_index_creation_threshold: Minimum entity count at which range
+            indexes are created automatically.
+        vector_index_creation_threshold: Minimum entity count at which HNSW
+            vector indexes are created automatically.
+        hnsw_m: pgvector HNSW ``m`` parameter (max connections per layer).
+        hnsw_ef_construction: pgvector HNSW ``ef_construction`` parameter.
+        metrics_factory: Optional metrics factory for operation tracking.
+    """
+
+    engine: InstanceOf[AsyncEngine] = Field(
+        ...,
+        description="Async SQLAlchemy engine connected to PostgreSQL with AGE",
+    )
+    graph_name: str = Field(
+        default=DEFAULT_GRAPH_NAME,
+        description="AGE graph name (also used as the side-table prefix)",
+    )
+    force_exact_similarity_search: bool = Field(
+        default=False,
+        description="Whether to force exact similarity search",
+    )
+    filtered_similarity_search_fudge_factor: int = Field(
+        default=4,
+        description=(
+            "Fudge factor for filtered similarity search. pgvector HNSW does "
+            "not support pre-filtering, so we over-fetch by this multiplier "
+            "and filter in SQL."
+        ),
+        gt=0,
+    )
+    exact_similarity_search_fallback_threshold: float = Field(
+        default=0.5,
+        description=(
+            "Threshold ratio of ANN results to limit below which to fall back "
+            "to exact similarity search when a property filter is applied."
+        ),
+        ge=0.0,
+        le=1.0,
+    )
+    range_index_hierarchies: list[list[str]] = Field(
+        default_factory=list,
+        description=(
+            "List of property name hierarchies for which to create composite "
+            "B-tree indexes on the underlying AGE vertex/edge tables."
+        ),
+    )
+    range_index_creation_threshold: int = Field(
+        default=10_000,
+        description=(
+            "Threshold number of entities at which range indexes may be created."
+        ),
+    )
+    vector_index_creation_threshold: int = Field(
+        default=10_000,
+        description=(
+            "Threshold number of entities at which vector indexes may be created."
+        ),
+    )
+    hnsw_m: int = Field(
+        default=16,
+        description="pgvector HNSW 'm' parameter (max connections per layer)",
+        gt=0,
+    )
+    hnsw_ef_construction: int = Field(
+        default=64,
+        description="pgvector HNSW 'ef_construction' parameter",
+        gt=0,
+    )
+    metrics_factory: InstanceOf[MetricsFactory] | None = Field(
+        default=None,
+        description="An instance of MetricsFactory for collecting usage metrics",
+    )
+
+
+# AGE label names cannot be parameterized and must be quoted carefully. We use
+# the same sanitization scheme as the Neo4j backend so the on-wire identifiers
+# only ever contain ASCII letters, digits, and underscores.
+class AgeVectorGraphStore(VectorGraphStore):
+    """Asynchronous vector graph store backed by PostgreSQL + Apache AGE."""
+
+    class CacheIndexState(Enum):
+        """Cached index state (not authoritative against the database)."""
+
+        CREATING = 0
+        ONLINE = 1
+
+    def __init__(self, params: AgeVectorGraphStoreParams) -> None:
+        """Initialize the graph store from ``params``."""
+        super().__init__()
+
+        self._engine: AsyncEngine = params.engine
+        self._graph_name = validate_graph_name(params.graph_name)
+
+        self._force_exact_similarity_search = params.force_exact_similarity_search
+        self._filtered_similarity_search_fudge_factor = (
+            params.filtered_similarity_search_fudge_factor
+        )
+        self._exact_similarity_search_fallback_threshold = (
+            params.exact_similarity_search_fallback_threshold
+        )
+        self._range_index_hierarchies = params.range_index_hierarchies
+        self._range_index_creation_threshold = params.range_index_creation_threshold
+        self._vector_index_creation_threshold = params.vector_index_creation_threshold
+        self._hnsw_m = params.hnsw_m
+        self._hnsw_ef_construction = params.hnsw_ef_construction
+
+        self._index_state_cache: dict[str, AgeVectorGraphStore.CacheIndexState] = {}
+        self._populate_index_state_cache_lock = asyncio.Lock()
+
+        # These are only used for tracking counts approximately.
+        self._collection_node_counts: dict[str, int] = {}
+        self._relation_edge_counts: dict[str, int] = {}
+
+        self._ensured_labels: set[tuple[EntityType, str]] = set()
+        self._ensured_labels_lock = asyncio.Lock()
+        self._ensured_vector_tables: set[str] = set()
+        self._ensured_vector_tables_lock = asyncio.Lock()
+
+        self._graph_initialized = False
+        self._graph_initialized_lock = asyncio.Lock()
+
+        self._background_tasks: set[asyncio.Task] = set()
+
+        self._tracker = OperationTracker(
+            params.metrics_factory, prefix="vector_graph_store_age"
+        )
+
+    def _track_task(self, task: asyncio.Task) -> None:
+        """Keep background tasks from being garbage collected prematurely."""
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def _ensure_graph_initialized(self) -> None:
+        """Idempotently create the AGE extension and graph namespace.
+
+        The AGE extension and per-graph schema must exist before any Cypher
+        call runs. We do this lazily on the first operation so tests and
+        applications can construct the store without blocking on IO.
+
+        ``CREATE EXTENSION`` requires elevated privileges. In environments
+        where the application role lacks them, operators are expected to
+        install ``age`` and ``vector`` ahead of time. We tolerate that case by
+        only raising if the extension is still missing after the attempt, and
+        we run each ``CREATE EXTENSION`` in its own transaction so a failure
+        does not poison subsequent queries in a shared transaction.
+        """
+        if self._graph_initialized:
+            return
+        async with self._graph_initialized_lock:
+            if self._graph_initialized:
+                return
+            await self._ensure_extension("age")
+            await self._ensure_extension("vector")
+            await self._assert_age_version_supported()
+            async with self._engine.begin() as conn:
+                await conn.exec_driver_sql("LOAD 'age'")
+                await conn.exec_driver_sql(
+                    'SET search_path = ag_catalog, "$user", public'
+                )
+                # ``create_graph`` throws if the graph already exists, so we
+                # guard with a lookup against ag_catalog.ag_graph.
+                exists_row = (
+                    await conn.exec_driver_sql(
+                        "SELECT 1 FROM ag_catalog.ag_graph WHERE name = $1",
+                        (self._graph_name,),
+                    )
+                ).first()
+                if exists_row is None:
+                    await conn.exec_driver_sql(
+                        "SELECT create_graph($1)",
+                        (self._graph_name,),
+                    )
+            self._graph_initialized = True
+
+    async def _ensure_extension(self, name: str) -> None:
+        """Install a PostgreSQL extension if possible, else verify it exists.
+
+        The CREATE and the follow-up probe each run in their own transaction.
+        Postgres marks a transaction as aborted after any error, so reusing a
+        single transaction would make the ``pg_extension`` lookup fail with
+        "current transaction is aborted" whenever the role lacks CREATE
+        privilege. Splitting them lets operators pre-install the extension
+        and still have startup succeed.
+        """
+        try:
+            async with self._engine.begin() as conn:
+                await conn.exec_driver_sql(f"CREATE EXTENSION IF NOT EXISTS {name}")
+        except SQLAlchemyError as exc:
+            async with self._engine.connect() as conn:
+                installed = (
+                    await conn.exec_driver_sql(
+                        "SELECT 1 FROM pg_extension WHERE extname = $1",
+                        (name,),
+                    )
+                ).first()
+            if installed is None:
+                raise RuntimeError(
+                    f"PostgreSQL extension '{name}' is not installed and "
+                    "could not be created automatically. Ask a superuser to "
+                    f"run 'CREATE EXTENSION {name}' in the target database."
+                ) from exc
+
+    async def _assert_age_version_supported(self) -> None:
+        # The ``WITH $param AS p`` workaround used by add_nodes/add_edges
+        # relies on cypher() parameter semantics that first shipped in AGE
+        # 1.6.0. Older versions silently reject ``SET n += p`` with a
+        # "SET clause expects a map" error that is opaque to operators.
+        async with self._engine.connect() as conn:
+            row = (
+                await conn.exec_driver_sql(
+                    "SELECT extversion FROM pg_extension WHERE extname = 'age'"
+                )
+            ).first()
+        if row is None:
+            return
+        version_str = str(row[0])
+        try:
+            parts = tuple(int(p) for p in version_str.split(".")[:3])
+        except ValueError:
+            logger.warning("Unparseable AGE extversion %r; skipping version check", version_str)
+            return
+        if parts < (1, 6, 0):
+            raise RuntimeError(
+                f"Apache AGE {version_str} is not supported by "
+                "AgeVectorGraphStore; require >= 1.6.0."
+            )
+
+    def _reset_in_memory_caches(self) -> None:
+        # Test-only helper: clear every in-process cache so a fixture that
+        # drops all data between cases doesn't leave stale counts or
+        # ensured-table/index state behind.
+        self._collection_node_counts.clear()
+        self._relation_edge_counts.clear()
+        self._ensured_vector_tables.clear()
+        self._ensured_labels.clear()
+        self._index_state_cache.clear()
+
+    async def close(self) -> None:
+        """Dispose of the underlying SQLAlchemy engine.
+
+        Any index-creation tasks spawned by ``add_nodes`` / ``add_edges`` are
+        drained first. Failures there don't block dispose — they're
+        best-effort optimizations — but we log them so they don't disappear
+        into the interpreter's default task finalizer.
+        """
+        if self._background_tasks:
+            results = await asyncio.gather(
+                *self._background_tasks,
+                return_exceptions=True,
+            )
+            for result in results:
+                if isinstance(result, BaseException):
+                    logger.warning(
+                        "Background index task raised during close: %s", result
+                    )
+        await self._engine.dispose()
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    async def add_nodes(
+        self,
+        *,
+        collection: str,
+        nodes: Iterable[Node],
+    ) -> None:
+        """Add nodes to a collection, creating labels and indexes as needed."""
+        async with self._tracker("add_nodes"):
+            await self._ensure_graph_initialized()
+
+            nodes = list(nodes)
+            if not nodes:
+                return
+
+            sanitized_collection = sanitize_identifier(collection)
+            # The label must exist before any MATCH/count on it, because AGE
+            # raises "label does not exist" if create_vlabel has not been
+            # called for the target label.
+            await self._ensure_vertex_label(sanitized_collection)
+
+            if collection not in self._collection_node_counts:
+                self._collection_node_counts[collection] = await self._count_nodes(
+                    collection,
+                )
+
+            embedding_dimensions: dict[str, int] = {}
+            embedding_similarity: dict[str, SimilarityMetric] = {}
+            sanitized_embedding_names: set[str] = set()
+
+            # Create vertex rows first. We do this one call per node so we can
+            # capture the generated AGE id and write the embedding rows in the
+            # same transaction-scoped connection.
+            async with self._engine.begin() as conn:
+                for node in nodes:
+                    sanitized_properties = _sanitize_properties(
+                        {
+                            mangle_property_name(key): value
+                            for key, value in node.properties.items()
+                        }
+                    )
+                    create_props: dict[str, Any] = {
+                        "uid": str(node.uid),
+                        **sanitized_properties,
+                    }
+                    params_json = encode_agtype_params({"props": create_props})
+                    # AGE 1.6.0 rejects ``SET n += $param`` with "SET clause
+                    # expects a map" even though the parameter resolves to a
+                    # map when returned directly. Aliasing the parameter with
+                    # ``WITH`` first sidesteps the bug without changing the
+                    # semantics.
+                    sql = build_cypher_call(
+                        self._graph_name,
+                        (
+                            "WITH $props AS p "
+                            f"CREATE (n:{sanitized_collection}) "
+                            "SET n += p RETURN id(n) AS id"
+                        ),
+                        returns=("id",),
+                        has_params=True,
+                    )
+                    result = await conn.exec_driver_sql(sql, (params_json,))
+                    row = result.first()
+                    if row is None:
+                        raise RuntimeError(
+                            f"AGE returned no id after CREATE for uid={node.uid}"
+                        )
+                    vertex_id = int(parse_agtype(row[0]))
+
+                    for embedding_name, (
+                        embedding,
+                        similarity_metric,
+                    ) in node.embeddings.items():
+                        sanitized_embedding_name = sanitize_identifier(
+                            mangle_embedding_name(embedding_name),
+                        )
+                        sanitized_embedding_names.add(sanitized_embedding_name)
+                        embedding_dimensions[sanitized_embedding_name] = len(embedding)
+                        embedding_similarity[sanitized_embedding_name] = (
+                            similarity_metric
+                        )
+
+                        table_name = self._vector_table_name(
+                            EntityType.NODE,
+                            sanitized_collection,
+                            sanitized_embedding_name,
+                        )
+                        await self._ensure_vector_table(
+                            table_name,
+                            entity_type=EntityType.NODE,
+                            sanitized_collection_or_relation=sanitized_collection,
+                            sanitized_embedding_name=sanitized_embedding_name,
+                            dimensions=len(embedding),
+                            uid_column="node_uid",
+                            conn=conn,
+                        )
+                        await conn.exec_driver_sql(
+                            (
+                                f'INSERT INTO public."{table_name}"'
+                                "  (node_uid, vertex_id, similarity_metric, embedding)"
+                                " VALUES ($1, $2, $3, $4::vector)"
+                                " ON CONFLICT (node_uid) DO UPDATE SET"
+                                "  vertex_id = EXCLUDED.vertex_id,"
+                                "  similarity_metric = EXCLUDED.similarity_metric,"
+                                "  embedding = EXCLUDED.embedding"
+                            ),
+                            (
+                                str(node.uid),
+                                vertex_id,
+                                similarity_metric.value,
+                                _vector_literal(embedding),
+                            ),
+                        )
+
+            self._collection_node_counts[collection] += len(nodes)
+
+            if (
+                self._collection_node_counts[collection]
+                >= self._range_index_creation_threshold
+            ):
+                self._track_task(
+                    asyncio.create_task(
+                        self._create_initial_indexes_if_not_exist(
+                            EntityType.NODE,
+                            sanitized_collection,
+                        ),
+                    )
+                )
+
+            if (
+                self._collection_node_counts[collection]
+                >= self._vector_index_creation_threshold
+            ):
+                for sanitized_embedding_name in sanitized_embedding_names:
+                    if (
+                        self._index_name(
+                            EntityType.NODE,
+                            sanitized_collection,
+                            sanitized_embedding_name,
+                        )
+                        not in self._index_state_cache
+                    ):
+                        self._track_task(
+                            asyncio.create_task(
+                                self._create_vector_index_if_not_exists(
+                                    entity_type=EntityType.NODE,
+                                    sanitized_collection_or_relation=(
+                                        sanitized_collection
+                                    ),
+                                    sanitized_embedding_name=(sanitized_embedding_name),
+                                    dimensions=embedding_dimensions[
+                                        sanitized_embedding_name
+                                    ],
+                                    similarity_metric=embedding_similarity[
+                                        sanitized_embedding_name
+                                    ],
+                                ),
+                            )
+                        )
+
+    async def add_edges(
+        self,
+        *,
+        relation: str,
+        source_collection: str,
+        target_collection: str,
+        edges: Iterable[Edge],
+    ) -> None:
+        """Add edges between collections, creating labels and indexes as needed."""
+        async with self._tracker("add_edges"):
+            await self._ensure_graph_initialized()
+
+            edges = list(edges)
+            if not edges:
+                return
+
+            sanitized_relation = sanitize_identifier(relation)
+            sanitized_source_collection = sanitize_identifier(source_collection)
+            sanitized_target_collection = sanitize_identifier(target_collection)
+
+            # Labels must exist before any MATCH/count references them.
+            await self._ensure_edge_label(sanitized_relation)
+            await self._ensure_vertex_label(sanitized_source_collection)
+            await self._ensure_vertex_label(sanitized_target_collection)
+
+            if relation not in self._relation_edge_counts:
+                self._relation_edge_counts[relation] = await self._count_edges(
+                    relation,
+                )
+
+            embedding_dimensions: dict[str, int] = {}
+            embedding_similarity: dict[str, SimilarityMetric] = {}
+            sanitized_embedding_names: set[str] = set()
+
+            async with self._engine.begin() as conn:
+                for edge in edges:
+                    sanitized_properties = _sanitize_properties(
+                        {
+                            mangle_property_name(key): value
+                            for key, value in edge.properties.items()
+                        }
+                    )
+                    create_props: dict[str, Any] = {
+                        "uid": str(edge.uid),
+                        **sanitized_properties,
+                    }
+                    params_json = encode_agtype_params(
+                        {
+                            "source_uid": str(edge.source_uid),
+                            "target_uid": str(edge.target_uid),
+                            "props": create_props,
+                        }
+                    )
+                    sql = build_cypher_call(
+                        self._graph_name,
+                        (
+                            f"MATCH (source:{sanitized_source_collection}"
+                            " {uid: $source_uid}),"
+                            f" (target:{sanitized_target_collection}"
+                            " {uid: $target_uid})"
+                            " WITH source, target, $props AS p"
+                            f" CREATE (source)-[r:{sanitized_relation}]->(target)"
+                            " SET r += p RETURN id(r) AS id"
+                        ),
+                        returns=("id",),
+                        has_params=True,
+                    )
+                    result = await conn.exec_driver_sql(sql, (params_json,))
+                    row = result.first()
+                    if row is None:
+                        # Source or target vertex did not exist; silently skip
+                        # to mirror the Neo4j behavior, which also yields no
+                        # relationship in that case.
+                        continue
+                    edge_id = int(parse_agtype(row[0]))
+
+                    for embedding_name, (
+                        embedding,
+                        similarity_metric,
+                    ) in edge.embeddings.items():
+                        sanitized_embedding_name = sanitize_identifier(
+                            mangle_embedding_name(embedding_name),
+                        )
+                        sanitized_embedding_names.add(sanitized_embedding_name)
+                        embedding_dimensions[sanitized_embedding_name] = len(embedding)
+                        embedding_similarity[sanitized_embedding_name] = (
+                            similarity_metric
+                        )
+
+                        table_name = self._vector_table_name(
+                            EntityType.EDGE,
+                            sanitized_relation,
+                            sanitized_embedding_name,
+                        )
+                        await self._ensure_vector_table(
+                            table_name,
+                            entity_type=EntityType.EDGE,
+                            sanitized_collection_or_relation=sanitized_relation,
+                            sanitized_embedding_name=sanitized_embedding_name,
+                            dimensions=len(embedding),
+                            uid_column="edge_uid",
+                            conn=conn,
+                        )
+                        await conn.exec_driver_sql(
+                            (
+                                f'INSERT INTO public."{table_name}"'
+                                "  (edge_uid, edge_id, similarity_metric, embedding)"
+                                " VALUES ($1, $2, $3, $4::vector)"
+                                " ON CONFLICT (edge_uid) DO UPDATE SET"
+                                "  edge_id = EXCLUDED.edge_id,"
+                                "  similarity_metric = EXCLUDED.similarity_metric,"
+                                "  embedding = EXCLUDED.embedding"
+                            ),
+                            (
+                                str(edge.uid),
+                                edge_id,
+                                similarity_metric.value,
+                                _vector_literal(embedding),
+                            ),
+                        )
+
+            self._relation_edge_counts[relation] += len(edges)
+
+            if (
+                self._relation_edge_counts[relation]
+                >= self._range_index_creation_threshold
+            ):
+                self._track_task(
+                    asyncio.create_task(
+                        self._create_initial_indexes_if_not_exist(
+                            EntityType.EDGE,
+                            sanitized_relation,
+                        ),
+                    )
+                )
+
+            if (
+                self._relation_edge_counts[relation]
+                >= self._vector_index_creation_threshold
+            ):
+                for sanitized_embedding_name in sanitized_embedding_names:
+                    if (
+                        self._index_name(
+                            EntityType.EDGE,
+                            sanitized_relation,
+                            sanitized_embedding_name,
+                        )
+                        not in self._index_state_cache
+                    ):
+                        self._track_task(
+                            asyncio.create_task(
+                                self._create_vector_index_if_not_exists(
+                                    entity_type=EntityType.EDGE,
+                                    sanitized_collection_or_relation=(
+                                        sanitized_relation
+                                    ),
+                                    sanitized_embedding_name=(sanitized_embedding_name),
+                                    dimensions=embedding_dimensions[
+                                        sanitized_embedding_name
+                                    ],
+                                    similarity_metric=embedding_similarity[
+                                        sanitized_embedding_name
+                                    ],
+                                ),
+                            )
+                        )
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    async def search_similar_nodes(
+        self,
+        *,
+        collection: str,
+        embedding_name: str,
+        query_embedding: list[float],
+        similarity_metric: SimilarityMetric = SimilarityMetric.COSINE,
+        limit: int | None = 100,
+        property_filter: FilterExpr | None = None,
+    ) -> list[Node]:
+        """Search nodes by vector similarity with optional property filters.
+
+        Delegates to the pgvector HNSW side table to produce a candidate list
+        of vertex uids, then hydrates the matching vertices via AGE. When a
+        property filter is provided, candidates are over-fetched and filtered
+        by re-reading the hydrated vertices; if the post-filter set is too
+        small we fall back to an exact scan that joins the side table directly.
+        """
+        async with self._tracker("search_similar_nodes"):
+            await self._ensure_graph_initialized()
+
+            sanitized_collection = sanitize_identifier(collection)
+            sanitized_embedding_name = sanitize_identifier(
+                mangle_embedding_name(embedding_name),
+            )
+            table_name = self._vector_table_name(
+                EntityType.NODE,
+                sanitized_collection,
+                sanitized_embedding_name,
+            )
+            if not await self._vector_table_exists(table_name):
+                return []
+
+            operator = _pgvector_distance_operator(similarity_metric)
+            effective_limit = limit
+
+            uids: list[str] = []
+            if not self._force_exact_similarity_search:
+                candidate_limit = (
+                    effective_limit
+                    if property_filter is None or effective_limit is None
+                    else effective_limit * self._filtered_similarity_search_fudge_factor
+                )
+                async with self._engine.connect() as conn:
+                    sql = (
+                        f'SELECT node_uid FROM public."{table_name}"'
+                        f" ORDER BY embedding {operator} $1::vector"
+                        + (" LIMIT $2" if candidate_limit is not None else "")
+                    )
+                    params: tuple[Any, ...] = (
+                        (_vector_literal(query_embedding), candidate_limit)
+                        if candidate_limit is not None
+                        else (_vector_literal(query_embedding),)
+                    )
+                    result = await conn.exec_driver_sql(sql, params)
+                    uids = [row[0] for row in result]
+
+                hydrated = await self._hydrate_nodes_by_uid(
+                    sanitized_collection,
+                    uids,
+                    property_filter=property_filter,
+                    preserve_order=True,
+                )
+                if effective_limit is not None:
+                    hydrated = hydrated[:effective_limit]
+
+                if (
+                    property_filter is not None
+                    and effective_limit is not None
+                    and len(hydrated)
+                    < effective_limit * self._exact_similarity_search_fallback_threshold
+                ):
+                    hydrated = await self._exact_similar_nodes(
+                        sanitized_collection=sanitized_collection,
+                        table_name=table_name,
+                        query_embedding=query_embedding,
+                        similarity_metric=similarity_metric,
+                        limit=effective_limit,
+                        property_filter=property_filter,
+                    )
+                return hydrated
+
+            return await self._exact_similar_nodes(
+                sanitized_collection=sanitized_collection,
+                table_name=table_name,
+                query_embedding=query_embedding,
+                similarity_metric=similarity_metric,
+                limit=effective_limit,
+                property_filter=property_filter,
+            )
+
+    async def _exact_similar_nodes(
+        self,
+        *,
+        sanitized_collection: str,
+        table_name: str,
+        query_embedding: list[float],
+        similarity_metric: SimilarityMetric,
+        limit: int | None,
+        property_filter: FilterExpr | None,
+    ) -> list[Node]:
+        operator = _pgvector_distance_operator(similarity_metric)
+        async with self._engine.connect() as conn:
+            sql = (
+                f'SELECT node_uid FROM public."{table_name}"'
+                f" ORDER BY embedding {operator} $1::vector"
+            )
+            result = await conn.exec_driver_sql(
+                sql,
+                (_vector_literal(query_embedding),),
+            )
+            ordered_uids = [row[0] for row in result]
+
+        hydrated = await self._hydrate_nodes_by_uid(
+            sanitized_collection,
+            ordered_uids,
+            property_filter=property_filter,
+            preserve_order=True,
+        )
+        if limit is not None:
+            hydrated = hydrated[:limit]
+        return hydrated
+
+    async def search_related_nodes(
+        self,
+        *,
+        relation: str,
+        other_collection: str,
+        this_collection: str,
+        this_node_uid: str,
+        find_sources: bool = True,
+        find_targets: bool = True,
+        limit: int | None = None,
+        edge_property_filter: FilterExpr | None = None,
+        node_property_filter: FilterExpr | None = None,
+    ) -> list[Node]:
+        """Search nodes connected by a relation with optional property filters."""
+        async with self._tracker("search_related_nodes"):
+            await self._ensure_graph_initialized()
+
+            if not (find_sources or find_targets):
+                return []
+
+            sanitized_this_collection = sanitize_identifier(this_collection)
+            sanitized_other_collection = sanitize_identifier(other_collection)
+            sanitized_relation = sanitize_identifier(relation)
+
+            # If any of the required labels has never been written to, AGE
+            # raises on MATCH. Short-circuit with an empty result instead.
+            if not (
+                await self._label_exists(sanitized_this_collection)
+                and await self._label_exists(sanitized_other_collection)
+                and await self._label_exists(sanitized_relation)
+            ):
+                return []
+
+            edge_filter_cypher, edge_filter_params = _render_filter_expr(
+                "r", edge_property_filter, prefix="edge_"
+            )
+            node_filter_cypher, node_filter_params = _render_filter_expr(
+                "n", node_property_filter, prefix="node_"
+            )
+
+            left = "-" if find_targets else "<-"
+            right = "-" if find_sources else "->"
+            match_clause = (
+                f"MATCH (m:{sanitized_this_collection} {{uid: $this_node_uid}})"
+                f"{left}[r:{sanitized_relation}]{right}"
+                f"(n:{sanitized_other_collection})"
+            )
+
+            cypher = (
+                f"{match_clause} "
+                f"WHERE {edge_filter_cypher} AND {node_filter_cypher} "
+                "RETURN DISTINCT n" + (" LIMIT $limit" if limit is not None else "")
+            )
+
+            params_map: dict[str, Any] = {
+                "this_node_uid": str(this_node_uid),
+                **edge_filter_params,
+                **node_filter_params,
+            }
+            if limit is not None:
+                params_map["limit"] = limit
+
+            sql = build_cypher_call(
+                self._graph_name,
+                cypher,
+                returns=("n",),
+                has_params=True,
+            )
+            params_json = encode_agtype_params(params_map)
+            async with self._engine.connect() as conn:
+                result = await conn.exec_driver_sql(sql, (params_json,))
+                raw_values = [row[0] for row in result]
+
+            nodes = _nodes_from_agtype_rows(raw_values)
+            await self._attach_node_embeddings(sanitized_other_collection, nodes)
+            return nodes
+
+    async def search_directional_nodes(
+        self,
+        *,
+        collection: str,
+        by_properties: Iterable[str],
+        starting_at: Iterable[OrderedValue | str | None],
+        order_ascending: Iterable[bool],
+        include_equal_start: bool = False,
+        limit: int | None = 1,
+        property_filter: FilterExpr | None = None,
+    ) -> list[Node]:
+        """Find nodes ordered by property values in a chosen direction."""
+        async with self._tracker("search_directional_nodes"):
+            await self._ensure_graph_initialized()
+
+            by_properties = list(by_properties)
+            starting_at = list(starting_at)
+            order_ascending = list(order_ascending)
+
+            if not (len(by_properties) == len(starting_at) == len(order_ascending) > 0):
+                raise ValueError(
+                    "Lengths of by_properties, starting_at, and "
+                    "order_ascending must be equal and greater than 0.",
+                )
+
+            sanitized_collection = sanitize_identifier(collection)
+            if not await self._label_exists(sanitized_collection):
+                return []
+            sanitized_by_properties = [
+                sanitize_identifier(mangle_property_name(by_property))
+                for by_property in by_properties
+            ]
+
+            params_map: dict[str, Any] = {}
+            starting_param_names: list[str] = []
+            for index, starting_value in enumerate(starting_at):
+                name = f"start_{index}"
+                starting_param_names.append(name)
+                if starting_value is None:
+                    params_map[name] = None
+                else:
+                    params_map[name] = age_value_from_python(starting_value)
+
+            lexicographic = _lexicographic_relational_cypher(
+                "n",
+                sanitized_by_properties,
+                starting_at,
+                starting_param_names,
+                order_ascending,
+            )
+
+            equal_clause = ""
+            if include_equal_start:
+                equal_parts = [
+                    render_comparison(
+                        f"n.{sanitized_by_property}",
+                        "=",
+                        f"${starting_param_names[index]}",
+                        starting_value,
+                    )
+                    for index, sanitized_by_property in enumerate(
+                        sanitized_by_properties,
+                    )
+                    if (starting_value := starting_at[index]) is not None
+                ]
+                equal_clause = " OR (" + (" AND ".join(equal_parts) or "TRUE") + ")"
+
+            filter_cypher, filter_params = _render_filter_expr(
+                "n", property_filter, prefix="pf_"
+            )
+            params_map.update(filter_params)
+
+            order_by = ", ".join(
+                f"n.{sanitized_by_property} {
+                    'ASC' if order_ascending[index] else 'DESC'
+                }"
+                for index, sanitized_by_property in enumerate(sanitized_by_properties)
+            )
+
+            cypher = (
+                f"MATCH (n:{sanitized_collection}) "
+                f"WHERE ({lexicographic}{equal_clause}) "
+                f"AND {filter_cypher} "
+                f"RETURN n ORDER BY {order_by}"
+                + (" LIMIT $limit" if limit is not None else "")
+            )
+
+            if limit is not None:
+                params_map["limit"] = limit
+
+            sql = build_cypher_call(
+                self._graph_name,
+                cypher,
+                returns=("n",),
+                has_params=True,
+            )
+            params_json = encode_agtype_params(params_map)
+            async with self._engine.connect() as conn:
+                result = await conn.exec_driver_sql(sql, (params_json,))
+                raw_values = [row[0] for row in result]
+
+            nodes = _nodes_from_agtype_rows(raw_values)
+            await self._attach_node_embeddings(sanitized_collection, nodes)
+            return nodes
+
+    async def search_matching_nodes(
+        self,
+        *,
+        collection: str,
+        limit: int | None = None,
+        property_filter: FilterExpr | None = None,
+    ) -> list[Node]:
+        """Search nodes that match the provided property filters."""
+        async with self._tracker("search_matching_nodes"):
+            await self._ensure_graph_initialized()
+
+            sanitized_collection = sanitize_identifier(collection)
+            if not await self._label_exists(sanitized_collection):
+                return []
+            filter_cypher, filter_params = _render_filter_expr(
+                "n", property_filter, prefix="pf_"
+            )
+
+            params_map: dict[str, Any] = dict(filter_params)
+            cypher = (
+                f"MATCH (n:{sanitized_collection}) "
+                f"WHERE {filter_cypher} "
+                "RETURN n" + (" LIMIT $limit" if limit is not None else "")
+            )
+            if limit is not None:
+                params_map["limit"] = limit
+
+            sql = build_cypher_call(
+                self._graph_name,
+                cypher,
+                returns=("n",),
+                has_params=True,
+            )
+            params_json = encode_agtype_params(params_map)
+            async with self._engine.connect() as conn:
+                result = await conn.exec_driver_sql(sql, (params_json,))
+                raw_values = [row[0] for row in result]
+
+            nodes = _nodes_from_agtype_rows(raw_values)
+            await self._attach_node_embeddings(sanitized_collection, nodes)
+            return nodes
+
+    async def get_nodes(
+        self,
+        *,
+        collection: str,
+        node_uids: Iterable[str],
+    ) -> list[Node]:
+        """Retrieve nodes by uid from a specific collection."""
+        async with self._tracker("get_nodes"):
+            await self._ensure_graph_initialized()
+
+            uids = [str(uid) for uid in node_uids]
+            if not uids:
+                return []
+
+            sanitized_collection = sanitize_identifier(collection)
+            if not await self._label_exists(sanitized_collection):
+                return []
+            return await self._hydrate_nodes_by_uid(
+                sanitized_collection,
+                uids,
+                property_filter=None,
+                preserve_order=False,
+            )
+
+    async def delete_nodes(
+        self,
+        *,
+        collection: str,
+        node_uids: Iterable[str],
+    ) -> None:
+        """Delete nodes by uid from a collection."""
+        async with self._tracker("delete_nodes"):
+            await self._ensure_graph_initialized()
+
+            uids = [str(uid) for uid in node_uids]
+            if not uids:
+                return
+
+            sanitized_collection = sanitize_identifier(collection)
+            if not await self._label_exists(sanitized_collection):
+                return
+            params_json = encode_agtype_params({"uids": uids})
+            # AGE's documented void-cypher pattern keeps the ``AS (v agtype)``
+            # column declaration but omits ``RETURN`` from the body. The
+            # wrapped query simply yields zero rows after the DELETE runs.
+            sql = build_cypher_call(
+                self._graph_name,
+                (
+                    f"MATCH (n:{sanitized_collection})"
+                    " WHERE n.uid IN $uids DETACH DELETE n"
+                ),
+                returns=("v",),
+                has_params=True,
+            )
+            async with self._engine.begin() as conn:
+                await conn.exec_driver_sql(sql, (params_json,))
+                # Clean up vector side tables that key by node_uid for this
+                # collection. The registry resolves hashed table names back
+                # to their (collection, embedding_name) origin.
+                entries = await self._list_registered_side_tables(
+                    conn,
+                    entity_type=EntityType.NODE,
+                    sanitized_collection_or_relation=sanitized_collection,
+                )
+                for table, _ in entries:
+                    await conn.exec_driver_sql(
+                        f'DELETE FROM public."{table}"'
+                        " WHERE node_uid = ANY($1::text[])",
+                        (uids,),
+                    )
+
+    async def delete_all_data(self) -> None:
+        """Delete all nodes, relationships, and side-table contents."""
+        await self._ensure_graph_initialized()
+        async with self._engine.begin() as conn:
+            sql = build_cypher_call(
+                self._graph_name,
+                "MATCH (n) DETACH DELETE n",
+                returns=("v",),
+                has_params=False,
+            )
+            await conn.exec_driver_sql(sql)
+
+            entries = await self._list_registered_side_tables(conn)
+            for table, _ in entries:
+                await conn.exec_driver_sql(f'TRUNCATE TABLE public."{table}"')
+
+    # ------------------------------------------------------------------
+    # Internal helpers: counting, hydration, label/table management
+    # ------------------------------------------------------------------
+
+    async def _hydrate_nodes_by_uid(
+        self,
+        sanitized_collection: str,
+        uids: list[str],
+        *,
+        property_filter: FilterExpr | None,
+        preserve_order: bool,
+    ) -> list[Node]:
+        if not uids:
+            return []
+
+        if not await self._label_exists(sanitized_collection):
+            return []
+
+        filter_cypher, filter_params = _render_filter_expr(
+            "n", property_filter, prefix="pf_"
+        )
+
+        cypher = (
+            f"MATCH (n:{sanitized_collection}) "
+            "WHERE n.uid IN $uids "
+            f"AND {filter_cypher} "
+            "RETURN n"
+        )
+        params_map: dict[str, Any] = {"uids": uids, **filter_params}
+        sql = build_cypher_call(
+            self._graph_name,
+            cypher,
+            returns=("n",),
+            has_params=True,
+        )
+        params_json = encode_agtype_params(params_map)
+        async with self._engine.connect() as conn:
+            result = await conn.exec_driver_sql(sql, (params_json,))
+            raw_values = [row[0] for row in result]
+
+        hydrated = _nodes_from_agtype_rows(raw_values)
+        await self._attach_node_embeddings(sanitized_collection, hydrated)
+        if not preserve_order:
+            return hydrated
+        index_by_uid = {uid: position for position, uid in enumerate(uids)}
+        hydrated.sort(key=lambda node: index_by_uid.get(node.uid, len(index_by_uid)))
+        return hydrated
+
+    async def _attach_node_embeddings(
+        self,
+        sanitized_collection: str,
+        nodes: list[Node],
+    ) -> None:
+        """Populate ``Node.embeddings`` from the pgvector side tables.
+
+        Embeddings live outside the AGE vertex (in per-(collection,
+        embedding_name) tables), so an extra join-by-uid is required to make
+        round-tripped nodes equal to the originals supplied to ``add_nodes``.
+        """
+        if not nodes:
+            return
+        node_uids = [node.uid for node in nodes]
+        nodes_by_uid = {node.uid: node for node in nodes}
+        async with self._engine.connect() as conn:
+            entries = await self._list_registered_side_tables(
+                conn,
+                entity_type=EntityType.NODE,
+                sanitized_collection_or_relation=sanitized_collection,
+            )
+            for table, sanitized_embedding_name in entries:
+                embedding_name = _demangle_embedding_from_sanitized(
+                    sanitized_embedding_name
+                )
+                if embedding_name is None:
+                    # Registry rows are always written through
+                    # ``_register_side_table`` with a freshly-sanitized name,
+                    # so a failed decode means the registry is corrupt. Log
+                    # and skip rather than crashing hydration.
+                    logger.warning(
+                        "Side-table registry entry %r did not decode to an"
+                        " embedding name; skipping",
+                        sanitized_embedding_name,
+                    )
+                    continue
+                result = await conn.exec_driver_sql(
+                    (
+                        "SELECT node_uid, similarity_metric, embedding::text"
+                        f' FROM public."{table}"'
+                        " WHERE node_uid = ANY($1::text[])"
+                    ),
+                    (node_uids,),
+                )
+                for row in result:
+                    uid_value = row[0]
+                    metric_value = row[1]
+                    embedding_text = row[2]
+                    # The SQL filter restricts rows to uids we just passed
+                    # in, so ``nodes_by_uid`` always resolves.
+                    node = nodes_by_uid[uid_value]
+                    node.embeddings[embedding_name] = (
+                        _parse_pgvector_text(embedding_text),
+                        SimilarityMetric(metric_value),
+                    )
+
+    async def _count_nodes(self, collection: str) -> int:
+        async with self._tracker("count_nodes"):
+            await self._ensure_graph_initialized()
+            sanitized_collection = sanitize_identifier(collection)
+            cypher = f"MATCH (n:{sanitized_collection}) RETURN count(n) AS node_count"
+            sql = build_cypher_call(
+                self._graph_name,
+                cypher,
+                returns=("node_count",),
+                has_params=False,
+            )
+            async with self._engine.connect() as conn:
+                result = await conn.exec_driver_sql(sql)
+                row = result.first()
+
+            if row is None:
+                return 0
+            value = parse_agtype(row[0])
+            return int(value) if value is not None else 0
+
+    async def _count_edges(self, relation: str) -> int:
+        async with self._tracker("count_edges"):
+            await self._ensure_graph_initialized()
+            sanitized_relation = sanitize_identifier(relation)
+            cypher = (
+                f"MATCH ()-[r:{sanitized_relation}]->() RETURN count(r) AS edge_count"
+            )
+            sql = build_cypher_call(
+                self._graph_name,
+                cypher,
+                returns=("edge_count",),
+                has_params=False,
+            )
+            async with self._engine.connect() as conn:
+                result = await conn.exec_driver_sql(sql)
+                row = result.first()
+
+            if row is None:
+                return 0
+            value = parse_agtype(row[0])
+            return int(value) if value is not None else 0
+
+    async def _ensure_vertex_label(self, sanitized_label: str) -> None:
+        await self._ensure_label(sanitized_label, kind="v")
+
+    async def _ensure_edge_label(self, sanitized_label: str) -> None:
+        await self._ensure_label(sanitized_label, kind="e")
+
+    async def _label_exists(self, sanitized_label: str) -> bool:
+        """Return True if the AGE label has a backing table in the graph schema.
+
+        Reads use this to bail out early with empty results when a label has
+        never been written to — recent AGE releases raise "label does not
+        exist" on ``MATCH (n:Label)`` for unknown labels, so we cannot rely on
+        Cypher returning zero rows.
+        """
+        await self._ensure_graph_initialized()
+        async with self._engine.connect() as conn:
+            result = await conn.exec_driver_sql(
+                "SELECT 1 FROM pg_tables WHERE schemaname = $1 AND tablename = $2",
+                (self._graph_name, sanitized_label),
+            )
+            return result.first() is not None
+
+    async def _ensure_label(self, sanitized_label: str, *, kind: str) -> None:
+        """Create an AGE vertex or edge label if it does not already exist.
+
+        AGE creates each label as a table in the graph's schema, so we detect
+        existence via ``pg_tables`` rather than relying on ``ag_catalog``
+        internals (which vary across AGE versions). The actual creation uses
+        AGE's built-in ``create_vlabel`` / ``create_elabel`` helpers.
+        """
+        entity_type = EntityType.NODE if kind == "v" else EntityType.EDGE
+        key = (entity_type, sanitized_label)
+        if key in self._ensured_labels:
+            return
+        async with self._ensured_labels_lock:
+            if key in self._ensured_labels:
+                return
+            await self._ensure_graph_initialized()
+            async with self._engine.begin() as conn:
+                exists = (
+                    await conn.exec_driver_sql(
+                        "SELECT 1 FROM pg_tables "
+                        "WHERE schemaname = $1 AND tablename = $2",
+                        (self._graph_name, sanitized_label),
+                    )
+                ).first()
+                if exists is None:
+                    creator = "create_vlabel" if kind == "v" else "create_elabel"
+                    await conn.exec_driver_sql(
+                        f"SELECT {creator}($1, $2)",
+                        (self._graph_name, sanitized_label),
+                    )
+            self._ensured_labels.add(key)
+
+    def _registry_table_name(self) -> str:
+        return f"{self._graph_name}{_SIDE_TABLE_REGISTRY_SUFFIX}"
+
+    def _vector_table_name(
+        self,
+        entity_type: EntityType,
+        sanitized_collection_or_relation: str,
+        sanitized_embedding_name: str,
+    ) -> str:
+        # Postgres caps identifiers at 63 bytes, so we cannot embed the
+        # full sanitized collection and embedding names directly. Hash the
+        # tuple into a short digest and resolve back through the registry
+        # table when we need to enumerate side tables or recover the
+        # embedding name for hydration.
+        kind = "node" if entity_type is EntityType.NODE else "edge"
+        key = f"{kind}|{sanitized_collection_or_relation}|{sanitized_embedding_name}"
+        digest = hashlib.sha1(key.encode("utf-8")).hexdigest()[:16]
+        return f"{self._graph_name}_emb_{digest}"
+
+    async def _ensure_registry_table(self, conn: AsyncConnection) -> None:
+        # Called from inside ``_ensure_vector_table`` which already dedupes
+        # per-table creation, so the idempotent CREATE runs at most once per
+        # new side table — cheap and tolerant of out-of-band registry drops
+        # (e.g. test cleanup fixtures).
+        registry = self._registry_table_name()
+        await conn.exec_driver_sql(
+            f'CREATE TABLE IF NOT EXISTS public."{registry}" ('
+            "  table_name TEXT PRIMARY KEY,"
+            "  kind TEXT NOT NULL,"
+            "  sanitized_collection_or_relation TEXT NOT NULL,"
+            "  sanitized_embedding_name TEXT NOT NULL,"
+            "  UNIQUE (kind, sanitized_collection_or_relation,"
+            "          sanitized_embedding_name)"
+            ")"
+        )
+
+    async def _register_side_table(
+        self,
+        conn: AsyncConnection,
+        *,
+        table_name: str,
+        entity_type: EntityType,
+        sanitized_collection_or_relation: str,
+        sanitized_embedding_name: str,
+    ) -> None:
+        kind = "node" if entity_type is EntityType.NODE else "edge"
+        registry = self._registry_table_name()
+        await conn.exec_driver_sql(
+            f'INSERT INTO public."{registry}"'
+            " (table_name, kind, sanitized_collection_or_relation,"
+            "  sanitized_embedding_name)"
+            " VALUES ($1, $2, $3, $4)"
+            " ON CONFLICT (table_name) DO NOTHING",
+            (
+                table_name,
+                kind,
+                sanitized_collection_or_relation,
+                sanitized_embedding_name,
+            ),
+        )
+
+    async def _list_registered_side_tables(
+        self,
+        conn: AsyncConnection,
+        *,
+        entity_type: EntityType | None = None,
+        sanitized_collection_or_relation: str | None = None,
+    ) -> list[tuple[str, str]]:
+        """Return ``(table_name, sanitized_embedding_name)`` pairs from the registry."""
+        registry = self._registry_table_name()
+        if not await self._table_exists(conn, registry):
+            return []
+        conditions: list[str] = []
+        params: list[Any] = []
+        if entity_type is not None:
+            kind = "node" if entity_type is EntityType.NODE else "edge"
+            params.append(kind)
+            conditions.append(f"kind = ${len(params)}")
+        if sanitized_collection_or_relation is not None:
+            params.append(sanitized_collection_or_relation)
+            conditions.append(f"sanitized_collection_or_relation = ${len(params)}")
+        where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
+        result = await conn.exec_driver_sql(
+            "SELECT table_name, sanitized_embedding_name"
+            f' FROM public."{registry}"{where}',
+            tuple(params),
+        )
+        return [(row[0], row[1]) for row in result]
+
+    async def _ensure_vector_table(
+        self,
+        table_name: str,
+        *,
+        entity_type: EntityType,
+        sanitized_collection_or_relation: str,
+        sanitized_embedding_name: str,
+        dimensions: int,
+        uid_column: str,
+        conn: AsyncConnection,
+    ) -> None:
+        if not (1 <= dimensions <= _MAX_VECTOR_DIMENSIONS):
+            raise ValueError(
+                f"dimensions must be between 1 and {_MAX_VECTOR_DIMENSIONS}"
+            )
+        if table_name in self._ensured_vector_tables:
+            return
+        async with self._ensured_vector_tables_lock:
+            if table_name in self._ensured_vector_tables:
+                return
+            await self._ensure_registry_table(conn)
+            id_column = "vertex_id" if uid_column == "node_uid" else "edge_id"
+            await conn.exec_driver_sql(
+                f'CREATE TABLE IF NOT EXISTS public."{table_name}" ('
+                f"  {uid_column} TEXT PRIMARY KEY,"
+                f"  {id_column} BIGINT NOT NULL,"
+                "  similarity_metric TEXT NOT NULL,"
+                f"  embedding vector({dimensions}) NOT NULL"
+                ")"
+            )
+            await self._register_side_table(
+                conn,
+                table_name=table_name,
+                entity_type=entity_type,
+                sanitized_collection_or_relation=(sanitized_collection_or_relation),
+                sanitized_embedding_name=sanitized_embedding_name,
+            )
+            self._ensured_vector_tables.add(table_name)
+
+    async def _table_exists(self, conn: AsyncConnection, table_name: str) -> bool:
+        result = await conn.exec_driver_sql(
+            "SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = $1",
+            (table_name,),
+        )
+        return result.first() is not None
+
+    async def _vector_table_exists(self, table_name: str) -> bool:
+        async with self._engine.connect() as conn:
+            result = await conn.exec_driver_sql(
+                "SELECT 1 FROM pg_tables "
+                "WHERE schemaname = 'public' AND tablename = $1",
+                (table_name,),
+            )
+            return result.first() is not None
+
+    # ------------------------------------------------------------------
+    # Index management
+    # ------------------------------------------------------------------
+
+    async def _populate_index_state_cache(self) -> None:
+        async with self._tracker("populate_index_state_cache"):
+            if self._index_state_cache:
+                return
+            async with self._populate_index_state_cache_lock:
+                if self._index_state_cache:
+                    return
+                await self._ensure_graph_initialized()
+                # Range indexes live on AGE's per-label tables inside the
+                # graph schema; vector HNSW indexes live on the pgvector
+                # side tables inside ``public``. Cover both so the cache
+                # matches any index name we might look up later.
+                async with self._engine.connect() as conn:
+                    result = await conn.exec_driver_sql(
+                        "SELECT indexname FROM pg_indexes "
+                        "WHERE schemaname = ANY($1::text[])",
+                        ([self._graph_name, "public"],),
+                    )
+                    rows = [row[0] for row in result]
+                self._index_state_cache.update(
+                    dict.fromkeys(rows, AgeVectorGraphStore.CacheIndexState.ONLINE)
+                )
+
+    async def _create_initial_indexes_if_not_exist(
+        self,
+        entity_type: EntityType,
+        sanitized_collection_or_relation: str,
+    ) -> None:
+        async with self._tracker("create_initial_indexes_if_not_exist"):
+            tasks = [
+                self._create_range_index_if_not_exists(
+                    entity_type=entity_type,
+                    sanitized_collection_or_relation=(sanitized_collection_or_relation),
+                    sanitized_property_names="uid",
+                ),
+            ]
+            tasks += [
+                self._create_range_index_if_not_exists(
+                    entity_type=entity_type,
+                    sanitized_collection_or_relation=(sanitized_collection_or_relation),
+                    sanitized_property_names=[
+                        sanitize_identifier(mangle_property_name(property_name))
+                        for property_name in property_name_hierarchy
+                    ],
+                )
+                for range_index_hierarchy in self._range_index_hierarchies
+                for property_name_hierarchy in [
+                    range_index_hierarchy[: i + 1]
+                    for i in range(len(range_index_hierarchy))
+                ]
+            ]
+            await asyncio.gather(*tasks)
+
+    async def _create_range_index_if_not_exists(
+        self,
+        entity_type: EntityType,
+        sanitized_collection_or_relation: str,
+        sanitized_property_names: str | Iterable[str],
+    ) -> None:
+        """Create a B-tree index on the AGE-underlying table for this label."""
+        async with self._tracker("create_range_index_if_not_exists"):
+            if isinstance(sanitized_property_names, str):
+                sanitized_property_names = [sanitized_property_names]
+            sanitized_property_names = list(sanitized_property_names)
+            if not sanitized_property_names:
+                raise ValueError("sanitized_property_names must be nonempty")
+
+            await self._populate_index_state_cache()
+            index_name = self._index_name(
+                entity_type,
+                sanitized_collection_or_relation,
+                sanitized_property_names,
+            )
+            cached_state = self._index_state_cache.get(index_name)
+            if cached_state is AgeVectorGraphStore.CacheIndexState.CREATING:
+                await self._await_create_index_if_not_exists(index_name, None)
+                return
+            if cached_state is AgeVectorGraphStore.CacheIndexState.ONLINE:
+                return
+            self._index_state_cache[index_name] = (
+                AgeVectorGraphStore.CacheIndexState.CREATING
+            )
+
+            expressions = ", ".join(
+                f"(properties->>'{name}')" for name in sanitized_property_names
+            )
+            sql = (
+                f'CREATE INDEX IF NOT EXISTS "{index_name}" '
+                f'ON "{self._graph_name}"."{sanitized_collection_or_relation}"'
+                f" ({expressions})"
+            )
+
+            async def _run() -> None:
+                # AGE stores properties as ``agtype`` rather than ``jsonb``;
+                # property-expression indexes via ``->>`` are best-effort and
+                # may not be supported on all AGE versions. Treat failure as a
+                # missed optimization rather than a hard error.
+                try:
+                    async with self._engine.begin() as conn:
+                        await conn.exec_driver_sql(sql)
+                except SQLAlchemyError as exc:
+                    logger.warning(
+                        "Skipping range index %s for %s: %s",
+                        index_name,
+                        sanitized_collection_or_relation,
+                        exc,
+                    )
+
+            await self._await_create_index_if_not_exists(index_name, _run())
+
+    async def _create_vector_index_if_not_exists(
+        self,
+        entity_type: EntityType,
+        sanitized_collection_or_relation: str,
+        sanitized_embedding_name: str,
+        dimensions: int,
+        similarity_metric: SimilarityMetric = SimilarityMetric.COSINE,
+    ) -> None:
+        if not (1 <= dimensions <= _MAX_VECTOR_DIMENSIONS):
+            raise ValueError(
+                f"dimensions must be between 1 and {_MAX_VECTOR_DIMENSIONS}"
+            )
+        async with self._tracker("create_vector_index_if_not_exists"):
+            await self._populate_index_state_cache()
+            index_name = self._index_name(
+                entity_type,
+                sanitized_collection_or_relation,
+                sanitized_embedding_name,
+            )
+            cached_state = self._index_state_cache.get(index_name)
+            if cached_state is AgeVectorGraphStore.CacheIndexState.CREATING:
+                await self._await_create_index_if_not_exists(index_name, None)
+                return
+            if cached_state is AgeVectorGraphStore.CacheIndexState.ONLINE:
+                return
+            self._index_state_cache[index_name] = (
+                AgeVectorGraphStore.CacheIndexState.CREATING
+            )
+
+            opclass = _pgvector_hnsw_opclass(similarity_metric)
+            table_name = self._vector_table_name(
+                entity_type,
+                sanitized_collection_or_relation,
+                sanitized_embedding_name,
+            )
+            sql = (
+                f'CREATE INDEX IF NOT EXISTS "{index_name}" '
+                f'ON public."{table_name}" USING hnsw (embedding {opclass}) '
+                f"WITH (m = {self._hnsw_m}, "
+                f"ef_construction = {self._hnsw_ef_construction})"
+            )
+
+            async def _run() -> None:
+                async with self._engine.begin() as conn:
+                    await conn.exec_driver_sql(sql)
+
+            await self._await_create_index_if_not_exists(index_name, _run())
+
+    @async_locked
+    async def _await_create_index_if_not_exists(
+        self,
+        index_name: str,
+        create_index_awaitable: Awaitable | None,
+    ) -> None:
+        # ``@async_locked`` serializes calls for the same ``index_name``. A
+        # None awaitable means another coroutine already owns the creation;
+        # we just wait on the lock and observe the final state.
+        if create_index_awaitable is not None:
+            await create_index_awaitable
+        self._index_state_cache[index_name] = AgeVectorGraphStore.CacheIndexState.ONLINE
+
+    def _index_name(
+        self,
+        entity_type: EntityType,
+        sanitized_collection_or_relation: str,
+        sanitized_property_names: str | Iterable[str],
+    ) -> str:
+        if isinstance(sanitized_property_names, str):
+            sanitized_property_names = [sanitized_property_names]
+        sanitized_property_names_string = "_and_".join(
+            f"{len(sanitized_property_name)}_{sanitized_property_name}"
+            for sanitized_property_name in sanitized_property_names
+        )
+        # PostgreSQL identifiers max out at 63 bytes. We hash if too long.
+        base = (
+            f"{entity_type.value}_idx_"
+            f"{len(sanitized_collection_or_relation)}_"
+            f"{sanitized_collection_or_relation}_on_"
+            f"{sanitized_property_names_string}"
+        )
+        if len(base) <= 63:
+            return base
+        digest = hashlib.sha1(base.encode("utf-8"), usedforsecurity=False).hexdigest()
+        return f"mm_idx_{digest[:40]}"
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _vector_literal(embedding: list[float]) -> str:
+    """Render a list of floats as the pgvector text input format."""
+    return "[" + ",".join(repr(float(value)) for value in embedding) + "]"
+
+
+def _pgvector_distance_operator(metric: SimilarityMetric) -> str:
+    if metric is SimilarityMetric.COSINE:
+        return "<=>"
+    if metric is SimilarityMetric.EUCLIDEAN:
+        return "<->"
+    if metric is SimilarityMetric.DOT:
+        return "<#>"
+    if metric is SimilarityMetric.MANHATTAN:
+        return "<+>"
+    return "<=>"
+
+
+def _pgvector_hnsw_opclass(metric: SimilarityMetric) -> str:
+    if metric is SimilarityMetric.COSINE:
+        return "vector_cosine_ops"
+    if metric is SimilarityMetric.EUCLIDEAN:
+        return "vector_l2_ops"
+    if metric is SimilarityMetric.DOT:
+        return "vector_ip_ops"
+    if metric is SimilarityMetric.MANHATTAN:
+        return "vector_l1_ops"
+    return "vector_cosine_ops"
+
+
+def _sanitize_properties(
+    properties: Mapping[str, PropertyValue] | None,
+) -> dict[str, Any]:
+    """Convert property keys/values into the shape stored inside AGE."""
+    if properties is None:
+        return {}
+    return {
+        sanitize_identifier(key): age_value_from_python(value)
+        for key, value in properties.items()
+    }
+
+
+def _render_filter_expr(
+    entity_alias: str,
+    expr: FilterExpr | None,
+    *,
+    prefix: str,
+) -> tuple[str, dict[str, Any]]:
+    """Render a FilterExpr into Cypher and a parameter map.
+
+    The caller chooses a unique ``prefix`` to avoid collisions when multiple
+    filter expressions share the same parameter namespace (for example, edge
+    and node filters in ``search_related_nodes``).
+    """
+    if expr is None:
+        return "TRUE", {}
+
+    params: dict[str, Any] = {}
+    # Sequential counter gives deterministic, collision-free parameter names
+    # within a single call; the caller's ``prefix`` keeps names distinct
+    # across sibling filter expressions sharing a namespace (e.g. edge and
+    # node filters in ``search_related_nodes``).
+    counter = [0]
+
+    def _next_name() -> str:
+        counter[0] += 1
+        return f"{prefix}{counter[0]}"
+
+    def _walk(e: FilterExpr) -> str:
+        if isinstance(e, FilterIsNull):
+            field_ref = (
+                f"{entity_alias}.{sanitize_identifier(mangle_property_name(e.field))}"
+            )
+            return f"{field_ref} IS NULL"
+        if isinstance(e, FilterIn):
+            field_ref = (
+                f"{entity_alias}.{sanitize_identifier(mangle_property_name(e.field))}"
+            )
+            name = _next_name()
+            params[name] = list(e.values)
+            return f"{field_ref} IN ${name}"
+        if isinstance(e, FilterComparison):
+            field_ref = (
+                f"{entity_alias}.{sanitize_identifier(mangle_property_name(e.field))}"
+            )
+            name = _next_name()
+            params[name] = age_value_from_python(e.value)
+            return render_comparison(
+                left=field_ref,
+                op=e.op,
+                right=f"${name}",
+                value=e.value,
+            )
+        if isinstance(e, FilterAnd):
+            left = _walk(e.left)
+            right = _walk(e.right)
+            return f"({left}) AND ({right})"
+        if isinstance(e, FilterOr):
+            left = _walk(e.left)
+            right = _walk(e.right)
+            return f"({left}) OR ({right})"
+        if isinstance(e, FilterNot):
+            inner = _walk(e.expr)
+            return f"NOT ({inner})"
+        raise TypeError(f"Unsupported filter expression type: {type(e)!r}")
+
+    return _walk(expr), params
+
+
+def _lexicographic_relational_cypher(
+    entity_alias: str,
+    sanitized_by_properties: list[str],
+    starting_at: list[OrderedValue | str | None],
+    starting_param_names: list[str],
+    order_ascending: list[bool],
+) -> str:
+    """Render the Cypher WHERE fragment for ``search_directional_nodes``.
+
+    The shape matches the Neo4j backend's lexicographic comparison: for each
+    tie-breaker level ``i``, require strict inequality on property ``i`` and
+    equality on all previous properties, joined with OR across levels.
+    """
+    clauses: list[str] = []
+    for index, sanitized_by_property in enumerate(sanitized_by_properties):
+        starting_value = starting_at[index]
+        if starting_value is None:
+            parts = [
+                f"{entity_alias}.{sanitized_by_property} IS NOT NULL",
+            ]
+        else:
+            parts = [
+                render_comparison(
+                    f"{entity_alias}.{sanitized_by_property}",
+                    ">" if order_ascending[index] else "<",
+                    f"${starting_param_names[index]}",
+                    starting_value,
+                )
+            ]
+        for equal_index in range(index):
+            equal_starting_value = starting_at[equal_index]
+            equal_property = sanitized_by_properties[equal_index]
+            if equal_starting_value is None:
+                parts.append(f"{entity_alias}.{equal_property} IS NOT NULL")
+            else:
+                parts.append(
+                    render_comparison(
+                        f"{entity_alias}.{equal_property}",
+                        "=",
+                        f"${starting_param_names[equal_index]}",
+                        equal_starting_value,
+                    )
+                )
+        clauses.append("(" + " AND ".join(parts) + ")")
+    return "(" + " OR ".join(clauses) + ")"
+
+
+def _nodes_from_agtype_rows(
+    raw_values: Iterable[str | bytes | None],
+) -> list[Node]:
+    """Decode a sequence of ``agtype`` row values into :class:`Node`s."""
+    nodes: list[Node] = []
+    for raw in raw_values:
+        if raw is None:
+            continue
+        vertex = parse_agtype(raw)
+        if not isinstance(vertex, AgeVertex):
+            raise TypeError(f"expected AgeVertex after decoding, got {type(vertex)!r}")
+        node_properties: dict[str, PropertyValue] = {}
+        for sanitized_key, raw_value in vertex.properties.items():
+            if sanitized_key == "uid":
+                continue
+            desanitized = desanitize_identifier(sanitized_key)
+            if is_mangled_property_name(desanitized):
+                name = demangle_property_name(desanitized)
+                node_properties[name] = age_value_to_python(raw_value)
+        uid = str(vertex.properties.get("uid", ""))
+        nodes.append(
+            Node(uid=uid, properties=node_properties),
+        )
+    return nodes
+
+
+def _demangle_embedding_from_sanitized(sanitized_embedding_name: str) -> str | None:
+    """Inverse of ``sanitize_identifier(mangle_embedding_name(name))``.
+
+    Returns ``None`` if the input does not actually decode to a mangled
+    embedding name (defensive guard against unrelated tables that happen to
+    share a prefix on disk).
+    """
+    desanitized = desanitize_identifier(sanitized_embedding_name)
+    if not is_mangled_embedding_name(desanitized):
+        return None
+    return demangle_embedding_name(desanitized)
+
+
+def _parse_pgvector_text(text: str) -> list[float]:
+    """Parse pgvector's text output ``[v1,v2,...]`` into a Python list."""
+    inner = text.strip()
+    if inner.startswith("[") and inner.endswith("]"):
+        inner = inner[1:-1]
+    if not inner:
+        return []
+    return [float(part) for part in inner.split(",")]
+
+
+__all__ = [
+    "DEFAULT_GRAPH_NAME",
+    "AgeVectorGraphStore",
+    "AgeVectorGraphStoreParams",
+]

--- a/packages/server/src/memmachine_server/installation/configuration_wizard.py
+++ b/packages/server/src/memmachine_server/installation/configuration_wizard.py
@@ -21,6 +21,7 @@ from memmachine_server.common.configuration import (
     SessionManagerConf,
 )
 from memmachine_server.common.configuration.database_conf import (
+    AgeConf,
     DatabasesConf,
     Neo4jConf,
     SqlAlchemyConf,
@@ -47,6 +48,7 @@ from memmachine_server.common.configuration.reranker_conf import (
 )
 from memmachine_server.common.configuration.retrieval_config import RetrievalAgentConf
 from memmachine_server.installation.utilities import (
+    AGE_DEFAULTS,
     DEFAULT_BEDROCK_EMBEDDING_MODEL,
     DEFAULT_BEDROCK_MODEL,
     DEFAULT_NEO4J_PASSWORD,
@@ -68,6 +70,11 @@ class ConfigurationWizard:
     """Interactive configuration wizard for MemMachine."""
 
     NEO4J_DB_ID = "neo4j_db"
+    AGE_DB_ID = "age_db"
+    # Companion SqlAlchemyConf pointing at the same Postgres instance as
+    # AGE_DB_ID. Lets semantic memory's pgvector store share a database with
+    # AGE's graph catalog — the whole point of the AGE backend.
+    AGE_POSTGRES_DB_ID = "age_postgres_db"
     SQLITE_DB_ID = "sqlite_db"
     LANGUAGE_MODEL_NAME = "llm_model"
     EMBEDDER_NAME = "my_embedder"
@@ -80,6 +87,10 @@ class ConfigurationWizard:
         neo4j_provided: bool
         destination: str
         prompt: bool = False
+        # "neo4j" (default) or "age". Picks which graph backend the wizard
+        # writes into the generated configuration. Default preserves existing
+        # installer behavior; AGE is the Apache-2.0 alternative.
+        graph_backend: str = "neo4j"
 
     def __init__(self, args: Params) -> None:
         """Initialize the configuration wizard with parameters."""
@@ -87,6 +98,11 @@ class ConfigurationWizard:
         self.configuration_path: Path = Path(self.destination, "cfg.yml")
         self.prompt: bool = args.prompt
         self.neo4j_provided: bool = args.neo4j_provided
+        if args.graph_backend not in ("neo4j", "age"):
+            raise ValueError(
+                f"graph_backend must be 'neo4j' or 'age' (got {args.graph_backend!r})"
+            )
+        self.graph_backend: str = args.graph_backend
 
     def run_wizard(self) -> str:
         """Run the configuration wizard and write the configuration file."""
@@ -121,11 +137,21 @@ class ConfigurationWizard:
 
     @cached_property
     def semantic_manager_conf(self) -> SemanticMemoryConf:
-        """Generate semantic memory configuration."""
+        """Generate semantic memory configuration.
+
+        In AGE mode, semantic memory rides on the companion SqlAlchemyConf
+        that points at the same Postgres instance as AGE — the single-stack
+        promise. In Neo4j mode, semantic memory is left unconfigured
+        (``database=None``) so the ``SemanticMemoryConf`` validator
+        auto-disables it; the Neo4j wizard flow never provisioned a
+        pgvector-capable relational database for semantic use.
+        """
         return SemanticMemoryConf(
             llm_model=self.LANGUAGE_MODEL_NAME,
             embedding_model=self.EMBEDDER_NAME,
-            database=self.NEO4J_DB_ID,
+            database=(
+                self.AGE_POSTGRES_DB_ID if self.graph_backend == "age" else None
+            ),
             config_database=self.SQLITE_DB_ID,
         )
 
@@ -143,8 +169,13 @@ class ConfigurationWizard:
         return LongTermMemoryConfPartial(
             embedder=self.EMBEDDER_NAME,
             reranker=self.RERANKER_NAME,
-            vector_graph_store=self.NEO4J_DB_ID,
+            vector_graph_store=self.graph_db_id,
         )
+
+    @property
+    def graph_db_id(self) -> str:
+        """DB id the long-term-memory ``vector_graph_store`` resolves to."""
+        return self.AGE_DB_ID if self.graph_backend == "age" else self.NEO4J_DB_ID
 
     @cached_property
     def retrieval_agent_conf(self) -> RetrievalAgentConf:
@@ -310,14 +341,36 @@ class ConfigurationWizard:
 
     @cached_property
     def database_conf(self) -> DatabasesConf:
-        neo4j_db_conf = self.neo4j_configs
         db_provider = SupportedDB.from_provider("sqlite")
         sqlite_db_conf = cast(
             SqlAlchemyConf,
             db_provider.build_config({"path": "memmachine.db"}),
         )
+        if self.graph_backend == "age":
+            # Register the same Postgres instance twice: once as an AgeConf
+            # for the graph store, once as a SqlAlchemyConf so semantic
+            # memory's pgvector store can ride along. Both rely on the
+            # Dockerfile in deployments/docker/postgres-age/ shipping both
+            # the ``age`` and ``vector`` extensions.
+            age_conf = self.age_configs
+            age_postgres_conf = SqlAlchemyConf(
+                dialect="postgresql",
+                driver="asyncpg",
+                host=age_conf.host,
+                port=age_conf.port,
+                user=age_conf.user,
+                password=age_conf.password,
+                db_name=age_conf.db_name,
+            )
+            return DatabasesConf(
+                age_confs={self.AGE_DB_ID: age_conf},
+                relational_db_confs={
+                    self.SQLITE_DB_ID: sqlite_db_conf,
+                    self.AGE_POSTGRES_DB_ID: age_postgres_conf,
+                },
+            )
         return DatabasesConf(
-            neo4j_confs={self.NEO4J_DB_ID: neo4j_db_conf},
+            neo4j_confs={self.NEO4J_DB_ID: self.neo4j_configs},
             relational_db_confs={self.SQLITE_DB_ID: sqlite_db_conf},
         )
 
@@ -340,6 +393,45 @@ class ConfigurationWizard:
             uri=neo4j_uri,
             user=neo4j_username,
             password=SecretStr(neo4j_password),
+        )
+
+    @cached_property
+    def age_configs(self) -> AgeConf:
+        # Always prompt for AGE connection details. Unlike Neo4j, there's no
+        # installer flow that pre-stands-up a local AGE-enabled Postgres, so
+        # ``AGE_DEFAULTS`` is the presented default rather than an assumed
+        # truth.
+        age_host = (
+            input(f"Enter AGE Postgres host [{AGE_DEFAULTS.host}]: ").strip()
+            or AGE_DEFAULTS.host
+        )
+        age_port = int(
+            input(f"Enter AGE Postgres port [{AGE_DEFAULTS.port}]: ").strip()
+            or AGE_DEFAULTS.port
+        )
+        age_user = (
+            input(f"Enter AGE Postgres user [{AGE_DEFAULTS.user}]: ").strip()
+            or AGE_DEFAULTS.user
+        )
+        age_password = (
+            input(f"Enter AGE Postgres password [{AGE_DEFAULTS.password}]: ").strip()
+            or AGE_DEFAULTS.password
+        )
+        age_db_name = (
+            input(f"Enter AGE database name [{AGE_DEFAULTS.database}]: ").strip()
+            or AGE_DEFAULTS.database
+        )
+        age_graph_name = (
+            input(f"Enter AGE graph name [{AGE_DEFAULTS.graph_name}]: ").strip()
+            or AGE_DEFAULTS.graph_name
+        )
+        return AgeConf(
+            host=age_host,
+            port=age_port,
+            user=age_user,
+            password=SecretStr(age_password),
+            db_name=age_db_name,
+            graph_name=age_graph_name,
         )
 
     @cached_property

--- a/packages/server/src/memmachine_server/installation/memmachine_configure.py
+++ b/packages/server/src/memmachine_server/installation/memmachine_configure.py
@@ -111,25 +111,49 @@ class Installer(ABC):
         else:
             logger.info("Using installation directory: %s", self.install_dir)
 
+    @staticmethod
+    def _ask_graph_backend() -> str:
+        """Prompt the user for the episodic-memory graph backend."""
+        choice = (
+            input(
+                "Which graph backend would you like to use for episodic "
+                "memory? (neo4j/age) [neo4j]: "
+            )
+            .strip()
+            .lower()
+        )
+        if choice in ("age", "a"):
+            return "age"
+        return "neo4j"
+
     def install(self, prompt: bool = True) -> None:
         """Install and configure MemMachine."""
+        graph_backend = self._ask_graph_backend()
         neo4j_started_by_installer = False
-        if not self.check_neo4j_running():
-            choice = (
-                input(
-                    "Cannot find Neo4j locally. Do you want to install and start Neo4j? (y/n): "
+
+        if graph_backend == "neo4j":
+            if not self.check_neo4j_running():
+                choice = (
+                    input(
+                        "Cannot find Neo4j locally. Do you want to install and "
+                        "start Neo4j? (y/n): "
+                    )
+                    .strip()
+                    .lower()
                 )
-                .strip()
-                .lower()
-            )
-            if choice == "y":
-                self.install_and_start_neo4j()
-                neo4j_started_by_installer = True
-        else:
-            logger.info("Neo4j is already running.")
+                if choice == "y":
+                    self.install_and_start_neo4j()
+                    neo4j_started_by_installer = True
+            else:
+                logger.info("Neo4j is already running.")
+        # AGE mode: no installer-side provisioning. Users stand up their own
+        # AGE-enabled Postgres (e.g. via ``docker compose -f
+        # docker-compose.age.yml up`` or their existing infrastructure) and
+        # the wizard prompts for connection details.
 
         wizard_args = ConfigurationWizard.Params(
             neo4j_provided=neo4j_started_by_installer,
+            graph_backend=graph_backend,
             destination=get_memmachine_config_dir(),
             prompt=prompt,
         )

--- a/packages/server/src/memmachine_server/installation/utilities.py
+++ b/packages/server/src/memmachine_server/installation/utilities.py
@@ -1,5 +1,6 @@
 """Utility functions and constants for MemMachine installation scripts."""
 
+from dataclasses import dataclass
 from enum import Enum
 
 LINUX_JDK_TAR_NAME = "jdk-21_linux-x64_bin.tar.gz"
@@ -49,6 +50,20 @@ DEFAULT_OLLAMA_EMBEDDING_DIMENSIONS = 768
 DEFAULT_NEO4J_URI = "bolt://localhost:7687"
 DEFAULT_NEO4J_USERNAME = "neo4j"
 DEFAULT_NEO4J_PASSWORD = "memmachine"
+
+@dataclass(frozen=True)
+class AgeDefaults:
+    """Fallback values the wizard uses when prompting for an AGE instance."""
+
+    host: str = "localhost"
+    port: int = 5432
+    user: str = "postgres"
+    password: str = "postgres"
+    database: str = "memmachine"
+    graph_name: str = "mem_graph"
+
+
+AGE_DEFAULTS = AgeDefaults()
 
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 

--- a/packages/server/src/memmachine_server/server/api_v2/config_service.py
+++ b/packages/server/src/memmachine_server/server/api_v2/config_service.py
@@ -339,6 +339,24 @@ class ConfigService:
             )
             for name, conf in db_manager.conf.relational_db_confs.items()
         )
+        databases.extend(
+            ResourceInfo(
+                name=name,
+                provider="nebula_graph",
+                status=ResourceStatus.READY,
+                error=None,
+            )
+            for name in db_manager.conf.nebula_graph_confs
+        )
+        databases.extend(
+            ResourceInfo(
+                name=name,
+                provider="age",
+                status=ResourceStatus.READY,
+                error=None,
+            )
+            for name in db_manager.conf.age_confs
+        )
 
         return ResourcesStatus(
             embedders=embedders,

--- a/sample_configs/episodic_memory_config.age.sample
+++ b/sample_configs/episodic_memory_config.age.sample
@@ -1,0 +1,121 @@
+logging:
+  path: mem-machine.log
+  level: info #| debug | error
+
+episode_store:
+  database: profile_storage
+
+episodic_memory:
+  long_term_memory:
+    embedder: openai_embedder
+    reranker: my_reranker_id
+    vector_graph_store: my_storage_id  # Using Apache AGE
+  short_term_memory:
+    llm_model: openai_model
+    message_capacity: 500
+
+retrieval_agent:
+  llm_model: openai_model
+  reranker: my_reranker_id
+
+semantic_memory:
+  llm_model: openai_model
+  embedding_model: openai_embedder
+  database: profile_storage        # pgvector on the same (or another) Postgres
+  config_database: profile_storage
+
+session_manager:
+  database: profile_storage
+
+prompt:
+  default_project_categories:
+  - profile_prompt
+
+resources:
+  databases:
+    # Pair the AGE backend below with the standard pgvector semantic backend
+    # here to run the complete MemMachine stack on a single Postgres instance
+    # (Apache-2.0-compatible; no Neo4j required).
+    profile_storage:
+      provider: postgres
+      config:
+        host: localhost
+        port: 5432
+        user: postgres
+        password: <YOUR_PASSWORD_HERE>
+        db_name: postgres
+        pool_size: 5
+        max_overflow: 10
+        pool_timeout: 30
+        pool_recycle: -1
+        pool_pre_ping: false
+
+    # Apache AGE Configuration: openCypher over PostgreSQL with pgvector-backed
+    # vector similarity search on side tables.
+    my_storage_id:
+      provider: age
+      config:
+        host: localhost
+        port: 5432
+        user: postgres
+        password: <YOUR_PASSWORD_HERE>
+        db_name: postgres
+
+        # AGE graph name (also used as the Postgres schema for AGE catalog
+        # tables and as the prefix for the pgvector side tables). Must be a
+        # valid Postgres identifier.
+        graph_name: mem_graph
+
+        # Index creation thresholds (optional - defaults shown)
+        range_index_creation_threshold: 10000
+        vector_index_creation_threshold: 10000
+
+        # Force exact similarity search (optional - default: false)
+        # Set to true to disable ANN and always use exact KNN.
+        force_exact_similarity_search: false
+
+        # pgvector HNSW tuning (optional - defaults shown)
+        hnsw_m: 16                 # Max neighbors per layer
+        hnsw_ef_construction: 64   # Build-time quality
+
+        # SQLAlchemy connection pool tuning (optional)
+        pool_size: 5
+        max_overflow: 10
+        pool_timeout: 30
+        pool_recycle: -1
+        pool_pre_ping: false
+
+    sqlite_test:
+      provider: sqlite
+      config:
+        path: sqlite_test.db
+
+  embedders:
+    openai_embedder:
+      provider: openai
+      config:
+        max_input_length: 2048
+        model: "text-embedding-3-small"
+        api_key: <YOUR_API_KEY>
+        base_url: "https://api.openai.com/v1"
+        dimensions: 1536
+
+  language_models:
+    openai_model:
+      provider: openai-responses
+      config:
+        model: "gpt-4o-mini"
+        api_key: <YOUR_API_KEY>
+        base_url: "https://api.openai.com/v1"
+
+  rerankers:
+    my_reranker_id:
+      provider: "rrf-hybrid"
+      config:
+        reranker_ids:
+          - id_ranker_id
+          - bm_ranker_id
+    id_ranker_id:
+      provider: "identity"
+    bm_ranker_id:
+      provider: "bm25"


### PR DESCRIPTION
### Purpose of the change

Adds Apache AGE (openCypher over PostgreSQL, Apache-2.0) as a third supported graph backend behind `VectorGraphStore`, alongside Neo4j and NebulaGraph. Enables a single-Postgres deployment where episodic memory (graph) and semantic memory (pgvector) share one database service, and provides an Apache-2.0-compatible alternative to Neo4j that's operationally lighter than NebulaGraph's 3-role distributed topology.

Opened in response to #1324.

### Description

MemMachine already requires Postgres + pgvector for semantic memory. AGE ships the `age` and `vector` extensions in the same Postgres, so with this PR a minimal AGE deployment collapses what was previously two database services (Neo4j + pgvector Postgres) into one. NebulaGraph already covers Apache-2.0 licensing for users at scale, but bundling it means running a 3-role distributed system; AGE fits single-instance and small-cluster deployments that want to drop Neo4j without adopting a new product.

**What's added:**

- `AgeVectorGraphStore` + `age_utils`: full `VectorGraphStore` implementation against AGE + pgvector. Graph structure lives in AGE; per-embedding similarity goes to pgvector side tables keyed by vertex `uid`, tracked via a per-graph registry table. Supports the full pgvector 1..16000 dimension range. Asserts AGE >= 1.6.0 on first use so older versions fail fast instead of hitting the cryptic "SET clause expects a map" runtime error.
- `AgeConf` + `DatabaseManager` plumbing symmetric with `Neo4jConf`. `/resources` status endpoint surfaces AGE backends (and, while touching that code, the pre-existing `nebula_graph` gap).
- `deployments/docker/postgres-age/Dockerfile` layering `postgresql-16-pgvector` on `apache/age:release_PG16_1.6.0`. Published as `memmachine/postgres-age:pg16-1.6.0` via a new build job in `.github/workflows/docker-image.yml`.
- `docker-compose.age.yml`: self-contained single-Postgres AGE stack (one command). Base `docker-compose.yml` keeps `postgres-age` under an opt-in `age` profile for the "run AGE alongside a pip-installed server" flow.
- Helm chart (bumped `0.1.0` -> `0.2.0`): new top-level `episodicBackend: neo4j | age` toggle, orthogonal to per-backend `*.enabled` flags. In AGE mode the standalone pgvector `postgres` Deployment is automatically skipped and all relational workloads ride on the AGE-enabled Postgres. Validation guard fails cleanly on invalid values.
- Installation wizard + installer: `memmachine-configure` prompts for backend choice and routes to the existing Neo4j auto-install or the wizard's interactive AGE prompts. Wizard emits a paired `AgeConf` + co-located `SqlAlchemyConf` so semantic memory's pgvector store shares the AGE Postgres.
- Also fixes a pre-existing bug where the wizard's generated `semantic_memory.database` pointed at `NEO4J_DB_ID` (a graph backend, not a relational one).
- Sample config `sample_configs/episodic_memory_config.age.sample`.
- Tests: unit coverage for `age_utils`, `AgeConf` lifecycle tests in `test_database_manager`, wizard tests for AGE and invalid-backend paths, and a testcontainer-backed integration test built from the shipped Dockerfile.

**Dependencies:** none added - `asyncpg`, `pgvector`, `sqlalchemy`, and `alembic` are already pinned in `packages/server/pyproject.toml`.

### Fixes/Closes

Fixes #(issue number)

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test
- [x] Manual verification

**Unit tests** (no Docker required):

    pytest packages/server/server_tests/memmachine_server/common/test_age_utils.py \
           packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py \
           packages/server/server_tests/memmachine_server/installation/

**Integration test** (requires Docker; built from the shipped `deployments/docker/postgres-age/Dockerfile` so the test environment matches prod):

    pytest -m integration \
      packages/server/server_tests/memmachine_server/common/vector_graph_store/test_age_vector_graph_store.py

**Helm template verified** on all four deployment scenarios plus invalid-input guard:

    cd deployments/helm
    helm template memmachine-test .                                                   # default: in-cluster Neo4j
    helm template memmachine-test . --set neo4j.enabled=false                         # external Neo4j
    helm template memmachine-test . \
        --set episodicBackend=age --set postgresAge.enabled=true --set neo4j.enabled=false   # in-cluster AGE single-stack
    helm template memmachine-test . \
        --set episodicBackend=age --set postgresAge.enabled=false \
        --set postgresAge.host=my-age.example.com --set neo4j.enabled=false           # external AGE
    helm template memmachine-test . --set episodicBackend=foobar                      # must fail

**Docker Compose verified:**

    docker compose -f docker-compose.yml config --quiet     # default Neo4j stack
    docker compose -f docker-compose.age.yml config --quiet # single-Postgres AGE stack

**Test Results:**

- Helm scenario 3 (AGE single-stack): exactly one Postgres Deployment (`postgres-age`), `db_postgres` and `db_age` both target it, one `wait-for-postgres` init container, `POSTGRES_PASSWORD` sourced from `postgres-age-secret`. No `postgres-deployment`, no `neo4j-deployment`.
- Helm scenario 5: aborts with `Error: ... episodicBackend must be one of: neo4j, age (got "foobar")` - expected.
- All Python files pass `ast.parse`; all YAML files pass `docker compose config --quiet`.

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A - backend + deployment change

### Further comments

- **Helm chart version bumped `0.1.0` -> `0.2.0`** because templates and values changed materially.
- **Behavior change in wizard-generated configs (Neo4j mode):** `semantic_memory.database` was previously set to `NEO4J_DB_ID` - a pre-existing bug since `SemanticMemoryConf.database` expects a relational backend. It's now left unset in Neo4j mode so `SemanticMemoryConf`'s existing `_auto_disable_when_incomplete` validator fires cleanly; in AGE mode it targets the companion `SqlAlchemyConf`. Users who relied on the broken behavior will see semantic memory cleanly disabled instead of failing obscurely at runtime.
- **Helm AGE mode collapses two Postgres services into one:** when `episodicBackend=age`, `postgres.enabled` is ignored because the postgres-age image already ships `vector`. This is intentional and documented in `values.yaml` / `deployments/helm/README.md`.
- **`memmachine/postgres-age:pg16-1.6.0`** doesn't exist in the registry yet - the new CI job publishes it on the first release cut with this PR merged. Until then, helm deployments will need to build and push locally (documented in `values.yaml`).
- **AGE 1.6.0-specific workaround**: `SET n += $param` inside `cypher()` fails with "SET clause expects a map"; aliased via `WITH $param AS p` before `SET`. The version probe enforces AGE >= 1.6.0 with a clear error.
- **`postgres-age` image build is pinned to `linux/amd64`**: apache/age has had inconsistent arm64 availability historically. Easy flip to multi-arch once confirmed upstream.

Happy to split any subsystem out into a follow-up if reviewers prefer a tighter scope (e.g. the NebulaGraph `/resources` status addition, or the wizard's `semantic_memory.database` fix), but they're small enough I've kept them bundled.