### PR TITLE
feat(client+langgraph): raw filter strings and EpisodeType normalization

### DIFF
--- a/integrations/langgraph/README.md
+++ b/integrations/langgraph/README.md
@@ -72,6 +72,10 @@ add_memory = create_add_memory_tool(tools)
 search_memory = create_search_memory_tool(tools)
 ```
 
+The generated tools support:
+- raw search filter strings via `filter='metadata.category = "work"'`
+- `episode_type` as either an `EpisodeType` enum or a string value like `"message"`
+
 ### 3. Use in LangGraph Nodes
 
 ```python
@@ -82,12 +86,14 @@ def memory_node(state: AgentState):
     search_result = search_memory(
         query=state["messages"][-1].content,
         user_id=state["user_id"],
+        filter='metadata.category = "work"',
     )
 
     # Add new memory
     add_memory(
         content=state["messages"][-1].content,
         user_id=state["user_id"],
+        episode_type="message",
     )
 
     return {

--- a/packages/client/client_tests/test_langgraph.py
+++ b/packages/client/client_tests/test_langgraph.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import Mock, patch
 
+from memmachine_common.api import EpisodeType
+
 from memmachine_client.langgraph import (
     MemMachineTools,
     create_add_memory_tool,
@@ -145,8 +147,42 @@ class TestAddMemory:
         assert result["uids"] == ["uid-123"]
         assert result["content"] == "Hello world"
         mock_memory.add.assert_called_once_with(
-            content="Hello world", role="user", metadata={}
+            content="Hello world", role="user", metadata={}, episode_type=None
         )
+
+    def test_raw_filter_passthrough(self):
+        tools, mock_memory = self._make_tools()
+
+        mock_content = Mock()
+        mock_content.episodic_memory = None
+        mock_content.semantic_memory = []
+
+        mock_search_result = Mock()
+        mock_search_result.content = mock_content
+        mock_memory.search.return_value = mock_search_result
+
+        result = tools.search_memory(query="food", filter='metadata.category = "work"')
+
+        assert result["status"] == "success"
+        mock_memory.search.assert_called_once_with(
+            query="food",
+            limit=20,
+            score_threshold=None,
+            filter_dict=None,
+            filter='metadata.category = "work"',
+        )
+
+    def test_episode_type_string_is_normalized(self):
+        tools, mock_memory = self._make_tools()
+        mock_result = Mock()
+        mock_result.uid = "uid-ep"
+        mock_memory.add.return_value = [mock_result]
+
+        result = tools.add_memory(content="Hello world", episode_type="message")
+
+        assert result["status"] == "success"
+        mock_memory.add.assert_called_once()
+        assert mock_memory.add.call_args.kwargs["episode_type"] == EpisodeType.MESSAGE
 
     def test_error_path(self):
         tools, mock_memory = self._make_tools()
@@ -203,7 +239,7 @@ class TestSearchMemory:
         assert result["results"]["episodic_memory"] == {"episodes": [{"content": "hi"}]}
         assert result["results"]["semantic_memory"] == [{"name": "likes pizza"}]
         mock_memory.search.assert_called_once_with(
-            query="food", limit=20, score_threshold=None, filter_dict=None
+            query="food", limit=20, score_threshold=None, filter_dict=None, filter=None
         )
 
     def test_error_path(self):
@@ -323,7 +359,7 @@ class TestFactoryFunctions:
         mock_memory.add.return_value = [mock_result]
 
         add_fn = create_add_memory_tool(tools)
-        result = add_fn("test content", None, None)
+        result = add_fn("test content", None, None, None)
 
         assert result["status"] == "success"
         assert result["uids"] == ["uid-1"]
@@ -335,7 +371,7 @@ class TestFactoryFunctions:
         mock_memory.add.return_value = [mock_result]
 
         add_fn = create_add_memory_tool(tools)
-        result = add_fn("content", "u1", None)
+        result = add_fn("content", "u1", None, "message")
 
         assert result["status"] == "success"
 
@@ -368,5 +404,5 @@ class TestFactoryFunctions:
         search_fn("hello", None, 10)
 
         mock_memory.search.assert_called_once_with(
-            query="hello", limit=10, score_threshold=None, filter_dict=None
+            query="hello", limit=10, score_threshold=None, filter_dict=None, filter=None
         )

--- a/packages/client/client_tests/test_memory.py
+++ b/packages/client/client_tests/test_memory.py
@@ -463,6 +463,54 @@ class TestMemory:
         assert "category='work'" in json_data["filter"]
         assert call_args[1]["timeout"] == 15
 
+    def test_search_with_filter_string(self, mock_client):
+        """Test search with raw filter string."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"status": 0, "content": {}}
+        mock_response.raise_for_status = Mock()
+        mock_client.request.return_value = mock_response
+
+        memory = Memory(
+            client=mock_client,
+            org_id="test_org",
+            project_id="test_project",
+            metadata={"agent_id": "agent1", "user_id": "user1"},
+        )
+
+        memory.search("query", filter='metadata.category = "work"')
+
+        call_args = mock_client.request.call_args
+        json_data = call_args[1]["json"]
+        filter_str = json_data["filter"]
+        assert "metadata.user_id='user1'" in filter_str
+        assert "metadata.agent_id='agent1'" in filter_str
+        assert '(metadata.category = "work")' in filter_str
+
+    def test_list_with_filter_string(self, mock_client):
+        """Test list with raw filter string."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"status": 0, "content": {}}
+        mock_response.raise_for_status = Mock()
+        mock_client.request.return_value = mock_response
+
+        memory = Memory(
+            client=mock_client,
+            org_id="test_org",
+            project_id="test_project",
+            metadata={"agent_id": "agent1", "user_id": "user1"},
+        )
+
+        memory.list(filter='metadata.category = "work"')
+
+        call_args = mock_client.request.call_args
+        json_data = call_args[1]["json"]
+        filter_str = json_data["filter"]
+        assert "metadata.user_id='user1'" in filter_str
+        assert "metadata.agent_id='agent1'" in filter_str
+        assert '(metadata.category = "work")' in filter_str
+
     def test_search_with_filters(self, mock_client):
         """Test search with filter dictionary."""
         mock_response = Mock()

--- a/packages/client/src/memmachine_client/langgraph.py
+++ b/packages/client/src/memmachine_client/langgraph.py
@@ -8,6 +8,8 @@ to enable AI agents with persistent memory capabilities.
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from memmachine_common.api import EpisodeType
+
 from .client import MemMachineClient
 
 if TYPE_CHECKING:
@@ -141,6 +143,7 @@ class MemMachineTools:
         group_id: str | None = None,
         session_id: str | None = None,
         metadata: dict[str, str] | None = None,
+        episode_type: EpisodeType | str | None = None,
     ) -> dict[str, Any]:
         """
         Add a memory to MemMachine.
@@ -159,6 +162,7 @@ class MemMachineTools:
             group_id: Group ID (overrides default, stored in metadata)
             session_id: Session ID (overrides default, stored in metadata)
             metadata: Additional metadata for the episode
+            episode_type: Optional episode type enum or string value
 
         Returns:
             Dictionary with success status and message
@@ -168,10 +172,16 @@ class MemMachineTools:
             memory = self.get_memory(
                 org_id, project_id, user_id, agent_id, group_id, session_id
             )
+            normalized_episode_type = (
+                EpisodeType(episode_type)
+                if isinstance(episode_type, str)
+                else episode_type
+            )
             results = memory.add(
                 content=content,
                 role=role,
                 metadata=metadata or {},
+                episode_type=normalized_episode_type,
             )
             if results:
                 return {
@@ -203,6 +213,7 @@ class MemMachineTools:
         limit: int = 20,
         score_threshold: float | None = None,
         filter_dict: dict[str, str] | None = None,
+        filter: str | None = None,  # noqa: A002 — matches API field name in `SearchMemoriesSpec.filter`
     ) -> dict[str, Any]:
         """
         Search for memories in MemMachine.
@@ -224,6 +235,7 @@ class MemMachineTools:
             limit: Maximum number of results to return (default: 20)
             score_threshold: Minimum score to include in results
             filter_dict: Additional metadata filters for the search. User metadata keys must be prefixed with `m.` / `metadata.`. Unknown or misspelled fields return a 400 error.
+            filter: Optional raw filter string passed through to the Python client
 
         Returns:
             Dictionary containing search results and relevant memories
@@ -238,6 +250,7 @@ class MemMachineTools:
                 limit=limit,
                 score_threshold=score_threshold,
                 filter_dict=filter_dict,
+                filter=filter,
             )
 
             # Format results for easier consumption
@@ -356,7 +369,10 @@ class MemMachineTools:
 # Convenience functions for LangGraph tool creation
 def create_add_memory_tool(
     tools: MemMachineTools,
-) -> Callable[[str, str | None, dict[str, Any] | None], dict[str, Any]]:
+) -> Callable[
+    [str, str | None, dict[str, Any] | None, EpisodeType | str | None],
+    dict[str, Any],
+]:
     """
     Create an add_memory tool function for LangGraph.
 
@@ -372,6 +388,7 @@ def create_add_memory_tool(
         content: str,
         user_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        episode_type: EpisodeType | str | None = None,
     ) -> dict[str, Any]:
         """
         Tool to add a memory to MemMachine.
@@ -380,6 +397,7 @@ def create_add_memory_tool(
             content: The content to store in memory
             user_id: Optional user ID override
             metadata: Optional metadata for the memory
+            episode_type: Optional episode type enum or string value
 
         Returns:
             Result dictionary with status and message
@@ -389,6 +407,7 @@ def create_add_memory_tool(
             content=content,
             user_id=user_id,
             metadata=metadata,
+            episode_type=episode_type,
         )
 
     return add_memory_tool

--- a/packages/client/src/memmachine_client/memory.py
+++ b/packages/client/src/memmachine_client/memory.py
@@ -367,6 +367,7 @@ class Memory:
         filter_dict: dict[str, str] | None = None,
         timeout: int | None = None,
         *,
+        filter: str | None = None,  # noqa: A002 — matches API field name in `SearchMemoriesSpec.filter`
         set_metadata: dict[str, JsonValue] | None = None,
         agent_mode: bool = False,
     ) -> SearchResult:
@@ -396,6 +397,8 @@ class Memory:
                         `metadata.<key>=A AND metadata.<key>=B` filter. Unknown or misspelled
                         user metadata fields return a 400 error.
             timeout: Request timeout in seconds (uses client default if not provided)
+            filter: Optional raw filter string. If provided together with built-in or
+                    `filter_dict` filters, all filters are combined with AND.
             set_metadata: Optional metadata key-value pairs used to select semantic sets.
             agent_mode: Whether to enable top-level retrieval-agent orchestration.
 
@@ -419,11 +422,15 @@ class Memory:
         if filter_dict:
             merged_filters.update(filter_dict)
 
-        # Use v2 API: convert to v2 format
-        # Convert merged filter_dict to string format: key='value' AND key='value'
-        filter_str = ""
-        if merged_filters:
-            filter_str = self._dict_to_filter_string(merged_filters)
+        dict_filter_str = (
+            self._dict_to_filter_string(merged_filters) if merged_filters else ""
+        )
+        explicit_filter = filter.strip() if filter else ""
+
+        if dict_filter_str and explicit_filter:
+            filter_str = f"{dict_filter_str} AND ({explicit_filter})"
+        else:
+            filter_str = dict_filter_str or explicit_filter
 
         # Use shared API Pydantic models
         spec = SearchMemoriesSpec(
@@ -464,6 +471,7 @@ class Memory:
         page_size: int = 100,
         page_num: int = 0,
         filter_dict: dict[str, str] | None = None,
+        filter: str | None = None,  # noqa: A002 — matches API field name in `ListMemoriesSpec.filter`
         set_metadata: dict[str, JsonValue] | None = None,
         timeout: int | None = None,
     ) -> ListResult:
@@ -477,6 +485,8 @@ class Memory:
             page_size: Page size (server default is 100)
             page_num: Page number (0-based)
             filter_dict: Optional extra filters; merged with built-in context filters
+            filter: Optional raw filter string. If provided together with built-in or
+                    `filter_dict` filters, all filters are combined with AND.
             set_metadata: Optional metadata key-value pairs used to select semantic sets.
             timeout: Request timeout override
 
@@ -492,9 +502,15 @@ class Memory:
         if filter_dict:
             merged_filters.update(filter_dict)
 
-        filter_str = (
+        dict_filter_str = (
             self._dict_to_filter_string(merged_filters) if merged_filters else ""
         )
+        explicit_filter = filter.strip() if filter else ""
+
+        if dict_filter_str and explicit_filter:
+            filter_str = f"{dict_filter_str} AND ({explicit_filter})"
+        else:
+            filter_str = dict_filter_str or explicit_filter
 
         spec = ListMemoriesSpec(
             org_id=self.__org_id,


### PR DESCRIPTION
## Summary

Rescues the substantive work from @haosenwang1018's 9-commit stack (#1341 → #1349) by cherry-picking the 3 commits that contain real feature code onto a fresh branch from current `main`, with lint and type fixes applied. The prefix-style doc and test commits in the original stack are not included here because `main` already absorbed them via #1352 and #1311.

This PR adds:

1. **`Memory.search(filter=...)` and `Memory.list(filter=...)`** — accept an optional raw filter string alongside `filter_dict`. When both are provided they are combined with `AND`. The raw filter passes through to the v2 `SearchMemoriesSpec.filter` / `ListMemoriesSpec.filter` API fields unchanged.
2. **`MemMachineTools.search_memory(filter=...)`** — pipes the raw filter through the LangGraph search-memory tool wrapper.
3. **`MemMachineTools.add_memory(episode_type=...)`** — accepts either an `EpisodeType` enum or its string value (e.g. `"message"`), normalizing strings via `EpisodeType(...)` before delegating to `Memory.add`. The factory tool's return-type annotation was widened to match.

Tests for all three additions are included.

## Original commits (preserved as the squash commit author)

- `921b55f2` feat(client): support raw filter strings (@haosenwang1018)
- `e0849bb1` feat(langgraph): support raw filter strings (@haosenwang1018)
- `53b489e5` fix(langgraph): normalize episode type strings (@haosenwang1018)

## Changes vs. originals

- One trivial rebase conflict resolved in `langgraph.py` docstring (merged main's updated `filter_dict` prefix wording with the new `filter` parameter doc).
- Added `# noqa: A002` at three `filter:` parameter sites with a comment pointing at the matching `SearchMemoriesSpec.filter` / `ListMemoriesSpec.filter` API field name. Same trade-off the API spec already makes.
- Updated `create_add_memory_tool`'s `Callable[...]` return-type annotation to include the new `EpisodeType | str | None` parameter introduced by `53b489e5`.

## Test plan

- [x] `uv run ruff check packages/client/` — clean
- [x] `uv run ty check packages/client/` — clean
- [x] `uv run pytest packages/client/client_tests/test_memory.py packages/client/client_tests/test_langgraph.py` — 151 passed
- [ ] GitHub Actions matrix once the PR opens

## Closes

Closes #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349

Co-authored-by: Steve Scargall <steve.scargall@gmail.com>
