### PR TITLE
Decrease frequency of macOS Intel CI timeout

### DIFF
--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -25,7 +25,7 @@ jobs:
   test-install:
     needs: build
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false

--- a/packages/client/client_tests/test_integration_complete.py
+++ b/packages/client/client_tests/test_integration_complete.py
@@ -1586,8 +1586,11 @@ class TestMemMachineToolsIntegration:
     @pytest.fixture
     def tools(self, unique_test_ids):
         """Create a MemMachineTools instance."""
+        client = MemMachineClient(
+            base_url=TEST_BASE_URL, timeout=CLIENT_TIMEOUT_SECONDS
+        )
         t = MemMachineTools(
-            base_url=TEST_BASE_URL,
+            client=client,
             org_id=unique_test_ids["org_id"],
             project_id=unique_test_ids["project_id"],
             user_id=unique_test_ids["user_id"],


### PR DESCRIPTION
### Purpose of the change

macOS installation test times out often, making CI failure a poor signal for PR quality/readiness.

### Description

Ran CI total 6+ times to ensure it actually fixes a large proportion of timeouts.

Increase MemMachine client timeout to CLIENT_TIMEOUT_SECONDS (180).
Increase job maximum execution time to 30 minutes (previously job execution time averaged near boundary of 20 minute limit).

### Fixes/Closes

Hope fixes #1065