### PR TITLE
test(client): update remaining filter prefix tests

### DIFF
--- a/packages/client/client_tests/test_integration_complete.py
+++ b/packages/client/client_tests/test_integration_complete.py
@@ -348,11 +348,11 @@ class TestMemMachineIntegration:
             "Should find both morning and afternoon memories without filter"
         )
 
-        # Search with filter (filter_dict is converted to SQL-like string format)
+        # Search with filter (user metadata fields use the metadata. prefix in filter_dict)
         try:
             results = memory.search(
                 "What do I like to drink?",
-                filter_dict={"time": "morning"},
+                filter_dict={"metadata.time": "morning"},
                 limit=10,
             )
             assert isinstance(results, SearchResult)

--- a/packages/client/client_tests/test_memory.py
+++ b/packages/client/client_tests/test_memory.py
@@ -497,9 +497,9 @@ class TestMemory:
             project_id="test_project",
         )
 
-        filter_dict = {"category": "work"}
+        filter_dict = {"metadata.category": "work"}
         filter_str = memory._dict_to_filter_string(filter_dict)
-        assert filter_str == "category='work'"
+        assert filter_str == "metadata.category='work'"
 
     def test_dict_to_filter_string_multiple_conditions(self, mock_client):
         """Test _dict_to_filter_string with multiple conditions."""
@@ -509,10 +509,10 @@ class TestMemory:
             project_id="test_project",
         )
 
-        filter_dict = {"category": "work", "type": "preference"}
+        filter_dict = {"metadata.category": "work", "m.type": "preference"}
         filter_str = memory._dict_to_filter_string(filter_dict)
-        assert "category='work'" in filter_str
-        assert "type='preference'" in filter_str
+        assert "metadata.category='work'" in filter_str
+        assert "m.type='preference'" in filter_str
         assert " AND " in filter_str
 
     def test_dict_to_filter_string_with_escaped_quotes(self, mock_client):
@@ -523,9 +523,9 @@ class TestMemory:
             project_id="test_project",
         )
 
-        filter_dict = {"name": "O'Brien"}
+        filter_dict = {"metadata.name": "O'Brien"}
         filter_str = memory._dict_to_filter_string(filter_dict)
-        assert filter_str == "name='O''Brien'"  # SQL escape: ' -> ''
+        assert filter_str == "metadata.name='O''Brien'"  # SQL escape: ' -> ''
 
     def test_dict_to_filter_string_with_non_string_value(self, mock_client):
         """Test _dict_to_filter_string raises TypeError for non-string values."""


### PR DESCRIPTION
### Purpose of the change

Finish aligning Python client tests with the strict filter prefix behavior introduced by PR #1291.

### Description

Follow-up to #1305

This updates the remaining Python client tests I found that still used unqualified metadata filter keys:
- `packages/client/client_tests/test_memory.py`
- `packages/client/client_tests/test_integration_complete.py`

Changes include:
- updating `_dict_to_filter_string()` test examples from bare keys like `category`, `type`, and `name` to prefixed keys like `metadata.category`, `m.type`, and `metadata.name`
- updating the integration test search example from `filter_dict={"time": "morning"}` to `filter_dict={"metadata.time": "morning"}`
- clarifying the nearby integration test comment to mention the `metadata.` prefix requirement

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [ ] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [x] Manual verification (list step-by-step instructions)

Manual verification:
1. Verified `test_memory.py` now expects prefixed filter keys in `_dict_to_filter_string()` examples
2. Verified `test_integration_complete.py` now uses `filter_dict={"metadata.time": "morning"}`
3. Verified the old unqualified examples were removed

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
