### PR TITLE
feat(ts-client): support deleting multiple memories

### DIFF
--- a/packages/ts-client/src/memory/memmachine-memory.ts
+++ b/packages/ts-client/src/memory/memmachine-memory.ts
@@ -114,7 +114,7 @@ export class MemMachineMemory {
    * @returns A promise that resolves when the memory is successfully deleted.
    * @throws {@link MemMachineAPIError} if the API request fails.
    */
-  delete(id: string, type: MemoryType): Promise<void> {
+  delete(id: string | string[], type: MemoryType): Promise<void> {
     return this._deleteMemory(id, type)
   }
 
@@ -258,9 +258,11 @@ export class MemMachineMemory {
    * @returns A promise that resolves when the memory is successfully deleted.
    * @throws {@link MemMachineAPIError} if the API request fails.
    */
-  private async _deleteMemory(id: string, memoryType: MemoryType): Promise<void> {
-    if (!id || !id.trim()) {
-      throw new MemMachineAPIError('Memory ID must be a non-empty string')
+  private async _deleteMemory(id: string | string[], memoryType: MemoryType): Promise<void> {
+    const ids = Array.isArray(id) ? id : [id]
+
+    if (ids.length === 0 || ids.some(memoryId => !memoryId || !memoryId.trim())) {
+      throw new MemMachineAPIError('Memory ID must be a non-empty string or non-empty string array')
     }
 
     this._validateMemoryType(memoryType)
@@ -272,8 +274,8 @@ export class MemMachineMemory {
 
     const payload = {
       ...this.projectContext,
-      ...(memoryType === 'episodic' ? { episodic_id: id } : {}),
-      ...(memoryType === 'semantic' ? { semantic_id: id } : {})
+      ...(memoryType === 'episodic' ? (ids.length === 1 ? { episodic_id: ids[0] } : { episodic_ids: ids }) : {}),
+      ...(memoryType === 'semantic' ? (ids.length === 1 ? { semantic_id: ids[0] } : { semantic_ids: ids }) : {})
     }
 
     try {

--- a/packages/ts-client/tests/memmachine-memory.spec.ts
+++ b/packages/ts-client/tests/memmachine-memory.spec.ts
@@ -164,11 +164,48 @@ describe('MemMachine Memory', () => {
     expect(deleteResponse).toBeUndefined()
   })
 
+  it('should delete multiple episodic memories successfully', async () => {
+    const client = new MemMachineClient({ api_key: 'test-api-key' })
+    const postSpy = jest.spyOn(client.client, 'post').mockResolvedValue({
+      data: null
+    })
+    const project = client.project(mockProjectContext)
+    const memory = project.memory(mockMemoryContext)
+    const deleteResponse = await memory.delete(['1', '2'], 'episodic')
+    expect(deleteResponse).toBeUndefined()
+    expect(postSpy).toHaveBeenCalledWith('/memories/episodic/delete', {
+      ...mockProjectContext,
+      episodic_ids: ['1', '2']
+    })
+  })
+
+  it('should delete multiple semantic memories successfully', async () => {
+    const client = new MemMachineClient({ api_key: 'test-api-key' })
+    const postSpy = jest.spyOn(client.client, 'post').mockResolvedValue({
+      data: null
+    })
+    const project = client.project(mockProjectContext)
+    const memory = project.memory(mockMemoryContext)
+    const deleteResponse = await memory.delete(['1', '2'], 'semantic')
+    expect(deleteResponse).toBeUndefined()
+    expect(postSpy).toHaveBeenCalledWith('/memories/semantic/delete', {
+      ...mockProjectContext,
+      semantic_ids: ['1', '2']
+    })
+  })
+
   it('should throw error if id is empty when deleting memory', async () => {
     const client = new MemMachineClient({ api_key: 'test-api-key' })
     const project = client.project(mockProjectContext)
     const memory = project.memory(mockMemoryContext)
-    await expect(memory.delete('', 'episodic')).rejects.toThrow('Memory ID must be a non-empty string')
+    await expect(memory.delete('', 'episodic')).rejects.toThrow('Memory ID must be a non-empty string or non-empty string array')
+  })
+
+  it('should throw error if any id is empty when deleting multiple memories', async () => {
+    const client = new MemMachineClient({ api_key: 'test-api-key' })
+    const project = client.project(mockProjectContext)
+    const memory = project.memory(mockMemoryContext)
+    await expect(memory.delete(['1', ''], 'episodic')).rejects.toThrow('Memory ID must be a non-empty string or non-empty string array')
   })
 
   it('should throw error if memory type is invalid when deleting memory', async () => {


### PR DESCRIPTION
### Purpose of the change

Add bulk memory deletion support to the TypeScript client so it matches the existing REST API delete payloads.

### Description

Fixes #1249

This change updates `MemMachineMemory.delete()` in the TypeScript client to accept either a single ID or a list of IDs:
- `memory.delete('1', 'episodic')`
- `memory.delete(['1', '2'], 'episodic')`

Behavior:
- single IDs keep using `episodic_id` / `semantic_id`
- multiple IDs use `episodic_ids` / `semantic_ids`
- validation now rejects empty arrays and arrays containing empty IDs

Also added regression coverage in `packages/ts-client/tests/memmachine-memory.spec.ts` for:
- deleting multiple episodic memories
- deleting multiple semantic memories
- rejecting invalid mixed arrays

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [x] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

Test command:
- `cd packages/ts-client && npx jest --runInBand tests/memmachine-memory.spec.ts`

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
