### PR TITLE
fix: use correct Neo4j config field name in sample configs

### DIFF
--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -50,7 +50,7 @@ resources:
       provider: neo4j
       config:
         uri: 'bolt://localhost:7687'
-        username: neo4j
+        user: neo4j
         password: <YOUR_PASSWORD_HERE>
         max_connection_pool_size: 100
         connection_acquisition_timeout: 60.0

--- a/sample_configs/episodic_memory_config.gpu.sample
+++ b/sample_configs/episodic_memory_config.gpu.sample
@@ -50,7 +50,7 @@ resources:
       provider: neo4j
       config:
         uri: 'bolt://localhost:7687'
-        username: neo4j
+        user: neo4j
         password: <YOUR_PASSWORD_HERE>
         max_connection_pool_size: 100
         connection_acquisition_timeout: 60.0


### PR DESCRIPTION
### Purpose of the change

Sample Config files use an incorrect `username` property instead of `user` for the Neo4j section.

### Description

Neo4j resource config uses `username`, but the supported Neo4j config field is `user` (see `Neo4jConf.user`). With current parsing, `username` will be ignored and the default user `neo4j` will be used. Renamed `username` to `user` to ensure non-default usernames work.

From [database_conf.py](https://github.com/MemMachine/MemMachine/blob/main/packages/server/src/memmachine_server/common/configuration/database_conf.py#L21):

```python
class Neo4jConf(YamlSerializableMixin, PasswordMixin):
    """Configuration options for a Neo4j instance."""

    uri: str = Field(default="", description="Neo4j database URI")
    host: str = Field(default="localhost", description="neo4j connection host")
    port: int = Field(default=7687, description="neo4j connection port")
    user: str = Field(default="neo4j", description="neo4j username")
    ...
```

### Fixes/Closes

Fixes #1359 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual verification (list step-by-step instructions)

Manually verified the issue with source code. 

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None
