### PR TITLE
docs: update remaining filter prefix examples

### DIFF
--- a/docs/api_reference/python/memory_api.mdx
+++ b/docs/api_reference/python/memory_api.mdx
@@ -50,7 +50,7 @@ results = client.memories.search(
     expand_context=2,
     score_threshold=0.65,
     agent_mode=True,
-    filter_dict={"source": "chat_v3"},
+    filter_dict={"metadata.source": "chat_v3"},
 )
 ```
 
@@ -63,7 +63,7 @@ results = client.memories.search(
 | `expand_context` | `int` | `0`          | Number of neighboring episodic entries to include around each long-term match. |
 | `score_threshold` | `float` | `None`     | Minimum episodic retrieval score to keep. Not supported when `agent_mode=True`. |
 | `agent_mode`  | `bool`   | `False`      | Whether to use retrieval-agent search orchestration.         |
-| `filter_dict` | `dict`   | `None`       | Key-value filters to apply to the search (metadata matching). |
+| `filter_dict` | `dict`   | `None`       | Structured filter criteria. User metadata fields should use `metadata.` / `m.` prefixes (for example `metadata.source`). |
 | `timeout`     | `int`    | `None`       | Request timeout in seconds. Uses client default if omitted.  |
 
 ------

--- a/docs/api_reference/python/semantic_api.mdx
+++ b/docs/api_reference/python/semantic_api.mdx
@@ -97,7 +97,7 @@ Retrieves all semantic features (sets, categories, and tags) associated with a p
 | ------------- | -------- | ------------ | -------------------------------------- |
 | `org_id`      | `str`    | **Required** | Organization identifier.               |
 | `project_id`  | `str`    | **Required** | Project identifier.                    |
-| `filter_dict` | `dict`   | `None`       | Filter by specific tags or categories. |
+| `filter_dict` | `dict`   | `None`       | Filter by specific fields. User metadata fields should use `metadata.` / `m.` prefixes where applicable. |
 
 ------
 

--- a/examples/memmachine_client_demo.py
+++ b/examples/memmachine_client_demo.py
@@ -127,7 +127,7 @@ def demo_advanced_memory_features() -> None:
         query = "What programming languages do I know?"
         results = memory.search(
             query=query,
-            filter_dict={"category": "programming"},
+            filter_dict={"metadata.category": "programming"},
             limit=5,
         )
         print_memory_results(results, query)
@@ -136,7 +136,7 @@ def demo_advanced_memory_features() -> None:
         query = "What conferences have I attended?"
         results = memory.search(
             query=query,
-            filter_dict={"category": "conference"},
+            filter_dict={"metadata.category": "conference"},
             limit=5,
         )
         print_memory_results(results, query)


### PR DESCRIPTION
### Purpose of the change

Finish updating lingering Python docs/examples that still show pre-#1291 unqualified filter keys.

### Description

Fixes #1307
Fixes #1308

This follow-up updates the remaining Python-facing docs/examples I found that still used bare metadata filter keys:
- `docs/api_reference/python/memory_api.mdx`
- `docs/api_reference/python/semantic_api.mdx`
- `examples/memmachine_client_demo.py`

Changes include:
- updating `filter_dict={"source": ...}` to `filter_dict={"metadata.source": ...}`
- updating the example client demo filter searches to use `metadata.category`
- clarifying filter parameter descriptions to mention the `metadata.` / `m.` prefix requirement

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [x] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [ ] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [x] Manual verification (list step-by-step instructions)

Manual verification:
1. Verified the Python memory API example now uses `filter_dict={"metadata.source": "chat_v3"}`
2. Verified semantic API filter docs mention `metadata.` / `m.` prefixes where applicable
3. Verified `examples/memmachine_client_demo.py` now uses `metadata.category` in filtered searches

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
