### PR TITLE
feat(client): support raw filter strings

### DIFF
--- a/packages/client/client_tests/test_integration_complete.py
+++ b/packages/client/client_tests/test_integration_complete.py
@@ -348,11 +348,11 @@ class TestMemMachineIntegration:
             "Should find both morning and afternoon memories without filter"
         )
 
-        # Search with filter (filter_dict is converted to SQL-like string format)
+        # Search with filter (user metadata fields use the metadata. prefix in filter_dict)
         try:
             results = memory.search(
                 "What do I like to drink?",
-                filter_dict={"time": "morning"},
+                filter_dict={"metadata.time": "morning"},
                 limit=10,
             )
             assert isinstance(results, SearchResult)

--- a/packages/client/client_tests/test_memory.py
+++ b/packages/client/client_tests/test_memory.py
@@ -463,6 +463,54 @@ class TestMemory:
         assert "category='work'" in json_data["filter"]
         assert call_args[1]["timeout"] == 15
 
+    def test_search_with_filter_string(self, mock_client):
+        """Test search with raw filter string."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"status": 0, "content": {}}
+        mock_response.raise_for_status = Mock()
+        mock_client.request.return_value = mock_response
+
+        memory = Memory(
+            client=mock_client,
+            org_id="test_org",
+            project_id="test_project",
+            metadata={"agent_id": "agent1", "user_id": "user1"},
+        )
+
+        memory.search("query", filter='metadata.category = "work"')
+
+        call_args = mock_client.request.call_args
+        json_data = call_args[1]["json"]
+        filter_str = json_data["filter"]
+        assert "metadata.user_id='user1'" in filter_str
+        assert "metadata.agent_id='agent1'" in filter_str
+        assert '(metadata.category = "work")' in filter_str
+
+    def test_list_with_filter_string(self, mock_client):
+        """Test list with raw filter string."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"status": 0, "content": {}}
+        mock_response.raise_for_status = Mock()
+        mock_client.request.return_value = mock_response
+
+        memory = Memory(
+            client=mock_client,
+            org_id="test_org",
+            project_id="test_project",
+            metadata={"agent_id": "agent1", "user_id": "user1"},
+        )
+
+        memory.list(filter='metadata.category = "work"')
+
+        call_args = mock_client.request.call_args
+        json_data = call_args[1]["json"]
+        filter_str = json_data["filter"]
+        assert "metadata.user_id='user1'" in filter_str
+        assert "metadata.agent_id='agent1'" in filter_str
+        assert '(metadata.category = "work")' in filter_str
+
     def test_search_with_filters(self, mock_client):
         """Test search with filter dictionary."""
         mock_response = Mock()

--- a/packages/client/client_tests/test_memory.py
+++ b/packages/client/client_tests/test_memory.py
@@ -497,9 +497,9 @@ class TestMemory:
             project_id="test_project",
         )
 
-        filter_dict = {"category": "work"}
+        filter_dict = {"metadata.category": "work"}
         filter_str = memory._dict_to_filter_string(filter_dict)
-        assert filter_str == "category='work'"
+        assert filter_str == "metadata.category='work'"
 
     def test_dict_to_filter_string_multiple_conditions(self, mock_client):
         """Test _dict_to_filter_string with multiple conditions."""
@@ -509,10 +509,10 @@ class TestMemory:
             project_id="test_project",
         )
 
-        filter_dict = {"category": "work", "type": "preference"}
+        filter_dict = {"metadata.category": "work", "m.type": "preference"}
         filter_str = memory._dict_to_filter_string(filter_dict)
-        assert "category='work'" in filter_str
-        assert "type='preference'" in filter_str
+        assert "metadata.category='work'" in filter_str
+        assert "m.type='preference'" in filter_str
         assert " AND " in filter_str
 
     def test_dict_to_filter_string_with_escaped_quotes(self, mock_client):
@@ -523,9 +523,9 @@ class TestMemory:
             project_id="test_project",
         )
 
-        filter_dict = {"name": "O'Brien"}
+        filter_dict = {"metadata.name": "O'Brien"}
         filter_str = memory._dict_to_filter_string(filter_dict)
-        assert filter_str == "name='O''Brien'"  # SQL escape: ' -> ''
+        assert filter_str == "metadata.name='O''Brien'"  # SQL escape: ' -> ''
 
     def test_dict_to_filter_string_with_non_string_value(self, mock_client):
         """Test _dict_to_filter_string raises TypeError for non-string values."""

--- a/packages/client/src/memmachine_client/memory.py
+++ b/packages/client/src/memmachine_client/memory.py
@@ -367,6 +367,7 @@ class Memory:
         filter_dict: dict[str, str] | None = None,
         timeout: int | None = None,
         *,
+        filter: str | None = None,
         set_metadata: dict[str, JsonValue] | None = None,
         agent_mode: bool = False,
     ) -> SearchResult:
@@ -389,6 +390,8 @@ class Memory:
                         User-provided filters take precedence over built-in filters
                         if there are key conflicts.
             timeout: Request timeout in seconds (uses client default if not provided)
+            filter: Optional raw filter string. If provided together with built-in or
+                    `filter_dict` filters, all filters are combined with AND.
             set_metadata: Optional metadata key-value pairs used to select semantic sets.
             agent_mode: Whether to enable top-level retrieval-agent orchestration.
 
@@ -412,11 +415,13 @@ class Memory:
         if filter_dict:
             merged_filters.update(filter_dict)
 
-        # Use v2 API: convert to v2 format
-        # Convert merged filter_dict to string format: key='value' AND key='value'
-        filter_str = ""
-        if merged_filters:
-            filter_str = self._dict_to_filter_string(merged_filters)
+        dict_filter_str = self._dict_to_filter_string(merged_filters) if merged_filters else ""
+        explicit_filter = filter.strip() if filter else ""
+
+        if dict_filter_str and explicit_filter:
+            filter_str = f"{dict_filter_str} AND ({explicit_filter})"
+        else:
+            filter_str = dict_filter_str or explicit_filter
 
         # Use shared API Pydantic models
         spec = SearchMemoriesSpec(
@@ -457,6 +462,7 @@ class Memory:
         page_size: int = 100,
         page_num: int = 0,
         filter_dict: dict[str, str] | None = None,
+        filter: str | None = None,
         set_metadata: dict[str, JsonValue] | None = None,
         timeout: int | None = None,
     ) -> ListResult:
@@ -470,6 +476,8 @@ class Memory:
             page_size: Page size (server default is 100)
             page_num: Page number (0-based)
             filter_dict: Optional extra filters; merged with built-in context filters
+            filter: Optional raw filter string. If provided together with built-in or
+                    `filter_dict` filters, all filters are combined with AND.
             set_metadata: Optional metadata key-value pairs used to select semantic sets.
             timeout: Request timeout override
 
@@ -485,9 +493,13 @@ class Memory:
         if filter_dict:
             merged_filters.update(filter_dict)
 
-        filter_str = (
-            self._dict_to_filter_string(merged_filters) if merged_filters else ""
-        )
+        dict_filter_str = self._dict_to_filter_string(merged_filters) if merged_filters else ""
+        explicit_filter = filter.strip() if filter else ""
+
+        if dict_filter_str and explicit_filter:
+            filter_str = f"{dict_filter_str} AND ({explicit_filter})"
+        else:
+            filter_str = dict_filter_str or explicit_filter
 
         spec = ListMemoriesSpec(
             org_id=self.__org_id,


### PR DESCRIPTION
### Purpose of the change

Add raw filter string support to the Python client so it matches the TypeScript client and underlying API capabilities.

### Description

Fixes #1310

This change updates the Python client `Memory.search()` and `Memory.list()` methods to accept an optional raw `filter` string in addition to `filter_dict`.

Behavior:
- existing `filter_dict` behavior remains unchanged
- callers can now pass `filter="metadata.category = \"work\""`
- if built-in metadata filters / `filter_dict` filters and a raw `filter` string are both present, they are combined as:
  - `dict_filters AND (raw_filter)`

This preserves backward compatibility while allowing parity with the TypeScript client and direct filter-string usage.

Also added test coverage in `packages/client/client_tests/test_memory.py` for:
- `search(..., filter=...)`
- `list(..., filter=...)`
- verifying that built-in metadata filters are still preserved when a raw filter string is used

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [x] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [x] Test Script (please provide)
- [ ] Manual verification (list step-by-step instructions)

Test command:
- `cd packages/client && PYTHONPATH=/home/node/.openclaw/workspace/MemMachine/packages/client/src:/home/node/.openclaw/workspace/MemMachine/packages/common/src python -m pytest client_tests/test_memory.py -q`

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
