### PR TITLE
fix(ci): tolerate upstream uv audit OSV parse failure

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -29,12 +29,16 @@ jobs:
         id: audit
         run: |
           audit_results="$RUNNER_TEMP/audit-results.json"
+          audit_stderr="$RUNNER_TEMP/audit-stderr.txt"
 
           set +e
-          uv audit --output-format json > "$audit_results"
+          uv audit --output-format json > "$audit_results" 2> "$audit_stderr"
           audit_exit_code=$?
           set -e
 
+          # Surface uv's own diagnostics (experimental warnings, network errors,
+          # parse failures) in the workflow log before we make decisions on them.
+          cat "$audit_stderr" >&2
           cat "$audit_results"
 
           # uv audit exits 0 when clean, 1 when vulnerabilities are found, and
@@ -42,6 +46,28 @@ jobs:
           # parse the (likely empty) JSON output, so the failure message is
           # the actual uv error rather than a downstream JSONDecodeError.
           if [ "$audit_exit_code" -gt 1 ]; then
+            # TEMPORARY: tolerate the upstream uv/OSV bug where uv audit's
+            # strict deserializer rejects malformed OSV records (empty `{}` in
+            # `affected.ranges.events`), aborting the entire audit. Tracked in
+            # this repo (see issue linked from PR description) and upstream at
+            # https://github.com/astral-sh/uv/issues/19492 (fix PR #19496).
+            # Remove this branch once the `version:` input above is bumped to
+            # a uv release containing the upstream fix.
+            if grep -qF 'error decoding response body' "$audit_stderr"; then
+              echo "::warning title=uv audit skipped::uv audit could not decode the OSV response (known upstream bug astral-sh/uv#19492). Exiting successfully without scanning; see the in-repo tracking issue for details."
+              {
+                echo "### Security Audit skipped"
+                echo
+                echo "\`uv audit\` exited with code \`$audit_exit_code\` because it could not parse the OSV vulnerability database response."
+                echo
+                echo "This is the known upstream bug [astral-sh/uv#19492](https://github.com/astral-sh/uv/issues/19492): an OSV record contains an empty \`{}\` in \`affected.ranges.events\`, which uv's deserializer rejects."
+                echo
+                echo "**No vulnerability scanning ran in this workflow execution.** When the upstream fix ([astral-sh/uv#19496](https://github.com/astral-sh/uv/pull/19496) or equivalent) is released, bump the \`setup-uv\` \`version:\` input in \`.github/workflows/security-audit.yml\` and remove this skip branch."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "has_vulnerabilities=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
             echo "uv audit exited with unexpected status: $audit_exit_code"
             exit "$audit_exit_code"
           fi


### PR DESCRIPTION
## Summary

Stops the `Security Audit` workflow from blocking unrelated PRs while we wait for the upstream uv/OSV bug fix. When (and only when) `uv audit` exits non-zero with the specific `error decoding response body` failure, the workflow now:

- Forwards uv's stderr to the run log for visibility.
- Emits a GitHub Actions `::warning::` annotation plus a Step Summary explaining what was skipped, why, and how to remove the shim.
- Sets `has_vulnerabilities=false` so the downstream upgrade and PR-creation steps no-op cleanly.
- Exits successfully.

All other `uv audit` exit codes >1 still fail loudly.

## Root cause (not in this repo)

Upstream: [astral-sh/uv#19492](https://github.com/astral-sh/uv/issues/19492). An OSV record (`PYSEC-2026-89` and similar) contains an empty `{}` in `affected.ranges.events` — invalid per OSV's schema. uv's strict Rust deserializer rejects the record, aborting the entire audit before any vulnerabilities can be reported. uv maintainers (`@woodruffw`) are deliberately holding back the lenient-parser fix ([astral-sh/uv#19496](https://github.com/astral-sh/uv/pull/19496)) so OSV fixes the bad records upstream first.

Locally reproducible against this repo's `uv.lock`: 5/5 attempts fail with the same error, so this is not transient.

## Why a shim (and not pip-audit / waiting)

Considered alternatives:

- **Switch to `pip-audit`** — robust, but requires re-implementing the JSON parse + upgrade loop around its different schema. Held in reserve if upstream takes weeks.
- **Wait** — leaves CI red on every PR until upstream merges.
- **`uv audit --ignore <id>`** — does not help; uv's `--ignore` filters *after* deserialization, and the parse aborts before filtering.
- **Mirror OSV via `--service-url`** — no maintained mirror exists.

The shim is the smallest reversible change that keeps PRs unblocked. It is gated on a very specific error string so it does not silently swallow other failure modes.

## Verification

Dispatched on this branch via `workflow_dispatch`:

- Job conclusion: **success**.
- Step `Run security audit`: emits `##[warning]uv audit could not decode the OSV response (known upstream bug astral-sh/uv#19492)…`.
- Steps `Upgrade vulnerable packages` and `Create security fix pull request`: both **skipped** (correct, because `has_vulnerabilities=false`).
- Step Summary contains a markdown block explaining the skip, with links to both the upstream issue and the resolution criteria.

Run: <https://github.com/sscargal/MemMachine/actions/runs/26188026375>

## How to remove this shim (resolution criteria)

When **both** of the following are true, delete the `grep -qF 'error decoding response body'` branch in `.github/workflows/security-audit.yml`:

1. A `uv` release containing `astral-sh/uv#19496` (or an equivalent fix) is available.
2. The `astral-sh/setup-uv` `version:` input is bumped to that release.

The in-repo tracking issue (to be filed alongside this PR) lists the full analysis, root cause, ruled-out theories, possible workarounds, and the decision to wait for upstream.

## Test plan

- [x] Dispatched the workflow on this branch with the current `uv.lock` (which triggers the OSV parse failure) — exits success with the warning annotation
- [x] Verified downstream steps (`Upgrade vulnerable packages`, `Create security fix pull request`) are skipped cleanly when `has_vulnerabilities=false`
- [ ] On merge, confirm the next Dependabot / scheduled-cron run also exits success with the same warning
- [ ] Once the upstream fix ships, remove the shim and bump the `setup-uv` `version:` input

Signed-off-by: Steve Scargall <37674041+sscargal@users.noreply.github.com>