### PR TITLE
fix(openclaw): document /v2 in MemMachine cloud baseUrl

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -77,7 +77,7 @@ Here is a sample `openclaw.json` entry:
         "enabled": true,
         "config": {
           "apiKey": "mm-...",
-          "baseUrl": "https://api.memmachine.ai",
+          "baseUrl": "https://api.memmachine.ai/v2",
           "autoCapture": true,
           "autoRecall": true,
           "orgId": "openclaw",
@@ -94,10 +94,16 @@ Here is a sample `openclaw.json` entry:
 
 ### Configuration entries
 
-Here are the required configuration entries:
+All fields are optional in the JSON schema, but in practice you must set
+`apiKey` for MemMachine Cloud, and you should set `baseUrl` when targeting a
+self-hosted deployment.
 
 - `apiKey`: MemMachine API key.
-- `baseUrl`: MemMachine API base URL.
+- `baseUrl`: MemMachine API base URL, including the API version path. For
+  MemMachine Cloud use `https://api.memmachine.ai/v2`. For a self-hosted
+  MemMachine server (this repo) routes are mounted under `/api/v2`, so use
+  `http://<host>:<port>/api/v2` (e.g. `http://localhost:8080/api/v2`). Omit
+  to use the client default (`https://api.memmachine.ai/v2`).
 - `autoCapture`: Enable automatic memory capture.
 - `autoRecall`: Enable automatic memory recall.
 - `orgId`: Organization identifier.

--- a/integrations/openclaw/index.mts
+++ b/integrations/openclaw/index.mts
@@ -66,8 +66,8 @@ const PluginConfigUiHints = {
   },
   baseUrl: {
     label: "MemMachine Base URL",
-    placeholder: "https://api.memmachine.ai",
-    help: "Base URL for the MemMachine service.",
+    placeholder: "https://api.memmachine.ai/v2",
+    help: "Base URL for the MemMachine service, including the API version path. MemMachine Cloud: https://api.memmachine.ai/v2. Self-hosted: http://<host>:<port>/api/v2 (e.g. http://localhost:8080/api/v2). Leave blank to use the client default.",
   },
   userId: {
     label: "Default User ID",
@@ -162,11 +162,25 @@ const MemoryForgetSchema = Type.Object({
   minScore: Type.Optional(Type.Number({ description: "Auto-delete threshold" })),
 });
 
+/**
+ * Normalizes a user-supplied `baseUrl` to either a trimmed non-empty string
+ * or `undefined`. Exported so tests can pin the contract: empty or
+ * whitespace-only values must collapse to `undefined`, so the underlying TS
+ * client falls back to its own default (`https://api.memmachine.ai/v2`)
+ * instead of receiving an empty `base_url` that would short-circuit the
+ * default in axios.
+ */
+export function resolveBaseUrl(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 function resolvePluginConfig(api: OpenClawPluginApi): PluginConfig {
   const raw = (api.pluginConfig ?? {}) as Record<string, unknown>;
   return {
     apiKey: typeof raw.apiKey === "string" ? raw.apiKey.trim() : undefined,
-    baseUrl: typeof raw.baseUrl === "string" ? raw.baseUrl.trim() : undefined,
+    baseUrl: resolveBaseUrl(raw.baseUrl),
     userId:
       typeof raw.userId === "string" && raw.userId.trim()
         ? raw.userId.trim()

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -18,8 +18,8 @@
     },
     "baseUrl": {
       "label": "MemMachine Base URL",
-      "placeholder": "https://api.memmachine.ai",
-      "help": "Base URL for the MemMachine service."
+      "placeholder": "https://api.memmachine.ai/v2",
+      "help": "Base URL for the MemMachine service, including the API version path. MemMachine Cloud: https://api.memmachine.ai/v2. Self-hosted: http://<host>:<port>/api/v2 (e.g. http://localhost:8080/api/v2). Leave blank to use the client default."
     },
     "userId": {
       "label": "Default User ID",

--- a/integrations/openclaw/tests/resolve-base-url.test.ts
+++ b/integrations/openclaw/tests/resolve-base-url.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression tests for #1268: when `baseUrl` is unset/blank, the OpenClaw
+ * plugin must pass `undefined` to MemMachineClient so the TS client's own
+ * default (`https://api.memmachine.ai/v2`) is used. Passing an empty string
+ * would defeat the default in axios and produce 404s against the cloud API.
+ *
+ * As with the other tests in this package, external deps are stubbed via
+ * moduleNameMapper in jest.config.cjs, so this is a pure-function unit test.
+ */
+import { resolveBaseUrl } from "../index.mts";
+
+describe("resolveBaseUrl", () => {
+  it("returns undefined when value is not a string", () => {
+    expect(resolveBaseUrl(undefined)).toBeUndefined();
+    expect(resolveBaseUrl(null)).toBeUndefined();
+    expect(resolveBaseUrl(42)).toBeUndefined();
+    expect(resolveBaseUrl({})).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(resolveBaseUrl("")).toBeUndefined();
+  });
+
+  it("returns undefined for whitespace-only strings", () => {
+    expect(resolveBaseUrl("   ")).toBeUndefined();
+    expect(resolveBaseUrl("\t\n")).toBeUndefined();
+  });
+
+  it("returns the trimmed value for non-empty strings", () => {
+    expect(resolveBaseUrl("https://api.memmachine.ai/v2")).toBe(
+      "https://api.memmachine.ai/v2",
+    );
+    expect(resolveBaseUrl("  https://api.memmachine.ai/v2  ")).toBe(
+      "https://api.memmachine.ai/v2",
+    );
+  });
+
+  it("preserves self-hosted URLs", () => {
+    expect(resolveBaseUrl("http://localhost:8080/api/v2")).toBe(
+      "http://localhost:8080/api/v2",
+    );
+  });
+});


### PR DESCRIPTION
### Purpose of the change

The OpenClaw documentation is incorrect and misses the `/v2` postfix string for the MemMachine Platform URL (same for locally hosted).

### Description

The OpenClaw plugin's documented baseUrl `https://api.memmachine.ai` lacked the `/v2` API version path, so requests via the underlying `@memmachine/client` (which appends routes like `/memories` to the configured base URL) resolved to non-existent paths on MemMachine Cloud. Update the README sample, JSON schema placeholder, and UI hints to `https://api.memmachine.ai/v2`, and ignore an empty `baseUrl` setting so the TypeScript client's built-in default is used when the field is blank.

Verified live: POST https://api.memmachine.ai/v2/projects/list returns 200 while POST https://api.memmachine.ai/projects/list returns 404. The openclaw plugin only calls project- and memory-scoped routes, all of which are served under /v2.

### Fixes/Closes

Fixes #1268

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual verification (list step-by-step instructions)

**Test Results:** [Attach logs, screenshots, or relevant output]

Verified — openclaw doesn't call healthCheck() or getMetrics(); it only uses project + memory routes, all of which live under /v2. So https://api.memmachine.ai/v2 is the correct base for the openclaw plugin, and the staged diff is good as-is.

  Live API verdict:
  - POST /projects/list → 404 ; POST /v2/projects/list → 200 (empty list). Confirms /v2 is required for business routes.
  - GET /health → 200 ; GET /v2/health → 404. Health is mounted at root, but openclaw never calls it.
  - /api/v2/... (Python-client style) is not served on this hostname — only bare /v2/.... That's worth noting for the Python
  client's docs, but it's out of scope for this issue. 

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None