### PR TITLE
Docs: Removing Playground References

### DIFF
--- a/docs/backup-docs.json
+++ b/docs/backup-docs.json
@@ -248,6 +248,10 @@
   "navbar": {
     "links": [
       {
+        "label": "Playground",
+        "href": "https://huggingface.co/spaces/Memverge/MemMachine-Playground"
+      },
+      {
         "label": "Support",
         "href": "https://discord.gg/usydANvKqD"
       },

--- a/docs/getting_started/faqs.mdx
+++ b/docs/getting_started/faqs.mdx
@@ -24,7 +24,7 @@ These questions may change or grow over time as we continue to develop and refin
         Yes! MemMachine is built to be flexible. It's designed to persist across **multiple sessions, agents, and large language models**, so it can be a versatile memory solution for a variety of AI applications.
     </Accordion>
     <Accordion title="Is MemMachine for developers or just end users?">
-        While it benefits end users by creating a more personalized experience, MemMachine is primarily an **open-source tool** for developers. The site offers resources like a playground and open-source packages to help developers easily integrate a powerful memory layer into their AI applications.
+        While it benefits end users by creating a more personalized experience, MemMachine is primarily an **open-source tool** for developers. The site offers resources like open-source packages to help developers easily integrate a powerful memory layer into their AI applications.
     </Accordion>
 </AccordionGroup>
 

--- a/docs/getting_started/introduction.mdx
+++ b/docs/getting_started/introduction.mdx
@@ -9,7 +9,7 @@ Meet **MemMachine**, an open-source memory layer for advanced AI agents.  It ena
 ## Let's Get Started
 
 You can get started with MemMachine in the following ways:
-<Columns cols={3}>
+<Columns cols={2}>
    <Card
     title="Get Started"
     icon="rocket"

--- a/docs/getting_started/introduction.mdx
+++ b/docs/getting_started/introduction.mdx
@@ -18,13 +18,6 @@ You can get started with MemMachine in the following ways:
    Get up and running fast 
   </Card>
   <Card
-    title="Playground"
-    icon="box"
-    href="https://memmachine.ai/playground"
-  >
-    Play with MemMachine now
-  </Card>
-  <Card
     title="Examples"
     icon="folder-open"
     href="/examples/introduction"


### PR DESCRIPTION
### Purpose of the change

The purpose of this pull request is to completely decommission and remove all public-facing references to the Huggingface Playground from the MemMachine documentation environment. 

### Description

Following a task to deprecate the Playground, this PR cleans up the documentation structure and layout to reflect its removal. To ensure we retain historical context for potential future reference, a local backup of the original configuration has been preserved.

Changes include:
* Created a local backup (`backup-docs.json`) of the original documentation layout.
* Removed the external link redirection to the Huggingface Playground from `docs.json`.
* Updated `introduction.mdx` to remove the Playground card component and adjusted the layout grid from 3 columns to 2 columns to keep the UI clean.
* Stripped out all copy and language mentioning Playgrounds within `faqs.mdx`.

No external dependencies are required for this change.

### Fixes/Closes

Fixes # 1412

### Type of change

- [x] Documentation update

### How Has This Been Tested?

- [x] Manual verification (list step-by-step instructions)

**Test Results:** 1. Manually verified that `docs.json` no longer contains the Huggingface Playground link.
2. Verified layout spacing in `introduction.mdx` to ensure the 2-column shift renders correctly.
3. Reviewed `faqs.mdx` to ensure no lingering mentions of the Playground exist.

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [X] Confirmed all checks passed
- [X] Contributor has signed the commit(s)
- [X] Reviewed the code
- [X] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

1. Accordion view for FAQ.mdx that shows language change to remove playground reference:
<img width="1097" height="595" alt="Screenshot 2026-05-19 at 10 53 35 AM" src="https://github.com/user-attachments/assets/c43e0615-e2e8-4c52-8e46-a6d93b8f7594" />

2. Screen capture of introduction.mdx page that shows both column/card removal and shift from 3 to 2.  It also shows a lack of reference to playground links via docs.json for the overall site:
<img width="2252" height="3902" alt="screencapture-super-space-xylophone-jjgj75xppjgw25xx6-3000-app-github-dev-getting-started-introduction-2026-05-19-10_51_57" src="https://github.com/user-attachments/assets/9cafc5d3-231f-499e-9e46-3cee1fca446d" />


### Further comments

The `backup-docs.json` file has been committed alongside these changes to serve as a reference point should the team decide to implement or point to a new Playground environment in the future.