### PR TITLE
fix(ts-client): Auto-select fetch adapter behind HTTPS proxies (#1269)

### DIFF
--- a/packages/ts-client/README.md
+++ b/packages/ts-client/README.md
@@ -129,6 +129,22 @@ Provides methods to manage and interact with the memory in MemMachine.
 - `MemoryType` — Allowed values: 'episodic' | 'semantic'
 - `MemoryProducerRole` — Allowed values: 'user' | 'assistant' | 'system'
 
+## HTTPS proxy environments
+
+When the client runs behind a TLS-terminating HTTPS proxy (e.g. corporate egress proxies, sandboxed CI runners), axios' default HTTP/HTTPS adapter can fail with errors like `stream has been aborted`. The client automatically selects Node's native `fetch` adapter when it detects `HTTPS_PROXY`, `HTTP_PROXY`, or their lowercase equivalents in the environment, because `fetch` (backed by undici) handles `CONNECT` tunneling through these proxies correctly.
+
+You can also pin the adapter explicitly via the `adapter` option:
+
+```typescript
+// Force Node's fetch adapter regardless of env vars
+const client = new MemMachineClient({ api_key: 'your_api_key', adapter: 'fetch' })
+
+// Opt out of auto-detection and keep axios' default http adapter
+const client = new MemMachineClient({ api_key: 'your_api_key', adapter: 'http' })
+```
+
+An explicit `adapter` value always wins over the env-var auto-detection. When no `adapter` is passed and no proxy env var is set, behavior is unchanged from axios' default.
+
 ## Examples
 
 See [basic usage examples](../../../examples/ts_rest_client_demo/) for practical code demonstrating memory management, project operations, and error handling with the MemMachine REST Client.

--- a/packages/ts-client/src/client/memmachine-client.ts
+++ b/packages/ts-client/src/client/memmachine-client.ts
@@ -6,6 +6,12 @@ import { MemMachineProject, type Project, type ProjectContext } from '@/project'
 import { VERSION } from '@/version'
 import type { ClientOptions, HealthStatus } from './memmachine-client.types'
 
+function hasProxyEnv(): boolean {
+  if (typeof process === 'undefined' || !process.env) return false
+  const { HTTPS_PROXY, HTTP_PROXY, https_proxy, http_proxy } = process.env
+  return Boolean(HTTPS_PROXY || HTTP_PROXY || https_proxy || http_proxy)
+}
+
 /**
  * Main API client for interacting with the MemMachine RESTful service.
  *
@@ -53,7 +59,7 @@ export class MemMachineClient {
   client: AxiosInstance
 
   constructor(options?: ClientOptions) {
-    const { base_url = 'https://api.memmachine.ai/v2', api_key, timeout, max_retries } = options ?? {}
+    const { base_url = 'https://api.memmachine.ai/v2', api_key, timeout, max_retries, adapter } = options ?? {}
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -63,10 +69,13 @@ export class MemMachineClient {
       headers['Authorization'] = `Bearer ${api_key}`
     }
 
+    const resolvedAdapter = adapter ?? (hasProxyEnv() ? 'fetch' : undefined)
+
     this.client = axios.create({
       baseURL: base_url,
       headers,
-      timeout: timeout ?? 60000
+      timeout: timeout ?? 60000,
+      ...(resolvedAdapter ? { adapter: resolvedAdapter } : {})
     })
 
     axiosRetry(this.client, {

--- a/packages/ts-client/src/client/memmachine-client.types.ts
+++ b/packages/ts-client/src/client/memmachine-client.types.ts
@@ -7,7 +7,8 @@
  * @property max_retries - Maximum number of retry attempts for failed requests (optional).
  * @property adapter - Axios adapter to use for HTTP requests (optional).
  *   When unset, `'fetch'` is selected automatically if an HTTPS/HTTP proxy env var
- *   is detected (HTTPS_PROXY / HTTP_PROXY); otherwise axios' default adapter is used.
+ *   is detected (`HTTPS_PROXY`, `HTTP_PROXY`, `https_proxy`, or `http_proxy`);
+ *   otherwise axios' default adapter is used.
  *   Set explicitly to opt in or out (e.g. `'fetch'` to force Node's native fetch,
  *   which handles CONNECT tunneling through TLS-terminating proxies correctly).
  */

--- a/packages/ts-client/src/client/memmachine-client.types.ts
+++ b/packages/ts-client/src/client/memmachine-client.types.ts
@@ -5,12 +5,18 @@
  * @property api_key - API key for authentication (optional).
  * @property timeout - Request timeout in milliseconds (optional).
  * @property max_retries - Maximum number of retry attempts for failed requests (optional).
+ * @property adapter - Axios adapter to use for HTTP requests (optional).
+ *   When unset, `'fetch'` is selected automatically if an HTTPS/HTTP proxy env var
+ *   is detected (HTTPS_PROXY / HTTP_PROXY); otherwise axios' default adapter is used.
+ *   Set explicitly to opt in or out (e.g. `'fetch'` to force Node's native fetch,
+ *   which handles CONNECT tunneling through TLS-terminating proxies correctly).
  */
 export interface ClientOptions {
   base_url?: string
   api_key?: string
   timeout?: number
   max_retries?: number
+  adapter?: 'http' | 'https' | 'fetch'
 }
 
 /**

--- a/packages/ts-client/tests/memmachine-client.spec.ts
+++ b/packages/ts-client/tests/memmachine-client.spec.ts
@@ -1,5 +1,7 @@
 import { MemMachineClient } from '@/client'
 
+const PROXY_ENV_VARS = ['HTTPS_PROXY', 'HTTP_PROXY', 'https_proxy', 'http_proxy'] as const
+
 describe('MemMachine Client', () => {
   afterEach(() => {
     jest.restoreAllMocks()
@@ -65,5 +67,48 @@ describe('MemMachine Client', () => {
     jest.spyOn(client.client, 'get').mockRejectedValue(new Error('Network Error'))
 
     await expect(client.healthCheck()).rejects.toThrow('Failed to check health status')
+  })
+
+  describe('HTTP adapter configuration', () => {
+    const savedEnv: Record<string, string | undefined> = {}
+
+    beforeEach(() => {
+      for (const key of PROXY_ENV_VARS) {
+        savedEnv[key] = process.env[key]
+        delete process.env[key]
+      }
+    })
+
+    afterEach(() => {
+      for (const key of PROXY_ENV_VARS) {
+        if (savedEnv[key] === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = savedEnv[key]
+        }
+      }
+    })
+
+    it('should forward an explicit adapter option to axios', () => {
+      const client = new MemMachineClient({ adapter: 'fetch' })
+      expect(client.client.defaults.adapter).toBe('fetch')
+    })
+
+    it('should auto-select the fetch adapter when HTTPS_PROXY is set', () => {
+      process.env.HTTPS_PROXY = 'http://proxy.example:3128'
+      const client = new MemMachineClient()
+      expect(client.client.defaults.adapter).toBe('fetch')
+    })
+
+    it('should let an explicit adapter override a detected proxy env var', () => {
+      process.env.HTTPS_PROXY = 'http://proxy.example:3128'
+      const client = new MemMachineClient({ adapter: 'http' })
+      expect(client.client.defaults.adapter).toBe('http')
+    })
+
+    it('should not force the fetch adapter when no proxy env var is present', () => {
+      const client = new MemMachineClient()
+      expect(client.client.defaults.adapter).not.toBe('fetch')
+    })
   })
 })


### PR DESCRIPTION
### Purpose of the change

Implements the configuration and auto-detection fix discussed in #1269 to allow `@memmachine/client` to properly bypass TLS-terminating proxies.

### Description

1. Exposes adapter as a ClientOptions field so users can explicitly pin `'http'`, `'https'`, or `'fetch'`.

2. Auto-selects the `'fetch'` adapter when an `HTTPS_PROXY` or `HTTP_PROXY` environment variable is detected in a Node environment (bypassing the axios HTTP stream abort bug).

3. Explicit user config always wins over auto-detection.

### Fixes/Closes

Fixes #1269 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Unit Test

**Test Results:** Ran the local test suite using Jest (`npx jest --runInBand tests/memmachine-client.spec.ts`). All 4 new branches of the HTTP adapter configuration logic passed successfully.

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected