### PR TITLE
docs: clarify filter prefix requirements

### DIFF
--- a/docs/api_reference/python/memory_api.mdx
+++ b/docs/api_reference/python/memory_api.mdx
@@ -50,7 +50,7 @@ results = client.memories.search(
     expand_context=2,
     score_threshold=0.65,
     agent_mode=True,
-    filter_dict={"source": "chat_v3"},
+    filter_dict={"m.source": "chat_v3"},
 )
 ```
 
@@ -63,8 +63,12 @@ results = client.memories.search(
 | `expand_context` | `int` | `0`          | Number of neighboring episodic entries to include around each long-term match. |
 | `score_threshold` | `float` | `None`     | Minimum episodic retrieval score to keep. Not supported when `agent_mode=True`. |
 | `agent_mode`  | `bool`   | `False`      | Whether to use retrieval-agent search orchestration.         |
-| `filter_dict` | `dict`   | `None`       | Key-value filters to apply to the search (metadata matching). |
+| `filter_dict` | `dict`   | `None`       | Metadata filters to apply to the search. User metadata keys must be prefixed with `m.` / `metadata.` (for example `{"m.source": "chat_v3"}`). Unknown or misspelled fields return a 400 error. |
 | `timeout`     | `int`    | `None`       | Request timeout in seconds. Uses client default if omitted.  |
+
+<Note>
+When constructing filters, always prefix user metadata fields with `m.` or `metadata.`. For example, use `{"m.user_id": "123"}` instead of `{"user_id": "123"}`. Filters that reference unknown or unqualified fields now fail fast with a 400 error instead of being ignored.
+</Note>
 
 ------
 

--- a/docs/api_reference/python/memory_api.mdx
+++ b/docs/api_reference/python/memory_api.mdx
@@ -50,7 +50,7 @@ results = client.memories.search(
     expand_context=2,
     score_threshold=0.65,
     agent_mode=True,
-    filter_dict={"source": "chat_v3"},
+    filter_dict={"m.source": "chat_v3"},
 )
 ```
 
@@ -63,8 +63,12 @@ results = client.memories.search(
 | `expand_context` | `int` | `0`          | Number of neighboring episodic entries to include around each long-term match. |
 | `score_threshold` | `float` | `None`     | Minimum episodic retrieval score to keep. Not supported when `agent_mode=True`. |
 | `agent_mode`  | `bool`   | `False`      | Whether to use retrieval-agent search orchestration.         |
-| `filter_dict` | `dict`   | `None`       | Key-value filters to apply to the search (metadata matching). |
+| `filter_dict` | `dict`   | `None`       | Metadata filters to apply to the search. User metadata keys must be prefixed with `m.` / `metadata.` (for example `{"m.source": "chat_v3"}`). Unknown or misspelled fields return a 400 error. |
 | `timeout`     | `int`    | `None`       | Request timeout in seconds. Uses client default if omitted.  |
+
+<Note>
+When constructing filters, always prefix user metadata fields with `m.` or `metadata.`. For example, use `{"m.user_id": "123"}` instead of `{"user_id": "123"}`. Filters that reference unqualified user metadata fields (or misspelled built-in fields) now fail fast with a 400 error instead of being ignored.
+</Note>
 
 ------
 

--- a/docs/api_reference/python/semantic_api.mdx
+++ b/docs/api_reference/python/semantic_api.mdx
@@ -97,7 +97,7 @@ Retrieves all semantic features (sets, categories, and tags) associated with a p
 | ------------- | -------- | ------------ | -------------------------------------- |
 | `org_id`      | `str`    | **Required** | Organization identifier.               |
 | `project_id`  | `str`    | **Required** | Project identifier.                    |
-| `filter_dict` | `dict`   | `None`       | Filter by specific tags or categories. |
+| `filter_dict` | `dict`   | `None`       | Filter by specific tags or categories. User metadata keys must be prefixed with `m.` / `metadata.`. Unknown or misspelled fields return a 400 error. |
 
 ------
 

--- a/docs/api_reference/ts-rest/interfaces/SearchMemoriesOptions.mdx
+++ b/docs/api_reference/ts-rest/interfaces/SearchMemoriesOptions.mdx
@@ -19,7 +19,7 @@ All properties in this interface are optional.
 | :--- | :--- | :--- |
 | `top_k` | `number` | The maximum number of relevant memories to return. |
 | `score_threshold` | `number` | The minimum similarity score required for a memory to be included in results. |
-| `filter` | `string` | A metadata-based filter string to narrow the search scope. |
+| `filter` | `string` | A metadata-based filter string to narrow the search scope. User metadata fields must be prefixed with `m.` / `metadata.` (for example `m.user_id = "123"`). Unknown or misspelled fields return a 400 error. |
 | `expand_context` | `number` | The number of surrounding chronological episodes to retrieve for each hit. |
 | `types` | [`MemoryType[]`](../types/MemoryType) | Restricts the search to specific memory classifications (e.g., `semantic`). |
 | `agent_mode` | `boolean` | Enables top-level retrieval-agent orchestration for episodic retrieval. |

--- a/docs/api_reference/ts-rest/interfaces/SearchMemoriesOptions.mdx
+++ b/docs/api_reference/ts-rest/interfaces/SearchMemoriesOptions.mdx
@@ -19,7 +19,7 @@ All properties in this interface are optional.
 | :--- | :--- | :--- |
 | `top_k` | `number` | The maximum number of relevant memories to return. |
 | `score_threshold` | `number` | The minimum similarity score required for a memory to be included in results. |
-| `filter` | `string` | A metadata-based filter string to narrow the search scope. |
+| `filter` | `string` | A metadata-based filter string to narrow the search scope. User metadata fields must be prefixed with `m.` / `metadata.` (for example `m.user_id = '123'`). String literals must be single-quoted. Unknown or misspelled user metadata fields return a 400 error. |
 | `expand_context` | `number` | The number of surrounding chronological episodes to retrieve for each hit. |
 | `types` | [`MemoryType[]`](../types/MemoryType) | Restricts the search to specific memory classifications (e.g., `semantic`). |
 | `agent_mode` | `boolean` | Enables top-level retrieval-agent orchestration for episodic retrieval. |

--- a/docs/install_guide/integrate/n8n.mdx
+++ b/docs/install_guide/integrate/n8n.mdx
@@ -97,7 +97,7 @@ Retrieves historical context to inject into an LLM prompt.
 | **query**             | String       | -                  | **Required.** Natural language query for semantic search.    |
 | **limit**             | Number       | 50                 | Maximum number of memory results to return.                  |
 | **scoreThreshold**    | Number       | -                  | Minimum relevance score required to include a memory.        |
-| **filter**            | String       | -                  | Filter expression to refine memory search results.           |
+| **filter**            | String       | -                  | Filter expression to refine memory search results. Prefix user metadata fields with `m.` / `metadata.` (for example `m.user_id = "123"`). Unknown or misspelled fields return a 400 error.           |
 | **expandContext**     | Number       | 0                  | Number of extra episodes to include for context.             |
 | **sessionId**         | String       | -                  | **Required.** Unique session identifier.                     |
 | **groupId**           | String       | `default`          | Unique group identifier.                                     |

--- a/docs/install_guide/integrate/n8n.mdx
+++ b/docs/install_guide/integrate/n8n.mdx
@@ -97,7 +97,7 @@ Retrieves historical context to inject into an LLM prompt.
 | **query**             | String       | -                  | **Required.** Natural language query for semantic search.    |
 | **limit**             | Number       | 50                 | Maximum number of memory results to return.                  |
 | **scoreThreshold**    | Number       | -                  | Minimum relevance score required to include a memory.        |
-| **filter**            | String       | -                  | Filter expression to refine memory search results.           |
+| **filter**            | String       | -                  | Filter expression to refine memory search results. Prefix user metadata fields with `m.` / `metadata.` (for example `m.user_id = '123'`). String literals must be single-quoted. Unknown or misspelled user metadata fields return a 400 error.           |
 | **expandContext**     | Number       | 0                  | Number of extra episodes to include for context.             |
 | **sessionId**         | String       | -                  | **Required.** Unique session identifier.                     |
 | **groupId**           | String       | `default`          | Unique group identifier.                                     |

--- a/examples/memmachine_client_demo.py
+++ b/examples/memmachine_client_demo.py
@@ -127,7 +127,7 @@ def demo_advanced_memory_features() -> None:
         query = "What programming languages do I know?"
         results = memory.search(
             query=query,
-            filter_dict={"category": "programming"},
+            filter_dict={"m.category": "programming"},
             limit=5,
         )
         print_memory_results(results, query)
@@ -136,7 +136,7 @@ def demo_advanced_memory_features() -> None:
         query = "What conferences have I attended?"
         results = memory.search(
             query=query,
-            filter_dict={"category": "conference"},
+            filter_dict={"m.category": "conference"},
             limit=5,
         )
         print_memory_results(results, query)

--- a/integrations/crewai/tool.py
+++ b/integrations/crewai/tool.py
@@ -205,7 +205,7 @@ class MemMachineTools:
             group_id: Group ID (overrides default, stored in metadata)
             session_id: Session ID (overrides default, stored in metadata)
             limit: Maximum number of results to return (default: 5)
-            filter_dict: Additional filters for the search
+            filter_dict: Additional metadata filters for the search. User metadata keys must be prefixed with `m.` / `metadata.`. Unknown or misspelled fields return a 400 error.
 
         Returns:
             Dictionary containing search results and relevant memories

--- a/integrations/fastgpt/README.md
+++ b/integrations/fastgpt/README.md
@@ -58,7 +58,7 @@ Retrieve relevant context, memories, or profile for a user.
 | types           | multipleSelect | ['episodic', 'semantic'] | Memory types; leave empty to search all types            |
 | query           | string         | -                        | **Required** Natural language query for memory retrieval |
 | limit           | number         | 10                       | **Required** Maximum number of search results            |
-| filter          | string         | -                        | Condition to filter memories                             |
+| filter          | string         | -                        | Condition to filter memories. Prefix user metadata fields with `m.` / `metadata.` (for example `m.source = "chat_v3"`). Unknown or misspelled fields now return a 400 error. |
 | contextTemplate | string         | default template         | Template for building memory context                     |
 
 **Output**

--- a/integrations/fastgpt/README.md
+++ b/integrations/fastgpt/README.md
@@ -58,7 +58,7 @@ Retrieve relevant context, memories, or profile for a user.
 | types           | multipleSelect | ['episodic', 'semantic'] | Memory types; leave empty to search all types            |
 | query           | string         | -                        | **Required** Natural language query for memory retrieval |
 | limit           | number         | 10                       | **Required** Maximum number of search results            |
-| filter          | string         | -                        | Condition to filter memories                             |
+| filter          | string         | -                        | Condition to filter memories. Prefix user metadata fields with `m.` / `metadata.` (for example `m.source = 'chat_v3'`). String literals must be single-quoted. Unknown or misspelled user metadata fields now return a 400 error. |
 | contextTemplate | string         | default template         | Template for building memory context                     |
 
 **Output**

--- a/integrations/n8n/README.md
+++ b/integrations/n8n/README.md
@@ -106,7 +106,7 @@ The Main Node provides two actions: Store a message and Enrich with context.
   | types           | multiOptions | ['episodic', 'semantic'] | **Required.** Memory types to use.                                         |
   | query           | string       | -                        | **Required.** Natural language query used to search for relevant memories. |
   | limit           | number       | 50                       | Maximum number of results to return.                                       |
-  | filter          | string       | -                        | Filter expression to refine memory search results.                         |
+  | filter          | string       | -                        | Filter expression to refine memory search results. Prefix user metadata fields with `m.` / `metadata.` (for example `m.user_id = '123'`). String literals must be single-quoted. Unknown or misspelled user metadata fields now return a 400 error. |
   | expandContext   | number       | 0                        | Number of extra episodes to include for context.                           |
   | scoreThreshold  | number       | -                        | Minimum relevance score required to include a memory.                      |
   | sessionId       | string       | -                        | **Required.** Unique session identifier.                                   |

--- a/integrations/n8n/README.md
+++ b/integrations/n8n/README.md
@@ -106,7 +106,7 @@ The Main Node provides two actions: Store a message and Enrich with context.
   | types           | multiOptions | ['episodic', 'semantic'] | **Required.** Memory types to use.                                         |
   | query           | string       | -                        | **Required.** Natural language query used to search for relevant memories. |
   | limit           | number       | 50                       | Maximum number of results to return.                                       |
-  | filter          | string       | -                        | Filter expression to refine memory search results.                         |
+  | filter          | string       | -                        | Filter expression to refine memory search results. Prefix user metadata fields with `m.` / `metadata.` (for example `m.user_id = "123"`). Unknown or misspelled fields now return a 400 error. |
   | expandContext   | number       | 0                        | Number of extra episodes to include for context.                           |
   | scoreThreshold  | number       | -                        | Minimum relevance score required to include a memory.                      |
   | sessionId       | string       | -                        | **Required.** Unique session identifier.                                   |

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -104,14 +104,14 @@ memory = client.memory(
 memory.add("I like pizza", metadata={"type": "preference", "category": "food"})
 memory.add("I work as a software engineer", metadata={"type": "fact", "category": "work"})
 
-# Search memories
+# Search memories — Memory.search() returns a SearchResult Pydantic model
 results = memory.search("What do I like to eat?")
-print(f"Episodic memory: {results.get('episodic_memory', [])}")
-print(f"Profile memory: {results.get('profile_memory', [])}")
+print(f"Episodic memory: {results.content.episodic_memory}")
+print(f"Semantic memory: {results.content.semantic_memory}")
 
-# Search with filters
-work_results = memory.search("Tell me about work", filter_dict={"category": "work"})
-print(f"Work results: {work_results}")
+# Search with filters (user metadata fields require the `m.` / `metadata.` prefix)
+work_results = memory.search("Tell me about work", filter_dict={"m.category": "work"})
+print(f"Work results: {work_results.model_dump()}")
 ```
 
 ### Multiple Users

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -110,7 +110,7 @@ print(f"Episodic memory: {results.get('episodic_memory', [])}")
 print(f"Profile memory: {results.get('profile_memory', [])}")
 
 # Search with filters
-work_results = memory.search("Tell me about work", filter_dict={"category": "work"})
+work_results = memory.search("Tell me about work", filter_dict={"m.category": "work"})
 print(f"Work results: {work_results}")
 ```
 

--- a/packages/client/src/memmachine_client/langgraph.py
+++ b/packages/client/src/memmachine_client/langgraph.py
@@ -223,7 +223,7 @@ class MemMachineTools:
             session_id: Session ID (overrides default, stored in metadata)
             limit: Maximum number of results to return (default: 20)
             score_threshold: Minimum score to include in results
-            filter_dict: Additional filters for the search
+            filter_dict: Additional metadata filters for the search. User metadata keys must be prefixed with `m.` / `metadata.`. Unknown or misspelled fields return a 400 error.
 
         Returns:
             Dictionary containing search results and relevant memories

--- a/packages/client/src/memmachine_client/memory.py
+++ b/packages/client/src/memmachine_client/memory.py
@@ -384,10 +384,17 @@ class Memory:
             expand_context: The number of additional episodes to include
                             around each matched episode from long term memory.
             score_threshold: Minimum score to include in results.
-            filter_dict: Additional filters for the search (key-value pairs as strings).
+            filter_dict: Additional metadata filters for the search (key-value pairs as strings).
+                        User metadata keys must be prefixed with `m.` / `metadata.`.
                         These filters will be merged with built-in filters from metadata.
                         User-provided filters take precedence over built-in filters
-                        if there are key conflicts.
+                        only when the exact same key is supplied. Built-in filters use the
+                        `metadata.` prefix; to override one, use the matching `metadata.<key>`
+                        form. Mixing `m.<key>` with a built-in `metadata.<key>` is treated as
+                        two distinct conditions by this merge (both are sent to the server),
+                        which after server-side normalization can produce a contradictory
+                        `metadata.<key>=A AND metadata.<key>=B` filter. Unknown or misspelled
+                        user metadata fields return a 400 error.
             timeout: Request timeout in seconds (uses client default if not provided)
             set_metadata: Optional metadata key-value pairs used to select semantic sets.
             agent_mode: Whether to enable top-level retrieval-agent orchestration.

--- a/packages/client/src/memmachine_client/memory.py
+++ b/packages/client/src/memmachine_client/memory.py
@@ -384,10 +384,11 @@ class Memory:
             expand_context: The number of additional episodes to include
                             around each matched episode from long term memory.
             score_threshold: Minimum score to include in results.
-            filter_dict: Additional filters for the search (key-value pairs as strings).
+            filter_dict: Additional metadata filters for the search (key-value pairs as strings).
+                        User metadata keys must be prefixed with `m.` / `metadata.`.
                         These filters will be merged with built-in filters from metadata.
                         User-provided filters take precedence over built-in filters
-                        if there are key conflicts.
+                        if there are key conflicts. Unknown or misspelled fields return a 400 error.
             timeout: Request timeout in seconds (uses client default if not provided)
             set_metadata: Optional metadata key-value pairs used to select semantic sets.
             agent_mode: Whether to enable top-level retrieval-agent orchestration.


### PR DESCRIPTION
### Purpose of the change

Audit the user-facing filter documentation after PR #1291 so examples and parameter descriptions consistently reflect the new metadata prefix requirement and strict validation behavior.

### Description

This PR updates public-facing docs/examples/docstrings that still implied bare metadata keys were valid in filters.

Changes included:
- update Python API docs to use prefixed metadata filter examples
- clarify `m.` / `metadata.` requirements in Python + TS REST docs
- document 400 behavior for unknown or unqualified filter fields
- sync integration docs (n8n, FastGPT, CrewAI, LangGraph) and the Python client demo/README with the stricter filter syntax

### Fixes/Closes

Fixes #1308
Fixes #1306
Fixes #1307

### Type of change

- [x] Documentation update

### How Has This Been Tested?

- [x] Manual verification (list step-by-step instructions)

**Test Results:**
- Ran `git diff --check`
- Ran a targeted repository grep over public-facing docs/examples/docstrings to verify the updated filter guidance consistently uses `m.` / `metadata.` prefixes and documents the strict 400 behavior, while excluding server/test internals from the docs-only scope.

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings

### Screenshots/Gifs

N/A

### Further comments

None.
