### PR TITLE
fix(embedder): always chunk text before cluster_texts() when max_input t_length is None

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/embedder/test_openai_embedder.py
+++ b/packages/server/server_tests/memmachine_server/common/embedder/test_openai_embedder.py
@@ -124,3 +124,48 @@ async def test_embed_fail_after_max_retries_on_internal_server_error(mock_sleep)
     assert mock_sleep.call_count == 2
     mock_sleep.assert_any_await(1)
     mock_sleep.assert_any_await(2)
+
+
+@pytest.mark.asyncio
+async def test_embed_oversized_input_with_no_max_input_length():
+    """Regression for #1298: text > 75,000 chars must not raise ValueError.
+
+    When max_input_length is None, _embed() must fall back to
+    max_total_input_length_per_request (75,000) as the chunking bound so that
+    cluster_texts() never receives a text that exceeds its hard limit.
+    Prior to the fix, this raised ValueError("Text length ... exceeds
+    max_total_length_per_cluster ..."), which surfaced as HTTP 500.
+    """
+    mock_client = AsyncMock(spec=openai.AsyncOpenAI)
+
+    mock_embedding = MagicMock()
+    mock_embedding.embedding = [0.1] * 256
+
+    mock_response = MagicMock()
+    mock_response.data = [mock_embedding]
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.total_tokens = 10
+
+    mock_client.embeddings.create = AsyncMock(return_value=mock_response)
+
+    embedder = OpenAIEmbedder(
+        OpenAIEmbedderParams(
+            client=mock_client,
+            model="test-model",
+            dimensions=256,
+            max_input_length=None,  # default — reproduces the crash scenario
+        )
+    )
+
+    # 80,000 chars exceeds the 75,000-char cluster hard limit by 5,000.
+    long_text = "x" * 80_000
+
+    # Before the fix this raised:
+    #   ValueError: Text length 80000 exceeds max_total_length_per_cluster 75000
+    result = await embedder.ingest_embed([long_text])
+
+    assert len(result) == 1
+    assert len(result[0]) == 256
+    # The text must have been split: balanced chunks of 80,000 chars at limit
+    # 75,000 produce two chunks of 40,000 each, each in its own cluster.
+    assert mock_client.embeddings.create.call_count >= 2

--- a/packages/server/src/memmachine_server/common/embedder/openai_embedder.py
+++ b/packages/server/src/memmachine_server/common/embedder/openai_embedder.py
@@ -150,11 +150,11 @@ class OpenAIEmbedder(Embedder):
             for input_text in inputs
         ]
 
+        effective_max = (
+            self._max_input_length or self.max_total_input_length_per_request
+        )
         inputs_chunks = [
-            chunk_text_balanced(input_text, self._max_input_length)
-            if self._max_input_length is not None
-            else [input_text]
-            for input_text in inputs
+            chunk_text_balanced(input_text, effective_max) for input_text in inputs
         ]
 
         chunks = [chunk for input_chunks in inputs_chunks for chunk in input_chunks]


### PR DESCRIPTION
### Purpose of the change

OpenAIEmbedder._embed() previously skipped chunk_text_balanced() when self._max_input_length was None (the default across every embedder conf). Any single input longer than cluster_texts()'s hard-coded 75,000-char ceiling then raised an unhandled ValueError, surfacing as HTTP 500 on ingestion of long messages.

### Description

Replace the conditional guard with an unconditional split that falls back to max_total_input_length_per_request (the same 75,000-char bound cluster_texts() enforces) when max_input_length is None. Every text is now guaranteed to fit before cluster_texts() sees it.

Scope is limited to OpenAIEmbedder per architect review: Bedrock and SentenceTransformer embedders do not call cluster_texts() and have no equivalent crash path. Conf defaults remain None by design — no single Unicode code-point value is correct across all supported models.

Adds regression test test_embed_oversized_input_with_no_max_input_length covering an 80,000-char input with max_input_length=None.

### Fixes/Closes

Fixes #1298 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Unit Test

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None