### PR TITLE
add retry logic for LLM judge and semantic memory consolidation

### DIFF
--- a/evaluation/retrieval_agent/llm_judge.py
+++ b/evaluation/retrieval_agent/llm_judge.py
@@ -160,16 +160,21 @@ def evaluate_llm_judge(
     )
     for attempt in range(1, _MAX_JUDGE_ATTEMPTS + 1):
         raw = call_fn(prompt)
+        label: str | None = None
         try:
             result = json_repair.loads(raw)
-            label = result.get("label") if isinstance(result, dict) else None
+            raw_label = result.get("label") if isinstance(result, dict) else None
+            if isinstance(raw_label, str):
+                normalized = raw_label.strip().upper()
+                if normalized in {"CORRECT", "WRONG"}:
+                    label = normalized
         except Exception:
             label = None
         if label is not None:
             return 1 if label == "CORRECT" else 0
         if attempt < _MAX_JUDGE_ATTEMPTS:
             logger.warning(
-                "LLM judge missing 'label' on attempt %d/%d, retrying",
+                "LLM judge missing or invalid 'label' on attempt %d/%d, retrying",
                 attempt,
                 _MAX_JUDGE_ATTEMPTS,
             )

--- a/evaluation/retrieval_agent/llm_judge.py
+++ b/evaluation/retrieval_agent/llm_judge.py
@@ -3,11 +3,16 @@
 
 import argparse
 import json
+import logging
 from collections import defaultdict
 from collections.abc import Callable
 
 import json_repair
 import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_MAX_JUDGE_ATTEMPTS = 2
 
 ACCURACY_PROMPT = """
 Your task is to label an answer to a question as 'CORRECT' or 'WRONG'. You will be given the following data:
@@ -153,9 +158,26 @@ def evaluate_llm_judge(
         gold_answer=gold_answer,
         generated_answer=generated_answer,
     )
-    raw = call_fn(prompt)
-    label = json_repair.loads(raw)["label"]
-    return 1 if label == "CORRECT" else 0
+    for attempt in range(1, _MAX_JUDGE_ATTEMPTS + 1):
+        raw = call_fn(prompt)
+        try:
+            result = json_repair.loads(raw)
+            label = result.get("label") if isinstance(result, dict) else None
+        except Exception:
+            label = None
+        if label is not None:
+            return 1 if label == "CORRECT" else 0
+        if attempt < _MAX_JUDGE_ATTEMPTS:
+            logger.warning(
+                "LLM judge missing 'label' on attempt %d/%d, retrying",
+                attempt,
+                _MAX_JUDGE_ATTEMPTS,
+            )
+    logger.error(
+        "LLM judge failed to return a valid 'label' after %d attempts; defaulting to WRONG",
+        _MAX_JUDGE_ATTEMPTS,
+    )
+    return 0
 
 
 def main():

--- a/evaluation/retrieval_agent/test_llm_judge.py
+++ b/evaluation/retrieval_agent/test_llm_judge.py
@@ -24,9 +24,13 @@ def test_wrong_label_returns_0():
     assert evaluate_llm_judge("q", "gold", "gen", call_fn) == 0
 
 
-def test_unknown_label_returns_0():
-    call_fn = _call_fn_returning(json.dumps({"label": "MAYBE"}))
+def test_unknown_label_retries_then_returns_0():
+    call_fn = _call_fn_returning(
+        json.dumps({"label": "MAYBE"}),
+        json.dumps({"label": "MAYBE"}),
+    )
     assert evaluate_llm_judge("q", "gold", "gen", call_fn) == 0
+    assert call_fn.call_count == _MAX_JUDGE_ATTEMPTS
 
 
 def test_call_fn_called_once_on_success():
@@ -82,9 +86,35 @@ def test_non_dict_both_attempts_returns_0():
     [
         (json.dumps({"label": "CORRECT"}), 1),
         (json.dumps({"label": "WRONG"}), 0),
-        (json.dumps({"label": "anything else"}), 0),
     ],
 )
 def test_label_values(raw, expected):
     call_fn = _call_fn_returning(raw)
     assert evaluate_llm_judge("q", "gold", "gen", call_fn) == expected
+
+
+def test_non_string_label_retries():
+    """Non-string label (e.g. numeric) is invalid and triggers retry."""
+    call_fn = _call_fn_returning(
+        json.dumps({"label": 123}),
+        json.dumps({"label": "CORRECT"}),
+    )
+    assert evaluate_llm_judge("q", "gold", "gen", call_fn) == 1
+    assert call_fn.call_count == 2
+
+
+def test_dict_label_retries():
+    """Nested-dict label is invalid and triggers retry."""
+    call_fn = _call_fn_returning(
+        json.dumps({"label": {"nested": "x"}}),
+        json.dumps({"label": "WRONG"}),
+    )
+    assert evaluate_llm_judge("q", "gold", "gen", call_fn) == 0
+    assert call_fn.call_count == 2
+
+
+def test_label_with_whitespace_and_case_normalized():
+    """Labels are stripped and upper-cased before matching."""
+    call_fn = _call_fn_returning(json.dumps({"label": "  correct\n"}))
+    assert evaluate_llm_judge("q", "gold", "gen", call_fn) == 1
+    assert call_fn.call_count == 1

--- a/evaluation/retrieval_agent/test_llm_judge.py
+++ b/evaluation/retrieval_agent/test_llm_judge.py
@@ -1,0 +1,90 @@
+"""Unit tests for evaluate_llm_judge retry logic."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from evaluation.retrieval_agent.llm_judge import _MAX_JUDGE_ATTEMPTS, evaluate_llm_judge
+
+
+def _call_fn_returning(*responses: str):
+    """Return a stub call_fn that yields each response in sequence."""
+    mock = MagicMock(side_effect=list(responses))
+    return mock
+
+
+def test_correct_label_returns_1():
+    call_fn = _call_fn_returning(json.dumps({"label": "CORRECT"}))
+    assert evaluate_llm_judge("q", "gold", "gen", call_fn) == 1
+
+
+def test_wrong_label_returns_0():
+    call_fn = _call_fn_returning(json.dumps({"label": "WRONG"}))
+    assert evaluate_llm_judge("q", "gold", "gen", call_fn) == 0
+
+
+def test_unknown_label_returns_0():
+    call_fn = _call_fn_returning(json.dumps({"label": "MAYBE"}))
+    assert evaluate_llm_judge("q", "gold", "gen", call_fn) == 0
+
+
+def test_call_fn_called_once_on_success():
+    call_fn = _call_fn_returning(json.dumps({"label": "CORRECT"}))
+    evaluate_llm_judge("q", "gold", "gen", call_fn)
+    assert call_fn.call_count == 1
+
+
+def test_missing_label_retries_then_succeeds():
+    call_fn = _call_fn_returning(
+        json.dumps({}),
+        json.dumps({"label": "CORRECT"}),
+    )
+    assert evaluate_llm_judge("q", "gold", "gen", call_fn) == 1
+    assert call_fn.call_count == 2
+
+
+def test_missing_label_both_attempts_returns_0():
+    call_fn = _call_fn_returning(
+        json.dumps({}),
+        json.dumps({}),
+    )
+    assert evaluate_llm_judge("q", "gold", "gen", call_fn) == 0
+    assert call_fn.call_count == _MAX_JUDGE_ATTEMPTS
+
+
+def test_non_dict_response_retries_then_succeeds():
+    call_fn = _call_fn_returning(
+        "just plain text",
+        json.dumps({"label": "WRONG"}),
+    )
+    assert evaluate_llm_judge("q", "gold", "gen", call_fn) == 0
+    assert call_fn.call_count == 2
+
+
+def test_call_fn_called_twice_on_retry():
+    call_fn = _call_fn_returning(
+        json.dumps({"no_label": "oops"}),
+        json.dumps({"label": "WRONG"}),
+    )
+    evaluate_llm_judge("q", "gold", "gen", call_fn)
+    assert call_fn.call_count == 2
+
+
+def test_non_dict_both_attempts_returns_0():
+    call_fn = _call_fn_returning("text", "also text")
+    assert evaluate_llm_judge("q", "gold", "gen", call_fn) == 0
+    assert call_fn.call_count == _MAX_JUDGE_ATTEMPTS
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (json.dumps({"label": "CORRECT"}), 1),
+        (json.dumps({"label": "WRONG"}), 0),
+        (json.dumps({"label": "anything else"}), 0),
+    ],
+)
+def test_label_values(raw, expected):
+    call_fn = _call_fn_returning(raw)
+    assert evaluate_llm_judge("q", "gold", "gen", call_fn) == expected

--- a/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py
@@ -1003,3 +1003,182 @@ async def test_user_tags_preserved_after_ingestion_and_consolidation(
     # "bugfix" and "decision" survive (each had < 2 entries)
     assert "bugfix" in remaining_tags
     assert "decision" in remaining_tags
+
+
+@pytest.mark.asyncio
+async def test_consolidation_retries_on_none_response(
+    ingestion_service: IngestionService,
+    semantic_storage: SemanticStorage,
+    episode_storage: EpisodeStorage,
+    resources: Resources,
+    semantic_category: SemanticCategory,
+    monkeypatch,
+):
+    """When llm_consolidate_features returns None on the first attempt but
+    succeeds on the second, consolidation completes and features are removed."""
+    hist1 = await add_history(episode_storage, content="msg1")
+    hist2 = await add_history(episode_storage, content="msg2")
+
+    id1 = await semantic_storage.add_feature(
+        set_id="user-retry-none",
+        category_name=semantic_category.name,
+        feature="feat_x",
+        value="value x",
+        tag="retry_tag",
+        embedding=np.array([1.0, 0.0]),
+    )
+    id2 = await semantic_storage.add_feature(
+        set_id="user-retry-none",
+        category_name=semantic_category.name,
+        feature="feat_y",
+        value="value y",
+        tag="retry_tag",
+        embedding=np.array([0.0, 1.0]),
+    )
+    await semantic_storage.add_citations(id1, [hist1])
+    await semantic_storage.add_citations(id2, [hist2])
+
+    filter_str = f"set_id IN ('user-retry-none') AND category_name IN ('{semantic_category.name}')"
+    memories = await _collect(
+        semantic_storage.get_feature_set(
+            filter_expr=parse_filter(filter_str),
+            load_citations=True,
+        )
+    )
+
+    valid_response = SemanticConsolidateMemoryRes(
+        consolidated_memories=[
+            LLMReducedFeature(tag="retry_tag", feature="combined", value="combined x+y")
+        ],
+        keep_memories=[],
+    )
+    llm_mock = AsyncMock(side_effect=[None, valid_response])
+    monkeypatch.setattr(
+        "memmachine_server.semantic_memory.semantic_ingestion.llm_consolidate_features",
+        llm_mock,
+    )
+
+    await ingestion_service._deduplicate_features(
+        set_id="user-retry-none",
+        memories=memories,
+        semantic_category=semantic_category,
+        resources=resources,
+    )
+
+    assert llm_mock.await_count == 2
+    assert await semantic_storage.get_feature(id1) is None
+    assert await semantic_storage.get_feature(id2) is None
+    remaining = await _collect(
+        semantic_storage.get_feature_set(filter_expr=parse_filter(filter_str))
+    )
+    assert len(remaining) == 1
+    assert remaining[0].value == "combined x+y"
+
+
+@pytest.mark.asyncio
+async def test_consolidation_exhausts_retries_and_returns(
+    ingestion_service: IngestionService,
+    semantic_storage: SemanticStorage,
+    episode_storage: EpisodeStorage,
+    resources: Resources,
+    semantic_category: SemanticCategory,
+    monkeypatch,
+):
+    """When llm_consolidate_features always returns None, _deduplicate_features
+    logs a warning and returns without raising and without touching features."""
+    id1 = await semantic_storage.add_feature(
+        set_id="user-retry-exhaust",
+        category_name=semantic_category.name,
+        feature="feat_a",
+        value="value a",
+        tag="exhaust_tag",
+        embedding=np.array([1.0, 0.0]),
+    )
+    id2 = await semantic_storage.add_feature(
+        set_id="user-retry-exhaust",
+        category_name=semantic_category.name,
+        feature="feat_b",
+        value="value b",
+        tag="exhaust_tag",
+        embedding=np.array([0.0, 1.0]),
+    )
+
+    filter_str = f"set_id IN ('user-retry-exhaust') AND category_name IN ('{semantic_category.name}')"
+    memories = await _collect(
+        semantic_storage.get_feature_set(filter_expr=parse_filter(filter_str))
+    )
+
+    llm_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "memmachine_server.semantic_memory.semantic_ingestion.llm_consolidate_features",
+        llm_mock,
+    )
+
+    await ingestion_service._deduplicate_features(
+        set_id="user-retry-exhaust",
+        memories=memories,
+        semantic_category=semantic_category,
+        resources=resources,
+    )
+
+    assert llm_mock.await_count == 2
+    assert await semantic_storage.get_feature(id1) is not None
+    assert await semantic_storage.get_feature(id2) is not None
+
+
+@pytest.mark.asyncio
+async def test_consolidation_skips_context_length_error(
+    ingestion_service: IngestionService,
+    semantic_storage: SemanticStorage,
+    episode_storage: EpisodeStorage,
+    resources: Resources,
+    semantic_category: SemanticCategory,
+    monkeypatch,
+):
+    """A context-length exception during consolidation is handled gracefully:
+    no exception propagates and features are left unchanged."""
+
+    class ContextLengthExceededError(Exception):
+        code = "context_length_exceeded"
+
+    id1 = await semantic_storage.add_feature(
+        set_id="user-consolidate-ctx",
+        category_name=semantic_category.name,
+        feature="feat_p",
+        value="value p",
+        tag="ctx_tag",
+        embedding=np.array([1.0, 0.0]),
+    )
+    id2 = await semantic_storage.add_feature(
+        set_id="user-consolidate-ctx",
+        category_name=semantic_category.name,
+        feature="feat_q",
+        value="value q",
+        tag="ctx_tag",
+        embedding=np.array([0.0, 1.0]),
+    )
+
+    filter_str = f"set_id IN ('user-consolidate-ctx') AND category_name IN ('{semantic_category.name}')"
+    memories = await _collect(
+        semantic_storage.get_feature_set(filter_expr=parse_filter(filter_str))
+    )
+
+    async def raise_ctx_error(*args, **kwargs):
+        raise ExternalServiceAPIError("context window exceeded") from ContextLengthExceededError(
+            "input exceeds context window"
+        )
+
+    monkeypatch.setattr(
+        "memmachine_server.semantic_memory.semantic_ingestion.llm_consolidate_features",
+        raise_ctx_error,
+    )
+
+    await ingestion_service._deduplicate_features(
+        set_id="user-consolidate-ctx",
+        memories=memories,
+        semantic_category=semantic_category,
+        resources=resources,
+    )
+
+    assert await semantic_storage.get_feature(id1) is not None
+    assert await semantic_storage.get_feature(id2) is not None

--- a/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py
@@ -1164,9 +1164,9 @@ async def test_consolidation_skips_context_length_error(
     )
 
     async def raise_ctx_error(*args, **kwargs):
-        raise ExternalServiceAPIError("context window exceeded") from ContextLengthExceededError(
-            "input exceeds context window"
-        )
+        raise ExternalServiceAPIError(
+            "context window exceeded"
+        ) from ContextLengthExceededError("input exceeds context window")
 
     monkeypatch.setattr(
         "memmachine_server.semantic_memory.semantic_ingestion.llm_consolidate_features",
@@ -1175,6 +1175,178 @@ async def test_consolidation_skips_context_length_error(
 
     await ingestion_service._deduplicate_features(
         set_id="user-consolidate-ctx",
+        memories=memories,
+        semantic_category=semantic_category,
+        resources=resources,
+    )
+
+    assert await semantic_storage.get_feature(id1) is not None
+    assert await semantic_storage.get_feature(id2) is not None
+
+
+@pytest.mark.asyncio
+async def test_consolidation_retries_on_exception(
+    ingestion_service: IngestionService,
+    semantic_storage: SemanticStorage,
+    episode_storage: EpisodeStorage,
+    resources: Resources,
+    semantic_category: SemanticCategory,
+    semantic_prompt,
+    monkeypatch,
+):
+    """A non-context exception on the first call must not short-circuit the
+    loop — the helper retries once and proceeds with the successful response."""
+    id1 = await semantic_storage.add_feature(
+        set_id="user-retry-exc",
+        category_name=semantic_category.name,
+        feature="feat_a",
+        value="value a",
+        tag="exc_tag",
+        embedding=np.array([1.0, 0.0]),
+    )
+    await semantic_storage.add_feature(
+        set_id="user-retry-exc",
+        category_name=semantic_category.name,
+        feature="feat_b",
+        value="value b",
+        tag="exc_tag",
+        embedding=np.array([0.0, 1.0]),
+    )
+
+    valid_response = SemanticConsolidateMemoryRes(
+        consolidated_memories=[
+            LLMReducedFeature(tag="exc_tag", feature="combined", value="combined a+b")
+        ],
+        keep_memories=[id1],
+    )
+
+    async def flaky(*args, **kwargs):
+        if llm_mock.await_count == 1:
+            raise ValueError("structured-output validation failed")
+        return valid_response
+
+    llm_mock = AsyncMock(side_effect=flaky)
+    monkeypatch.setattr(
+        "memmachine_server.semantic_memory.semantic_ingestion.llm_consolidate_features",
+        llm_mock,
+    )
+
+    result = await ingestion_service._try_consolidate(
+        set_id="user-retry-exc",
+        features=[],
+        model=resources.language_model,
+        consolidation_prompt=semantic_prompt.consolidation_prompt,
+    )
+
+    assert llm_mock.await_count == 2
+    assert result is valid_response
+
+
+@pytest.mark.asyncio
+async def test_consolidation_exhausted_exceptions_respects_debug_fail_loudly(
+    semantic_storage: SemanticStorage,
+    episode_storage: EpisodeStorage,
+    resource_retriever: MockResourceRetriever,
+    resources: Resources,
+    semantic_category: SemanticCategory,
+    semantic_prompt,
+    monkeypatch,
+):
+    """When every attempt raises a non-context exception, _try_consolidate
+    re-raises under debug_fail_loudly only after the retry is exhausted."""
+    ingestion_service = IngestionService(
+        IngestionService.Params(
+            semantic_storage=semantic_storage,
+            history_store=episode_storage,
+            resource_retriever=resource_retriever.get_resources,
+            consolidated_threshold=2,
+            debug_fail_loudly=True,
+        )
+    )
+
+    async def always_raise(*args, **kwargs):
+        raise ValueError("structured-output validation failed")
+
+    llm_mock = AsyncMock(side_effect=always_raise)
+    monkeypatch.setattr(
+        "memmachine_server.semantic_memory.semantic_ingestion.llm_consolidate_features",
+        llm_mock,
+    )
+
+    with pytest.raises(ValueError, match="structured-output validation failed"):
+        await ingestion_service._try_consolidate(
+            set_id="user-exc-loud",
+            features=[],
+            model=resources.language_model,
+            consolidation_prompt=semantic_prompt.consolidation_prompt,
+        )
+
+    # Retry must still happen before the loud re-raise.
+    assert llm_mock.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_deduplicate_features_context_length_does_not_raise_in_debug_mode(
+    semantic_storage: SemanticStorage,
+    episode_storage: EpisodeStorage,
+    resource_retriever: MockResourceRetriever,
+    resources: Resources,
+    semantic_category: SemanticCategory,
+    monkeypatch,
+):
+    """Context-length errors during consolidation must be handled gracefully
+    even when debug_fail_loudly is True, matching the feature-update path."""
+
+    class ContextLengthExceededError(Exception):
+        code = "context_length_exceeded"
+
+    ingestion_service = IngestionService(
+        IngestionService.Params(
+            semantic_storage=semantic_storage,
+            history_store=episode_storage,
+            resource_retriever=resource_retriever.get_resources,
+            consolidated_threshold=2,
+            debug_fail_loudly=True,
+        )
+    )
+
+    id1 = await semantic_storage.add_feature(
+        set_id="user-ctx-loud",
+        category_name=semantic_category.name,
+        feature="feat_p",
+        value="value p",
+        tag="ctx_tag",
+        embedding=np.array([1.0, 0.0]),
+    )
+    id2 = await semantic_storage.add_feature(
+        set_id="user-ctx-loud",
+        category_name=semantic_category.name,
+        feature="feat_q",
+        value="value q",
+        tag="ctx_tag",
+        embedding=np.array([0.0, 1.0]),
+    )
+
+    filter_str = (
+        f"set_id IN ('user-ctx-loud') AND category_name IN ('{semantic_category.name}')"
+    )
+    memories = await _collect(
+        semantic_storage.get_feature_set(filter_expr=parse_filter(filter_str))
+    )
+
+    async def raise_ctx_error(*args, **kwargs):
+        raise ExternalServiceAPIError(
+            "context window exceeded"
+        ) from ContextLengthExceededError("input exceeds context window")
+
+    monkeypatch.setattr(
+        "memmachine_server.semantic_memory.semantic_ingestion.llm_consolidate_features",
+        raise_ctx_error,
+    )
+
+    # Must not raise even though debug_fail_loudly=True.
+    await ingestion_service._deduplicate_features(
+        set_id="user-ctx-loud",
         memories=memories,
         semantic_category=semantic_category,
         resources=resources,

--- a/packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py
+++ b/packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py
@@ -12,8 +12,10 @@ from pydantic import BaseModel, Field, InstanceOf, TypeAdapter
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.episode_store import Episode, EpisodeIdT, EpisodeStorage
 from memmachine_server.common.filter.filter_parser import And, Comparison
+from memmachine_server.common.language_model import LanguageModel
 from memmachine_server.semantic_memory.semantic_llm import (
     LLMReducedFeature,
+    SemanticConsolidateMemoryRes,
     llm_consolidate_features,
     llm_feature_update,
 )
@@ -29,6 +31,8 @@ from memmachine_server.semantic_memory.semantic_model import (
 from memmachine_server.semantic_memory.storage.storage_base import SemanticStorage
 
 logger = logging.getLogger(__name__)
+
+_MAX_CONSOLIDATION_ATTEMPTS = 2
 
 
 def _is_context_length_exceeded_error(error: Exception) -> bool:
@@ -370,6 +374,47 @@ class IngestionService:
 
         await asyncio.gather(*category_tasks)
 
+    async def _try_consolidate(
+        self,
+        *,
+        set_id: str,
+        features: list[SemanticFeature],
+        model: LanguageModel,
+        consolidation_prompt: str,
+    ) -> SemanticConsolidateMemoryRes | None:
+        """Call llm_consolidate_features with retry on None (parse failure).
+
+        Returns None when all attempts fail or a non-retryable error occurs.
+        Raises only when self._debug_fail_loudly is True and a non-context error fires.
+        """
+        for attempt in range(1, _MAX_CONSOLIDATION_ATTEMPTS + 1):
+            try:
+                result = await llm_consolidate_features(
+                    features=features,
+                    model=model,
+                    consolidate_prompt=consolidation_prompt,
+                )
+            except Exception as err:
+                if _is_context_length_exceeded_error(err):
+                    logger.warning(
+                        "Skipping consolidation for set %s due to non-retryable context length error",
+                        set_id,
+                    )
+                else:
+                    logger.exception("Failed to update features while calling LLM")
+                    if self._debug_fail_loudly:
+                        raise
+                return None
+            if result is not None:
+                return result
+            if attempt < _MAX_CONSOLIDATION_ATTEMPTS:
+                logger.warning(
+                    "Consolidation returned None on attempt %d/%d, retrying",
+                    attempt,
+                    _MAX_CONSOLIDATION_ATTEMPTS,
+                )
+        return None
+
     async def _deduplicate_features(
         self,
         *,
@@ -378,20 +423,18 @@ class IngestionService:
         semantic_category: InstanceOf[SemanticCategory],
         resources: InstanceOf[Resources],
     ) -> None:
-        try:
-            consolidate_resp = await llm_consolidate_features(
-                features=list(memories),
-                model=resources.language_model,
-                consolidate_prompt=semantic_category.prompt.consolidation_prompt,
-            )
-        except (ValueError, TypeError):
-            logger.exception("Failed to update features while calling LLM")
-            if self._debug_fail_loudly:
-                raise
-            return
+        consolidate_resp = await self._try_consolidate(
+            set_id=set_id,
+            features=list(memories),
+            model=resources.language_model,
+            consolidation_prompt=semantic_category.prompt.consolidation_prompt,
+        )
 
         if consolidate_resp is None or consolidate_resp.keep_memories is None:
-            logger.warning("Failed to consolidate features")
+            logger.warning(
+                "Failed to consolidate features after %d attempts",
+                _MAX_CONSOLIDATION_ATTEMPTS,
+            )
             if self._debug_fail_loudly:
                 raise ValueError("Failed to consolidate features")
             return

--- a/packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py
+++ b/packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py
@@ -35,6 +35,15 @@ logger = logging.getLogger(__name__)
 _MAX_CONSOLIDATION_ATTEMPTS = 2
 
 
+class _ConsolidationContextLengthError(Exception):
+    """Signals that consolidation must be skipped due to a context-length error.
+
+    Caught inside the ingestion service to distinguish the graceful-skip path
+    from genuine consolidation failure, so that `debug_fail_loudly` does not
+    raise for scenarios the feature-update path already handles silently.
+    """
+
+
 def _is_context_length_exceeded_error(error: Exception) -> bool:
     seen: set[int] = set()
     current: BaseException | None = error
@@ -382,10 +391,15 @@ class IngestionService:
         model: LanguageModel,
         consolidation_prompt: str,
     ) -> SemanticConsolidateMemoryRes | None:
-        """Call llm_consolidate_features with retry on None (parse failure).
+        """Call llm_consolidate_features with retry on transient failures.
 
-        Returns None when all attempts fail or a non-retryable error occurs.
-        Raises only when self._debug_fail_loudly is True and a non-context error fires.
+        Retries on parse/validation exceptions and on ``None`` returns (which
+        indicate a structured-output parse failure upstream). A context-length
+        exception is raised as :class:`_ConsolidationContextLengthError` so
+        the caller can skip the group without tripping ``debug_fail_loudly``.
+        Returns ``None`` once retries are exhausted, raising instead when
+        ``self._debug_fail_loudly`` is True and the last failure was not a
+        context-length error.
         """
         for attempt in range(1, _MAX_CONSOLIDATION_ATTEMPTS + 1):
             try:
@@ -400,18 +414,33 @@ class IngestionService:
                         "Skipping consolidation for set %s due to non-retryable context length error",
                         set_id,
                     )
-                else:
-                    logger.exception("Failed to update features while calling LLM")
-                    if self._debug_fail_loudly:
-                        raise
+                    raise _ConsolidationContextLengthError from err
+                if attempt < _MAX_CONSOLIDATION_ATTEMPTS:
+                    logger.warning(
+                        "Consolidation raised %s on attempt %d/%d for set %s, retrying",
+                        type(err).__name__,
+                        attempt,
+                        _MAX_CONSOLIDATION_ATTEMPTS,
+                        set_id,
+                    )
+                    continue
+                logger.exception(
+                    "Failed to consolidate features while calling LLM for set %s on attempt %d/%d",
+                    set_id,
+                    attempt,
+                    _MAX_CONSOLIDATION_ATTEMPTS,
+                )
+                if self._debug_fail_loudly:
+                    raise
                 return None
             if result is not None:
                 return result
             if attempt < _MAX_CONSOLIDATION_ATTEMPTS:
                 logger.warning(
-                    "Consolidation returned None on attempt %d/%d, retrying",
+                    "Consolidation returned None on attempt %d/%d for set %s, retrying",
                     attempt,
                     _MAX_CONSOLIDATION_ATTEMPTS,
+                    set_id,
                 )
         return None
 
@@ -423,12 +452,15 @@ class IngestionService:
         semantic_category: InstanceOf[SemanticCategory],
         resources: InstanceOf[Resources],
     ) -> None:
-        consolidate_resp = await self._try_consolidate(
-            set_id=set_id,
-            features=list(memories),
-            model=resources.language_model,
-            consolidation_prompt=semantic_category.prompt.consolidation_prompt,
-        )
+        try:
+            consolidate_resp = await self._try_consolidate(
+                set_id=set_id,
+                features=list(memories),
+                model=resources.language_model,
+                consolidation_prompt=semantic_category.prompt.consolidation_prompt,
+            )
+        except _ConsolidationContextLengthError:
+            return
 
         if consolidate_resp is None or consolidate_resp.keep_memories is None:
             logger.warning(


### PR DESCRIPTION
### Purpose of the change

Both `evaluate_llm_judge` and `_deduplicate_features` now retry once on JSON parse failures (missing/malformed 'label' key or None response) instead of crashing or silently dropping results. Consolidation also gains context-length error handling, matching the feature-update path.

### Description

Changes made:

  `evaluation/retrieval_agent/llm_judge.py`
  - Added import logging, logger, and _MAX_JUDGE_ATTEMPTS = 2                                                                                                                                                                                    
  - Replaced the single-shot json_repair.loads(raw)["label"] with a retry loop: safe dict access via .get("label"), retries once on missing/non-dict result, defaults to 0 (WRONG) after all attempts are exhausted                              
                                                                                                                                                                                                                                                 
  `packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py`                                                                                                                                                                    
  - Added _MAX_CONSOLIDATION_ATTEMPTS = 2                                                                                                                                                                                                        
  - Extracted a new _try_consolidate helper method that: retries on None (parse failure), handles context-length errors (logs warning, returns None without propagating), handles other exceptions (respects debug_fail_loudly)                  
  - Simplified _deduplicate_features to call the helper and act on its result — this also resolves the C901 complexity violation                                                                                                                 
                                                                                                                                                                                                                                                 
  `evaluation/retrieval_agent/test_llm_judge.py` (new file)                                                                                                                                                                                        
  - 12 unit tests covering: correct/wrong/unknown labels, retry on missing label, exhausted retries default, non-dict responses, call count verification, parametrized label values                                                              
                                                                                                                                                                                                                                                 
  `packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py`                                                                                                                                                      
  - 3 new tests: retry succeeds on second attempt, exhausted retries leaves features unchanged, context-length error is handled gracefully                     

### Fixes/Closes

Fixes #1332 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Unit Test

**Test Results:** [Attach logs, screenshots, or relevant output]

  New LLM judge tests (fast, no dependencies):                                                                                                                                                                                                   
  uv run pytest evaluation/retrieval_agent/test_llm_judge.py -v                                                                                                                                                                                  
                                                                                                                                                                                                                                                 
  Semantic ingestion tests (includes the 3 new consolidation tests):                                                                                                                                                                             
  uv run --frozen --all-extras pytest packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py -v                                                                                                               
   
  Filter to just the new tests if you want a quicker check:                                                                                                                                                                                      
  uv run --frozen --all-extras pytest packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py -v -k "retry or exhaust or context_length_error"
                                                                                                                                                                                                                                                 
  Full server suite (validates nothing was broken):                                                                                                                                                                                              
  uv run --frozen --all-extras pytest packages/server/server_tests -q
                                                                                                                                                                                                                                                 
  Lint/format (mirrors CI):                                                                                                                                                                                                                      
  uv run ruff check evaluation/retrieval_agent/ packages/server/src/memmachine_server/semantic_memory/
  uv run ruff format --check evaluation/retrieval_agent/ packages/server/src/memmachine_server/semantic_memory/ 

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None