### PR TITLE
fix(ci): resolve security-audit workflow failures

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.11.15"
 
@@ -37,6 +37,15 @@ jobs:
 
           cat "$audit_results"
 
+          # uv audit exits 0 when clean, 1 when vulnerabilities are found, and
+          # >1 on internal/audit errors. Surface those before attempting to
+          # parse the (likely empty) JSON output, so the failure message is
+          # the actual uv error rather than a downstream JSONDecodeError.
+          if [ "$audit_exit_code" -gt 1 ]; then
+            echo "uv audit exited with unexpected status: $audit_exit_code"
+            exit "$audit_exit_code"
+          fi
+
           python3 -c "
           import json
           from pathlib import Path
@@ -46,11 +55,6 @@ jobs:
           with open('$GITHUB_OUTPUT', 'a') as f:
               f.write(f'has_vulnerabilities={str(bool(vulnerabilities)).lower()}\n')
           "
-
-          if [ "$audit_exit_code" -gt 1 ]; then
-            echo "uv audit exited with unexpected status: $audit_exit_code"
-            exit "$audit_exit_code"
-          fi
 
       - name: Upgrade vulnerable packages
         if: steps.audit.outputs.has_vulnerabilities == 'true'


### PR DESCRIPTION
## Summary

- Pin `astral-sh/setup-uv@v8` to `@v8.1.0`. The v8 release series only ships immutable tags (`v8.0.0`, `v8.1.0`); there is no floating `v8` tag, so the workflow fails at the *Install uv* step with: `Unable to resolve action ` + \`astral-sh/setup-uv@v8\` + `, unable to find version` + \`v8\`. Confirmed via `git ls-remote --tags astral-sh/setup-uv` and the v8.0.0 release notes (\"Immutable releases and secure tags\").
- Run the `uv audit` exit-code guard **before** the `python3` JSON parse so transient audit errors (e.g. OSV API decode failures, exit code > 1) surface as the actual `uv` error message instead of a downstream `JSONDecodeError` on the empty results file.

## Context on the original `--format` failure

The job log showing `error: unexpected argument '--format' found` came from PR runs whose branches predate #1419 (the workflow on a `pull_request` run uses the PR branch's copy of the file, not `main`'s). #1419 already changed `--format json` to `--output-format json` on `main`, so once any affected Dependabot/feature PR is rebased onto `main` it will pick up that fix. That left the `@v8` resolution bug as the actual blocker on `main` going forward.

## Test plan

- [x] Verified `astral-sh/setup-uv` lacks a `v8` floating tag (only `v8.0.0` / `v8.1.0` exist)
- [x] Triggered the workflow via `workflow_dispatch` on `main` before the fix — failed at *Set up job* with `Unable to resolve action astral-sh/setup-uv@v8`
- [x] Triggered the workflow via `workflow_dispatch` on this branch — *Install uv* succeeds, the audit step runs to completion, and the (transient) OSV API decode error from `uv audit` is now surfaced clearly as `uv audit exited with unexpected status: 2`
- [ ] On merge, re-run on `main` once the OSV API is healthy; the audit should report `has_vulnerabilities` correctly and open the auto-fix PR if any CVEs are present
- [ ] Rebase the failing Dependabot PRs (e.g. `dependabot/uv/uv-c7433584f1`, `dependabot/uv/requests-2.34.2`) so they pick up both this fix and #1419

🤖 Generated with [Claude Code](https://claude.com/claude-code)