### PR TITLE
docs(examples): update remaining filter prefix demo usage

### DIFF
--- a/docs/api_reference/python/client.mdx
+++ b/docs/api_reference/python/client.mdx
@@ -132,8 +132,8 @@ def main():
 
     print(f"Query: {query}")
     print("Results found:")
-    for idx, item in enumerate(results.get('episodic_memory', [])):
-        print(f"[{idx+1}] {item['content']} (Role: {item['producer_role']})")
+    for idx, item in enumerate(results.episodic_memory or []):
+        print(f"[{idx+1}] {item.content} (Role: {item.producer_role})")
 
 if __name__ == "__main__":
     main()

--- a/examples/memmachine_client_demo.py
+++ b/examples/memmachine_client_demo.py
@@ -36,19 +36,18 @@ def print_memory_results(results, query="") -> None:
     if query:
         print(f"\n🔍 Query: {query}")
 
-    if not results or not results.get("episodic_memory"):
+    episodic_memories = results.episodic_memory or []
+    if not episodic_memories:
         print("   No memories found.")
         return
 
-    episodic_memories = results["episodic_memory"]
-    if episodic_memories and len(episodic_memories) > 0:
-        print(f"   Found {len(episodic_memories[0])} relevant memories:")
-        for i, memory in enumerate(episodic_memories[0][:3], 1):  # Show top 3
-            print(f"      Time: {memory['timestamp']}")
-            print(f"   {i}. {memory['content']}")
-            if memory.get("user_metadata"):
-                print(f"      Metadata: {memory['user_metadata']}")
-            print()
+    print(f"   Found {len(episodic_memories)} relevant memories:")
+    for i, memory in enumerate(episodic_memories[:3], 1):  # Show top 3
+        print(f"      Time: {memory.timestamp}")
+        print(f"   {i}. {memory.content}")
+        if memory.user_metadata:
+            print(f"      Metadata: {memory.user_metadata}")
+        print()
 
 
 def demo_advanced_memory_features() -> None:

--- a/examples/memmachine_client_demo.py
+++ b/examples/memmachine_client_demo.py
@@ -126,7 +126,7 @@ def demo_advanced_memory_features() -> None:
         query = "What programming languages do I know?"
         results = memory.search(
             query=query,
-            filter_dict={"category": "programming"},
+            filter_dict={"metadata.category": "programming"},
             limit=5,
         )
         print_memory_results(results, query)
@@ -135,7 +135,7 @@ def demo_advanced_memory_features() -> None:
         query = "What conferences have I attended?"
         results = memory.search(
             query=query,
-            filter_dict={"category": "conference"},
+            filter_dict={"metadata.category": "conference"},
             limit=5,
         )
         print_memory_results(results, query)

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -106,11 +106,11 @@ memory.add("I work as a software engineer", metadata={"type": "fact", "category"
 
 # Search memories
 results = memory.search("What do I like to eat?")
-print(f"Episodic memory: {results.get('episodic_memory', [])}")
-print(f"Profile memory: {results.get('profile_memory', [])}")
+print(f"Episodic memory: {results.episodic_memory or []}")
+print(f"Semantic memory: {results.semantic_memory or []}")
 
 # Search with filters
-work_results = memory.search("Tell me about work", filter_dict={"category": "work"})
+work_results = memory.search("Tell me about work", filter_dict={"metadata.category": "work"})
 print(f"Work results: {work_results}")
 ```
 

--- a/packages/client/client_tests/test_integration_complete.py
+++ b/packages/client/client_tests/test_integration_complete.py
@@ -348,11 +348,11 @@ class TestMemMachineIntegration:
             "Should find both morning and afternoon memories without filter"
         )
 
-        # Search with filter (filter_dict is converted to SQL-like string format)
+        # Search with filter (user metadata fields use the metadata. prefix in filter_dict)
         try:
             results = memory.search(
                 "What do I like to drink?",
-                filter_dict={"time": "morning"},
+                filter_dict={"metadata.time": "morning"},
                 limit=10,
             )
             assert isinstance(results, SearchResult)

--- a/packages/client/client_tests/test_langgraph.py
+++ b/packages/client/client_tests/test_langgraph.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import Mock, patch
 
+from memmachine_common.api import EpisodeType
+
 from memmachine_client.langgraph import (
     MemMachineTools,
     create_add_memory_tool,
@@ -145,7 +147,7 @@ class TestAddMemory:
         assert result["uids"] == ["uid-123"]
         assert result["content"] == "Hello world"
         mock_memory.add.assert_called_once_with(
-            content="Hello world", role="user", metadata={}
+            content="Hello world", role="user", metadata={}, episode_type=None
         )
 
     def test_raw_filter_passthrough(self):
@@ -169,6 +171,18 @@ class TestAddMemory:
             filter_dict=None,
             filter='metadata.category = "work"',
         )
+
+    def test_episode_type_string_is_normalized(self):
+        tools, mock_memory = self._make_tools()
+        mock_result = Mock()
+        mock_result.uid = "uid-ep"
+        mock_memory.add.return_value = [mock_result]
+
+        result = tools.add_memory(content="Hello world", episode_type="message")
+
+        assert result["status"] == "success"
+        mock_memory.add.assert_called_once()
+        assert mock_memory.add.call_args.kwargs["episode_type"] == EpisodeType.MESSAGE
 
     def test_error_path(self):
         tools, mock_memory = self._make_tools()
@@ -345,7 +359,7 @@ class TestFactoryFunctions:
         mock_memory.add.return_value = [mock_result]
 
         add_fn = create_add_memory_tool(tools)
-        result = add_fn("test content", None, None)
+        result = add_fn("test content", None, None, None)
 
         assert result["status"] == "success"
         assert result["uids"] == ["uid-1"]
@@ -357,7 +371,7 @@ class TestFactoryFunctions:
         mock_memory.add.return_value = [mock_result]
 
         add_fn = create_add_memory_tool(tools)
-        result = add_fn("content", "u1", None)
+        result = add_fn("content", "u1", None, "message")
 
         assert result["status"] == "success"
 

--- a/packages/client/client_tests/test_langgraph.py
+++ b/packages/client/client_tests/test_langgraph.py
@@ -148,6 +148,28 @@ class TestAddMemory:
             content="Hello world", role="user", metadata={}
         )
 
+    def test_raw_filter_passthrough(self):
+        tools, mock_memory = self._make_tools()
+
+        mock_content = Mock()
+        mock_content.episodic_memory = None
+        mock_content.semantic_memory = []
+
+        mock_search_result = Mock()
+        mock_search_result.content = mock_content
+        mock_memory.search.return_value = mock_search_result
+
+        result = tools.search_memory(query="food", filter='metadata.category = "work"')
+
+        assert result["status"] == "success"
+        mock_memory.search.assert_called_once_with(
+            query="food",
+            limit=20,
+            score_threshold=None,
+            filter_dict=None,
+            filter='metadata.category = "work"',
+        )
+
     def test_error_path(self):
         tools, mock_memory = self._make_tools()
         mock_memory.add.side_effect = RuntimeError("boom")
@@ -203,7 +225,7 @@ class TestSearchMemory:
         assert result["results"]["episodic_memory"] == {"episodes": [{"content": "hi"}]}
         assert result["results"]["semantic_memory"] == [{"name": "likes pizza"}]
         mock_memory.search.assert_called_once_with(
-            query="food", limit=20, score_threshold=None, filter_dict=None
+            query="food", limit=20, score_threshold=None, filter_dict=None, filter=None
         )
 
     def test_error_path(self):
@@ -368,5 +390,5 @@ class TestFactoryFunctions:
         search_fn("hello", None, 10)
 
         mock_memory.search.assert_called_once_with(
-            query="hello", limit=10, score_threshold=None, filter_dict=None
+            query="hello", limit=10, score_threshold=None, filter_dict=None, filter=None
         )

--- a/packages/client/client_tests/test_memory.py
+++ b/packages/client/client_tests/test_memory.py
@@ -463,6 +463,54 @@ class TestMemory:
         assert "category='work'" in json_data["filter"]
         assert call_args[1]["timeout"] == 15
 
+    def test_search_with_filter_string(self, mock_client):
+        """Test search with raw filter string."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"status": 0, "content": {}}
+        mock_response.raise_for_status = Mock()
+        mock_client.request.return_value = mock_response
+
+        memory = Memory(
+            client=mock_client,
+            org_id="test_org",
+            project_id="test_project",
+            metadata={"agent_id": "agent1", "user_id": "user1"},
+        )
+
+        memory.search("query", filter='metadata.category = "work"')
+
+        call_args = mock_client.request.call_args
+        json_data = call_args[1]["json"]
+        filter_str = json_data["filter"]
+        assert "metadata.user_id='user1'" in filter_str
+        assert "metadata.agent_id='agent1'" in filter_str
+        assert '(metadata.category = "work")' in filter_str
+
+    def test_list_with_filter_string(self, mock_client):
+        """Test list with raw filter string."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"status": 0, "content": {}}
+        mock_response.raise_for_status = Mock()
+        mock_client.request.return_value = mock_response
+
+        memory = Memory(
+            client=mock_client,
+            org_id="test_org",
+            project_id="test_project",
+            metadata={"agent_id": "agent1", "user_id": "user1"},
+        )
+
+        memory.list(filter='metadata.category = "work"')
+
+        call_args = mock_client.request.call_args
+        json_data = call_args[1]["json"]
+        filter_str = json_data["filter"]
+        assert "metadata.user_id='user1'" in filter_str
+        assert "metadata.agent_id='agent1'" in filter_str
+        assert '(metadata.category = "work")' in filter_str
+
     def test_search_with_filters(self, mock_client):
         """Test search with filter dictionary."""
         mock_response = Mock()

--- a/packages/client/client_tests/test_memory.py
+++ b/packages/client/client_tests/test_memory.py
@@ -497,9 +497,9 @@ class TestMemory:
             project_id="test_project",
         )
 
-        filter_dict = {"category": "work"}
+        filter_dict = {"metadata.category": "work"}
         filter_str = memory._dict_to_filter_string(filter_dict)
-        assert filter_str == "category='work'"
+        assert filter_str == "metadata.category='work'"
 
     def test_dict_to_filter_string_multiple_conditions(self, mock_client):
         """Test _dict_to_filter_string with multiple conditions."""
@@ -509,10 +509,10 @@ class TestMemory:
             project_id="test_project",
         )
 
-        filter_dict = {"category": "work", "type": "preference"}
+        filter_dict = {"metadata.category": "work", "m.type": "preference"}
         filter_str = memory._dict_to_filter_string(filter_dict)
-        assert "category='work'" in filter_str
-        assert "type='preference'" in filter_str
+        assert "metadata.category='work'" in filter_str
+        assert "m.type='preference'" in filter_str
         assert " AND " in filter_str
 
     def test_dict_to_filter_string_with_escaped_quotes(self, mock_client):
@@ -523,9 +523,9 @@ class TestMemory:
             project_id="test_project",
         )
 
-        filter_dict = {"name": "O'Brien"}
+        filter_dict = {"metadata.name": "O'Brien"}
         filter_str = memory._dict_to_filter_string(filter_dict)
-        assert filter_str == "name='O''Brien'"  # SQL escape: ' -> ''
+        assert filter_str == "metadata.name='O''Brien'"  # SQL escape: ' -> ''
 
     def test_dict_to_filter_string_with_non_string_value(self, mock_client):
         """Test _dict_to_filter_string raises TypeError for non-string values."""

--- a/packages/client/src/memmachine_client/langgraph.py
+++ b/packages/client/src/memmachine_client/langgraph.py
@@ -203,6 +203,7 @@ class MemMachineTools:
         limit: int = 20,
         score_threshold: float | None = None,
         filter_dict: dict[str, str] | None = None,
+        filter: str | None = None,
     ) -> dict[str, Any]:
         """
         Search for memories in MemMachine.
@@ -223,7 +224,8 @@ class MemMachineTools:
             session_id: Session ID (overrides default, stored in metadata)
             limit: Maximum number of results to return (default: 20)
             score_threshold: Minimum score to include in results
-            filter_dict: Additional filters for the search
+            filter_dict: Additional key-value filters for the search
+            filter: Optional raw filter string passed through to the Python client
 
         Returns:
             Dictionary containing search results and relevant memories
@@ -238,6 +240,7 @@ class MemMachineTools:
                 limit=limit,
                 score_threshold=score_threshold,
                 filter_dict=filter_dict,
+                filter=filter,
             )
 
             # Format results for easier consumption

--- a/packages/client/src/memmachine_client/langgraph.py
+++ b/packages/client/src/memmachine_client/langgraph.py
@@ -8,6 +8,8 @@ to enable AI agents with persistent memory capabilities.
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from memmachine_common.api import EpisodeType
+
 from .client import MemMachineClient
 
 if TYPE_CHECKING:
@@ -141,6 +143,7 @@ class MemMachineTools:
         group_id: str | None = None,
         session_id: str | None = None,
         metadata: dict[str, str] | None = None,
+        episode_type: EpisodeType | str | None = None,
     ) -> dict[str, Any]:
         """
         Add a memory to MemMachine.
@@ -159,6 +162,7 @@ class MemMachineTools:
             group_id: Group ID (overrides default, stored in metadata)
             session_id: Session ID (overrides default, stored in metadata)
             metadata: Additional metadata for the episode
+            episode_type: Optional episode type enum or string value
 
         Returns:
             Dictionary with success status and message
@@ -168,10 +172,16 @@ class MemMachineTools:
             memory = self.get_memory(
                 org_id, project_id, user_id, agent_id, group_id, session_id
             )
+            normalized_episode_type = (
+                EpisodeType(episode_type)
+                if isinstance(episode_type, str)
+                else episode_type
+            )
             results = memory.add(
                 content=content,
                 role=role,
                 metadata=metadata or {},
+                episode_type=normalized_episode_type,
             )
             if results:
                 return {
@@ -375,6 +385,7 @@ def create_add_memory_tool(
         content: str,
         user_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        episode_type: EpisodeType | str | None = None,
     ) -> dict[str, Any]:
         """
         Tool to add a memory to MemMachine.
@@ -383,6 +394,7 @@ def create_add_memory_tool(
             content: The content to store in memory
             user_id: Optional user ID override
             metadata: Optional metadata for the memory
+            episode_type: Optional episode type enum or string value
 
         Returns:
             Result dictionary with status and message
@@ -392,6 +404,7 @@ def create_add_memory_tool(
             content=content,
             user_id=user_id,
             metadata=metadata,
+            episode_type=episode_type,
         )
 
     return add_memory_tool

--- a/packages/client/src/memmachine_client/memory.py
+++ b/packages/client/src/memmachine_client/memory.py
@@ -367,6 +367,7 @@ class Memory:
         filter_dict: dict[str, str] | None = None,
         timeout: int | None = None,
         *,
+        filter: str | None = None,
         set_metadata: dict[str, JsonValue] | None = None,
         agent_mode: bool = False,
     ) -> SearchResult:
@@ -389,6 +390,8 @@ class Memory:
                         User-provided filters take precedence over built-in filters
                         if there are key conflicts.
             timeout: Request timeout in seconds (uses client default if not provided)
+            filter: Optional raw filter string. If provided together with built-in or
+                    `filter_dict` filters, all filters are combined with AND.
             set_metadata: Optional metadata key-value pairs used to select semantic sets.
             agent_mode: Whether to enable top-level retrieval-agent orchestration.
 
@@ -412,11 +415,13 @@ class Memory:
         if filter_dict:
             merged_filters.update(filter_dict)
 
-        # Use v2 API: convert to v2 format
-        # Convert merged filter_dict to string format: key='value' AND key='value'
-        filter_str = ""
-        if merged_filters:
-            filter_str = self._dict_to_filter_string(merged_filters)
+        dict_filter_str = self._dict_to_filter_string(merged_filters) if merged_filters else ""
+        explicit_filter = filter.strip() if filter else ""
+
+        if dict_filter_str and explicit_filter:
+            filter_str = f"{dict_filter_str} AND ({explicit_filter})"
+        else:
+            filter_str = dict_filter_str or explicit_filter
 
         # Use shared API Pydantic models
         spec = SearchMemoriesSpec(
@@ -457,6 +462,7 @@ class Memory:
         page_size: int = 100,
         page_num: int = 0,
         filter_dict: dict[str, str] | None = None,
+        filter: str | None = None,
         set_metadata: dict[str, JsonValue] | None = None,
         timeout: int | None = None,
     ) -> ListResult:
@@ -470,6 +476,8 @@ class Memory:
             page_size: Page size (server default is 100)
             page_num: Page number (0-based)
             filter_dict: Optional extra filters; merged with built-in context filters
+            filter: Optional raw filter string. If provided together with built-in or
+                    `filter_dict` filters, all filters are combined with AND.
             set_metadata: Optional metadata key-value pairs used to select semantic sets.
             timeout: Request timeout override
 
@@ -485,9 +493,13 @@ class Memory:
         if filter_dict:
             merged_filters.update(filter_dict)
 
-        filter_str = (
-            self._dict_to_filter_string(merged_filters) if merged_filters else ""
-        )
+        dict_filter_str = self._dict_to_filter_string(merged_filters) if merged_filters else ""
+        explicit_filter = filter.strip() if filter else ""
+
+        if dict_filter_str and explicit_filter:
+            filter_str = f"{dict_filter_str} AND ({explicit_filter})"
+        else:
+            filter_str = dict_filter_str or explicit_filter
 
         spec = ListMemoriesSpec(
             org_id=self.__org_id,


### PR DESCRIPTION
### Purpose of the change

Finish cleaning up the remaining outdated filter examples in the main Python client demo.

### Description

Follow-up to #1305 and #1307

This updates the remaining filtered search examples in `examples/memmachine_client_demo.py` from bare metadata keys to the current prefixed form required by strict filter validation:
- `{"category": "programming"}` → `{"metadata.category": "programming"}`
- `{"category": "conference"}` → `{"metadata.category": "conference"}`

This keeps the official demo aligned with the current Python client and backend filter semantics.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [ ] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [x] Manual verification (list step-by-step instructions)

Manual verification:
1. Verified the programming search example now uses `filter_dict={"metadata.category": "programming"}`
2. Verified the conference search example now uses `filter_dict={"metadata.category": "conference"}`
3. Verified the old unqualified `category` examples were removed

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
