### PR TITLE
fix(server): preserve original LLM error in ExternalServiceAPIError

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/language_model/test_openai_chat_completions_language_model.py
+++ b/packages/server/server_tests/memmachine_server/common/language_model/test_openai_chat_completions_language_model.py
@@ -820,6 +820,25 @@ async def test_generate_response_runtime_exception_mapping(
 
 
 @pytest.mark.asyncio
+async def test_generate_response_preserves_original_error_message(
+    mock_async_openai,
+    minimal_config,
+):
+    # Regression for #1309: the wrapped ExternalServiceAPIError must carry the
+    # original LLM error text so _is_exceed_context_window_error can key off it.
+    mock_client = mock_async_openai.return_value
+    mock_client.chat.completions.create.side_effect = openai.BadRequestError(
+        "This model's maximum context length is 202752 tokens...",
+        response=MagicMock(),
+        body=None,
+    )
+
+    lm = OpenAIChatCompletionsLanguageModel(minimal_config)
+    with pytest.raises(ExternalServiceAPIError, match="context length"):
+        await lm.generate_response()
+
+
+@pytest.mark.asyncio
 async def test_metrics_collection(mock_async_openai, full_config):
     """Test that metrics are collected on a successful call."""
     mock_usage = MagicMock()

--- a/packages/server/src/memmachine_server/common/language_model/openai_chat_completions_language_model.py
+++ b/packages/server/src/memmachine_server/common/language_model/openai_chat_completions_language_model.py
@@ -269,7 +269,7 @@ class OpenAIChatCompletionsLanguageModel(LanguageModel):
                     f"[call uuid: {generate_response_call_uuid}] "
                     "Giving up generating response "
                     f"after failed attempt {attempt} "
-                    f"due to non-retryable {type(e).__name__}"
+                    f"due to non-retryable {type(e).__name__}: {e}"
                 )
                 logger.exception(error_message)
                 raise ExternalServiceAPIError(error_message) from e


### PR DESCRIPTION
  


### Purpose of the change

preserve original LLM error in ExternalServiceAPIError

### Description

  The non-retryable branch in OpenAIChatCompletionsLanguageModel wrapped the
  OpenAI error with a generic "due to non-retryable BadRequestError" message
  and dropped str(e). That stripped the keywords ("context length", "token
  limit", …) that ShortTermMemoryConsolidator._is_exceed_context_window_error
  relies on, so the split-and-retry path never triggered and episodic
  summaries silently failed on oversized prompts.

  Append str(e) to the wrapper message so the detector sees the original
  text and recursion kicks in as designed. Adds a regression test that
  raises openai.BadRequestError("…context length is only 202752 tokens…")
  and asserts the wrapped ExternalServiceAPIError still matches "context
  length".

### Fixes/Closes

Fixes #1309 
Refs: #1247

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Unit Test

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None