### PR TITLE
Improve vector store API again

### DIFF
--- a/packages/server/src/memmachine_server/common/vector_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_store/data_types.py
@@ -16,13 +16,25 @@ from .utils import validate_identifier
 
 
 class VectorStoreCollectionConfig(BaseModel):
-    """Configuration for a logical collection in a vector store."""
+    """
+    Configuration for a logical collection in a vector store.
+
+    Attributes:
+        vector_dimensions (int):
+            Dimensionality of vectors stored in the collection.
+        similarity_metric (SimilarityMetric):
+            Metric used to compare vectors.
+        indexed_properties_schema (dict[str, type[PropertyValue]]):
+            Schema suggesting which properties should be indexed for filtering.
+    """
 
     vector_dimensions: int
     similarity_metric: SimilarityMetric = SimilarityMetric.COSINE
-    properties_schema: dict[str, type[PropertyValue]] = Field(default_factory=dict)
+    indexed_properties_schema: dict[str, type[PropertyValue]] = Field(
+        default_factory=dict
+    )
 
-    @field_validator("properties_schema", mode="after")
+    @field_validator("indexed_properties_schema", mode="after")
     @classmethod
     def _validate_property_keys(
         cls, v: dict[str, type[PropertyValue]]
@@ -34,9 +46,9 @@ class VectorStoreCollectionConfig(BaseModel):
                 )
         return v
 
-    @field_validator("properties_schema", mode="before")
+    @field_validator("indexed_properties_schema", mode="before")
     @classmethod
-    def _coerce_properties_schema(cls, v: object) -> object:
+    def _coerce_indexed_properties_schema(cls, v: object) -> object:
         if v is None:
             return {}
         if isinstance(v, Mapping):
@@ -54,8 +66,8 @@ class VectorStoreCollectionConfig(BaseModel):
 
         return v
 
-    @field_serializer("properties_schema")
-    def _serialize_properties_schema(
+    @field_serializer("indexed_properties_schema")
+    def _serialize_indexed_properties_schema(
         self, v: dict[str, type[PropertyValue]]
     ) -> dict[str, str]:
         return {

--- a/packages/server/src/memmachine_server/common/vector_store/vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_store.py
@@ -48,6 +48,9 @@ class VectorStoreCollection(ABC):
         Args:
             records (Iterable[Record]):
                 Iterable of records to upsert.
+                Records containing properties
+                not in the indexed properties schema
+                are allowed.
         """
         raise NotImplementedError
 
@@ -56,8 +59,8 @@ class VectorStoreCollection(ABC):
         self,
         *,
         query_vectors: Iterable[Sequence[float]],
+        limit: int,
         score_threshold: float | None = None,
-        limit: int | None = None,
         property_filter: FilterExpr | None = None,
         return_vector: bool = False,
         return_properties: bool = True,
@@ -68,12 +71,10 @@ class VectorStoreCollection(ABC):
         Args:
             query_vectors (Iterable[Sequence[float]]):
                 The vectors to compare against.
+            limit (int):
+                Maximum number of matching records to return per query vector.
             score_threshold (float | None):
                 Score threshold to consider a match
-                (default: None).
-            limit (int | None):
-                Maximum number of matching records to return per query vector.
-                If None, return as many matching records as possible
                 (default: None).
             property_filter (FilterExpr | None):
                 Filter expression tree.
@@ -146,7 +147,7 @@ class VectorStore(ABC):
     The consumer is responsible for sharding names across processes.
 
     Different namespaces are fully independent (separate native collections).
-    Multiple logical collections with the same (namespace, vector dimensions, similarity metric, properties schema)
+    Multiple logical collections with the same (namespace, vector dimensions, similarity metric, indexed properties schema)
     may share a native collection to reduce overhead.
 
     Naming constraints:


### PR DESCRIPTION
### Purpose of the change

Address review for #1086

Clearly specify that vector records with properties not in the indexed properties schema are allowed.
Require an explicit vector search limit to avoid confusion and unlimited searches.

### Description

No consumers yet so not breaking.

### Type of change

Internal API change with no consumers.