### PR TITLE
chore(ci): run security-audit on cron only, not per pull request

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -7,11 +7,6 @@ permissions:
 on:
   schedule:
     - cron: '0 6 * * 1,4'
-  pull_request:
-    paths:
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - 'packages/**/pyproject.toml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Drops the `pull_request:` trigger from `.github/workflows/security-audit.yml`. The workflow now runs only on the existing Mon/Thu cron and on manual `workflow_dispatch`.

## Why

The workflow's primary side-effect is opening `security/auto-fix-vulnerabilities` against `main` (via `peter-evans/create-pull-request`). That target makes sense for the lockfile-on-`main`, not for a contributor's in-progress branch, so running it on every dep-touching PR produces noise — either no-op churn or a second auto-fix PR opened from a PR branch's audit results.

- **PR-time vulnerability discovery is already covered** by Dependabot Security Updates, which the repo already uses (see existing `dependabot/uv/*` branches).
- **Scheduled sweeps** are handled by the existing cron (`0 6 * * 1,4` — Mon and Thu at 06:00 UTC).
- **Ad-hoc runs** remain available via `workflow_dispatch`.

## Test plan

- [x] Diff is a one-block removal of `pull_request:` plus its `paths:` filter — no behavior change for cron or manual dispatch
- [ ] After merge, confirm Dependabot PRs no longer trigger the Security Audit workflow
- [ ] Next scheduled cron (next Mon/Thu 06:00 UTC) still runs as expected

Signed-off-by: Steve Scargall <37674041+sscargal@users.noreply.github.com>