### PR TITLE
feat: add `delete` RUN_TYPE to retrieval-agent benchmarks

### DIFF
--- a/evaluation/retrieval_agent/README.md
+++ b/evaluation/retrieval_agent/README.md
@@ -459,3 +459,33 @@ For the full argument reference run:
 ./run_test.sh --help
 ./run_test.sh wikimultihop --help
 ```
+
+---
+
+## Deleting Ingested Data
+
+`run_test.sh delete` removes all episodes a prior `ingest` wrote to the configured
+long-term memory store for each benchmark's session key(s). Use it between runs to
+reuse the same `RESULT_POSTFIX` without double-counting earlier data.
+
+```sh
+# From evaluation/retrieval_agent/
+./run_test.sh locomo       exp1 delete retrieval_agent
+./run_test.sh wikimultihop exp1 delete retrieval_agent
+./run_test.sh hotpotqa     exp1 delete retrieval_agent
+./run_test.sh longmemeval  exp1 delete retrieval_agent
+```
+
+Notes:
+
+- `delete` ignores `SPLIT_NAME` and `LENGTH` — only `RESULT_POSTFIX` and
+  `TEST_TARGET` are needed. `TEST_TARGET` is accepted for argument symmetry with
+  `ingest`/`search` but is unused by the delete path.
+- For LoCoMo the delete iterates all 10 conversation groups (`group_0` … `group_9`),
+  since ingestion uses one session per conversation.
+- For WikiMultiHop / HotpotQA the delete clears the single fixed session_id used
+  by ingestion (`group1` and `hotpotqa_group` respectively).
+- For LongMemEval the session_id is derived from `RESULT_POSTFIX`
+  (`longmemeval_<RESULT_POSTFIX>`), matching the ingest-time session.
+- Concurrency flags (`--ingest-concurrency`, `--search-concurrency`,
+  `--judge-concurrency`) are rejected with `delete`.

--- a/evaluation/retrieval_agent/hotpotQA_test.py
+++ b/evaluation/retrieval_agent/hotpotQA_test.py
@@ -192,6 +192,20 @@ async def hotpotqa_search(
             json.dump(results, f, indent=4)
 
 
+async def hotpotqa_delete(config_path: str):
+    from evaluation.utils import agent_utils
+
+    resource_manager = agent_utils.load_eval_config(config_path)
+    memory, _, _ = await agent_utils.init_memmachine_params(
+        resource_manager=resource_manager,
+        session_id="hotpotqa_group",
+    )
+
+    print("Deleting episodes for session_id='hotpotqa_group'...")
+    await memory.delete_session_episodes()
+    print("Completed HotpotQA delete.")
+
+
 def load_hotpotqa_dataset(length: int, split: str) -> list[dict[str, any]]:
     from datasets import load_dataset
 
@@ -213,7 +227,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--run-type",
         required=False,
-        help="Type of run: ingest or search",
+        help="Type of run: ingest, search, or delete",
         default="search",
     )
     parser.add_argument(
@@ -252,6 +266,10 @@ def build_parser() -> argparse.ArgumentParser:
 async def main():
     args = build_parser().parse_args()
 
+    if args.run_type == "delete":
+        await hotpotqa_delete(args.config_path)
+        return
+
     dataset = load_hotpotqa_dataset(args.length, args.split_name)
 
     if args.run_type == "ingest":
@@ -277,7 +295,7 @@ async def main():
         )
     else:
         raise ValueError(
-            f"Unknown run type: {args.run_type}, please use 'ingest' or 'search'."
+            f"Unknown run type: {args.run_type}, please use 'ingest', 'search', or 'delete'."
         )
 
 

--- a/evaluation/retrieval_agent/locomo_delete.py
+++ b/evaluation/retrieval_agent/locomo_delete.py
@@ -1,62 +1,49 @@
 import argparse
 import asyncio
 import json
-from typing import cast
+import sys
+from pathlib import Path
 
 from dotenv import load_dotenv
-from memmachine_server.episodic_memory.episodic_memory import EpisodicMemory
-from memmachine_server.episodic_memory.episodic_memory_manager import (
-    EpisodicMemoryManager,
-)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
 
 
 async def main():
+    from evaluation.utils import agent_utils
+
     parser = argparse.ArgumentParser()
-
     parser.add_argument("--data-path", required=True, help="Path to the data file")
-
+    parser.add_argument(
+        "--config-path",
+        required=True,
+        help="Path to configuration.yml",
+    )
     args = parser.parse_args()
 
-    data_path = args.data_path
-
-    with open(data_path, "r") as f:
+    with open(args.data_path, "r") as f:
         locomo_data = json.load(f)
 
-    memory_manager = EpisodicMemoryManager.create_episodic_memory_manager(
-        "locomo_config.yaml"
-    )
+    resource_manager = agent_utils.load_eval_config(args.config_path)
 
-    async def process_conversation(idx, item, memory_manager: EpisodicMemoryManager):
+    async def process_conversation(idx, item):
         if "conversation" not in item:
             return
 
-        conversation = item["conversation"]
-        speaker_a = conversation["speaker_a"]
-        speaker_b = conversation["speaker_b"]
-
-        print(
-            f"Processing conversation for group {idx} with speakers {speaker_a} and {speaker_b}..."
-        )
-
         group_id = f"group_{idx}"
+        print(f"Deleting episodes for group {group_id}...")
 
-        memory = cast(
-            EpisodicMemory,
-            await memory_manager.get_episodic_memory_instance(
-                group_id=group_id,
-                session_id=group_id,
-                user_id=[speaker_a, speaker_b],
-            ),
+        memory, _, _ = await agent_utils.init_memmachine_params(
+            resource_manager=resource_manager,
+            session_id=group_id,
         )
+        await memory.delete_session_episodes()
 
-        await memory.delete_data()
-        await memory.close()
-
-    tasks = [
-        process_conversation(idx, item, memory_manager)
-        for idx, item in enumerate(locomo_data)
-    ]
+    tasks = [process_conversation(idx, item) for idx, item in enumerate(locomo_data)]
     await asyncio.gather(*tasks)
+    print(f"Completed LoCoMo delete for {len(locomo_data)} groups.")
 
 
 if __name__ == "__main__":

--- a/evaluation/retrieval_agent/longmemeval_test.py
+++ b/evaluation/retrieval_agent/longmemeval_test.py
@@ -245,6 +245,21 @@ async def longmemeval_search(
             json.dump(results, file, indent=4)
 
 
+async def longmemeval_delete(config_path: str, session_id: str):
+    from evaluation.utils import agent_utils
+
+    resource_manager = agent_utils.load_eval_config(config_path)
+    memory, _, _ = await agent_utils.init_memmachine_params(
+        resource_manager=resource_manager,
+        session_id=session_id,
+    )
+    _set_safe_embedder_request_limits(memory)
+
+    print(f"Deleting episodes for session_id='{session_id}'...")
+    await memory.delete_session_episodes()
+    print("Completed LongMemEval delete.")
+
+
 def load_longmemeval_dataset(length: int, split: str) -> list[dict[str, Any]]:
     split_file = split if split.endswith(".json") else f"{split}.json"
 
@@ -303,7 +318,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--run-type",
         required=False,
-        help="Type of run: ingest or search",
+        help="Type of run: ingest, search, or delete",
         default="search",
     )
     parser.add_argument(
@@ -348,6 +363,10 @@ def build_parser() -> argparse.ArgumentParser:
 async def main():
     args = build_parser().parse_args()
 
+    if args.run_type == "delete":
+        await longmemeval_delete(args.config_path, args.session_id)
+        return
+
     dataset = load_longmemeval_dataset(args.length, args.split_name)
 
     if args.run_type == "ingest":
@@ -374,7 +393,7 @@ async def main():
         )
     else:
         raise ValueError(
-            f"Unknown run type: {args.run_type}, please use 'ingest' or 'search'."
+            f"Unknown run type: {args.run_type}, please use 'ingest', 'search', or 'delete'."
         )
 
 

--- a/evaluation/retrieval_agent/run_test.sh
+++ b/evaluation/retrieval_agent/run_test.sh
@@ -5,7 +5,7 @@ usage_locomo() {
     echo
     echo "Arguments:"
     echo "  RESULT_POSTFIX    Custom postfix for output files"
-    echo "  RUN_TYPE          Run ingestion or search [ingest | search]"
+    echo "  RUN_TYPE          Run ingestion, search, or delete [ingest | search | delete]"
     echo "  TEST_TARGET       [memmachine | retrieval_agent | llm]"
     echo "Options:"
     echo "  --ingest-concurrency N"
@@ -21,13 +21,13 @@ usage_locomo() {
 }
 
 usage_wiki() {
-    echo "WikiMultihop Usage: wikimultihop $0 RESULT_POSTFIX RUN_TYPE TEST_TARGET LENGTH"
+    echo "WikiMultihop Usage: wikimultihop $0 RESULT_POSTFIX RUN_TYPE TEST_TARGET [LENGTH]"
     echo
     echo "Arguments:"
     echo "  RESULT_POSTFIX    Custom postfix for output files"
-    echo "  RUN_TYPE          Run ingestion or search [ingest | search]"
+    echo "  RUN_TYPE          Run ingestion, search, or delete [ingest | search | delete]"
     echo "  TEST_TARGET       [memmachine | retrieval_agent | llm]"
-    echo "  LENGTH            Number of examples to run [1 - 12576]"
+    echo "  LENGTH            Number of examples to run [1 - 12576] (ingest/search only)"
     echo "Options:"
     echo "  --search-concurrency N"
     echo "                     Optional max concurrent WikiMultiHop search requests"
@@ -39,16 +39,19 @@ usage_wiki() {
 }
 
 usage_hotpotqa() {
-    echo "HotpotQA Usage: $0 hotpotqa RESULT_POSTFIX RUN_TYPE SPLIT_NAME TEST_TARGET LENGTH"
+    echo "HotpotQA Usage:"
+    echo "  $0 hotpotqa RESULT_POSTFIX {ingest|search} SPLIT_NAME TEST_TARGET LENGTH"
+    echo "  $0 hotpotqa RESULT_POSTFIX delete TEST_TARGET"
     echo
     echo "Arguments:"
     echo "  RESULT_POSTFIX    Custom postfix for output files"
-    echo "  RUN_TYPE          Run ingestion or search [ingest | search]"
+    echo "  RUN_TYPE          Run ingestion, search, or delete [ingest | search | delete]"
     echo "  SPLIT_NAME        Dataset split name [train | validation]. Train set contains 19.9%"
     echo "                      easy, 62.8% medium, 17.3% hard questions. Validation set contains"
-    echo "                      hard questions only."
+    echo "                      hard questions only. (ingest/search only)"
     echo "  TEST_TARGET       [memmachine | retrieval_agent | llm]"
     echo "  LENGTH            Number of examples to run [train set 1 - 90447 | validation set 1 - 7405]"
+    echo "                      (ingest/search only)"
     echo "Options:"
     echo "  --search-concurrency N"
     echo "                     Optional max concurrent HotpotQA search requests"
@@ -60,14 +63,16 @@ usage_hotpotqa() {
 }
 
 usage_longmemeval() {
-    echo "LongMemEval Usage: $0 longmemeval RESULT_POSTFIX RUN_TYPE SPLIT_NAME TEST_TARGET LENGTH"
+    echo "LongMemEval Usage:"
+    echo "  $0 longmemeval RESULT_POSTFIX {ingest|search} SPLIT_NAME TEST_TARGET LENGTH"
+    echo "  $0 longmemeval RESULT_POSTFIX delete TEST_TARGET"
     echo
     echo "Arguments:"
     echo "  RESULT_POSTFIX    Custom postfix for output files"
-    echo "  RUN_TYPE          Run ingestion or search [ingest | search]"
-    echo "  SPLIT_NAME        Dataset split name, e.g. longmemeval_s_cleaned"
+    echo "  RUN_TYPE          Run ingestion, search, or delete [ingest | search | delete]"
+    echo "  SPLIT_NAME        Dataset split name, e.g. longmemeval_s_cleaned (ingest/search only)"
     echo "  TEST_TARGET       [memmachine | retrieval_agent | llm]"
-    echo "  LENGTH            Number of examples to run [1 - split size]"
+    echo "  LENGTH            Number of examples to run [1 - split size] (ingest/search only)"
     echo "Options:"
     echo "  --search-concurrency N"
     echo "                     Optional max concurrent LongMemEval search requests"
@@ -199,7 +204,11 @@ validate_args() {
                 echo "--ingest-concurrency is only supported for locomo ingest"
                 exit 1
             fi
-            if [ "$#" -ne 5 ]; then
+            if [ "${3:-}" = "delete" ]; then
+                if [ "$#" -ne 4 ]; then
+                    show_help wikimultihop
+                fi
+            elif [ "$#" -ne 5 ]; then
                 show_help wikimultihop
             fi
             if [ -n "${SEARCH_CONCURRENCY:-}" ] && [ "$3" != "search" ]; then
@@ -218,7 +227,11 @@ validate_args() {
                 echo "--ingest-concurrency is only supported for locomo ingest"
                 exit 1
             fi
-            if [ "$#" -ne 6 ]; then
+            if [ "${3:-}" = "delete" ]; then
+                if [ "$#" -ne 4 ]; then
+                    show_help hotpotqa
+                fi
+            elif [ "$#" -ne 6 ]; then
                 show_help hotpotqa
             fi
             if [ -n "${SEARCH_CONCURRENCY:-}" ] && [ "$3" != "search" ]; then
@@ -237,7 +250,11 @@ validate_args() {
                 echo "--ingest-concurrency is only supported for locomo ingest"
                 exit 1
             fi
-            if [ "$#" -ne 6 ]; then
+            if [ "${3:-}" = "delete" ]; then
+                if [ "$#" -ne 4 ]; then
+                    show_help longmemeval
+                fi
+            elif [ "$#" -ne 6 ]; then
                 show_help longmemeval
             fi
             if [ -n "${SEARCH_CONCURRENCY:-}" ] && [ "$3" != "search" ]; then
@@ -308,22 +325,39 @@ run_test() {
         wikimultihop)
             RESULT_POSTFIX=$2
             INGEST=$3
-            TEST_TARGET=$4
-            LENGTH=$5
+            if [ "$INGEST" = "delete" ]; then
+                TEST_TARGET=$4
+                LENGTH=""
+            else
+                TEST_TARGET=$4
+                LENGTH=$5
+            fi
             ;;
         hotpotqa)
             RESULT_POSTFIX=$2
             INGEST=$3
-            SPLIT_NAME=$4
-            TEST_TARGET=$5
-            LENGTH=$6
+            if [ "$INGEST" = "delete" ]; then
+                SPLIT_NAME=""
+                TEST_TARGET=$4
+                LENGTH=""
+            else
+                SPLIT_NAME=$4
+                TEST_TARGET=$5
+                LENGTH=$6
+            fi
             ;;
         longmemeval)
             RESULT_POSTFIX=$2
             INGEST=$3
-            SPLIT_NAME=$4
-            TEST_TARGET=$5
-            LENGTH=$6
+            if [ "$INGEST" = "delete" ]; then
+                SPLIT_NAME=""
+                TEST_TARGET=$4
+                LENGTH=""
+            else
+                SPLIT_NAME=$4
+                TEST_TARGET=$5
+                LENGTH=$6
+            fi
             ;;
         *)
             echo "Unknown test: $TEST"
@@ -352,12 +386,17 @@ run_test() {
     FINAL_SCORE_FILE="${SCRIPT_DIR}/result/final_score/${TEST}_${TEST_TARGET}_${RESULT_POSTFIX}.result"
     SESSION_ID="${TEST}_${RESULT_POSTFIX}"
 
-    rm -f "$RESULT_FILE" "$EVAL_FILE" "$FINAL_SCORE_FILE"
+    if [ "$INGEST" != "delete" ]; then
+        rm -f "$RESULT_FILE" "$EVAL_FILE" "$FINAL_SCORE_FILE"
+    fi
+
+    DELETE_CMD=()
 
     case "$TEST" in
         locomo)
             INGEST_CMD=("${PYTHON_CMD[@]}" -u "$SCRIPT_DIR/locomo_ingest.py" --data-path "$SCRIPT_DIR/../data/locomo10.json" --config-path "$CONFIG_FILE")
             SEARCH_CMD=("${PYTHON_CMD[@]}" -u "$SCRIPT_DIR/locomo_search.py" --data-path "$SCRIPT_DIR/../data/locomo10.json" --eval-result-path "$RESULT_FILE" --test-target "$TEST_TARGET" --config-path "$CONFIG_FILE")
+            DELETE_CMD=("${PYTHON_CMD[@]}" -u "$SCRIPT_DIR/locomo_delete.py" --data-path "$SCRIPT_DIR/../data/locomo10.json" --config-path "$CONFIG_FILE")
             if [ -n "${INGEST_CONCURRENCY:-}" ]; then
                 INGEST_CMD+=(--concurrency "$INGEST_CONCURRENCY")
             fi
@@ -368,6 +407,7 @@ run_test() {
         wikimultihop)
             INGEST_CMD=("${PYTHON_CMD[@]}" -u "$SCRIPT_DIR/wikimultihop_ingest.py" --data-path "$SCRIPT_DIR/../data/wikimultihop.json" --length "$LENGTH" --config-path "$CONFIG_FILE")
             SEARCH_CMD=("${PYTHON_CMD[@]}" -u "$SCRIPT_DIR/wikimultihop_search.py" --data-path "$SCRIPT_DIR/../data/wikimultihop.json" --eval-result-path "$RESULT_FILE" --test-target "$TEST_TARGET" --length "$LENGTH" --config-path "$CONFIG_FILE")
+            DELETE_CMD=("${PYTHON_CMD[@]}" -u "$SCRIPT_DIR/wikimultihop_delete.py" --config-path "$CONFIG_FILE")
             if [ -n "${SEARCH_CONCURRENCY:-}" ]; then
                 SEARCH_CMD+=(--concurrency "$SEARCH_CONCURRENCY")
             fi
@@ -375,6 +415,7 @@ run_test() {
         hotpotqa)
             INGEST_CMD=("${PYTHON_CMD[@]}" -u "$SCRIPT_DIR/hotpotQA_test.py" --run-type ingest --eval-result-path "$RESULT_FILE" --length "$LENGTH" --split-name "$SPLIT_NAME" --test-target "$TEST_TARGET" --config-path "$CONFIG_FILE")
             SEARCH_CMD=("${PYTHON_CMD[@]}" -u "$SCRIPT_DIR/hotpotQA_test.py" --run-type search --eval-result-path "$RESULT_FILE" --length "$LENGTH" --split-name "$SPLIT_NAME" --test-target "$TEST_TARGET" --config-path "$CONFIG_FILE")
+            DELETE_CMD=("${PYTHON_CMD[@]}" -u "$SCRIPT_DIR/hotpotQA_test.py" --run-type delete --test-target "$TEST_TARGET" --config-path "$CONFIG_FILE")
             if [ -n "${SEARCH_CONCURRENCY:-}" ]; then
                 SEARCH_CMD+=(--concurrency "$SEARCH_CONCURRENCY")
             fi
@@ -384,6 +425,7 @@ run_test() {
             PYTHON_INSTALL_CMD='uv run python -m pip install -r requirements.txt'
             INGEST_CMD=("${PYTHON_CMD[@]}" -u "$SCRIPT_DIR/longmemeval_test.py" --run-type ingest --eval-result-path "$RESULT_FILE" --length "$LENGTH" --split-name "$SPLIT_NAME" --test-target "$TEST_TARGET" --session-id "$SESSION_ID" --config-path "$CONFIG_FILE")
             SEARCH_CMD=("${PYTHON_CMD[@]}" -u "$SCRIPT_DIR/longmemeval_test.py" --run-type search --eval-result-path "$RESULT_FILE" --length "$LENGTH" --split-name "$SPLIT_NAME" --test-target "$TEST_TARGET" --session-id "$SESSION_ID" --config-path "$CONFIG_FILE")
+            DELETE_CMD=("${PYTHON_CMD[@]}" -u "$SCRIPT_DIR/longmemeval_test.py" --run-type delete --test-target "$TEST_TARGET" --session-id "$SESSION_ID" --config-path "$CONFIG_FILE")
             if [ -n "${SEARCH_CONCURRENCY:-}" ]; then
                 SEARCH_CMD+=(--concurrency "$SEARCH_CONCURRENCY")
             fi
@@ -405,6 +447,8 @@ run_test() {
         "${EVALUATE_CMD[@]}"
         "${PYTHON_CMD[@]}" "$SCRIPT_DIR/generate_scores.py" --data-path "$EVAL_FILE" > "$FINAL_SCORE_FILE"
         cat "$FINAL_SCORE_FILE"
+    elif [[ "$INGEST" = "delete" ]]; then
+        "${DELETE_CMD[@]}"
     else
         echo "Unknown RUN_TYPE: $INGEST"
         show_help "$TEST"

--- a/evaluation/retrieval_agent/test_run_test.py
+++ b/evaluation/retrieval_agent/test_run_test.py
@@ -91,6 +91,150 @@ def test_wikimultihop_rejects_ingest_concurrency():
     assert "--ingest-concurrency is only supported for locomo ingest" in result.stdout
 
 
+def test_help_mentions_delete_run_type():
+    for benchmark in ("locomo", "wikimultihop", "hotpotqa", "longmemeval"):
+        result = subprocess.run(
+            ["bash", str(RUN_TEST), benchmark, "--help"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1, benchmark
+        assert "delete" in result.stdout, f"{benchmark} help missing 'delete'"
+
+
+def test_locomo_delete_rejects_ingest_concurrency():
+    result = subprocess.run(
+        [
+            "bash",
+            str(RUN_TEST),
+            "locomo",
+            "exp1",
+            "delete",
+            "retrieval_agent",
+            "--ingest-concurrency",
+            "2",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "--ingest-concurrency can only be used with locomo ingest" in result.stdout
+
+
+def test_wikimultihop_delete_rejects_search_concurrency():
+    result = subprocess.run(
+        [
+            "bash",
+            str(RUN_TEST),
+            "wikimultihop",
+            "exp1",
+            "delete",
+            "retrieval_agent",
+            "--search-concurrency",
+            "1",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "--search-concurrency can only be used with search runs" in result.stdout
+
+
+def test_wikimultihop_delete_rejects_extra_positional_args():
+    # With delete, wikimultihop should accept exactly 4 positional args.
+    # Passing a 5th (LENGTH) must be rejected by validate_args.
+    result = subprocess.run(
+        [
+            "bash",
+            str(RUN_TEST),
+            "wikimultihop",
+            "exp1",
+            "delete",
+            "retrieval_agent",
+            "10",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "WikiMultihop Usage" in result.stdout
+
+
+def test_longmemeval_delete_invokes_delete_script(tmp_path):
+    repo_root = tmp_path / "repo"
+    script_dir = repo_root / "evaluation" / "retrieval_agent"
+    bin_dir = tmp_path / "bin"
+    script_dir.mkdir(parents=True)
+    bin_dir.mkdir()
+
+    run_test_copy = script_dir / "run_test.sh"
+    shutil.copy(RUN_TEST, run_test_copy)
+    run_test_copy.chmod(run_test_copy.stat().st_mode | stat.S_IXUSR)
+
+    (script_dir / "configuration.yml").write_text(
+        "logging:\n  level: INFO\n", encoding="utf-8"
+    )
+
+    invocations_log = tmp_path / "invocations.log"
+    _write_file(
+        script_dir / "longmemeval_test.py",
+        f"""
+        import sys
+        from pathlib import Path
+
+        Path(r"{invocations_log}").write_text(" ".join(sys.argv[1:]), encoding="utf-8")
+        """,
+    )
+
+    _write_file(
+        bin_dir / "uv",
+        f"""
+        #!/usr/bin/env bash
+        if [ "$1" = "run" ] && [ "$2" = "python" ]; then
+            shift 2
+            exec "{sys.executable}" "$@"
+        fi
+        exit 1
+        """,
+        executable=True,
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(run_test_copy),
+            "longmemeval",
+            "exp1",
+            "delete",
+            "retrieval_agent",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    invoked_args = invocations_log.read_text(encoding="utf-8")
+    assert "--run-type delete" in invoked_args
+    assert "--session-id longmemeval_exp1" in invoked_args
+
+
 def test_longmemeval_search_uses_uv_for_preflight_and_postprocessing(tmp_path):
     repo_root = tmp_path / "repo"
     script_dir = repo_root / "evaluation" / "retrieval_agent"

--- a/evaluation/retrieval_agent/wikimultihop_delete.py
+++ b/evaluation/retrieval_agent/wikimultihop_delete.py
@@ -1,0 +1,37 @@
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+
+async def main():
+    from evaluation.utils import agent_utils
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config-path",
+        required=True,
+        help="Path to configuration.yml",
+    )
+    args = parser.parse_args()
+
+    resource_manager = agent_utils.load_eval_config(args.config_path)
+    memory, _, _ = await agent_utils.init_memmachine_params(
+        resource_manager=resource_manager,
+        session_id="group1",
+    )
+
+    print("Deleting episodes for session_id='group1'...")
+    await memory.delete_session_episodes()
+    print("Completed WikiMultiHop delete.")
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    asyncio.run(main())


### PR DESCRIPTION
### Purpose of the change

  Standardizes cleanup of ingested benchmark data across locomo, wikimultihop,
  hotpotqa, and longmemeval. Before this, only a broken stand-alone locomo
  delete script existed; iterative experiments had to clear data by hand.

### Description

  Wired delete RUN_TYPE across all four retrieval-agent benchmarks.                                                                                                                                                                              
  
  - evaluation/retrieval_agent/locomo_delete.py — rewrote using the current agent_utils.init_memmachine_params + EpisodicMemory.delete_session_episodes() pattern (old code called a removed API and pointed at a stale config file).            
  - evaluation/retrieval_agent/wikimultihop_delete.py — new file, deletes session group1.
  - evaluation/retrieval_agent/hotpotQA_test.py — added hotpotqa_delete() + --run-type delete branch (session hotpotqa_group).                                                                                                                   
  - evaluation/retrieval_agent/longmemeval_test.py — added longmemeval_delete() + --run-type delete branch (session from --session-id).                                                                                                          
  - evaluation/retrieval_agent/run_test.sh — updated per-benchmark usage strings, validate_args (delete = 4 positional args for all), conditional positional unpack, DELETE_CMD per benchmark, and a new elif delete dispatch branch. Skips rm -f
   on result files when run-type is delete.                                                                                                                                                                                                      
  - evaluation/retrieval_agent/README.md — added a "Deleting Ingested Data" section with per-benchmark invocations.                                                                                                                              
  - evaluation/retrieval_agent/test_run_test.py — 5 new tests: help text, concurrency-flag rejection for delete, extra-positional rejection, and an end-to-end delete dispatch check using a tmp run_test.sh copy. 

### Fixes/Closes

Fixes #1235

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

Verified: bash -n passes, ruff check and ruff format --check pass, all 10 test_run_test.py tests pass. Help output for every benchmark now documents delete. Real end-to-end delete requires a configured Neo4j/postgres backend and was not   exercised in this session. 

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None
