### PR TITLE
fix(mcp)!: trim context, format LLM-readable, scope identity to host (#1278)

### DIFF
--- a/packages/server/server_tests/memmachine_server/server/api_v2/test_mcp.py
+++ b/packages/server/server_tests/memmachine_server/server/api_v2/test_mcp.py
@@ -1,5 +1,7 @@
+import inspect
 import os
 import re
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -9,7 +11,14 @@ from fastmcp import Client
 from memmachine_common.api.spec import SearchResult
 
 from memmachine_server.main.memmachine import ALL_MEMORY_TYPES
-from memmachine_server.server.api_v2.mcp import MCP_SUCCESS, Params
+from memmachine_server.server.api_v2.mcp import (
+    MCP_SUCCESS,
+    Params,
+    _format_search_result_for_mcp,
+    mcp_add_memory,
+    mcp_delete_memory,
+    mcp_search_memory,
+)
 from memmachine_server.server.mcp_stdio import mcp
 
 
@@ -169,38 +178,42 @@ def patch_memmachine():
     mcp_module.mem_machine = None  # cleanup
 
 
+@pytest.fixture
+def host_identity_env(monkeypatch):
+    """Simulate an MCP host that bound identity via MM_*_ID env vars."""
+    monkeypatch.setenv("MM_ORG_ID", "host_org")
+    monkeypatch.setenv("MM_PROJ_ID", "host_proj")
+    monkeypatch.setenv("MM_USER_ID", "host_user")
+
+
 @pytest.mark.asyncio
 @patch("memmachine_server.server.api_v2.mcp._add_messages_to", new_callable=AsyncMock)
-async def test_add_memory_success(mock_add, params, mcp_client):
+async def test_add_memory_success(mock_add, host_identity_env, mcp_client):
     result = await mcp_client.call_tool(
         name="add_memory",
-        arguments={
-            "content": "hello memory",
-            "org_id": params.org_id,
-            "proj_id": params.proj_id,
-            "user_id": params.user_id,
-        },
+        arguments={"content": "hello memory"},
     )
     mock_add.assert_awaited_once()
+    # The spec the host built must reflect the host-bound identity, not
+    # anything LLM-supplied.
+    call_kwargs = mock_add.call_args.kwargs
+    spec = call_kwargs["spec"]
+    assert spec.org_id == "host_org"
+    assert spec.project_id == "host_proj"
+    assert spec.messages[0].producer == "host_user"
     assert result.data is not None
-    root = result.data
-    assert root.status == 200
-    assert root.message == "Success"
+    assert result.data.status == 200
+    assert result.data.message == "Success"
 
 
 @pytest.mark.asyncio
 @patch("memmachine_server.server.api_v2.mcp._add_messages_to", new_callable=AsyncMock)
-async def test_add_memory_failure(mock_add, params, mcp_client):
+async def test_add_memory_failure(mock_add, host_identity_env, mcp_client):
     mock_add.side_effect = HTTPException(status_code=500, detail="DB down")
 
     result = await mcp_client.call_tool(
         name="add_memory",
-        arguments={
-            "content": "hello memory",
-            "org_id": params.org_id,
-            "proj_id": params.proj_id,
-            "user_id": params.user_id,
-        },
+        arguments={"content": "hello memory"},
     )
     assert result.data is not None
     assert result.data.status == 422
@@ -212,17 +225,12 @@ async def test_add_memory_failure(mock_add, params, mcp_client):
     "memmachine_server.server.api_v2.mcp._search_target_memories",
     new_callable=AsyncMock,
 )
-async def test_search_memory_failure(mock_search, params, mcp_client):
+async def test_search_memory_failure(mock_search, host_identity_env, mcp_client):
     mock_search.side_effect = HTTPException(status_code=422, detail="Not found")
 
     result = await mcp_client.call_tool(
         name="search_memory",
-        arguments={
-            "org_id": params.org_id,
-            "proj_id": params.proj_id,
-            "user_id": params.user_id,
-            "query": "find me",
-        },
+        arguments={"query": "find me"},
     )
     mock_search.assert_awaited_once()
     assert result.data is not None
@@ -235,62 +243,273 @@ async def test_search_memory_failure(mock_search, params, mcp_client):
     "memmachine_server.server.api_v2.mcp._search_target_memories",
     new_callable=AsyncMock,
 )
-async def test_search_memory_variants(mock_search, params, mcp_client):
+async def test_search_memory_returns_string_for_empty_result(
+    mock_search, host_identity_env, mcp_client
+):
+    """Empty results should return an empty string, never a SearchResult JSON."""
     content = {"semantic_memory": [], "episodic_memory": None}
     mock_search.return_value = SearchResult.model_validate(
         {"status": 200, "content": content}
     )
     result = await mcp_client.call_tool(
         name="search_memory",
-        arguments={
-            "org_id": params.org_id,
-            "proj_id": params.proj_id,
-            "user_id": params.user_id,
-            "query": "find me",
-        },
+        arguments={"query": "find me"},
     )
     mock_search.assert_awaited_once()
-    assert result.data is not None
-    assert result.data.status == 200
-    assert result.data.content.episodic_memory is None
-    assert result.data.content.semantic_memory == []
+    # FastMCP wraps a plain string in a structured result; assert via the
+    # raw text content blocks rather than .data (which is None for str
+    # returns).
+    text_blocks = [block.text for block in result.content if hasattr(block, "text")]
+    assert text_blocks == [""]
+
+
+@pytest.mark.asyncio
+@patch(
+    "memmachine_server.server.api_v2.mcp._search_target_memories",
+    new_callable=AsyncMock,
+)
+async def test_search_memory_returns_formatted_string(
+    mock_search, host_identity_env, mcp_client
+):
+    """Populated results should render as the LLM-readable format."""
+    payload = {
+        "status": 200,
+        "content": {
+            "episodic_memory": {
+                "long_term_memory": {
+                    "episodes": [
+                        {
+                            "uid": "ep-1",
+                            "content": "I like pizza",
+                            "producer_id": "alice",
+                            "producer_role": "user",
+                            "created_at": datetime(
+                                2026, 1, 5, 13, 30, tzinfo=UTC
+                            ).isoformat(),
+                        },
+                    ],
+                },
+                "short_term_memory": {"episodes": [], "episode_summary": []},
+            },
+            "semantic_memory": [
+                {
+                    "category": "food",
+                    "tag": "preferences",
+                    "feature_name": "favorite_food",
+                    "value": "pizza",
+                },
+            ],
+        },
+    }
+    mock_search.return_value = SearchResult.model_validate(payload)
+
+    result = await mcp_client.call_tool(
+        name="search_memory",
+        arguments={"query": "what do I like to eat"},
+    )
+
+    text_blocks = [block.text for block in result.content if hasattr(block, "text")]
+    assert len(text_blocks) == 1
+    rendered = text_blocks[0]
+    # Episodic section: format mirrors string_from_episode_context.
+    assert "[Episodic Memory]" in rendered
+    assert "Monday, January 05, 2026" in rendered
+    assert "alice:" in rendered
+    assert '"I like pizza"' in rendered
+    # Semantic section: tag → feature_name → value, no metadata IDs.
+    assert "[Semantic Memory]" in rendered
+    assert '"preferences"' in rendered
+    assert '"favorite_food"' in rendered
+    assert '"pizza"' in rendered
+    # Critically: no UIDs or scores leak through.
+    assert "ep-1" not in rendered
+    assert "score" not in rendered
 
 
 @pytest.mark.asyncio
 @patch("memmachine_server.server.api_v2.mcp._delete_memories", new_callable=AsyncMock)
-async def test_delete_memory_success(mock_delete, params, mcp_client):
+async def test_delete_memory_success(mock_delete, host_identity_env, mcp_client):
     result = await mcp_client.call_tool(
         name="delete_memory",
         arguments={
-            "org_id": params.org_id,
-            "proj_id": params.proj_id,
             "episodic_memory_uids": ["episode1"],
             "semantic_memory_uids": ["semantic1"],
         },
     )
     mock_delete.assert_awaited_once()
+    spec = mock_delete.call_args.args[0]
+    assert spec.org_id == "host_org"
+    assert spec.project_id == "host_proj"
     assert result.data is not None
-    root = result.data
-    assert root.status == 200
-    assert root.message == "Success"
+    assert result.data.status == 200
+    assert result.data.message == "Success"
 
 
 @pytest.mark.asyncio
 @patch("memmachine_server.server.api_v2.mcp._delete_memories", new_callable=AsyncMock)
-async def test_delete_memory_failure(mock_delete, params, mcp_client):
+async def test_delete_memory_failure(mock_delete, host_identity_env, mcp_client):
     mock_delete.side_effect = HTTPException(status_code=500, detail="Deletion failed")
 
     result = await mcp_client.call_tool(
         name="delete_memory",
         arguments={
-            "org_id": params.org_id,
-            "proj_id": params.proj_id,
             "episodic_memory_uids": ["episode1"],
             "semantic_memory_uids": ["semantic1"],
         },
     )
     mock_delete.assert_awaited_once()
     assert result.data is not None
-    root = result.data
-    assert root.status == 422
-    assert "Deletion failed" in root.message
+    assert result.data.status == 422
+    assert "Deletion failed" in result.data.message
+
+
+# --- New tests for the #1278 fix -----------------------------------------
+
+
+def test_search_memory_default_top_k_is_5():
+    """Default top_k should be 5, not 20 — addresses the context-creep bug."""
+    sig = inspect.signature(mcp_search_memory)
+    assert sig.parameters["top_k"].default == 5
+
+
+@pytest.mark.parametrize(
+    ("tool_fn", "forbidden_params"),
+    [
+        (mcp_add_memory, {"org_id", "proj_id", "user_id"}),
+        (mcp_search_memory, {"org_id", "proj_id", "user_id"}),
+        (mcp_delete_memory, {"org_id", "proj_id"}),
+    ],
+)
+def test_mcp_tool_signatures_omit_identity_params(tool_fn, forbidden_params):
+    """The LLM must not be able to supply identity as tool arguments.
+
+    Identity is bound by the host (env vars in stdio, headers in HTTP);
+    leaving these in the tool signature would re-introduce the
+    LLM-spoofing surface that issue #1278 reports.
+    """
+    sig = inspect.signature(tool_fn)
+    leaked = forbidden_params & set(sig.parameters)
+    assert not leaked, f"{tool_fn.__name__} still exposes {leaked} to the LLM"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_schemas_omit_identity_params(mcp_client):
+    """Same as above but verified via the wire-level MCP tool schema."""
+    tools = await mcp_client.list_tools()
+    expected = {
+        "add_memory": {"org_id", "proj_id", "user_id"},
+        "search_memory": {"org_id", "proj_id", "user_id"},
+        "delete_memory": {"org_id", "proj_id"},
+    }
+    for tool in tools:
+        if tool.name not in expected:
+            continue
+        schema_props = set((tool.inputSchema or {}).get("properties", {}).keys())
+        leaked = expected[tool.name] & schema_props
+        assert not leaked, (
+            f"MCP tool '{tool.name}' advertises identity params: {leaked}"
+        )
+
+
+@pytest.mark.asyncio
+@patch("memmachine_server.server.api_v2.mcp._add_messages_to", new_callable=AsyncMock)
+async def test_add_memory_rejects_llm_supplied_identity(
+    mock_add, host_identity_env, mcp_client
+):
+    """A malicious LLM trying to pass identity must be rejected outright.
+
+    FastMCP validates each call against the tool's input schema, which
+    no longer contains identity fields. Passing them must raise an MCP
+    tool-level error and never reach the underlying service.
+    """
+    from fastmcp.exceptions import ToolError
+
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_client.call_tool(
+            name="add_memory",
+            arguments={
+                "content": "hello",
+                "user_id": "attacker",
+                "org_id": "attacker_org",
+            },
+        )
+    # The error must cite the unexpected identity arguments so a host
+    # operator can diagnose a misbehaving LLM client.
+    msg = str(excinfo.value)
+    assert "user_id" in msg
+    assert "org_id" in msg
+    # The downstream service must never have been called for the spoof
+    # attempt.
+    mock_add.assert_not_awaited()
+
+
+# --- Direct tests for the formatter --------------------------------------
+
+
+def test_format_search_result_empty():
+    result = SearchResult.model_validate(
+        {"status": 200, "content": {"episodic_memory": None, "semantic_memory": []}}
+    )
+    assert _format_search_result_for_mcp(result) == ""
+
+
+def test_format_search_result_semantic_only():
+    result = SearchResult.model_validate(
+        {
+            "status": 200,
+            "content": {
+                "episodic_memory": None,
+                "semantic_memory": [
+                    {
+                        "category": "food",
+                        "tag": "preferences",
+                        "feature_name": "favorite_food",
+                        "value": "pizza",
+                    },
+                ],
+            },
+        }
+    )
+    rendered = _format_search_result_for_mcp(result)
+    assert rendered.startswith("[Semantic Memory]\n")
+    assert '{"preferences": {"favorite_food": "pizza"}}' in rendered
+    assert "[Episodic Memory]" not in rendered
+
+
+def test_format_search_result_drops_uids_and_scores():
+    """Regression guard for issue #1278: per-entry width must be trimmed."""
+    payload = {
+        "status": 200,
+        "content": {
+            "episodic_memory": {
+                "long_term_memory": {
+                    "episodes": [
+                        {
+                            "uid": "leak-uid",
+                            "content": "secret",
+                            "producer_id": "alice",
+                            "producer_role": "user",
+                            "score": 0.99,
+                            "created_at": datetime(
+                                2026, 1, 5, 13, 30, tzinfo=UTC
+                            ).isoformat(),
+                        }
+                    ]
+                },
+                "short_term_memory": {"episodes": [], "episode_summary": []},
+            },
+            "semantic_memory": [
+                {
+                    "category": "food",
+                    "tag": "preferences",
+                    "feature_name": "favorite_food",
+                    "value": "pizza",
+                    "metadata": {"id": "leak-feature-id"},
+                }
+            ],
+        },
+    }
+    rendered = _format_search_result_for_mcp(SearchResult.model_validate(payload))
+    assert "leak-uid" not in rendered
+    assert "leak-feature-id" not in rendered
+    assert "0.99" not in rendered

--- a/packages/server/src/memmachine_server/server/api_v2/mcp.py
+++ b/packages/server/src/memmachine_server/server/api_v2/mcp.py
@@ -1,6 +1,7 @@
 """MCP tool implementations for MemMachine."""
 
 import contextvars
+import json
 import logging
 import os
 import uuid
@@ -17,10 +18,13 @@ from memmachine_common.api.spec import (
     AddMemoriesSpec,
     DeleteMemoriesSpec,
     EpisodeIdT,
+    EpisodeResponse,
+    EpisodicSearchResult,
     FeatureIdT,
     MemoryMessage,
     SearchMemoriesSpec,
     SearchResult,
+    SemanticFeature,
 )
 from pydantic import BaseModel, Field, model_validator
 from starlette import status
@@ -119,6 +123,70 @@ def get_current_user_id() -> str | None:
 
 
 MCP_SUCCESS = McpResponse(status=McpStatus.SUCCESS, message="Success")
+
+
+def _format_episode_line(episode: EpisodeResponse) -> str:
+    """Render a single episode in the LLM-readable shape.
+
+    Matches :meth:`DeclarativeMemory.string_from_episode_context`:
+    ``[Weekday, Month DD, YYYY at HH:MM AM/PM] producer: "content"``.
+    Falls back to ``producer: "content"`` if no timestamp is available.
+    """
+    if episode.created_at is not None:
+        date_str = episode.created_at.strftime("%A, %B %d, %Y")
+        time_str = episode.created_at.strftime("%I:%M %p")
+        return (
+            f"[{date_str} at {time_str}] {episode.producer_id}: "
+            f"{json.dumps(episode.content)}"
+        )
+    return f"{episode.producer_id}: {json.dumps(episode.content)}"
+
+
+def _format_episodic_section(episodic: EpisodicSearchResult | None) -> str:
+    """Build the ``[Episodic Memory]`` section, or "" if there's nothing."""
+    if episodic is None:
+        return ""
+    episodes = list(episodic.long_term_memory.episodes) + list(
+        episodic.short_term_memory.episodes
+    )
+    if not episodes:
+        return ""
+    lines = [_format_episode_line(ep) for ep in episodes]
+    return "[Episodic Memory]\n" + "\n".join(lines)
+
+
+def _format_semantic_section(features: list[SemanticFeature] | None) -> str:
+    """Build the ``[Semantic Memory]`` section, or "" if there's nothing.
+
+    Mirrors :func:`_features_to_llm_format`: groups by tag, drops UIDs
+    and other metadata.
+    """
+    if not features:
+        return ""
+    structured: dict[str, dict[str, str]] = {}
+    for feature in features:
+        structured.setdefault(feature.tag, {})[feature.feature_name] = feature.value
+    return "[Semantic Memory]\n" + json.dumps(structured)
+
+
+def _format_search_result_for_mcp(result: SearchResult) -> str:
+    """Render a ``SearchResult`` as a compact LLM-friendly string.
+
+    Mirrors :func:`memmachine_client.format.format_search_result` so the
+    MCP tool returns the same shape consumers see via the Python client.
+
+    Returns an empty string when the result has no content; the LLM
+    should treat that as "no relevant memories found".
+    """
+    sections: list[str] = []
+    episodic_section = _format_episodic_section(result.content.episodic_memory)
+    if episodic_section:
+        sections.append(episodic_section)
+    semantic_section = _format_semantic_section(result.content.semantic_memory)
+    if semantic_section:
+        sections.append(semantic_section)
+    return "\n".join(sections)
+
 
 default_mcp_id = hex(uuid.getnode())
 
@@ -420,31 +488,26 @@ async def mcp_http_lifespan(application: FastAPI) -> AsyncIterator[None]:
         "This tool writes to both short-term (episodic) and long-term (profile) memory, "
         "so that future interactions can recall relevant background knowledge even "
         "across different sessions. "
-        "\n\n**Parameters**: Supports both nested (param object) and flat (user_id, content) styles."
+        "\n\nIdentity (org / project / user) is bound to this MCP connection by the host "
+        "(via `MM_ORG_ID` / `MM_PROJ_ID` / `MM_USER_ID` env vars in stdio mode, or "
+        "`org-id` / `proj-id` / `user-id` request headers in HTTP mode) and is not "
+        "configurable per call."
     ),
 )
-async def mcp_add_memory(
-    content: str,
-    org_id: str = "",
-    proj_id: str = "",
-    user_id: str = "",
-) -> McpResponse:
+async def mcp_add_memory(content: str) -> McpResponse:
     """
-    Add a new memory for the specified user.
+    Add a new memory for the user bound to this MCP connection.
 
     The model should call this whenever it detects new information
     worth remembering — for example, user preferences, recurring topics,
     or summaries of recent exchanges.
 
-    This function supports both nested and flat parameter styles:
-    - Nested: pass an AddMemoryParam object to the param argument
-    - Flat: pass user_id and content as separate arguments
+    Identity is bound to the MCP connection by the host (env vars in
+    stdio mode, request headers in HTTP mode). The LLM cannot supply or
+    override it.
 
     Args:
-        org_id: The organization ID (optional, flat style).
-        proj_id: The project ID (optional, flat style).
-        user_id: The unique identifier of the user (flat style).
-        content: The complete context or summary to store in memory (flat style).
+        content: The complete context or summary to store in memory.
 
     Returns:
         McpResponse indicating success or failure.
@@ -457,11 +520,7 @@ async def mcp_add_memory(
             message="MemMachine is not initialized",
         )
     try:
-        param = Params(
-            org_id=org_id,
-            proj_id=proj_id,
-            user_id=user_id,
-        )
+        param = Params()
         spec = param.to_add_memories_spec(content)
         await _add_messages_to(
             target_memories=ALL_MEMORY_TYPES, spec=spec, memmachine=mem_machine
@@ -476,38 +535,38 @@ async def mcp_add_memory(
 @mcp.tool(
     name="search_memory",
     description=(
-        "Retrieve relevant context, memories or profile for a user whenever "
-        "context is missing or unclear. Use this whenever you need to recall "
-        "what has been previously discussed, "
-        "even if it was from an earlier conversation or session. "
-        "This searches both profile memory (long-term user traits and facts) "
-        "and episodic memory (past conversations and experiences). "
-        "\n\n**Parameters**: Supports both nested (param object) and flat (user_id, query, limit) styles."
+        "Retrieve relevant context, memories or profile for the user bound to "
+        "this MCP connection whenever context is missing or unclear. Use this "
+        "whenever you need to recall what has been previously discussed, even "
+        "if it was from an earlier conversation or session. This searches both "
+        "profile memory (long-term user traits and facts) and episodic memory "
+        "(past conversations and experiences). The response is a compact "
+        "LLM-readable string, not a structured object."
+        "\n\nIdentity (org / project / user) is bound to this MCP connection by "
+        "the host (via `MM_ORG_ID` / `MM_PROJ_ID` / `MM_USER_ID` env vars in "
+        "stdio mode, or `org-id` / `proj-id` / `user-id` request headers in HTTP "
+        "mode) and is not configurable per call."
     ),
 )
 async def mcp_search_memory(
     query: str,
-    org_id: str = "",
-    proj_id: str = "",
-    user_id: str = "",
-    top_k: int = 20,
-) -> McpResponse | SearchResult:
+    top_k: int = 5,
+) -> McpResponse | str:
     """
-    Search memory for the specified user.
+    Search memory for the user bound to this MCP connection.
 
-    This function supports both nested and flat parameter styles:
-    - Nested: pass a SearchMemoryParam object to the param argument
-    - Flat: pass user_id, query, and optionally limit as separate arguments
+    Identity is bound to the MCP connection by the host (env vars in
+    stdio mode, request headers in HTTP mode). The LLM cannot supply or
+    override it.
 
     Args:
-        org_id: The organization ID (optional, flat style).
-        proj_id: The project ID (optional, flat style).
-        user_id: The unique identifier of the user (flat style).
-        query: The current user message or topic of discussion (flat style).
-        top_k: The maximum number of memory entries to retrieve (flat style). Defaults to 5.
+        query: The current user message or topic of discussion.
+        top_k: The maximum number of memory entries to retrieve. Defaults
+            to 5.
 
     Returns:
-        McpResponse on failure, or SearchResult on success
+        McpResponse on failure, or a formatted LLM-readable string on
+        success. Returns an empty string when no memories matched.
 
     """
     global mem_machine
@@ -517,15 +576,12 @@ async def mcp_search_memory(
             message="MemMachine is not initialized",
         )
     try:
-        param = Params(
-            org_id=org_id,
-            proj_id=proj_id,
-            user_id=user_id,
-        )
+        param = Params()
         spec = param.to_search_memories_spec(query, top_k)
-        return await _search_target_memories(
+        result = await _search_target_memories(
             target_memories=ALL_MEMORY_TYPES, spec=spec, memmachine=mem_machine
         )
+        return _format_search_result_for_mcp(result)
     except Exception as e:
         status_code = status.HTTP_422_UNPROCESSABLE_CONTENT
         logger.exception("Failed to search memory")
@@ -535,23 +591,28 @@ async def mcp_search_memory(
 @mcp.tool(
     name="delete_memory",
     description=(
-        "Delete specific memories from the user's memory store. "
-        "Use this to remove outdated, incorrect, or sensitive information "
-        "that should no longer be retained. Specify the unique IDs of the "
-        "memories to delete from episodic or semantic memory stores. Note"
-        "episodic memories and semantic memories are deleted separately. "
-        "They have different ID spaces."
-        "\n\n**Parameters**: Supports flat style with org_id, proj_id, "
-        "semantic_ids, and episodic_ids."
+        "Delete specific memories from the memory store of the user bound to "
+        "this MCP connection. Use this to remove outdated, incorrect, or "
+        "sensitive information that should no longer be retained. Specify the "
+        "unique IDs of the memories to delete from episodic or semantic memory "
+        "stores. Note: episodic memories and semantic memories are deleted "
+        "separately. They have different ID spaces."
+        "\n\nIdentity (org / project) is bound to this MCP connection by the "
+        "host (via `MM_ORG_ID` / `MM_PROJ_ID` env vars in stdio mode, or "
+        "`org-id` / `proj-id` request headers in HTTP mode) and is not "
+        "configurable per call."
     ),
 )
 async def mcp_delete_memory(
-    org_id: str = "",
-    proj_id: str = "",
     episodic_memory_uids: list[EpisodeIdT] | None = None,
     semantic_memory_uids: list[FeatureIdT] | None = None,
 ) -> McpResponse:
-    """Delete specific memories from the user's memory store."""
+    """Delete specific memories from the user's memory store.
+
+    Identity is bound to the MCP connection by the host (env vars in
+    stdio mode, request headers in HTTP mode). The LLM cannot supply or
+    override it.
+    """
     if semantic_memory_uids is None:
         semantic_memory_uids = []
     if episodic_memory_uids is None:
@@ -563,10 +624,7 @@ async def mcp_delete_memory(
             message="MemMachine is not initialized",
         )
     try:
-        param = Params(
-            org_id=org_id,
-            proj_id=proj_id,
-        )
+        param = Params()
         spec = param.to_delete_memories_spec(
             episodic_memory_uids=episodic_memory_uids,
             semantic_memory_uids=semantic_memory_uids,


### PR DESCRIPTION
### Purpose of the change

Resolves context bloat and identity spoofing vulnerabilities in the MCP server, specifically addressing the two hard requirements raised in the thread for issue #1278:

1. **LLM-readable formatting**
2. **Scoped handle / security**

### Description

This patch resolves the security and context issues in #1278.

### Changes

- **Identity Scoping (Security)** Removed `org_id`, `proj_id`, and `user_id` parameters from `mcp_add_memory`, `mcp_search_memory`, and `mcp_delete_memory` signatures. Identity is now strictly host-bound via env vars or HTTP headers. Because FastMCP automatically derives its input-schema from these signatures, spoof attempts are now outright rejected with a `ToolError` rather than silently dropped.

- **Context Trimming (Performance)** `mcp_search_memory` now returns a token-efficient, formatted string using internal helpers (`_format_episode_line`, `_format_episodic_section`, `_format_semantic_section`) instead of a raw Pydantic JSON dump.

- **Housekeeping** Fixed `mcp_search_memory` default `top_k` from 20 to 5 to match the docstring.

### Compatibility Shield

**REST API** Unchanged. Programmatic clients keep the structured `SearchResult`.

**MCP Hosts** Breaking. Hosts passing identity as MCP tool arguments will now receive a `ToolError`. Hosts that rely on `MM_*_ID` env vars or `org-id`/`proj-id`/`user-id` request headers keep working unchanged.

### Fixes/Closes

Fixes #1278 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Security (improves security without changing functionality)

### How Has This Been Tested?

- [x] Unit Test

- Added `host_identity_env` fixture to simulate host-bound identity.

- Verified FastMCP schema validation rejects attempted spoofs and the downstream service is never invoked.

- Guarded the security contract at both Python-signature and wire-schema levels.

- Verified new return types and ensured episodic + semantic sections render correctly without leaking UIDs, scores, or metadata IDs.

**Test Results:**

```bash
uv run ruff check packages/server/src/memmachine_server/server/api_v2/mcp.py \
                  packages/server/server_tests/memmachine_server/server/api_v2/test_mcp.py
uv run ruff format --check ...
uv run complexipy packages/server/src/memmachine_server/server/api_v2/mcp.py
uv run pytest packages/server/server_tests/memmachine_server/server/api_v2/ -v
# 255 passed (28 in test_mcp.py). 1182-test server suite + 229-test client suite remain green.
```
### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Further comments

This implements a hard removal of identity parameters rather than a soft-deprecation. This follows the explicit direction from issue #1297 to "disregard backward compatibility" for the MCP server, instantly closing the identity spoofing surface.