### PR TITLE
Potential fix for code scanning alert no. 46: Prototype-polluting assignment

### DIFF
--- a/packages/ts-client/src/memory/format.ts
+++ b/packages/ts-client/src/memory/format.ts
@@ -101,10 +101,10 @@ export function formatEpisodes(episodes: FormattableEpisode[]): string {
  * @returns JSON string of the grouped features.
  */
 export function formatSemanticMemories(features: SemanticMemory[]): string {
-  const structured: Record<string, Record<string, string>> = {}
+  const structured = Object.create(null) as Record<string, Record<string, string>>
   for (const feature of features) {
     if (!(feature.tag in structured)) {
-      structured[feature.tag] = {}
+      structured[feature.tag] = Object.create(null) as Record<string, string>
     }
     structured[feature.tag]![feature.feature_name] = feature.value
   }


### PR DESCRIPTION
Potential fix for [https://github.com/MemMachine/MemMachine/security/code-scanning/46](https://github.com/MemMachine/MemMachine/security/code-scanning/46)

Use a prototype-less dictionary for `structured` and for each nested tag bucket, so dangerous keys like `__proto__` are treated as ordinary data keys rather than prototype mutators.

Best fix in this file: in `packages/ts-client/src/memory/format.ts`, update `formatSemanticMemories` to:
- initialize `structured` with `Object.create(null)` (typed as `Record<string, Record<string, string>>`);
- initialize each `structured[feature.tag]` bucket with `Object.create(null)` as well.

This preserves existing functionality and output shape (`JSON.stringify` still produces the same JSON structure), while removing prototype-chain pollution behavior. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
