### PR TITLE
Add temporal scoring

### DIFF
--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -70,6 +70,12 @@ qdrant = [
 litellm = [
     "litellm>=1.63.0,<1.86",
 ]
+dateparser = [
+    "dateparser>=1.4.0",
+]
+duckling = [
+    "httpx>=0.27.0",
+]
 
 [project.scripts]
 memmachine-server = "memmachine_server.server.app:main"

--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -74,6 +74,12 @@ milvus = [
 litellm = [
     "litellm>=1.63.0,<1.86",
 ]
+dateparser = [
+    "dateparser>=1.4.0",
+]
+duckling = [
+    "httpx>=0.27.0",
+]
 
 [project.scripts]
 memmachine-server = "memmachine_server.server.app:main"

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_episodic_config.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_episodic_config.py
@@ -8,13 +8,18 @@ from memmachine_server.common.configuration.episodic_config import (
     DateparserTemporalExtractorConf,
     DucklingTemporalExtractorConf,
     EpisodicMemoryConfPartial,
+    EventLongTermMemoryConf,
+    ExtractorTemporalQueryPlannerConf,
     LanguageModelTemporalExtractorConf,
+    LanguageModelTemporalQueryPlannerConf,
     SegmenterConf,
+    TemporalRetrievalConf,
     TemporalSegmenterConf,
     TextSegmenterConf,
 )
 
 _SEGMENTER_ADAPTER = TypeAdapter(SegmenterConf)
+_TEMPORAL_RETRIEVAL_ADAPTER = TypeAdapter(TemporalRetrievalConf)
 
 
 @pytest.fixture
@@ -80,3 +85,55 @@ def test_temporal_segmenter_config_round_trips():
         }
     )
     assert _SEGMENTER_ADAPTER.validate_python(conf.model_dump()) == conf
+
+
+def test_temporal_retrieval_defaults_off_on_event_backend():
+    conf = EventLongTermMemoryConf(
+        session_id="s", vector_store="v", segment_store="db", embedder="e"
+    )
+    assert conf.temporal_retrieval is None
+
+
+def test_temporal_retrieval_planner_discriminates_and_defaults():
+    conf = _TEMPORAL_RETRIEVAL_ADAPTER.validate_python(
+        {"planner": {"type": "language_model", "language_model": "gpt"}}
+    )
+    assert isinstance(conf.planner, LanguageModelTemporalQueryPlannerConf)
+    assert conf.planner.language_model == "gpt"
+    # k2 = one-third of k; wide overfetch; gate at >0.
+    assert conf.overfetch_multiplier == 8
+    assert conf.temporal_fraction == pytest.approx(1.0 / 3.0)
+    assert conf.match_threshold == 0.0
+
+
+def test_temporal_retrieval_extractor_planner_nests_extractor_union():
+    conf = _TEMPORAL_RETRIEVAL_ADAPTER.validate_python(
+        {
+            "planner": {"type": "extractor", "extractor": {"type": "dateparser"}},
+            "overfetch_multiplier": 12,
+            "temporal_fraction": 0.5,
+            "match_threshold": 0.1,
+        }
+    )
+    assert isinstance(conf.planner, ExtractorTemporalQueryPlannerConf)
+    assert isinstance(conf.planner.extractor, DateparserTemporalExtractorConf)
+    assert conf.overfetch_multiplier == 12
+    assert conf.temporal_fraction == 0.5
+    assert conf.match_threshold == 0.1
+
+
+def test_temporal_retrieval_rejects_out_of_range_fraction():
+    with pytest.raises(ValueError, match="temporal_fraction"):
+        _TEMPORAL_RETRIEVAL_ADAPTER.validate_python(
+            {
+                "planner": {"type": "language_model", "language_model": "gpt"},
+                "temporal_fraction": 1.5,
+            }
+        )
+
+
+def test_temporal_retrieval_round_trips():
+    conf = _TEMPORAL_RETRIEVAL_ADAPTER.validate_python(
+        {"planner": {"type": "extractor", "extractor": {"type": "duckling"}}}
+    )
+    assert _TEMPORAL_RETRIEVAL_ADAPTER.validate_python(conf.model_dump()) == conf

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_episodic_config.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_episodic_config.py
@@ -2,10 +2,19 @@ from typing import Any
 
 import pytest
 import yaml
+from pydantic import TypeAdapter
 
 from memmachine_server.common.configuration.episodic_config import (
+    DateparserTemporalExtractorConf,
+    DucklingTemporalExtractorConf,
     EpisodicMemoryConfPartial,
+    LanguageModelTemporalExtractorConf,
+    SegmenterConf,
+    TemporalSegmenterConf,
+    TextSegmenterConf,
 )
+
+_SEGMENTER_ADAPTER = TypeAdapter(SegmenterConf)
 
 
 @pytest.fixture
@@ -32,3 +41,42 @@ def test_episodic_config_to_yaml(episodic_memory_conf):
     assert conf_cp.short_term_memory is not None
     assert conf_cp.short_term_memory == conf.short_term_memory
     assert conf_cp.short_term_memory.llm_model == "my_model"
+
+
+def test_temporal_segmenter_config_defaults_base_to_text():
+    conf = _SEGMENTER_ADAPTER.validate_python(
+        {"type": "temporal", "extractor": {"type": "dateparser"}}
+    )
+    assert isinstance(conf, TemporalSegmenterConf)
+    assert isinstance(conf.extractor, DateparserTemporalExtractorConf)
+    assert isinstance(conf.base_segmenter, TextSegmenterConf)
+
+
+def test_temporal_segmenter_config_discriminates_extractor():
+    lm = _SEGMENTER_ADAPTER.validate_python(
+        {
+            "type": "temporal",
+            "extractor": {"type": "language_model", "language_model": "gpt"},
+        }
+    )
+    assert isinstance(lm, TemporalSegmenterConf)
+    assert isinstance(lm.extractor, LanguageModelTemporalExtractorConf)
+    assert lm.extractor.language_model == "gpt"
+
+    duckling = _SEGMENTER_ADAPTER.validate_python(
+        {"type": "temporal", "extractor": {"type": "duckling", "url": "http://d/parse"}}
+    )
+    assert isinstance(duckling, TemporalSegmenterConf)
+    assert isinstance(duckling.extractor, DucklingTemporalExtractorConf)
+    assert duckling.extractor.url == "http://d/parse"
+
+
+def test_temporal_segmenter_config_round_trips():
+    conf = _SEGMENTER_ADAPTER.validate_python(
+        {
+            "type": "temporal",
+            "extractor": {"type": "duckling"},
+            "base_segmenter": {"type": "passthrough"},
+        }
+    )
+    assert _SEGMENTER_ADAPTER.validate_python(conf.model_dump()) == conf

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_resource_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_resource_manager.py
@@ -179,3 +179,16 @@ def test_resource_manager_config_property(invalid_configure):
     """Test that config property returns the configuration."""
     resource_manager = ResourceManagerImpl(invalid_configure)
     assert resource_manager.config == invalid_configure
+
+
+@pytest.mark.asyncio
+async def test_get_http_client_is_shared_and_closed_on_shutdown(invalid_configure):
+    """The shared HTTP client is bounded to one instance and closed by close()."""
+    resource_manager = ResourceManagerImpl(invalid_configure)
+    client_a = await resource_manager.get_http_client()
+    client_b = await resource_manager.get_http_client()
+    # Bounded to a single shared client (no per-call leak).
+    assert client_a is client_b
+    assert not client_a.is_closed
+    await resource_manager.close()
+    assert client_a.is_closed

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_resource_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_resource_manager.py
@@ -184,6 +184,7 @@ def test_resource_manager_config_property(invalid_configure):
 @pytest.mark.asyncio
 async def test_get_http_client_is_shared_and_closed_on_shutdown(invalid_configure):
     """The shared HTTP client is bounded to one instance and closed by close()."""
+    pytest.importorskip("httpx")
     resource_manager = ResourceManagerImpl(invalid_configure)
     client_a = await resource_manager.get_http_client()
     client_b = await resource_manager.get_http_client()

--- a/packages/server/server_tests/memmachine_server/common/test_request_context.py
+++ b/packages/server/server_tests/memmachine_server/common/test_request_context.py
@@ -1,0 +1,24 @@
+"""Tests for the request-locale contextvar."""
+
+from babel import Locale
+
+from memmachine_server.common.request_context import (
+    DEFAULT_LOCALE,
+    get_request_locale,
+    reset_request_locale,
+    set_request_locale,
+)
+
+
+def test_default_is_en_us():
+    assert Locale("en", "US") == DEFAULT_LOCALE
+    assert get_request_locale() == DEFAULT_LOCALE
+
+
+def test_set_then_reset_restores_previous():
+    token = set_request_locale(Locale("fr", "FR"))
+    try:
+        assert get_request_locale() == Locale("fr", "FR")
+    finally:
+        reset_request_locale(token)
+    assert get_request_locale() == DEFAULT_LOCALE

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
@@ -16,10 +16,13 @@ from memmachine_server.common.payload_codec.payload_codec_config import (
     PlaintextPayloadCodecConfig,
 )
 from memmachine_server.episodic_memory.event_memory.data_types import (
+    CompositeContext,
+    Context,
     NullContext,
     ProducerContext,
     Segment,
     TextBlock,
+    TimeRangesContext,
 )
 from memmachine_server.episodic_memory.event_memory.segment_store import (
     SegmentStorePartitionAlreadyExistsError,
@@ -32,6 +35,7 @@ from memmachine_server.episodic_memory.event_memory.segment_store.sqlalchemy_seg
     SQLAlchemySegmentStoreParams,
     SQLAlchemySegmentStorePartition,
 )
+from memmachine_server.temporal.time_range import TimeInterval, TimeRange
 
 PARTITION_KEY = "test_partition"
 BASE_TIME = datetime(2024, 1, 1, tzinfo=UTC)
@@ -50,7 +54,7 @@ def _seg(
     offset: int = 0,
     ts_offset_seconds: int = 0,
     text: str = "hello",
-    context: ProducerContext | NullContext = _NULL_CONTEXT,
+    context: Context = _NULL_CONTEXT,
     properties: dict | None = None,
 ) -> Segment:
     return Segment(
@@ -173,6 +177,109 @@ async def test_add_segments_with_producer_context(
         ).scalar_one()
     assert json.loads(row.context) == {"context_type": "producer", "producer": "User"}
     assert json.loads(row.block) == {"block_type": "text", "text": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_add_segments_with_time_range_context(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    ctx = TimeRangesContext(
+        time_ranges=[
+            # One reference with an internal gap (two intervals).
+            TimeRange(
+                intervals=[
+                    TimeInterval(
+                        start=datetime(2024, 1, 1, tzinfo=UTC),
+                        end=datetime(2024, 6, 1, tzinfo=UTC),
+                    ),
+                    TimeInterval(
+                        start=datetime(2024, 9, 1, tzinfo=UTC),
+                        end=datetime(2025, 1, 1, tzinfo=UTC),
+                    ),
+                ]
+            ),
+            # One reference, single open-ended interval.
+            TimeRange(
+                intervals=[
+                    TimeInterval(start=datetime(2024, 3, 1, tzinfo=UTC), end=None)
+                ]
+            ),
+        ]
+    )
+    seg = _seg(context=ctx)
+    await partition.add_segments(_links(seg))
+
+    result = await partition.get_segment_contexts([seg.uuid])
+    assert result[seg.uuid][0].context == ctx
+
+    async with partition._create_session() as session:
+        row = (
+            await session.execute(select(SegmentRow).where(SegmentRow.uuid == seg.uuid))
+        ).scalar_one()
+    assert json.loads(row.context) == {
+        "context_type": "time_ranges",
+        "time_ranges": [
+            {
+                "intervals": [
+                    {"start": "2024-01-01T00:00:00Z", "end": "2024-06-01T00:00:00Z"},
+                    {"start": "2024-09-01T00:00:00Z", "end": "2025-01-01T00:00:00Z"},
+                ]
+            },
+            {"intervals": [{"start": "2024-03-01T00:00:00Z", "end": None}]},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_add_segments_with_composed_context(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    ctx = CompositeContext(
+        contexts=[
+            ProducerContext(producer="Alice"),
+            TimeRangesContext(
+                time_ranges=[
+                    TimeRange(
+                        intervals=[
+                            TimeInterval(
+                                start=datetime(2024, 1, 1, tzinfo=UTC),
+                                end=datetime(2024, 1, 2, tzinfo=UTC),
+                            )
+                        ]
+                    )
+                ]
+            ),
+        ]
+    )
+    seg = _seg(context=ctx)
+    await partition.add_segments(_links(seg))
+
+    result = await partition.get_segment_contexts([seg.uuid])
+    assert result[seg.uuid][0].context == ctx
+
+    async with partition._create_session() as session:
+        row = (
+            await session.execute(select(SegmentRow).where(SegmentRow.uuid == seg.uuid))
+        ).scalar_one()
+    assert json.loads(row.context) == {
+        "context_type": "composite",
+        "contexts": [
+            {"context_type": "producer", "producer": "Alice"},
+            {
+                "context_type": "time_ranges",
+                "time_ranges": [
+                    {
+                        "intervals": [
+                            {
+                                "start": "2024-01-01T00:00:00Z",
+                                "end": "2024-01-02T00:00:00Z",
+                            }
+                        ]
+                    }
+                ],
+            },
+        ],
+    }
 
 
 @pytest.mark.asyncio

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segmenter/test_temporal_segmenter.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segmenter/test_temporal_segmenter.py
@@ -1,0 +1,129 @@
+"""Tests for TemporalSegmenter (base-segmenter injection + composition)."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from memmachine_server.episodic_memory.event_memory.data_types import (
+    CompositeContext,
+    Event,
+    NullContext,
+    ProducerContext,
+    TextBlock,
+    TimeRangesContext,
+    find_contexts,
+)
+from memmachine_server.episodic_memory.event_memory.segmenter.passthrough_segmenter import (
+    PassthroughSegmenter,
+)
+from memmachine_server.episodic_memory.event_memory.segmenter.temporal_segmenter import (
+    TemporalSegmenter,
+    TemporalSegmenterParams,
+)
+from memmachine_server.temporal.extractor import TemporalExtractor
+from memmachine_server.temporal.time_range import TimeInterval, TimeRange
+
+BASE_TIME = datetime(2024, 6, 1, tzinfo=UTC)
+EXTRACTED_RANGES = [
+    TimeRange(
+        intervals=[
+            TimeInterval(
+                start=datetime(2024, 1, 1, tzinfo=UTC),
+                end=datetime(2024, 1, 2, tzinfo=UTC),
+            )
+        ]
+    )
+]
+
+
+class RecordingExtractor(TemporalExtractor):
+    def __init__(self, ranges, calls):
+        self._ranges = ranges
+        self.calls = calls
+
+    async def extract(self, text, *, ref_time=None):
+        self.calls.append((text, ref_time))
+        return list(self._ranges)
+
+
+def make_temporal_extractor(calls):
+    return RecordingExtractor(EXTRACTED_RANGES, calls)
+
+
+def make_event(text, context=None):
+    return Event(
+        uuid=uuid4(),
+        timestamp=BASE_TIME,
+        context=context or NullContext(),
+        blocks=[TextBlock(text=text)],
+        properties={"doc_id": "d1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_attaches_time_range_context():
+    calls = []
+    segmenter = TemporalSegmenter(
+        TemporalSegmenterParams(temporal_extractor=make_temporal_extractor(calls))
+    )
+    segments = await segmenter.segment(make_event("Shipped on March 15, 2024."))
+
+    assert len(segments) == 1
+    ctx = segments[0].context
+    temporal = find_contexts(ctx, TimeRangesContext)
+    assert len(temporal) == 1
+    assert temporal[0].time_ranges == EXTRACTED_RANGES
+    # Event timestamp is the extraction reference time.
+    assert calls == [("Shipped on March 15, 2024.", BASE_TIME)]
+    assert segments[0].properties == {"doc_id": "d1"}
+
+
+@pytest.mark.asyncio
+async def test_composes_with_existing_producer_context():
+    segmenter = TemporalSegmenter(
+        TemporalSegmenterParams(temporal_extractor=make_temporal_extractor([]))
+    )
+    event = make_event("Shipped March 2024.", context=ProducerContext(producer="Alice"))
+    segments = await segmenter.segment(event)
+
+    ctx = segments[0].context
+    assert isinstance(ctx, CompositeContext)
+    producers = find_contexts(ctx, ProducerContext)
+    temporal = find_contexts(ctx, TimeRangesContext)
+    assert len(producers) == 1
+    assert producers[0].producer == "Alice"
+    assert len(temporal) == 1
+    assert len(temporal[0].time_ranges) == 1
+
+
+@pytest.mark.asyncio
+async def test_uses_injected_base_segmenter():
+    # PassthroughSegmenter emits one segment per block (no chunking), so a
+    # long text stays a single segment -> one extraction call.
+    calls = []
+    segmenter = TemporalSegmenter(
+        TemporalSegmenterParams(
+            temporal_extractor=make_temporal_extractor(calls),
+            base_segmenter=PassthroughSegmenter(),
+        )
+    )
+    long_text = "First sentence here. " * 50
+    segments = await segmenter.segment(make_event(long_text))
+
+    assert len(segments) == 1
+    assert len(calls) == 1
+    assert find_contexts(segments[0].context, TimeRangesContext)
+
+
+@pytest.mark.asyncio
+async def test_empty_extraction_yields_empty_ranges():
+    segmenter = TemporalSegmenter(
+        TemporalSegmenterParams(temporal_extractor=RecordingExtractor([], []))
+    )
+    segments = await segmenter.segment(make_event("No dates here."))
+
+    ctx = segments[0].context
+    temporal = find_contexts(ctx, TimeRangesContext)
+    assert len(temporal) == 1
+    assert temporal[0].time_ranges == []

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segmenter/test_temporal_segmenter.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segmenter/test_temporal_segmenter.py
@@ -1,6 +1,7 @@
 """Tests for TemporalSegmenter (base-segmenter injection + composition)."""
 
 from datetime import UTC, datetime
+from typing import override
 from uuid import uuid4
 
 import pytest
@@ -42,6 +43,7 @@ class RecordingExtractor(TemporalExtractor):
         self._ranges = ranges
         self.calls = calls
 
+    @override
     async def extract(self, text, *, ref_time=None):
         self.calls.append((text, ref_time))
         return list(self._ranges)

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_data_types.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_data_types.py
@@ -7,16 +7,21 @@ import pytest
 from pydantic import ValidationError
 
 from memmachine_server.episodic_memory.event_memory.data_types import (
+    CompositeContext,
     Derivative,
     Event,
+    NullContext,
     ProducerContext,
     Segment,
     TextBlock,
+    TimeRangesContext,
     decode_block,
     decode_context,
     encode_block,
     encode_context,
+    find_contexts,
 )
+from memmachine_server.temporal.time_range import TimeInterval, TimeRange
 
 SAMPLE_PROPERTIES = {
     "dt": datetime(2026, 1, 15, tzinfo=UTC),
@@ -25,6 +30,16 @@ SAMPLE_PROPERTIES = {
     "f": True,
     "s": "hello",
 }
+
+
+def dt(day: int) -> datetime:
+    """A distinct UTC datetime for time-range round-trip fixtures."""
+    return datetime(2024, 1, day, tzinfo=UTC)
+
+
+def tr(start: datetime | None, end: datetime | None) -> TimeRange:
+    """A single-interval ``TimeRange`` for round-trip fixtures."""
+    return TimeRange(intervals=[TimeInterval(start=start, end=end)])
 
 
 class TestSegmentRoundTrip:
@@ -171,6 +186,117 @@ class TestContextAndBlockSerialization:
 
     def test_context_none_round_trip(self):
         assert decode_context(encode_context(None)) is None
+
+    def test_time_range_context_round_trip(self):
+        context = TimeRangesContext(
+            time_ranges=[
+                tr(dt(1), dt(2)),
+                tr(None, dt(3)),
+                tr(dt(4), None),
+            ]
+        )
+
+        deserialized = decode_context(encode_context(context))
+
+        assert isinstance(deserialized, TimeRangesContext)
+        assert deserialized == context
+
+    def test_multi_interval_time_range_context_round_trip(self):
+        # A doc anchor that is one reference with an internal gap survives
+        # the encode/decode round-trip as a single multi-interval TimeRange.
+        context = TimeRangesContext(
+            time_ranges=[
+                TimeRange(
+                    intervals=[
+                        TimeInterval(start=dt(1), end=dt(2)),
+                        TimeInterval(start=dt(4), end=dt(5)),
+                    ]
+                )
+            ]
+        )
+
+        deserialized = decode_context(encode_context(context))
+
+        assert isinstance(deserialized, TimeRangesContext)
+        assert deserialized == context
+        assert len(deserialized.time_ranges[0].intervals) == 2
+
+    def test_empty_time_range_context_round_trip(self):
+        context = TimeRangesContext()
+
+        deserialized = decode_context(encode_context(context))
+
+        assert isinstance(deserialized, TimeRangesContext)
+        assert deserialized == context
+        assert deserialized.time_ranges == []
+
+    def test_composed_context_round_trip(self):
+        context = CompositeContext(
+            contexts=[
+                ProducerContext(producer="Alice"),
+                TimeRangesContext(time_ranges=[tr(dt(1), dt(2))]),
+            ]
+        )
+
+        deserialized = decode_context(encode_context(context))
+
+        assert isinstance(deserialized, CompositeContext)
+        assert deserialized == context
+
+    def test_atomic_context_still_decodes_unchanged(self):
+        # Backward compatibility: data written before CompositeContext
+        # existed still round-trips to its atomic type.
+        for context in (
+            ProducerContext(producer="Bob"),
+            NullContext(),
+            TimeRangesContext(time_ranges=[tr(dt(5), dt(9))]),
+        ):
+            assert decode_context(encode_context(context)) == context
+
+
+class TestContextComposition:
+    def test_find_contexts_resolves_atomic_and_composed(self):
+        producer = ProducerContext(producer="Alice")
+        temporal = TimeRangesContext(time_ranges=[tr(dt(1), dt(2))])
+        composed = CompositeContext(contexts=[producer, temporal])
+
+        # Same access whether the aspect is bare or composed.
+        assert find_contexts(producer, ProducerContext) == [producer]
+        assert find_contexts(composed, ProducerContext) == [producer]
+        assert find_contexts(composed, TimeRangesContext) == [temporal]
+        # Absent aspect → empty.
+        assert find_contexts(producer, TimeRangesContext) == []
+        assert find_contexts(None, ProducerContext) == []
+
+        # Nested composition is searched depth-first.
+        nested = CompositeContext(
+            contexts=[CompositeContext(contexts=[producer]), temporal]
+        )
+        assert find_contexts(nested, ProducerContext) == [producer]
+        assert find_contexts(nested, TimeRangesContext) == [temporal]
+
+    def test_find_contexts_collects_every_match_in_order(self):
+        # Composition imposes no at-most-one limit; all matches are
+        # returned in depth-first, left-to-right order so callers can
+        # aggregate rather than arbitrarily pick one.
+        first = TimeRangesContext(time_ranges=[tr(dt(1), dt(2))])
+        second = TimeRangesContext(time_ranges=[tr(dt(3), dt(4))])
+        nested = CompositeContext(contexts=[CompositeContext(contexts=[first]), second])
+
+        assert find_contexts(nested, TimeRangesContext) == [first, second]
+
+    def test_empty_or_null_only_composition_is_inert(self):
+        # A CompositeContext with no members, or only NullContext members,
+        # carries no aspect — it behaves like NullContext for lookups.
+        for context in (
+            CompositeContext(contexts=[]),
+            CompositeContext(contexts=[NullContext()]),
+            CompositeContext(contexts=[NullContext(), NullContext()]),
+        ):
+            assert find_contexts(context, ProducerContext) == []
+            assert find_contexts(context, TimeRangesContext) == []
+            # Round-trips unchanged.
+            assert decode_context(encode_context(context)) == context
 
     def test_block_round_trip(self):
         block = TextBlock(text="hello")

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_temporal_ranking.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_temporal_ranking.py
@@ -20,7 +20,7 @@ from memmachine_server.episodic_memory.event_memory.temporal_ranking import (
     temporal_rerank_query_results,
 )
 from memmachine_server.temporal.query_planner import TemporalQueryPlan
-from memmachine_server.temporal.scoring import TemporalScorer
+from memmachine_server.temporal.scoring import TemporalScorer, TemporalScorerParams
 from memmachine_server.temporal.time_range import TimeInterval, TimeRange
 
 BASE_TIME = datetime(2024, 1, 1, tzinfo=UTC)
@@ -92,7 +92,7 @@ class TestRerankQueryResult:
         query_result = QueryResult(scored_segment_contexts=[b, a, c])
 
         out = temporal_rerank_query_results(
-            TemporalScorer(),
+            TemporalScorer(TemporalScorerParams()),
             TemporalQueryPlan(targets=[year_target(2024)]),
             query_result,
         )
@@ -113,7 +113,7 @@ class TestRerankQueryResult:
     def test_does_not_mutate_caller_input(self):
         a = scored(0.50, [anchor(dt(2024, 3), dt(2024, 4))])
         temporal_rerank_query_results(
-            TemporalScorer(),
+            TemporalScorer(TemporalScorerParams()),
             TemporalQueryPlan(targets=[year_target(2024)]),
             QueryResult(scored_segment_contexts=[a]),
         )
@@ -123,7 +123,7 @@ class TestRerankQueryResult:
         a = scored(0.30, [anchor(dt(2024, 3), dt(2024, 4))])
         b = scored(0.90, [anchor(dt(2020, 1), dt(2020, 2))])
         out = temporal_rerank_query_results(
-            TemporalScorer(),
+            TemporalScorer(TemporalScorerParams()),
             TemporalQueryPlan(targets=[]),
             QueryResult(scored_segment_contexts=[a, b]),
         )
@@ -164,7 +164,7 @@ class TestRerankQueryResult:
         lower = scored(0.40, [anchor(dt(2019, 1), dt(2019, 2))])
 
         out = temporal_rerank_query_results(
-            TemporalScorer(),
+            TemporalScorer(TemporalScorerParams()),
             TemporalQueryPlan(targets=[year_target(2024)]),
             QueryResult(scored_segment_contexts=[higher, unit, lower]),
         )

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_temporal_ranking.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_temporal_ranking.py
@@ -1,0 +1,175 @@
+"""Tests for the EventMemory temporal-ranking adapter."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from memmachine_server.episodic_memory.event_memory.data_types import (
+    CompositeContext,
+    NullContext,
+    ProducerContext,
+    QueryResult,
+    ScoredSegmentContext,
+    Segment,
+    TextBlock,
+    TimeRangesContext,
+)
+from memmachine_server.episodic_memory.event_memory.temporal_ranking import (
+    _temporal_anchors_from_context,
+    temporal_rerank_query_results,
+)
+from memmachine_server.temporal.query_planner import TemporalQueryPlan
+from memmachine_server.temporal.scoring import TemporalScorer
+from memmachine_server.temporal.time_range import TimeInterval, TimeRange
+
+BASE_TIME = datetime(2024, 1, 1, tzinfo=UTC)
+
+
+def dt(year: int, month: int = 1, day: int = 1) -> datetime:
+    return datetime(year, month, day, tzinfo=UTC)
+
+
+def anchor(start: datetime | None, end: datetime | None) -> TimeRange:
+    """A single-interval ``TimeRange``."""
+    return TimeRange(intervals=[TimeInterval(start=start, end=end)])
+
+
+def year_target(y: int) -> TimeRange:
+    return TimeRange(intervals=[TimeInterval(start=dt(y, 1, 1), end=dt(y + 1, 1, 1))])
+
+
+def scored(base: float, anchors: list[TimeRange]) -> ScoredSegmentContext:
+    seg = Segment(
+        uuid=uuid4(),
+        event_uuid=uuid4(),
+        index=0,
+        offset=0,
+        timestamp=BASE_TIME,
+        context=TimeRangesContext(time_ranges=anchors),
+        block=TextBlock(text="x"),
+    )
+    return ScoredSegmentContext(score=base, seed_segment_uuid=seg.uuid, segments=[seg])
+
+
+class TestAnchorsFromContext:
+    def test_atomic_and_composed(self):
+        temporal = TimeRangesContext(time_ranges=[anchor(dt(2024, 1), dt(2024, 2))])
+        assert len(_temporal_anchors_from_context(temporal)) == 1
+
+        composed = CompositeContext(
+            contexts=[ProducerContext(producer="Alice"), temporal]
+        )
+        anchors = _temporal_anchors_from_context(composed)
+        assert len(anchors) == 1
+        assert anchors[0].intervals[0].start == dt(2024, 1)
+
+        assert _temporal_anchors_from_context(NullContext()) == []
+        assert _temporal_anchors_from_context(None) == []
+
+    def test_aggregates_multiple_temporal_aspects(self):
+        first = TimeRangesContext(time_ranges=[anchor(dt(2020), dt(2021))])
+        second = TimeRangesContext(time_ranges=[anchor(dt(2024), dt(2025))])
+        composed = CompositeContext(contexts=[first, second])
+
+        anchors = _temporal_anchors_from_context(composed)
+        assert [a.intervals[0].start for a in anchors] == [dt(2020), dt(2024)]
+
+    def test_unbounded_endpoint_preserved(self):
+        ctx = TimeRangesContext(time_ranges=[anchor(None, dt(2020, 1))])
+        anchors = _temporal_anchors_from_context(ctx)
+        assert anchors[0].intervals[0].start is None
+        assert anchors[0].intervals[0].end == dt(2020, 1)
+
+
+class TestRerankQueryResult:
+    def test_returns_query_result_reordered_and_rescored(self):
+        # A third doc widens the pool spread so the 2024 match's lift lands it
+        # above the higher-base off-year doc.
+        a = scored(0.50, [anchor(dt(2024, 3), dt(2024, 4))])
+        b = scored(0.60, [anchor(dt(2020, 1), dt(2020, 2))])
+        c = scored(0.40, [anchor(dt(2019, 1), dt(2019, 2))])
+        query_result = QueryResult(scored_segment_contexts=[b, a, c])
+
+        out = temporal_rerank_query_results(
+            TemporalScorer(),
+            TemporalQueryPlan(targets=[year_target(2024)]),
+            query_result,
+        )
+
+        # Same shape: a QueryResult of the same contexts, nothing added/dropped.
+        assert isinstance(out, QueryResult)
+        assert {s.seed_segment_uuid for s in out.scored_segment_contexts} == {
+            a.seed_segment_uuid,
+            b.seed_segment_uuid,
+            c.seed_segment_uuid,
+        }
+        # The 2024 match is first, carrying the temporally-fused score.
+        assert out.scored_segment_contexts[0].seed_segment_uuid == a.seed_segment_uuid
+        assert out.scored_segment_contexts[0].score == pytest.approx(
+            0.70
+        )  # 0.50 + 1.0*(0.60-0.40)
+
+    def test_does_not_mutate_caller_input(self):
+        a = scored(0.50, [anchor(dt(2024, 3), dt(2024, 4))])
+        temporal_rerank_query_results(
+            TemporalScorer(),
+            TemporalQueryPlan(targets=[year_target(2024)]),
+            QueryResult(scored_segment_contexts=[a]),
+        )
+        assert a.score == 0.50  # the caller's context keeps its original score
+
+    def test_empty_plan_orders_by_base_and_keeps_scores(self):
+        a = scored(0.30, [anchor(dt(2024, 3), dt(2024, 4))])
+        b = scored(0.90, [anchor(dt(2020, 1), dt(2020, 2))])
+        out = temporal_rerank_query_results(
+            TemporalScorer(),
+            TemporalQueryPlan(targets=[]),
+            QueryResult(scored_segment_contexts=[a, b]),
+        )
+        # No targets -> no temporal lift -> ordered by base, scores unchanged.
+        assert [s.seed_segment_uuid for s in out.scored_segment_contexts] == [
+            b.seed_segment_uuid,
+            a.seed_segment_uuid,
+        ]
+        assert out.scored_segment_contexts[0].score == 0.90
+
+    def test_scores_over_all_segments_not_just_seed(self):
+        # The seed carries no date; only a neighbor segment does. Temporal fit
+        # is scored over the whole unit, so the neighbor's 2024 anchor lifts the
+        # unit above a higher-base off-year doc -- which seed-only scoring would
+        # not do.
+        seed = Segment(
+            uuid=uuid4(),
+            event_uuid=uuid4(),
+            index=0,
+            offset=0,
+            timestamp=BASE_TIME,
+            context=NullContext(),
+            block=TextBlock(text="seed"),
+        )
+        neighbor = Segment(
+            uuid=uuid4(),
+            event_uuid=uuid4(),
+            index=1,
+            offset=0,
+            timestamp=BASE_TIME,
+            context=TimeRangesContext(time_ranges=[anchor(dt(2024, 3), dt(2024, 4))]),
+            block=TextBlock(text="neighbor"),
+        )
+        unit = ScoredSegmentContext(
+            score=0.50, seed_segment_uuid=seed.uuid, segments=[seed, neighbor]
+        )
+        higher = scored(0.70, [anchor(dt(2020, 1), dt(2020, 2))])
+        lower = scored(0.40, [anchor(dt(2019, 1), dt(2019, 2))])
+
+        out = temporal_rerank_query_results(
+            TemporalScorer(),
+            TemporalQueryPlan(targets=[year_target(2024)]),
+            QueryResult(scored_segment_contexts=[higher, unit, lower]),
+        )
+
+        # Pool spread = 0.70 - 0.40 = 0.30; the neighbor's 2024 match lifts the
+        # unit to 0.50 + 1.0*0.30 = 0.80, above the higher-base (0.70) off-year doc.
+        assert out.scored_segment_contexts[0].seed_segment_uuid == seed.uuid
+        assert out.scored_segment_contexts[0].score == pytest.approx(0.80)

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_long_term_memory_overfetch.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_long_term_memory_overfetch.py
@@ -1,0 +1,97 @@
+"""Unit tests for the temporal overfetch selection policy.
+
+The selection is a pure function of best-first match scores plus knobs; it lives
+on ``LongTermMemory`` because it is part of the event-backend search wiring (not
+a temporal primitive). These tests exercise it directly, with no backend.
+"""
+
+from memmachine_server.episodic_memory.long_term_memory.long_term_memory import (
+    LongTermMemory,
+)
+
+
+def test_no_temporal_match_collapses_to_top_k_by_cosine():
+    # All-zero match scores -> nothing clears the gate -> pure cosine top-k.
+    selected = LongTermMemory._select_temporal_overfetch_indices(
+        [0.0, 0.0, 0.0, 0.0, 0.0],
+        limit=3,
+        temporal_fraction=1.0 / 3.0,
+        match_threshold=0.0,
+    )
+    assert selected == [0, 1, 2]
+
+
+def test_promotes_low_cosine_match_into_k2():
+    # k=3 -> k2=round(1)=1, k1=2. Indices 0,1 fill k1 by cosine; the only
+    # temporal match (index 4) is promoted over the higher-cosine 2,3. Output
+    # stays in cosine (index) order: membership changes, not ordering.
+    selected = LongTermMemory._select_temporal_overfetch_indices(
+        [0.0, 0.0, 0.0, 0.0, 0.5, 0.0],
+        limit=3,
+        temporal_fraction=1.0 / 3.0,
+        match_threshold=0.0,
+    )
+    assert selected == [0, 1, 4]
+
+
+def test_backfills_with_cosine_when_too_few_match():
+    # k2 reserves 1 slot but nothing matches -> backfill the next cosine hit.
+    selected = LongTermMemory._select_temporal_overfetch_indices(
+        [0.0, 0.0, 0.0, 0.0],
+        limit=3,
+        temporal_fraction=1.0 / 3.0,
+        match_threshold=0.0,
+    )
+    assert selected == [0, 1, 2]
+
+
+def test_gate_is_strictly_greater_than_threshold():
+    # k=2 -> k2=1, k1=1. With threshold 0.0001, the 0.0001 candidate does NOT
+    # clear the strict gate, so k2 backfills with cosine (index 1).
+    selected = LongTermMemory._select_temporal_overfetch_indices(
+        [0.0, 0.0, 0.0, 0.0001],
+        limit=2,
+        temporal_fraction=0.5,
+        match_threshold=0.0001,
+    )
+    assert selected == [0, 1]
+    # Lowering the threshold below the match lets it clear the gate and promote
+    # over the higher-cosine index 1.
+    selected = LongTermMemory._select_temporal_overfetch_indices(
+        [0.0, 0.0, 0.0, 0.0001],
+        limit=2,
+        temporal_fraction=0.5,
+        match_threshold=0.0,
+    )
+    assert selected == [0, 3]
+
+
+def test_fraction_one_fills_entirely_from_matches():
+    # temporal_fraction=1 -> k2=k, k1=0: drop the top-cosine non-matches in
+    # favour of temporally-matching candidates.
+    selected = LongTermMemory._select_temporal_overfetch_indices(
+        [0.0, 0.0, 0.5, 0.5],
+        limit=2,
+        temporal_fraction=1.0,
+        match_threshold=0.0,
+    )
+    assert selected == [2, 3]
+
+
+def test_limit_exceeding_pool_returns_all():
+    selected = LongTermMemory._select_temporal_overfetch_indices(
+        [0.0, 0.5],
+        limit=5,
+        temporal_fraction=1.0 / 3.0,
+        match_threshold=0.0,
+    )
+    assert selected == [0, 1]
+
+
+def test_empty_pool():
+    assert (
+        LongTermMemory._select_temporal_overfetch_indices(
+            [], limit=3, temporal_fraction=0.5, match_threshold=0.0
+        )
+        == []
+    )

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_service_locator.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_service_locator.py
@@ -1,10 +1,15 @@
 """Unit tests for service_locator helpers."""
 
-import re
-from typing import cast, override
+from __future__ import annotations
 
-import httpx
+import re
+from typing import TYPE_CHECKING, cast, override
+
 import pytest
+
+if TYPE_CHECKING:
+    # `httpx` is the optional `duckling` extra; only the duckling test needs it.
+    import httpx
 
 from memmachine_server.common.configuration.episodic_config import (
     DateparserTemporalExtractorConf,
@@ -154,6 +159,8 @@ class _StubResourceManager:
         return self._language_model
 
     async def get_http_client(self) -> httpx.AsyncClient:
+        import httpx
+
         if self._http_client is None:
             self._http_client = httpx.AsyncClient()
         return self._http_client
@@ -195,6 +202,7 @@ async def test_build_temporal_extractor_language_model():
 
 @pytest.mark.asyncio
 async def test_build_temporal_extractor_duckling():
+    pytest.importorskip("httpx")
     manager = _StubResourceManager(None)
     extractor = await _build_temporal_extractor(
         DucklingTemporalExtractorConf(url="http://duck.test/parse"),

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_service_locator.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_service_locator.py
@@ -9,7 +9,9 @@ import pytest
 from memmachine_server.common.configuration.episodic_config import (
     DateparserTemporalExtractorConf,
     DucklingTemporalExtractorConf,
+    ExtractorTemporalQueryPlannerConf,
     LanguageModelTemporalExtractorConf,
+    LanguageModelTemporalQueryPlannerConf,
     PassthroughSegmenterConf,
     TemporalSegmenterConf,
 )
@@ -21,6 +23,7 @@ from memmachine_server.episodic_memory.event_memory.segmenter.temporal_segmenter
 from memmachine_server.episodic_memory.long_term_memory.service_locator import (
     _build_segmenter,
     _build_temporal_extractor,
+    _build_temporal_query_planner,
     _resolve_user_properties_schema,
     partition_key_for_session,
 )
@@ -30,8 +33,14 @@ from memmachine_server.temporal.extractor.dateparser_temporal_extractor import (
 from memmachine_server.temporal.extractor.duckling_temporal_extractor import (
     DucklingTemporalExtractor,
 )
+from memmachine_server.temporal.extractor.extractor_temporal_query_planner import (
+    ExtractorTemporalQueryPlanner,
+)
 from memmachine_server.temporal.extractor.language_model_temporal_extractor import (
     LanguageModelTemporalExtractor,
+)
+from memmachine_server.temporal.query_planner.language_model_temporal_query_planner import (
+    LanguageModelTemporalQueryPlanner,
 )
 
 _PARTITION_KEY_RE = re.compile(r"^[a-z0-9_]+$")
@@ -207,3 +216,26 @@ async def test_build_segmenter_temporal_wraps_base():
         _resource_manager(),
     )
     assert isinstance(segmenter, TemporalSegmenter)
+
+
+# --- temporal query planner construction -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_temporal_query_planner_language_model():
+    manager = _StubResourceManager(_StubLanguageModel())
+    planner = await _build_temporal_query_planner(
+        LanguageModelTemporalQueryPlannerConf(language_model="planner-lm"),
+        cast(CommonResourceManager, manager),
+    )
+    assert isinstance(planner, LanguageModelTemporalQueryPlanner)
+    assert manager.requested == ["planner-lm"]
+
+
+@pytest.mark.asyncio
+async def test_build_temporal_query_planner_extractor_reuses_extractor_builder():
+    planner = await _build_temporal_query_planner(
+        ExtractorTemporalQueryPlannerConf(extractor=DateparserTemporalExtractorConf()),
+        _resource_manager(),
+    )
+    assert isinstance(planner, ExtractorTemporalQueryPlanner)

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_service_locator.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_service_locator.py
@@ -27,9 +27,6 @@ from memmachine_server.episodic_memory.long_term_memory.service_locator import (
     _resolve_user_properties_schema,
     partition_key_for_session,
 )
-from memmachine_server.temporal.extractor.dateparser_temporal_extractor import (
-    DateparserTemporalExtractor,
-)
 from memmachine_server.temporal.extractor.duckling_temporal_extractor import (
     DucklingTemporalExtractor,
 )
@@ -174,6 +171,11 @@ def _resource_manager(
 
 @pytest.mark.asyncio
 async def test_build_temporal_extractor_dateparser():
+    pytest.importorskip("dateparser")
+    from memmachine_server.temporal.extractor.dateparser_temporal_extractor import (
+        DateparserTemporalExtractor,
+    )
+
     extractor = await _build_temporal_extractor(
         DateparserTemporalExtractorConf(), _resource_manager()
     )
@@ -208,6 +210,7 @@ async def test_build_temporal_extractor_duckling():
 
 @pytest.mark.asyncio
 async def test_build_segmenter_temporal_wraps_base():
+    pytest.importorskip("dateparser")
     segmenter = await _build_segmenter(
         TemporalSegmenterConf(
             extractor=DateparserTemporalExtractorConf(),
@@ -234,6 +237,7 @@ async def test_build_temporal_query_planner_language_model():
 
 @pytest.mark.asyncio
 async def test_build_temporal_query_planner_extractor_reuses_extractor_builder():
+    pytest.importorskip("dateparser")
     planner = await _build_temporal_query_planner(
         ExtractorTemporalQueryPlannerConf(extractor=DateparserTemporalExtractorConf()),
         _resource_manager(),

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_service_locator.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_service_locator.py
@@ -1,12 +1,37 @@
 """Unit tests for service_locator helpers."""
 
 import re
+from typing import cast, override
 
+import httpx
 import pytest
 
+from memmachine_server.common.configuration.episodic_config import (
+    DateparserTemporalExtractorConf,
+    DucklingTemporalExtractorConf,
+    LanguageModelTemporalExtractorConf,
+    PassthroughSegmenterConf,
+    TemporalSegmenterConf,
+)
+from memmachine_server.common.language_model.language_model import LanguageModel
+from memmachine_server.common.resource_manager import CommonResourceManager
+from memmachine_server.episodic_memory.event_memory.segmenter.temporal_segmenter import (
+    TemporalSegmenter,
+)
 from memmachine_server.episodic_memory.long_term_memory.service_locator import (
+    _build_segmenter,
+    _build_temporal_extractor,
     _resolve_user_properties_schema,
     partition_key_for_session,
+)
+from memmachine_server.temporal.extractor.dateparser_temporal_extractor import (
+    DateparserTemporalExtractor,
+)
+from memmachine_server.temporal.extractor.duckling_temporal_extractor import (
+    DucklingTemporalExtractor,
+)
+from memmachine_server.temporal.extractor.language_model_temporal_extractor import (
+    LanguageModelTemporalExtractor,
 )
 
 _PARTITION_KEY_RE = re.compile(r"^[a-z0-9_]+$")
@@ -86,3 +111,99 @@ def test_resolve_user_properties_schema_rejects_underscore_prefixed_keys():
 def test_resolve_user_properties_schema_rejects_unknown_type_name():
     with pytest.raises(ValueError, match="unknown type name"):
         _resolve_user_properties_schema({"customer_tier": "date"})
+
+
+# --- temporal segmenter / extractor construction ---------------------------
+
+
+class _StubLanguageModel(LanguageModel):
+    """A LanguageModel that satisfies InstanceOf but is never invoked here."""
+
+    @override
+    async def generate_parsed_response(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @override
+    async def generate_response(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @override
+    async def generate_response_with_token_usage(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class _StubResourceManager:
+    """Minimal resource manager exposing only the methods used here."""
+
+    def __init__(self, language_model: LanguageModel | None) -> None:
+        self._language_model = language_model
+        self.requested: list[str] = []
+        self._http_client: httpx.AsyncClient | None = None
+
+    async def get_language_model(
+        self, name: str, validate: bool = False
+    ) -> LanguageModel:
+        self.requested.append(name)
+        assert self._language_model is not None
+        return self._language_model
+
+    async def get_http_client(self) -> httpx.AsyncClient:
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient()
+        return self._http_client
+
+    async def aclose(self) -> None:
+        if self._http_client is not None:
+            await self._http_client.aclose()
+
+
+def _resource_manager(
+    language_model: LanguageModel | None = None,
+) -> CommonResourceManager:
+    return cast(CommonResourceManager, _StubResourceManager(language_model))
+
+
+@pytest.mark.asyncio
+async def test_build_temporal_extractor_dateparser():
+    extractor = await _build_temporal_extractor(
+        DateparserTemporalExtractorConf(), _resource_manager()
+    )
+    assert isinstance(extractor, DateparserTemporalExtractor)
+
+
+@pytest.mark.asyncio
+async def test_build_temporal_extractor_language_model():
+    manager = _StubResourceManager(_StubLanguageModel())
+    extractor = await _build_temporal_extractor(
+        LanguageModelTemporalExtractorConf(language_model="my-lm"),
+        cast(CommonResourceManager, manager),
+    )
+    assert isinstance(extractor, LanguageModelTemporalExtractor)
+    assert manager.requested == ["my-lm"]
+
+
+@pytest.mark.asyncio
+async def test_build_temporal_extractor_duckling():
+    manager = _StubResourceManager(None)
+    extractor = await _build_temporal_extractor(
+        DucklingTemporalExtractorConf(url="http://duck.test/parse"),
+        cast(CommonResourceManager, manager),
+    )
+    assert isinstance(extractor, DucklingTemporalExtractor)
+    # The client is owned by the resource manager, not the extractor: it is the
+    # manager's shared client, reused across extractors.
+    assert extractor._client is await manager.get_http_client()
+    # This stub has no close() lifecycle, so close the shared client here.
+    await manager.aclose()
+
+
+@pytest.mark.asyncio
+async def test_build_segmenter_temporal_wraps_base():
+    segmenter = await _build_segmenter(
+        TemporalSegmenterConf(
+            extractor=DateparserTemporalExtractorConf(),
+            base_segmenter=PassthroughSegmenterConf(),
+        ),
+        _resource_manager(),
+    )
+    assert isinstance(segmenter, TemporalSegmenter)

--- a/packages/server/server_tests/memmachine_server/server/api_v2/test_request_locale.py
+++ b/packages/server/server_tests/memmachine_server/server/api_v2/test_request_locale.py
@@ -1,0 +1,36 @@
+"""Tests for the locale query parameter and the request-locale dependency."""
+
+import pytest
+from babel import Locale
+
+from memmachine_server.common.request_context import (
+    DEFAULT_LOCALE,
+    get_request_locale,
+)
+from memmachine_server.server.api_v2.service import (
+    _parse_locale,
+    provide_request_locale,
+)
+
+
+def test_parse_locale_falls_back_to_default():
+    assert _parse_locale(None) == DEFAULT_LOCALE
+    assert _parse_locale("") == DEFAULT_LOCALE
+    assert _parse_locale("zz-ZZ") == DEFAULT_LOCALE  # unrecognized
+
+
+def test_parse_locale_resolves_bcp47():
+    assert _parse_locale("en-GB") == Locale("en", "GB")
+    assert _parse_locale("fr-FR") == Locale("fr", "FR")
+    assert _parse_locale("ja") == Locale("ja")  # language-only is fine
+
+
+@pytest.mark.asyncio
+async def test_provide_request_locale_sets_and_resets():
+    gen = provide_request_locale("de-DE")
+    await anext(gen)
+    assert get_request_locale() == Locale("de", "DE")
+    # Exhausting the generator runs the teardown that resets the contextvar.
+    with pytest.raises(StopAsyncIteration):
+        await anext(gen)
+    assert get_request_locale() == DEFAULT_LOCALE

--- a/packages/server/server_tests/memmachine_server/temporal/test_dateparser.py
+++ b/packages/server/server_tests/memmachine_server/temporal/test_dateparser.py
@@ -1,0 +1,64 @@
+"""Interface / structure tests for the dateparser-backed temporal extractor.
+
+These assert the structural contract -- return types, the extract
+contract and the pure interval-expansion helpers -- not the
+resolved date values, which depend on the ``dateparser`` library version.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+pytest.importorskip("dateparser")
+
+from memmachine_server.temporal.extractor.dateparser_temporal_extractor import (
+    DateparserTemporalExtractor,
+    _interval_for,
+)
+from memmachine_server.temporal.time_range import TimeRange
+
+# --- pure interval-expansion helpers ---------------------------------------
+
+
+class TestIntervalFor:
+    @pytest.mark.parametrize("period", ["day", "week", "month", "year"])
+    def test_known_period_half_open_contains_instant(self, period):
+        instant = datetime(2024, 2, 15, 9, 30, tzinfo=UTC)
+        interval = _interval_for(instant, period)
+        assert interval is not None
+        assert interval.start is not None
+        assert interval.end is not None
+        # Half-open containment: start <= instant < end.
+        assert interval.start <= instant < interval.end
+        assert interval.start.utcoffset() == timedelta(0)
+
+    def test_unknown_period_is_none(self):
+        assert _interval_for(datetime(2024, 2, 15, tzinfo=UTC), "decade") is None
+
+    def test_naive_instant_treated_as_utc(self):
+        naive = datetime(2024, 2, 15, tzinfo=UTC).replace(tzinfo=None)
+        interval = _interval_for(naive, "day")
+        assert interval is not None
+        assert interval.start is not None
+        assert interval.start.utcoffset() == timedelta(0)
+
+
+# --- DateparserTemporalExtractor --------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDateparserExtractor:
+    async def test_returns_list_of_time_ranges(self):
+        extractor = DateparserTemporalExtractor()
+        result = await extractor.extract(
+            "the launch was in 2020", ref_time=datetime(2024, 6, 15, tzinfo=UTC)
+        )
+        assert isinstance(result, list)
+        assert all(isinstance(r, TimeRange) for r in result)
+
+    async def test_no_date_text_returns_empty_list(self):
+        extractor = DateparserTemporalExtractor()
+        result = await extractor.extract(
+            "no date here at all", ref_time=datetime(2024, 6, 15, tzinfo=UTC)
+        )
+        assert result == []

--- a/packages/server/server_tests/memmachine_server/temporal/test_dateparser.py
+++ b/packages/server/server_tests/memmachine_server/temporal/test_dateparser.py
@@ -11,6 +11,12 @@ import pytest
 
 pytest.importorskip("dateparser")
 
+from babel import Locale
+
+from memmachine_server.common.request_context import (
+    reset_request_locale,
+    set_request_locale,
+)
 from memmachine_server.temporal.extractor.dateparser_temporal_extractor import (
     DateparserTemporalExtractor,
     _interval_for,
@@ -62,3 +68,21 @@ class TestDateparserExtractor:
             "no date here at all", ref_time=datetime(2024, 6, 15, tzinfo=UTC)
         )
         assert result == []
+
+    async def test_uses_request_locale_language(self, monkeypatch):
+        # dateparser is fed the language subtag of the request locale.
+        extractor = DateparserTemporalExtractor()
+        captured = {}
+
+        def fake_extract(text, ref_time, languages):
+            captured["languages"] = languages
+            return []
+
+        monkeypatch.setattr(extractor, "_extract_time_ranges", fake_extract)
+        token = set_request_locale(Locale("fr", "FR"))
+        try:
+            await extractor.extract("hier", ref_time=datetime(2024, 6, 15, tzinfo=UTC))
+        finally:
+            reset_request_locale(token)
+
+        assert captured["languages"] == ["fr"]

--- a/packages/server/server_tests/memmachine_server/temporal/test_duckling.py
+++ b/packages/server/server_tests/memmachine_server/temporal/test_duckling.py
@@ -1,0 +1,277 @@
+"""Interface / structure tests for the Duckling-backed temporal extractor.
+
+These exercise the structural contract -- return types, request shape,
+error-to-empty-list handling, and field wiring -- using a mocked
+HTTP transport and synthetic Duckling entities (whose shape is the server's
+documented API contract). They deliberately do NOT assert on resolved date
+values, which depend on the Duckling server version.
+"""
+
+import json
+import urllib.parse
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+pytest.importorskip("httpx")
+
+import httpx
+
+from memmachine_server.temporal.extractor.duckling_temporal_extractor import (
+    DucklingTemporalExtractor,
+    DucklingTemporalExtractorParams,
+    _end_of,
+    _entity_to_time_range,
+    _interval_bound,
+    _interval_to_time_range,
+    _parse_iso,
+    _value_to_time_range,
+)
+from memmachine_server.temporal.time_range import TimeRange
+
+URL = "http://duck.test/parse"
+
+
+def value_entity(stamp="2024-03-05T00:00:00.000Z", grain="day"):
+    """A synthetic Duckling ``type="value"`` time entity."""
+    return {"dim": "time", "value": {"type": "value", "value": stamp, "grain": grain}}
+
+
+def interval_entity(from_stamp=None, to_stamp=None):
+    """A synthetic Duckling ``type="interval"`` time entity."""
+    value: dict[str, object] = {"type": "interval"}
+    if from_stamp is not None:
+        value["from"] = {"value": from_stamp, "grain": "day"}
+    if to_stamp is not None:
+        value["to"] = {"value": to_stamp, "grain": "day"}
+    return {"dim": "time", "value": value}
+
+
+@asynccontextmanager
+async def mock_extractor(handler, **kwargs):
+    """A ``DucklingTemporalExtractor`` whose injected client is backed by ``handler``."""
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        yield DucklingTemporalExtractor(
+            DucklingTemporalExtractorParams(client=client, url=URL, **kwargs)
+        )
+
+
+# --- pure mapping helpers (synthetic entity -> TimeRange) ------------------
+
+
+class TestEntityMapping:
+    def test_value_entity_is_single_bounded_interval(self):
+        result = _entity_to_time_range(value_entity())
+        assert isinstance(result, TimeRange)
+        assert len(result.intervals) == 1
+        interval = result.intervals[0]
+        assert interval.start is not None
+        assert interval.end is not None
+        assert interval.start < interval.end  # half-open, non-empty
+
+    def test_closed_interval_wires_from_to_start_and_to_to_end(self):
+        start_stamp = "2020-01-01T00:00:00.000Z"
+        end_stamp = "2024-01-01T00:00:00.000Z"
+        result = _entity_to_time_range(interval_entity(start_stamp, end_stamp))
+        assert isinstance(result, TimeRange)
+        interval = result.intervals[0]
+        # Field wiring (oracle is our own parser, not a version-specific value).
+        assert interval.start == _parse_iso(start_stamp)
+        assert interval.end == _parse_iso(end_stamp)
+
+    def test_from_only_interval_is_left_bounded(self):
+        result = _entity_to_time_range(
+            interval_entity(from_stamp="2020-01-01T00:00:00.000Z")
+        )
+        assert isinstance(result, TimeRange)
+        assert result.intervals[0].start is not None
+        assert result.intervals[0].end is None
+
+    def test_to_only_interval_is_right_bounded(self):
+        result = _entity_to_time_range(
+            interval_entity(to_stamp="2024-01-01T00:00:00.000Z")
+        )
+        assert isinstance(result, TimeRange)
+        assert result.intervals[0].start is None
+        assert result.intervals[0].end is not None
+
+    def test_empty_interval_is_dropped(self):
+        assert _entity_to_time_range(interval_entity()) is None
+
+    def test_unknown_value_type_is_dropped(self):
+        assert (
+            _entity_to_time_range({"dim": "time", "value": {"type": "duration"}})
+            is None
+        )
+
+    def test_missing_value_is_dropped(self):
+        assert _entity_to_time_range({"dim": "time"}) is None
+
+    def test_value_missing_timestamp_is_dropped(self):
+        assert _value_to_time_range({"type": "value", "grain": "day"}) is None
+
+    def test_value_unparseable_timestamp_is_dropped(self):
+        assert (
+            _value_to_time_range({"type": "value", "value": "nope", "grain": "day"})
+            is None
+        )
+
+    def test_value_unknown_grain_is_dropped(self):
+        entity = {
+            "type": "value",
+            "value": "2024-03-05T00:00:00.000Z",
+            "grain": "fortnight",
+        }
+        assert _value_to_time_range(entity) is None
+
+
+class TestIntervalBound:
+    def test_absent_bound_is_none(self):
+        assert _interval_bound(None) is None
+
+    def test_present_bound_parses(self):
+        stamp = "2024-01-01T00:00:00.000Z"
+        assert _interval_bound({"value": stamp}) == _parse_iso(stamp)
+
+    def test_malformed_bound_missing_value_raises(self):
+        # Present-but-malformed must surface (so the caller can reject it),
+        # distinct from an absent bound.
+        with pytest.raises(KeyError):
+            _interval_bound({"grain": "day"})
+
+    def test_malformed_bound_bad_iso_raises(self):
+        with pytest.raises(ValueError, match="isoformat"):
+            _interval_bound({"value": "not-a-date"})
+
+    def test_interval_with_malformed_bound_is_dropped(self):
+        # The raise from a present-but-malformed bound is caught here -> the
+        # whole interval is dropped rather than half-parsed.
+        result = _interval_to_time_range({"type": "interval", "from": {"grain": "day"}})
+        assert result is None
+
+
+class TestEndOf:
+    @pytest.mark.parametrize(
+        "grain", ["second", "minute", "hour", "day", "week", "month", "quarter", "year"]
+    )
+    def test_known_grain_returns_later_utc_instant(self, grain):
+        start = datetime(2024, 2, 15, tzinfo=UTC)
+        end = _end_of(start, grain)
+        assert end is not None
+        assert end > start  # period end is strictly after its start
+        assert end.utcoffset() == timedelta(0)
+
+    def test_unknown_grain_is_none(self):
+        assert _end_of(datetime(2024, 2, 15, tzinfo=UTC), "fortnight") is None
+
+
+class TestParseIso:
+    def test_returns_utc_aware(self):
+        assert _parse_iso("2024-03-05T00:00:00.000Z").utcoffset() == timedelta(0)
+
+    def test_normalizes_offset_to_utc(self):
+        # A +08:00 stamp and its UTC equivalent denote the same instant.
+        assert _parse_iso("2024-03-05T08:00:00.000+08:00") == _parse_iso(
+            "2024-03-05T00:00:00.000Z"
+        )
+
+
+# --- DucklingTemporalExtractor (HTTP interface, via MockTransport) ---------
+
+
+@pytest.mark.asyncio
+class TestDucklingExtractor:
+    async def test_returns_list_of_time_ranges(self):
+        def handler(request):
+            return httpx.Response(200, json=[value_entity()])
+
+        async with mock_extractor(handler) as extractor:
+            result = await extractor.extract(
+                "anything", ref_time=datetime(2024, 6, 15, tzinfo=UTC)
+            )
+            assert isinstance(result, list)
+            assert all(isinstance(r, TimeRange) for r in result)
+            assert len(result) == 1
+
+    async def test_request_shape(self):
+        captured = {}
+
+        def handler(request):
+            captured["method"] = request.method
+            captured["url"] = str(request.url)
+            captured["form"] = urllib.parse.parse_qs(request.content.decode())
+            return httpx.Response(200, json=[])
+
+        ref = datetime(2024, 6, 15, 12, tzinfo=UTC)
+        async with mock_extractor(handler, locale="en_GB") as extractor:
+            await extractor.extract("when did x happen", ref_time=ref)
+
+        assert captured["method"] == "POST"
+        assert captured["url"] == URL
+        form = captured["form"]
+        assert form["text"] == ["when did x happen"]
+        assert form["locale"] == ["en_GB"]
+        assert form["tz"] == ["UTC"]
+        assert json.loads(form["dims"][0]) == ["time"]
+        # reftime is epoch-milliseconds of ref_time (our deterministic contract).
+        assert form["reftime"] == [str(int(ref.timestamp() * 1000))]
+
+    async def test_tz_is_derived_from_ref_time(self):
+        captured = {}
+
+        def handler(request):
+            captured["form"] = urllib.parse.parse_qs(request.content.decode())
+            return httpx.Response(200, json=[])
+
+        ref = datetime(2024, 6, 15, 12, tzinfo=ZoneInfo("America/Los_Angeles"))
+        async with mock_extractor(handler) as extractor:
+            await extractor.extract("when did x happen", ref_time=ref)
+
+        # tz comes from the input datetime's zone, not a config parameter.
+        assert captured["form"]["tz"] == ["America/Los_Angeles"]
+        # reftime stays the absolute UTC epoch of that instant.
+        assert captured["form"]["reftime"] == [str(int(ref.timestamp() * 1000))]
+
+    async def test_filters_out_non_time_dims(self):
+        def handler(request):
+            return httpx.Response(
+                200, json=[value_entity(), {"dim": "number", "value": {"value": 7}}]
+            )
+
+        async with mock_extractor(handler) as extractor:
+            result = await extractor.extract(
+                "x", ref_time=datetime(2024, 1, 1, tzinfo=UTC)
+            )
+            assert len(result) == 1  # the non-time entity is ignored
+
+    async def test_non_200_returns_empty(self):
+        def handler(request):
+            return httpx.Response(500)
+
+        async with mock_extractor(handler) as extractor:
+            assert (
+                await extractor.extract("x", ref_time=datetime(2024, 1, 1, tzinfo=UTC))
+                == []
+            )
+
+    async def test_invalid_json_returns_empty(self):
+        def handler(request):
+            return httpx.Response(200, text="not json")
+
+        async with mock_extractor(handler) as extractor:
+            assert (
+                await extractor.extract("x", ref_time=datetime(2024, 1, 1, tzinfo=UTC))
+                == []
+            )
+
+    async def test_transport_error_returns_empty(self):
+        def handler(request):
+            raise httpx.ConnectError("boom")
+
+        async with mock_extractor(handler) as extractor:
+            assert (
+                await extractor.extract("x", ref_time=datetime(2024, 1, 1, tzinfo=UTC))
+                == []
+            )

--- a/packages/server/server_tests/memmachine_server/temporal/test_duckling.py
+++ b/packages/server/server_tests/memmachine_server/temporal/test_duckling.py
@@ -18,7 +18,12 @@ import pytest
 pytest.importorskip("httpx")
 
 import httpx
+from babel import Locale
 
+from memmachine_server.common.request_context import (
+    reset_request_locale,
+    set_request_locale,
+)
 from memmachine_server.temporal.extractor.duckling_temporal_extractor import (
     DucklingTemporalExtractor,
     DucklingTemporalExtractorParams,
@@ -205,18 +210,36 @@ class TestDucklingExtractor:
             return httpx.Response(200, json=[])
 
         ref = datetime(2024, 6, 15, 12, tzinfo=UTC)
-        async with mock_extractor(handler, locale="en_GB") as extractor:
+        async with mock_extractor(handler) as extractor:
             await extractor.extract("when did x happen", ref_time=ref)
 
         assert captured["method"] == "POST"
         assert captured["url"] == URL
         form = captured["form"]
         assert form["text"] == ["when did x happen"]
-        assert form["locale"] == ["en_GB"]
+        # Default request locale (en-US) maps to Duckling's lang_REGION form.
+        assert form["locale"] == ["en_US"]
         assert form["tz"] == ["UTC"]
         assert json.loads(form["dims"][0]) == ["time"]
         # reftime is epoch-milliseconds of ref_time (our deterministic contract).
         assert form["reftime"] == [str(int(ref.timestamp() * 1000))]
+
+    async def test_locale_comes_from_request_context(self):
+        captured = {}
+
+        def handler(request):
+            captured["form"] = urllib.parse.parse_qs(request.content.decode())
+            return httpx.Response(200, json=[])
+
+        token = set_request_locale(Locale("en", "GB"))
+        try:
+            async with mock_extractor(handler) as extractor:
+                await extractor.extract("x", ref_time=datetime(2024, 1, 1, tzinfo=UTC))
+        finally:
+            reset_request_locale(token)
+
+        # The request locale (en-GB) maps to Duckling's lang_REGION form.
+        assert captured["form"]["locale"] == ["en_GB"]
 
     async def test_tz_is_derived_from_ref_time(self):
         captured = {}

--- a/packages/server/server_tests/memmachine_server/temporal/test_end_to_end.py
+++ b/packages/server/server_tests/memmachine_server/temporal/test_end_to_end.py
@@ -1,0 +1,177 @@
+"""End-to-end: temporal pieces plugged into a real EventMemory.
+
+Wires ``TemporalSegmenter`` (plus a stock ``WholeTextDeriver``) into
+``EventMemory`` (with the in-memory test embedder / vector store / segment
+store), encodes events, queries, and ranks the result caller-side with
+``TemporalScorer``. Proves the whole loop: EventMemory stores
+``TimeRangesContext`` through its real encode path and returns it on query,
+while staying unaware of the temporal scoring ``TemporalScorer`` then applies.
+The deriver is deliberately a stock one -- only the segmenter is
+temporal-specific.
+"""
+
+from datetime import UTC, datetime
+from typing import override
+from uuid import uuid4
+
+import pytest
+
+from memmachine_server.common.vector_store.data_types import (
+    VectorStoreCollectionConfig,
+)
+from memmachine_server.episodic_memory.event_memory.data_types import (
+    CompositeContext,
+    Context,
+    Event,
+    NullContext,
+    ProducerContext,
+    QueryResult,
+    TextBlock,
+    TimeRangesContext,
+    find_contexts,
+)
+from memmachine_server.episodic_memory.event_memory.deriver.text_deriver import (
+    WholeTextDeriver,
+)
+from memmachine_server.episodic_memory.event_memory.event_memory import (
+    EventMemory,
+    EventMemoryParams,
+)
+from memmachine_server.episodic_memory.event_memory.segmenter.temporal_segmenter import (
+    TemporalSegmenter,
+    TemporalSegmenterParams,
+)
+from memmachine_server.episodic_memory.event_memory.temporal_ranking import (
+    temporal_rerank_query_results,
+)
+from memmachine_server.temporal.extractor import TemporalExtractor
+from memmachine_server.temporal.query_planner import TemporalQueryPlan
+from memmachine_server.temporal.scoring import TemporalScorer, TemporalScorerParams
+from memmachine_server.temporal.time_range import TimeInterval, TimeRange
+from server_tests.memmachine_server.common.reranker.fake_embedder import FakeEmbedder
+from server_tests.memmachine_server.common.vector_store.in_memory_vector_store_collection import (
+    InMemoryVectorStoreCollection,
+)
+from server_tests.memmachine_server.episodic_memory.event_memory.conftest import (
+    InMemorySegmentStorePartition,
+)
+
+
+def dt(year: int, month: int = 1, day: int = 1) -> datetime:
+    return datetime(year, month, day, tzinfo=UTC)
+
+
+def time_range(start: datetime, end: datetime) -> TimeRange:
+    """A single-interval ``TimeRange``."""
+    return TimeRange(intervals=[TimeInterval(start=start, end=end)])
+
+
+class FakeExtractor(TemporalExtractor):
+    @override
+    async def extract(self, text, *, ref_time=None):
+        if "2024" in text:
+            return [time_range(dt(2024, 1), dt(2025, 1))]
+        if "2020" in text:
+            return [time_range(dt(2020, 1), dt(2021, 1))]
+        return []
+
+
+def make_event(text: str, context: Context | None = None) -> Event:
+    return Event(
+        uuid=uuid4(),
+        timestamp=datetime(2025, 1, 1, tzinfo=UTC),
+        context=context or NullContext(),
+        blocks=[TextBlock(text=text)],
+    )
+
+
+def make_memory() -> EventMemory:
+    embedder = FakeEmbedder()
+    config = VectorStoreCollectionConfig(
+        vector_dimensions=embedder.dimensions,
+        similarity_metric=embedder.similarity_metric,
+        indexed_properties_schema=EventMemory.expected_vector_store_collection_schema(),
+    )
+    return EventMemory(
+        EventMemoryParams(
+            segment_store_partition=InMemorySegmentStorePartition(),
+            vector_store_collection=InMemoryVectorStoreCollection(config),
+            segmenter=TemporalSegmenter(
+                TemporalSegmenterParams(temporal_extractor=FakeExtractor())
+            ),
+            deriver=WholeTextDeriver(),
+            embedder=embedder,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_encode_query_and_caller_rank():
+    memory = make_memory()
+    # Equal-length texts (differ only in the year) so the length-based test
+    # embedder gives identical vectors; the temporal match is the sole
+    # discriminator at rank time.
+    await memory.encode_events(
+        [
+            make_event("The launch happened in the year 2024."),
+            make_event("The launch happened in the year 2020."),
+        ]
+    )
+
+    result = await memory.query("when did the launch happen", vector_search_limit=10)
+
+    assert len(result.scored_segment_contexts) == 2
+    for scored in result.scored_segment_contexts:
+        seed = next(s for s in scored.segments if s.uuid == scored.seed_segment_uuid)
+        assert find_contexts(seed.context, TimeRangesContext)
+
+    plan = TemporalQueryPlan(targets=[time_range(dt(2024, 1), dt(2025, 1))])
+    reranked = temporal_rerank_query_results(
+        TemporalScorer(TemporalScorerParams()), plan, result
+    )
+
+    # Transparent layer: QueryResult in, QueryResult out, same two contexts.
+    assert isinstance(reranked, QueryResult)
+    assert len(reranked.scored_segment_contexts) == 2
+    top, other = reranked.scored_segment_contexts
+    # The 2024 doc ranks first, carrying a higher (temporally-lifted) score.
+    assert "2024" in top.segments[0].block.text
+    assert top.score > other.score
+
+
+@pytest.mark.asyncio
+async def test_composed_producer_and_temporal_end_to_end():
+    memory = make_memory()
+    # WholeTextDeriver prefixes the producer into the embedded text, so the two
+    # producer names are kept equal length: with the length-based FakeEmbedder
+    # that keeps both docs' vectors identical (pool spread 0), leaving the
+    # temporal match as the sole rank discriminator.
+    await memory.encode_events(
+        [
+            make_event(
+                "The launch happened in the year 2024.",
+                context=ProducerContext(producer="Alice"),
+            ),
+            make_event(
+                "The launch happened in the year 2020.",
+                context=ProducerContext(producer="Carol"),
+            ),
+        ]
+    )
+
+    result = await memory.query("when did the launch happen", vector_search_limit=10)
+    assert len(result.scored_segment_contexts) == 2
+    for scored in result.scored_segment_contexts:
+        seed = next(s for s in scored.segments if s.uuid == scored.seed_segment_uuid)
+        # Both aspects survived storage, accessible uniformly.
+        assert isinstance(seed.context, CompositeContext)
+        assert find_contexts(seed.context, ProducerContext)
+        assert find_contexts(seed.context, TimeRangesContext)
+
+    plan = TemporalQueryPlan(targets=[time_range(dt(2024, 1), dt(2025, 1))])
+    reranked = temporal_rerank_query_results(
+        TemporalScorer(TemporalScorerParams()), plan, result
+    )
+    top, other = reranked.scored_segment_contexts
+    assert "2024" in top.segments[0].block.text
+    assert top.score > other.score

--- a/packages/server/server_tests/memmachine_server/temporal/test_extractor_temporal_query_planner.py
+++ b/packages/server/server_tests/memmachine_server/temporal/test_extractor_temporal_query_planner.py
@@ -38,7 +38,7 @@ class RecordingExtractor(TemporalExtractor):
         self.calls = []
 
     @override
-    async def extract(self, text, ref_time=None):
+    async def extract(self, text, *, ref_time=None):
         self.calls.append((text, ref_time))
         return list(self._ranges)
 

--- a/packages/server/server_tests/memmachine_server/temporal/test_extractor_temporal_query_planner.py
+++ b/packages/server/server_tests/memmachine_server/temporal/test_extractor_temporal_query_planner.py
@@ -1,0 +1,70 @@
+"""Interface / structure tests for the extractor-backed temporal query planner.
+
+Tests the unified planner (which wraps any ``TemporalExtractor``) with a
+recording stub extractor: plan shape and ref-time pass-through --
+independent of any specific extractor backend.
+"""
+
+from datetime import UTC, datetime
+from typing import override
+
+import pytest
+
+from memmachine_server.temporal.extractor import TemporalExtractor
+from memmachine_server.temporal.extractor.extractor_temporal_query_planner import (
+    ExtractorTemporalQueryPlanner,
+    ExtractorTemporalQueryPlannerParams,
+)
+from memmachine_server.temporal.query_planner import TemporalQueryPlan
+from memmachine_server.temporal.time_range import TimeInterval, TimeRange
+
+
+def year_range(year=2024):
+    return TimeRange(
+        intervals=[
+            TimeInterval(
+                start=datetime(year, 1, 1, tzinfo=UTC),
+                end=datetime(year + 1, 1, 1, tzinfo=UTC),
+            )
+        ]
+    )
+
+
+class RecordingExtractor(TemporalExtractor):
+    """A ``TemporalExtractor`` stub that records calls and returns fixed ranges."""
+
+    def __init__(self, ranges):
+        self._ranges = ranges
+        self.calls = []
+
+    @override
+    async def extract(self, text, ref_time=None):
+        self.calls.append((text, ref_time))
+        return list(self._ranges)
+
+
+def planner_with(extractor):
+    return ExtractorTemporalQueryPlanner(
+        ExtractorTemporalQueryPlannerParams(extractor=extractor)
+    )
+
+
+@pytest.mark.asyncio
+class TestExtractorTemporalQueryPlanner:
+    async def test_plan_passes_targets_through(self):
+        ranges = [year_range()]
+        planner = planner_with(RecordingExtractor(ranges))
+        plan = await planner.plan(
+            "when did x happen", ref_time=datetime(2024, 6, 15, tzinfo=UTC)
+        )
+        assert isinstance(plan, TemporalQueryPlan)
+        assert plan.targets == ranges  # extractor output passed through
+
+    async def test_passes_ref_time_through_to_extractor(self):
+        extractor = RecordingExtractor([])
+        planner = planner_with(extractor)
+        ref_time = datetime(2024, 6, 15, tzinfo=UTC)
+        await planner.plan("q", ref_time=ref_time)
+        assert len(extractor.calls) == 1
+        _text, passed = extractor.calls[0]
+        assert passed is ref_time  # datetime passed straight through, no parsing

--- a/packages/server/server_tests/memmachine_server/temporal/test_scoring.py
+++ b/packages/server/server_tests/memmachine_server/temporal/test_scoring.py
@@ -1,0 +1,171 @@
+"""Tests for temporal match scoring and the generic TemporalScorer."""
+
+from datetime import UTC, datetime
+
+from memmachine_server.temporal.query_planner import TemporalQueryPlan
+from memmachine_server.temporal.scoring import (
+    TemporalScorer,
+    TemporalScoringCandidate,
+    TemporalScoringResult,
+    document_temporal_match_score,
+    temporal_match_score,
+)
+from memmachine_server.temporal.time_range import TimeInterval, TimeRange
+
+
+def dt(year: int, month: int = 1, day: int = 1) -> datetime:
+    return datetime(year, month, day, tzinfo=UTC)
+
+
+def interval(start: datetime | None, end: datetime | None) -> TimeInterval:
+    return TimeInterval(start=start, end=end)
+
+
+def month(year: int, month_num: int) -> TimeRange:
+    """A single-month range (one interval)."""
+    end = dt(year + 1, 1, 1) if month_num == 12 else dt(year, month_num + 1, 1)
+    return TimeRange(intervals=[interval(dt(year, month_num, 1), end)])
+
+
+def year(y: int) -> TimeRange:
+    """A whole-year range (one interval)."""
+    return TimeRange(intervals=[interval(dt(y, 1, 1), dt(y + 1, 1, 1))])
+
+
+def anchor(start: datetime, end: datetime) -> TimeRange:
+    """A single-interval ``TimeRange`` anchor."""
+    return TimeRange(intervals=[interval(start, end)])
+
+
+def candidate(base: float, anchors: list[TimeRange]) -> TemporalScoringCandidate:
+    return TemporalScoringCandidate(base_score=base, anchors=anchors)
+
+
+def ranked_indices(scores: list[TemporalScoringResult]) -> list[int]:
+    """Candidate indices ordered by ``final_score`` descending -- the ranking."""
+    return sorted(range(len(scores)), key=lambda i: scores[i].final_score, reverse=True)
+
+
+# --- temporal_match_score ----------------------------------------------------
+
+
+def test_temporal_match_score_identical() -> None:
+    assert temporal_match_score(year(2024), year(2024)) == 1.0
+
+
+def test_temporal_match_score_anchor_narrower_than_target() -> None:
+    # Anchor (one month) fully inside the target year -> full overlap of min.
+    assert temporal_match_score(year(2024), month(2024, 6)) == 1.0
+
+
+def test_temporal_match_score_disjoint_is_zero() -> None:
+    assert temporal_match_score(year(2024), month(2020, 3)) == 0.0
+
+
+def test_temporal_match_score_partial_is_fraction_of_min() -> None:
+    target = TimeRange(intervals=[interval(dt(2024, 1, 1), dt(2024, 1, 3))])  # 2 days
+    anchor_ = TimeRange(intervals=[interval(dt(2024, 1, 2), dt(2024, 1, 4))])  # 2 days
+    # Intersection is one day; min measure is two days -> 0.5.
+    assert temporal_match_score(target, anchor_) == 0.5
+
+
+def test_temporal_match_score_both_unbounded_is_one() -> None:
+    target = TimeRange(intervals=[interval(dt(2020), None)])
+    anchor_ = TimeRange(intervals=[interval(dt(2021), None)])
+    assert temporal_match_score(target, anchor_) == 1.0
+
+
+def test_temporal_match_score_multi_interval_target_matches_any_piece() -> None:
+    target = TimeRange(
+        intervals=[
+            interval(dt(2020, 1), dt(2020, 2)),
+            interval(dt(2024, 11), dt(2024, 12)),
+        ]
+    )
+    assert temporal_match_score(target, month(2024, 11)) == 1.0
+
+
+def test_temporal_match_score_multi_interval_anchor_honors_gap() -> None:
+    # The doc-side fix: an anchor that is itself a period with a gap, e.g.
+    # "active in 2024 except over the summer" -> [Jan, Jun) and [Sep, Jan).
+    anchor_ = TimeRange(
+        intervals=[
+            interval(dt(2024, 1), dt(2024, 6)),
+            interval(dt(2024, 9), dt(2025, 1)),
+        ]
+    )
+    # A June query lands in the gap (misses); November lands in the 2nd piece.
+    assert temporal_match_score(month(2024, 6), anchor_) == 0.0
+    assert temporal_match_score(month(2024, 11), anchor_) == 1.0
+
+
+# --- document_temporal_match_score (graded coverage) -------------------------
+
+
+def test_document_temporal_match_score_no_targets_is_zero() -> None:
+    # No temporal constraint -> 0.0 for every doc (a constant), so ranking
+    # falls back to base.
+    assert document_temporal_match_score([], [month(2024, 3)]) == 0.0
+
+
+def test_document_temporal_match_score_no_anchors_is_zero() -> None:
+    # A timeless doc (no anchors) gets no temporal lift: 0.0, the same as a
+    # date mismatch. Additive fusion leaves it on its base score, not buried.
+    assert document_temporal_match_score([year(2024)], []) == 0.0
+
+
+def test_document_temporal_match_score_two_targets_one_match_is_half() -> None:
+    targets = [year(2020), year(2024)]
+    assert document_temporal_match_score(targets, [month(2020, 3)]) == 0.5
+
+
+def test_document_temporal_match_score_two_targets_both_match_is_one() -> None:
+    targets = [year(2020), year(2024)]
+    assert (
+        document_temporal_match_score(targets, [month(2020, 3), month(2024, 11)]) == 1.0
+    )
+
+
+# --- TemporalScorer ----------------------------------------------------------
+
+
+def test_temporal_match_lifts_lower_base_candidate():
+    a = candidate(0.50, [anchor(dt(2024, 3), dt(2024, 4))])  # matches 2024
+    b = candidate(0.60, [anchor(dt(2020, 1), dt(2020, 2))])
+    c = candidate(0.40, [anchor(dt(2019, 1), dt(2019, 2))])
+
+    plan = TemporalQueryPlan(targets=[year(2024)])
+    scores = TemporalScorer().score(plan, [a, b, c])
+
+    # The 2024 match takes the top final_score despite its lower base.
+    assert ranked_indices(scores)[0] == 0
+    assert scores[0].temporal_match_score == 1.0
+
+
+def test_scores_are_returned_in_candidate_order():
+    a = candidate(0.50, [anchor(dt(2024, 3), dt(2024, 4))])  # matches 2024
+    b = candidate(0.60, [anchor(dt(2020, 1), dt(2020, 2))])  # does not
+
+    plan = TemporalQueryPlan(targets=[year(2024)])
+    scores = TemporalScorer().score(plan, [a, b])
+
+    assert scores[0].temporal_match_score == 1.0
+    assert scores[1].temporal_match_score == 0.0
+
+
+def test_empty_plan_ranks_by_base():
+    a = candidate(0.30, [anchor(dt(2024, 3), dt(2024, 4))])
+    b = candidate(0.90, [anchor(dt(2020, 1), dt(2020, 2))])
+    c = candidate(0.60, [])
+
+    plan = TemporalQueryPlan(targets=[])
+    scores = TemporalScorer().score(plan, [a, b, c])
+
+    # No targets -> no temporal lift -> ordered by base: b, c, a.
+    assert ranked_indices(scores) == [1, 2, 0]
+    assert all(s.temporal_match_score == 0.0 for s in scores)
+
+
+def test_empty_candidates():
+    plan = TemporalQueryPlan(targets=[year(2024)])
+    assert TemporalScorer().score(plan, []) == []

--- a/packages/server/server_tests/memmachine_server/temporal/test_scoring.py
+++ b/packages/server/server_tests/memmachine_server/temporal/test_scoring.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from memmachine_server.temporal.query_planner import TemporalQueryPlan
 from memmachine_server.temporal.scoring import (
     TemporalScorer,
+    TemporalScorerParams,
     TemporalScoringCandidate,
     TemporalScoringResult,
     document_temporal_match_score,
@@ -135,7 +136,7 @@ def test_temporal_match_lifts_lower_base_candidate():
     c = candidate(0.40, [anchor(dt(2019, 1), dt(2019, 2))])
 
     plan = TemporalQueryPlan(targets=[year(2024)])
-    scores = TemporalScorer().score(plan, [a, b, c])
+    scores = TemporalScorer(TemporalScorerParams()).score(plan, [a, b, c])
 
     # The 2024 match takes the top final_score despite its lower base.
     assert ranked_indices(scores)[0] == 0
@@ -147,7 +148,7 @@ def test_scores_are_returned_in_candidate_order():
     b = candidate(0.60, [anchor(dt(2020, 1), dt(2020, 2))])  # does not
 
     plan = TemporalQueryPlan(targets=[year(2024)])
-    scores = TemporalScorer().score(plan, [a, b])
+    scores = TemporalScorer(TemporalScorerParams()).score(plan, [a, b])
 
     assert scores[0].temporal_match_score == 1.0
     assert scores[1].temporal_match_score == 0.0
@@ -159,7 +160,7 @@ def test_empty_plan_ranks_by_base():
     c = candidate(0.60, [])
 
     plan = TemporalQueryPlan(targets=[])
-    scores = TemporalScorer().score(plan, [a, b, c])
+    scores = TemporalScorer(TemporalScorerParams()).score(plan, [a, b, c])
 
     # No targets -> no temporal lift -> ordered by base: b, c, a.
     assert ranked_indices(scores) == [1, 2, 0]
@@ -168,4 +169,4 @@ def test_empty_plan_ranks_by_base():
 
 def test_empty_candidates():
     plan = TemporalQueryPlan(targets=[year(2024)])
-    assert TemporalScorer().score(plan, []) == []
+    assert TemporalScorer(TemporalScorerParams()).score(plan, []) == []

--- a/packages/server/server_tests/memmachine_server/temporal/test_time_range.py
+++ b/packages/server/server_tests/memmachine_server/temporal/test_time_range.py
@@ -1,0 +1,248 @@
+"""Tests for TimeRange canonicalization, & (intersection), and .measure_seconds."""
+
+import math
+from datetime import UTC, datetime
+
+from memmachine_server.temporal.time_range import TimeInterval, TimeRange
+
+DAY = 86400.0  # seconds
+
+
+def dt(day: int) -> datetime:
+    return datetime(2024, 1, day, tzinfo=UTC)
+
+
+def bounds(time_range: TimeRange) -> list[tuple[datetime | None, datetime | None]]:
+    return [(iv.start, iv.end) for iv in time_range.intervals]
+
+
+def test_empty_stays_empty():
+    assert TimeRange().intervals == []
+    assert TimeRange(intervals=[]).intervals == []
+
+
+def test_single_interval_unchanged():
+    tr = TimeRange(intervals=[TimeInterval(start=dt(1), end=dt(2))])
+    assert bounds(tr) == [(dt(1), dt(2))]
+
+
+def test_orders_chronologically():
+    tr = TimeRange(
+        intervals=[
+            TimeInterval(start=dt(5), end=dt(6)),
+            TimeInterval(start=dt(1), end=dt(2)),
+            TimeInterval(start=dt(3), end=dt(4)),
+        ]
+    )
+    assert bounds(tr) == [(dt(1), dt(2)), (dt(3), dt(4)), (dt(5), dt(6))]
+
+
+def test_merges_overlapping():
+    tr = TimeRange(
+        intervals=[
+            TimeInterval(start=dt(1), end=dt(4)),
+            TimeInterval(start=dt(3), end=dt(6)),
+        ]
+    )
+    assert bounds(tr) == [(dt(1), dt(6))]
+
+
+def test_merges_adjacent_half_open():
+    # [1, 3) and [3, 5) touch only at the excluded boundary -> one [1, 5).
+    tr = TimeRange(
+        intervals=[
+            TimeInterval(start=dt(1), end=dt(3)),
+            TimeInterval(start=dt(3), end=dt(5)),
+        ]
+    )
+    assert bounds(tr) == [(dt(1), dt(5))]
+
+
+def test_keeps_disjoint_nonadjacent():
+    tr = TimeRange(
+        intervals=[
+            TimeInterval(start=dt(1), end=dt(2)),
+            TimeInterval(start=dt(4), end=dt(5)),
+        ]
+    )
+    assert bounds(tr) == [(dt(1), dt(2)), (dt(4), dt(5))]
+
+
+def test_absorbs_contained_interval():
+    tr = TimeRange(
+        intervals=[
+            TimeInterval(start=dt(1), end=dt(9)),
+            TimeInterval(start=dt(3), end=dt(4)),
+        ]
+    )
+    assert bounds(tr) == [(dt(1), dt(9))]
+
+
+def test_collapses_duplicates():
+    tr = TimeRange(
+        intervals=[
+            TimeInterval(start=dt(1), end=dt(2)),
+            TimeInterval(start=dt(1), end=dt(2)),
+        ]
+    )
+    assert bounds(tr) == [(dt(1), dt(2))]
+
+
+def test_drops_empty_and_inverted_intervals():
+    tr = TimeRange(
+        intervals=[
+            TimeInterval(start=dt(2), end=dt(2)),  # zero width
+            TimeInterval(start=dt(5), end=dt(3)),  # inverted
+            TimeInterval(start=dt(1), end=dt(2)),
+        ]
+    )
+    assert bounds(tr) == [(dt(1), dt(2))]
+
+
+def test_unbounded_endpoints_merge_to_universal():
+    # (-inf, 3) and [2, +inf) overlap -> the whole line.
+    tr = TimeRange(
+        intervals=[
+            TimeInterval(start=None, end=dt(3)),
+            TimeInterval(start=dt(2), end=None),
+        ]
+    )
+    assert bounds(tr) == [(None, None)]
+
+
+def test_unbounded_left_sorts_first():
+    tr = TimeRange(
+        intervals=[
+            TimeInterval(start=dt(5), end=dt(6)),
+            TimeInterval(start=None, end=dt(2)),
+        ]
+    )
+    assert bounds(tr) == [(None, dt(2)), (dt(5), dt(6))]
+
+
+def test_canonicalization_is_idempotent_across_round_trip():
+    tr = TimeRange(
+        intervals=[
+            TimeInterval(start=dt(1), end=dt(4)),
+            TimeInterval(start=dt(3), end=dt(6)),
+        ]
+    )
+    again = TimeRange.model_validate(tr.model_dump())
+    assert again == tr
+    assert bounds(again) == [(dt(1), dt(6))]
+
+
+# --- measure_seconds ------------------------------------------------------
+
+
+def test_interval_measure_is_length_in_seconds():
+    assert TimeInterval(start=dt(1), end=dt(3)).measure_seconds == 2 * DAY
+
+
+def test_interval_measure_unbounded_is_inf():
+    assert TimeInterval(start=dt(1), end=None).measure_seconds == math.inf
+    assert TimeInterval(start=None, end=dt(1)).measure_seconds == math.inf
+
+
+def test_range_measure_sums_intervals():
+    tr = TimeRange(
+        intervals=[
+            TimeInterval(start=dt(1), end=dt(2)),
+            TimeInterval(start=dt(4), end=dt(6)),
+        ]
+    )
+    assert tr.measure_seconds == 3 * DAY
+
+
+def test_empty_range_measure_is_zero():
+    assert TimeRange().measure_seconds == 0
+
+
+# --- & (intersection) -----------------------------------------------------
+
+
+def test_interval_intersection_overlapping():
+    a = TimeInterval(start=dt(1), end=dt(4))
+    b = TimeInterval(start=dt(3), end=dt(6))
+    assert bounds(a & b) == [(dt(3), dt(4))]
+
+
+def test_interval_intersection_disjoint_is_empty():
+    a = TimeInterval(start=dt(1), end=dt(2))
+    b = TimeInterval(start=dt(4), end=dt(5))
+    assert (a & b).intervals == []
+
+
+def test_range_intersection_keeps_overlap_per_piece():
+    a = TimeRange(
+        intervals=[
+            TimeInterval(start=dt(1), end=dt(4)),
+            TimeInterval(start=dt(6), end=dt(9)),
+        ]
+    )
+    b = TimeRange(intervals=[TimeInterval(start=dt(3), end=dt(7))])
+    # a & b keeps each piece's overlap: [3, 4) and [6, 7)
+    assert bounds(a & b) == [(dt(3), dt(4)), (dt(6), dt(7))]
+
+
+def test_range_intersection_disjoint_is_empty():
+    a = TimeRange(intervals=[TimeInterval(start=dt(1), end=dt(2))])
+    b = TimeRange(intervals=[TimeInterval(start=dt(5), end=dt(6))])
+    assert (a & b).intervals == []
+
+
+def test_range_intersection_unbounded():
+    a = TimeRange(intervals=[TimeInterval(start=None, end=dt(5))])
+    b = TimeRange(intervals=[TimeInterval(start=dt(3), end=None)])
+    assert bounds(a & b) == [(dt(3), dt(5))]
+
+
+def test_intersection_then_measure_is_overlap_length():
+    a = TimeRange(intervals=[TimeInterval(start=dt(1), end=dt(4))])
+    b = TimeRange(intervals=[TimeInterval(start=dt(3), end=dt(6))])
+    assert (a & b).measure_seconds == DAY  # overlap [3, 4) is one day
+
+
+# --- | (union) ------------------------------------------------------------
+
+
+def test_interval_union_overlapping_merges():
+    a = TimeInterval(start=dt(1), end=dt(4))
+    b = TimeInterval(start=dt(3), end=dt(6))
+    assert bounds(a | b) == [(dt(1), dt(6))]
+
+
+def test_interval_union_adjacent_merges():
+    a = TimeInterval(start=dt(1), end=dt(3))
+    b = TimeInterval(start=dt(3), end=dt(5))
+    assert bounds(a | b) == [(dt(1), dt(5))]
+
+
+def test_interval_union_disjoint_keeps_both():
+    a = TimeInterval(start=dt(1), end=dt(2))
+    b = TimeInterval(start=dt(4), end=dt(5))
+    assert bounds(a | b) == [(dt(1), dt(2)), (dt(4), dt(5))]
+
+
+def test_range_union_merges_across_ranges():
+    a = TimeRange(
+        intervals=[
+            TimeInterval(start=dt(1), end=dt(3)),
+            TimeInterval(start=dt(7), end=dt(9)),
+        ]
+    )
+    b = TimeRange(intervals=[TimeInterval(start=dt(2), end=dt(5))])
+    # [1, 3) and [2, 5) merge to [1, 5); [7, 9) stays separate.
+    assert bounds(a | b) == [(dt(1), dt(5)), (dt(7), dt(9))]
+
+
+def test_range_union_disjoint_keeps_separate():
+    a = TimeRange(intervals=[TimeInterval(start=dt(1), end=dt(2))])
+    b = TimeRange(intervals=[TimeInterval(start=dt(5), end=dt(6))])
+    assert bounds(a | b) == [(dt(1), dt(2)), (dt(5), dt(6))]
+
+
+def test_union_then_measure_is_covered_length():
+    a = TimeRange(intervals=[TimeInterval(start=dt(1), end=dt(4))])
+    b = TimeRange(intervals=[TimeInterval(start=dt(3), end=dt(6))])
+    assert (a | b).measure_seconds == 5 * DAY  # union [1, 6) covers five days

--- a/packages/server/src/memmachine_server/common/configuration/episodic_config.py
+++ b/packages/server/src/memmachine_server/common/configuration/episodic_config.py
@@ -227,6 +227,77 @@ DeriverConf = Annotated[
 ]
 
 
+# Query-side temporal retrieval: planner backends + overfetch selection.
+
+
+class LanguageModelTemporalQueryPlannerConf(BaseModel):
+    """LLM-backed temporal query planner."""
+
+    type: Literal["language_model"] = "language_model"
+    language_model: str = Field(
+        ...,
+        description="ID of the LanguageModel instance for temporal query planning",
+    )
+
+
+class ExtractorTemporalQueryPlannerConf(BaseModel):
+    """Temporal query planner backed by a temporal extractor."""
+
+    type: Literal["extractor"] = "extractor"
+    extractor: TemporalExtractorConf = Field(
+        ...,
+        description="Temporal extractor backend used to resolve the query's dates",
+    )
+
+
+TemporalQueryPlannerConf = Annotated[
+    LanguageModelTemporalQueryPlannerConf | ExtractorTemporalQueryPlannerConf,
+    Field(discriminator="type"),
+]
+
+
+class TemporalRetrievalConf(BaseModel):
+    """Query-side temporal-aware overfetch selection.
+
+    Over-fetches the vector pool, plans the query's target time ranges, then
+    fills the final top-k from k1 cosine-only results plus k2 results that ALSO
+    have a temporal match (k1 + k2 = k), backfilling with cosine when fewer than
+    k2 candidates clear the match threshold.
+    """
+
+    planner: TemporalQueryPlannerConf = Field(
+        ...,
+        description="Temporal query planner backend",
+    )
+    overfetch_multiplier: int = Field(
+        8,
+        ge=1,
+        description=(
+            "Vector-search pool size as a multiple of the requested result "
+            "count, so temporally-relevant candidates below the top cosine band "
+            "are available to promote into the result set."
+        ),
+    )
+    temporal_fraction: float = Field(
+        1.0 / 3.0,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Fraction of the final top-k reserved for temporally-matching "
+            "results (k2 = round(k * temporal_fraction)); the remainder (k1) is "
+            "filled by cosine alone."
+        ),
+    )
+    match_threshold: float = Field(
+        0.0,
+        ge=0.0,
+        description=(
+            "A candidate counts as temporally matching when its document "
+            "temporal match score is strictly greater than this threshold."
+        ),
+    )
+
+
 class DeclarativeLongTermMemoryConf(BaseModel):
     """Declarative-backend long-term memory (VectorGraphStore)."""
 
@@ -298,6 +369,13 @@ class EventLongTermMemoryConf(BaseModel):
         default_factory=WholeTextDeriverConf,
         description="Deriver sub-configuration (default: whole_text)",
     )
+    temporal_retrieval: TemporalRetrievalConf | None = Field(
+        default=None,
+        description=(
+            "Query-side temporal overfetch selection (event backend only). "
+            "None disables it (default)."
+        ),
+    )
 
 
 LongTermMemoryConf = Annotated[
@@ -359,6 +437,10 @@ class LongTermMemoryConfPartial(BaseModel):
     deriver: DeriverConf | None = Field(
         default=None,
         description="Deriver sub-configuration (event backend only)",
+    )
+    temporal_retrieval: TemporalRetrievalConf | None = Field(
+        default=None,
+        description="Query-side temporal overfetch selection (event backend only)",
     )
 
     # Shared fields.

--- a/packages/server/src/memmachine_server/common/configuration/episodic_config.py
+++ b/packages/server/src/memmachine_server/common/configuration/episodic_config.py
@@ -148,8 +148,63 @@ class TextSegmenterConf(BaseModel):
     )
 
 
-SegmenterConf = Annotated[
+# Non-temporal segmenters the temporal segmenter can wrap.
+BaseSegmenterConf = Annotated[
     PassthroughSegmenterConf | TextSegmenterConf,
+    Field(discriminator="type"),
+]
+
+
+class DateparserTemporalExtractorConf(BaseModel):
+    """Rule-based dateparser temporal extractor (no external dependencies)."""
+
+    type: Literal["dateparser"] = "dateparser"
+
+
+class LanguageModelTemporalExtractorConf(BaseModel):
+    """LLM-backed temporal extractor."""
+
+    type: Literal["language_model"] = "language_model"
+    language_model: str = Field(
+        ...,
+        description="ID of the LanguageModel instance for temporal extraction",
+    )
+
+
+class DucklingTemporalExtractorConf(BaseModel):
+    """HTTP-backed Duckling temporal extractor."""
+
+    type: Literal["duckling"] = "duckling"
+    url: str = Field(
+        "http://localhost:8000/parse",
+        description="Duckling parse endpoint URL",
+    )
+
+
+TemporalExtractorConf = Annotated[
+    DateparserTemporalExtractorConf
+    | LanguageModelTemporalExtractorConf
+    | DucklingTemporalExtractorConf,
+    Field(discriminator="type"),
+]
+
+
+class TemporalSegmenterConf(BaseModel):
+    """Augments a base segmenter with extracted ``TimeRange`` anchors."""
+
+    type: Literal["temporal"] = "temporal"
+    extractor: TemporalExtractorConf = Field(
+        ...,
+        description="Temporal extractor backend",
+    )
+    base_segmenter: BaseSegmenterConf = Field(
+        default_factory=TextSegmenterConf,
+        description="Base segmenter wrapped by the temporal segmenter (default: text)",
+    )
+
+
+SegmenterConf = Annotated[
+    PassthroughSegmenterConf | TextSegmenterConf | TemporalSegmenterConf,
     Field(discriminator="type"),
 ]
 

--- a/packages/server/src/memmachine_server/common/request_context.py
+++ b/packages/server/src/memmachine_server/common/request_context.py
@@ -1,0 +1,32 @@
+"""
+Ambient per-request context.
+
+Holds request-scoped values that deep, generic code needs
+without threading them through every call signature.
+"""
+
+from contextvars import ContextVar, Token
+
+from babel import Locale
+
+# Client locale assumed when a request carries none (or an unrecognized one).
+DEFAULT_LOCALE = Locale("en", "US")
+
+_request_locale: ContextVar[Locale] = ContextVar(
+    "request_locale", default=DEFAULT_LOCALE
+)
+
+
+def get_request_locale() -> Locale:
+    """Return the current request's locale."""
+    return _request_locale.get()
+
+
+def set_request_locale(locale: Locale) -> Token[Locale]:
+    """Set the current request's locale; returns a token for `reset_request_locale`."""
+    return _request_locale.set(locale)
+
+
+def reset_request_locale(token: Token[Locale]) -> None:
+    """Restore the locale to its value before the matching `set_request_locale`."""
+    _request_locale.reset(token)

--- a/packages/server/src/memmachine_server/common/resource_manager/__init__.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Protocol, runtime_checkable
 
+import httpx
 from neo4j import AsyncDriver
 from sqlalchemy.ext.asyncio import AsyncEngine
 
@@ -76,4 +77,8 @@ class CommonResourceManager(Protocol):
 
     async def get_episode_storage(self) -> EpisodeStorage:
         """Return the episode storage instance."""
+        raise NotImplementedError
+
+    async def get_http_client(self) -> httpx.AsyncClient:
+        """Return a shared HTTP client owned (and closed) by the manager."""
         raise NotImplementedError

--- a/packages/server/src/memmachine_server/common/resource_manager/__init__.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/__init__.py
@@ -1,10 +1,17 @@
 """Protocols for accessing shared MemMachine resources."""
 
-from typing import Protocol, runtime_checkable
+from __future__ import annotations
 
-import httpx
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
 from neo4j import AsyncDriver
 from sqlalchemy.ext.asyncio import AsyncEngine
+
+if TYPE_CHECKING:
+    # `httpx` is an optional dependency (the `duckling` extra); only the
+    # `get_http_client` return annotation references it, so it stays import-time
+    # optional for everyone who merely imports the resource-manager protocol.
+    import httpx
 
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.episode_store import EpisodeStorage

--- a/packages/server/src/memmachine_server/common/resource_manager/resource_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/resource_manager.py
@@ -1,12 +1,19 @@
 """Resource manager wiring together storage, embedders, and models."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 from asyncio import Lock
+from typing import TYPE_CHECKING
 
-import httpx
 from neo4j import AsyncDriver
 from sqlalchemy.ext.asyncio import AsyncEngine
+
+if TYPE_CHECKING:
+    # `httpx` is an optional dependency (the `duckling` extra); imported lazily
+    # inside `get_http_client` so the resource manager imports without it.
+    import httpx
 
 from memmachine_server.common.configuration import Configuration
 from memmachine_server.common.configuration.mixin_confs import MetricsFactoryIdMixin
@@ -164,7 +171,12 @@ class ResourceManagerImpl:
         Duckling temporal extractor), so the number of open clients is bounded
         to one regardless of how many sessions or extractors are constructed.
         It is closed in ``close()``.
+
+        `httpx` is imported lazily here (it is the optional `duckling` extra), so
+        callers that never use an HTTP-backed resource need not install it.
         """
+        import httpx
+
         if self._http_client is None:
             async with self._http_client_lock:
                 if self._http_client is None:

--- a/packages/server/src/memmachine_server/common/resource_manager/resource_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/resource_manager.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from asyncio import Lock
 
+import httpx
 from neo4j import AsyncDriver
 from sqlalchemy.ext.asyncio import AsyncEngine
 
@@ -83,12 +84,14 @@ class ResourceManagerImpl:
         self._episode_storage: EpisodeStorage | None = None
         self._semantic_manager: SemanticResourceManager | None = None
         self._segment_stores: dict[str, SegmentStore] = {}
+        self._http_client: httpx.AsyncClient | None = None
 
         self._session_data_manager_lock = Lock()
         self._episodic_memory_manager_lock = Lock()
         self._episode_storage_lock = Lock()
         self._semantic_manager_lock = Lock()
         self._segment_store_lock = Lock()
+        self._http_client_lock = Lock()
 
     async def build(self) -> None:
         """Build all configured resources in parallel."""
@@ -112,6 +115,9 @@ class ResourceManagerImpl:
         tasks.extend(
             segment_store.shutdown() for segment_store in self._segment_stores.values()
         )
+
+        if self._http_client is not None:
+            tasks.append(self._http_client.aclose())
 
         tasks.append(self._database_manager.close())
 
@@ -149,6 +155,21 @@ class ResourceManagerImpl:
                     await store.startup()
                     self._segment_stores[name] = store
         return self._segment_stores[name]
+
+    async def get_http_client(self) -> httpx.AsyncClient:
+        """
+        Return a process-lifetime shared HTTP client, built on first use.
+
+        A single client is reused across every HTTP-backed resource (e.g. the
+        Duckling temporal extractor), so the number of open clients is bounded
+        to one regardless of how many sessions or extractors are constructed.
+        It is closed in ``close()``.
+        """
+        if self._http_client is None:
+            async with self._http_client_lock:
+                if self._http_client is None:
+                    self._http_client = httpx.AsyncClient()
+        return self._http_client
 
     async def get_embedder(self, name: str, validate: bool = False) -> Embedder:
         """Return an embedder by name."""

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/data_types.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/data_types.py
@@ -23,6 +23,7 @@ from memmachine_server.common.properties_json import (
     decode_properties,
     encode_properties,
 )
+from memmachine_server.temporal.time_range import TimeRange
 
 # Block: leaf content type.
 #
@@ -46,6 +47,12 @@ Block = Annotated[
 ]
 
 
+class NullContext(BaseModel):
+    """No context is attached."""
+
+    context_type: Literal["null"] = "null"
+
+
 class ProducerContext(BaseModel):
     """The content is produced by a producer."""
 
@@ -53,21 +60,44 @@ class ProducerContext(BaseModel):
     producer: str
 
 
-class NullContext(BaseModel):
-    """No context is attached."""
+class TimeRangesContext(BaseModel):
+    """Time ranges associated with the content."""
 
-    context_type: Literal["null"] = "null"
+    context_type: Literal["time_ranges"] = "time_ranges"
+    time_ranges: list[TimeRange] = Field(default_factory=list)
 
 
-ContextUnion = ProducerContext | NullContext
+class CompositeContext(BaseModel):
+    """A sequence of contexts applied to the same content, in order."""
+
+    context_type: Literal["composite"] = "composite"
+    contexts: list["Context"] = Field(default_factory=list)
+
 
 Context = Annotated[
-    ContextUnion,
+    NullContext | ProducerContext | TimeRangesContext | CompositeContext,
     Field(discriminator="context_type"),
 ]
 
+# Resolve forward reference to Context.
+CompositeContext.model_rebuild()
+
 _CONTEXT_ADAPTER = TypeAdapter(Context | None)
 _BLOCK_ADAPTER = TypeAdapter(Block)
+
+
+def find_contexts[ContextT: Context](
+    context: Context | None,
+    context_type: type[ContextT],
+) -> list[ContextT]:
+    """Return every context of the given type, in depth-first order."""
+    if isinstance(context, CompositeContext):
+        return [
+            found
+            for member in context.contexts
+            for found in find_contexts(member, context_type)
+        ]
+    return [context] if isinstance(context, context_type) else []
 
 
 def encode_context(context: Context | None) -> dict[str, JsonValue] | None:

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/deriver/text_deriver.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/deriver/text_deriver.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from memmachine_server.common.utils import extract_sentences
 from memmachine_server.episodic_memory.event_memory.data_types import (
+    CompositeContext,
     Context,
     Derivative,
     FormatOptions,
@@ -14,6 +15,7 @@ from memmachine_server.episodic_memory.event_memory.data_types import (
     ProducerContext,
     Segment,
     TextBlock,
+    TimeRangesContext,
 )
 from memmachine_server.episodic_memory.event_memory.deriver.deriver import Deriver
 from memmachine_server.episodic_memory.event_memory.formatting import (
@@ -26,7 +28,11 @@ def _format_with_context(context: Context, text: str) -> str:
     match context:
         case ProducerContext(producer=producer):
             return f"{producer}: {text}"
-        case NullContext():
+        case NullContext() | TimeRangesContext():
+            return text
+        case CompositeContext(contexts=contexts):
+            for member in contexts:
+                text = _format_with_context(member, text)
             return text
         case _:
             raise NotImplementedError(

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
@@ -31,6 +31,9 @@ from memmachine_server.common.vector_store import (
 
 from .data_types import (
     Block,
+    CompositeContext,
+    Context,
+    DateTimeStyle,
     Derivative,
     Event,
     FormatOptions,
@@ -40,6 +43,7 @@ from .data_types import (
     ScoredSegmentContext,
     Segment,
     TextBlock,
+    TimeRangesContext,
 )
 from .deriver import Deriver
 from .formatting import format_timestamp
@@ -658,14 +662,24 @@ class EventMemory:
         formatted_timestamp = format_timestamp(segment.timestamp, format_options)
         timestamp_prefix = f"[{formatted_timestamp}] " if formatted_timestamp else ""
 
-        match segment.context:
+        return f"{timestamp_prefix}{EventMemory._context_prefix(segment.context)}"
+
+    @staticmethod
+    def _context_prefix(context: Context) -> str:
+        """Build the attribution prefix a context contributes to a header."""
+        match context:
             case ProducerContext(producer=producer):
-                return f"{timestamp_prefix}{producer}: "
-            case NullContext():
-                return timestamp_prefix
+                return f"{producer}: "
+            case NullContext() | TimeRangesContext():
+                return ""
+            case CompositeContext(contexts=contexts):
+                return "".join(
+                    EventMemory._context_prefix(member_context)
+                    for member_context in contexts
+                )
             case _:
                 raise NotImplementedError(
-                    f"Unsupported context type: {type(segment.context).__name__}"
+                    f"Unsupported context type: {type(context).__name__}"
                 )
 
     @staticmethod

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
@@ -33,7 +33,6 @@ from .data_types import (
     Block,
     CompositeContext,
     Context,
-    DateTimeStyle,
     Derivative,
     Event,
     FormatOptions,

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segmenter/temporal_segmenter.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segmenter/temporal_segmenter.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, InstanceOf
 from memmachine_server.episodic_memory.event_memory.data_types import (
     CompositeContext,
     Event,
+    FormatOptions,
     Segment,
     TextBlock,
     TimeRangesContext,
@@ -50,8 +51,15 @@ class TemporalSegmenter(Segmenter):
         self._base_segmenter = params.base_segmenter
 
     @override
-    async def segment(self, event: Event) -> list[Segment]:
-        base_segments = await self._base_segmenter.segment(event)
+    async def segment(
+        self,
+        event: Event,
+        *,
+        format_options: FormatOptions | None = None,
+    ) -> list[Segment]:
+        base_segments = await self._base_segmenter.segment(
+            event, format_options=format_options
+        )
         if not base_segments:
             return []
 

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segmenter/temporal_segmenter.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segmenter/temporal_segmenter.py
@@ -1,0 +1,90 @@
+"""Segmenter for temporal retrieval."""
+
+import asyncio
+from typing import override
+
+from pydantic import BaseModel, Field, InstanceOf
+
+from memmachine_server.episodic_memory.event_memory.data_types import (
+    CompositeContext,
+    Event,
+    Segment,
+    TextBlock,
+    TimeRangesContext,
+)
+from memmachine_server.episodic_memory.event_memory.segmenter.segmenter import (
+    Segmenter,
+)
+from memmachine_server.episodic_memory.event_memory.segmenter.text_segmenter import (
+    TextSegmenter,
+)
+from memmachine_server.temporal.extractor import TemporalExtractor
+
+
+class TemporalSegmenterParams(BaseModel):
+    """Parameters for TemporalSegmenter.
+
+    Attributes:
+        temporal_extractor (TemporalExtractor):
+            Temporal extractor resolving text and a reference time into time ranges.
+        base_segmenter (Segmenter):
+            Base segmenter for the initial segmentation.
+    """
+
+    temporal_extractor: InstanceOf[TemporalExtractor] = Field(
+        ...,
+        description="Temporal extractor resolving text and a reference time into time ranges",
+    )
+    base_segmenter: InstanceOf[Segmenter] = Field(
+        default_factory=TextSegmenter,
+        description="Base segmenter for the initial segmentation",
+    )
+
+
+class TemporalSegmenter(Segmenter):
+    """Wraps a base segmenter and augments each segment with extracted time ranges."""
+
+    def __init__(self, params: TemporalSegmenterParams) -> None:
+        """Initialize the segmenter."""
+        self._temporal_extractor = params.temporal_extractor
+        self._base_segmenter = params.base_segmenter
+
+    @override
+    async def segment(self, event: Event) -> list[Segment]:
+        base_segments = await self._base_segmenter.segment(event)
+        if not base_segments:
+            return []
+
+        ref_time = event.timestamp
+        texts: list[str] = []
+        for segment in base_segments:
+            match segment.block:
+                case TextBlock(text=text):
+                    texts.append(text)
+                case _:
+                    raise NotImplementedError(
+                        f"Unsupported block type: {type(segment.block).__name__}"
+                    )
+
+        time_ranges_per_segment = await asyncio.gather(
+            *(
+                self._temporal_extractor.extract(text, ref_time=ref_time)
+                for text in texts
+            )
+        )
+
+        return [
+            base_segment.model_copy(
+                update={
+                    "context": CompositeContext(
+                        contexts=[
+                            base_segment.context,
+                            TimeRangesContext(time_ranges=list(ranges)),
+                        ]
+                    )
+                }
+            )
+            for base_segment, ranges in zip(
+                base_segments, time_ranges_per_segment, strict=True
+            )
+        ]

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/temporal_ranking.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/temporal_ranking.py
@@ -28,7 +28,7 @@ def _temporal_anchors_from_context(context: Context | None) -> list[TimeRange]:
     ]
 
 
-def _temporal_anchors_from_segments(segments: Iterable[Segment]) -> list[TimeRange]:
+def temporal_anchors_from_segments(segments: Iterable[Segment]) -> list[TimeRange]:
     """Merge the time ranges of the segments."""
     return [
         anchor
@@ -60,7 +60,7 @@ def _temporal_scoring_candidates_from_query_result(
     return [
         TemporalScoringCandidate(
             base_score=scored.score,
-            anchors=_temporal_anchors_from_segments(scored.segments),
+            anchors=temporal_anchors_from_segments(scored.segments),
         )
         for scored in query_result.scored_segment_contexts
     ]

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/temporal_ranking.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/temporal_ranking.py
@@ -1,0 +1,82 @@
+"""Transparent temporal reranking layer over EventMemory query results."""
+
+from collections.abc import Iterable
+
+from memmachine_server.episodic_memory.event_memory.data_types import (
+    Context,
+    QueryResult,
+    ScoredSegmentContext,
+    Segment,
+    TimeRangesContext,
+    find_contexts,
+)
+from memmachine_server.temporal.query_planner import TemporalQueryPlan
+from memmachine_server.temporal.scoring import (
+    TemporalScorer,
+    TemporalScoringCandidate,
+    TemporalScoringResult,
+)
+from memmachine_server.temporal.time_range import TimeRange
+
+
+def _temporal_anchors_from_context(context: Context | None) -> list[TimeRange]:
+    """Return the time ranges of the context."""
+    return [
+        time_range
+        for time_range_context in find_contexts(context, TimeRangesContext)
+        for time_range in time_range_context.time_ranges
+    ]
+
+
+def _temporal_anchors_from_segments(segments: Iterable[Segment]) -> list[TimeRange]:
+    """Merge the time ranges of the segments."""
+    return [
+        anchor
+        for segment in segments
+        for anchor in _temporal_anchors_from_context(segment.context)
+    ]
+
+
+def temporal_rerank_query_results(
+    scorer: TemporalScorer,
+    plan: TemporalQueryPlan,
+    query_result: QueryResult,
+) -> QueryResult:
+    """Rerank query results."""
+    scores = scorer.score(
+        plan, _temporal_scoring_candidates_from_query_result(query_result)
+    )
+    return QueryResult(
+        scored_segment_contexts=_temporal_rerank_rescored_segment_contexts(
+            query_result.scored_segment_contexts, scores
+        )
+    )
+
+
+def _temporal_scoring_candidates_from_query_result(
+    query_result: QueryResult,
+) -> list[TemporalScoringCandidate]:
+    """Produce temporal scoring candidates from query results."""
+    return [
+        TemporalScoringCandidate(
+            base_score=scored.score,
+            anchors=_temporal_anchors_from_segments(scored.segments),
+        )
+        for scored in query_result.scored_segment_contexts
+    ]
+
+
+def _temporal_rerank_rescored_segment_contexts(
+    contexts: list[ScoredSegmentContext],
+    scores: list[TemporalScoringResult],
+) -> list[ScoredSegmentContext]:
+    """Order segment contexts by their new scores."""
+    ranked = sorted(
+        zip(contexts, scores, strict=True),
+        key=lambda pair: pair[1].final_score,
+        reverse=True,
+    )
+    return [
+        context.model_copy(update={"score": score.final_score})
+        for context, score in ranked
+    ]

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -2,7 +2,7 @@
 
 import datetime
 import logging
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import Annotated, Literal, cast
 from uuid import UUID, uuid4, uuid5
 
@@ -42,6 +42,7 @@ from memmachine_server.episodic_memory.event_memory.data_types import (
     Event,
     NullContext,
     ProducerContext,
+    ScoredSegmentContext,
     TextBlock,
 )
 from memmachine_server.episodic_memory.event_memory.deriver import Deriver
@@ -54,6 +55,11 @@ from memmachine_server.episodic_memory.event_memory.segment_store import (
     SegmentStorePartition,
 )
 from memmachine_server.episodic_memory.event_memory.segmenter import Segmenter
+from memmachine_server.episodic_memory.event_memory.temporal_ranking import (
+    temporal_anchors_from_segments,
+)
+from memmachine_server.temporal.query_planner import TemporalQueryPlanner
+from memmachine_server.temporal.scoring import document_temporal_match_score
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +163,28 @@ class EventBackendParams(BaseModel):
             "accepted)."
         ),
     )
+    # Query-side temporal overfetch selection. `temporal_query_planner=None`
+    # (default) disables it; the remaining knobs are unused while disabled.
+    temporal_query_planner: InstanceOf[TemporalQueryPlanner] | None = Field(
+        default=None,
+        description="Planner resolving the query's target time ranges (None=off)",
+    )
+    temporal_overfetch_multiplier: int = Field(
+        default=_EVENT_BACKEND_DEDUP_OVERFETCH,
+        ge=1,
+        description="Vector pool size as a multiple of the requested result count",
+    )
+    temporal_fraction: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Fraction of top-k reserved for temporally-matching results",
+    )
+    temporal_match_threshold: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="A candidate matches when its temporal score exceeds this",
+    )
 
 
 LongTermMemoryParams = Annotated[
@@ -196,6 +224,12 @@ class LongTermMemory:
         # ValueError at the LongTermMemory layer.
         self._user_property_keys: frozenset[str] = frozenset()
         self._session_id: str = params.session_id
+        # Event backend only: query-side temporal overfetch selection. None
+        # planner means the feature is off and the search path is unchanged.
+        self._temporal_query_planner: TemporalQueryPlanner | None = None
+        self._temporal_overfetch_multiplier: int = _EVENT_BACKEND_DEDUP_OVERFETCH
+        self._temporal_fraction: float = 0.0
+        self._temporal_match_threshold: float = 0.0
 
         match params:
             case DeclarativeBackendParams():
@@ -229,6 +263,12 @@ class LongTermMemory:
                     or params.vector_store_collection.config.similarity_metric.higher_is_better
                 )
                 self._user_property_keys = params.user_property_keys
+                self._temporal_query_planner = params.temporal_query_planner
+                self._temporal_overfetch_multiplier = (
+                    params.temporal_overfetch_multiplier
+                )
+                self._temporal_fraction = params.temporal_fraction
+                self._temporal_match_threshold = params.temporal_match_threshold
 
     async def add_episodes(self, episodes: Iterable[Episode]) -> None:
         episodes = list(episodes)
@@ -318,12 +358,14 @@ class LongTermMemory:
         self._validate_event_backend_filter(property_filter)
         # Over-fetch from EventMemory: the per-segment results can have many
         # segments per episode under non-passthrough segmenters, and we dedup
-        # them by `_episode_uid` below. Without headroom, the dedup loop can
-        # return fewer than `num_episodes_limit` distinct episodes.
-        vector_search_limit = max(
-            num_episodes_limit * _EVENT_BACKEND_DEDUP_OVERFETCH,
-            num_episodes_limit,
-        )
+        # them by `_episode_uid` below. Without headroom, dedup can return fewer
+        # than `num_episodes_limit` distinct episodes. When temporal retrieval is
+        # on, widen the pool further so temporally-relevant candidates below the
+        # top cosine band are available to promote.
+        overfetch = _EVENT_BACKEND_DEDUP_OVERFETCH
+        if self._temporal_query_planner is not None:
+            overfetch = max(overfetch, self._temporal_overfetch_multiplier)
+        vector_search_limit = max(num_episodes_limit * overfetch, num_episodes_limit)
         result = await event_memory.query(
             query,
             vector_search_limit=vector_search_limit,
@@ -332,24 +374,26 @@ class LongTermMemory:
         )
 
         # Map seed segment -> _episode_uid (system field already lives on
-        # event/segment.properties under the underscore-prefixed key). Keep
-        # first-seen score per episode_uid; preserve query result ordering.
+        # event/segment.properties under the underscore-prefixed key). Keep the
+        # first-seen context per episode_uid, in query-result (best-first) order.
         # The threshold comparison direction depends on the scoring metric:
         # higher-is-better (cosine + any reranker) → drop scores BELOW threshold;
         # lower-is-better (raw euclidean without a reranker) → drop scores
         # ABOVE threshold.
-        ordered_uids: list[str] = []
-        scores_by_uid: dict[str, float] = {}
+        deduped: list[tuple[str, ScoredSegmentContext]] = []
+        seen: set[str] = set()
         for scored_context in result.scored_segment_contexts:
             if not self._score_passes_threshold(scored_context.score, score_threshold):
                 continue
             episode_uid = LongTermMemory._scored_context_episode_uid(scored_context)
-            if episode_uid is None or episode_uid in scores_by_uid:
+            if episode_uid is None or episode_uid in seen:
                 continue
-            scores_by_uid[episode_uid] = scored_context.score
-            ordered_uids.append(episode_uid)
-            if len(ordered_uids) >= num_episodes_limit:
-                break
+            seen.add(episode_uid)
+            deduped.append((episode_uid, scored_context))
+
+        chosen = await self._select_event_episodes(query, deduped, num_episodes_limit)
+        ordered_uids = [uid for uid, _ in chosen]
+        scores_by_uid = {uid: context.score for uid, context in chosen}
 
         if not ordered_uids:
             return []
@@ -376,6 +420,94 @@ class LongTermMemory:
             for uid in ordered_uids
             if uid in episodes_by_uid
         ]
+
+    async def _select_event_episodes(
+        self,
+        query: str,
+        deduped: list[tuple[str, ScoredSegmentContext]],
+        num_episodes_limit: int,
+    ) -> list[tuple[str, ScoredSegmentContext]]:
+        """Pick the final episodes from the deduped, best-first candidate pool.
+
+        With no temporal planner this is just the top-`num_episodes_limit` by
+        cosine. With one, the query's target time ranges are planned and the
+        pool is filled by the temporal overfetch recipe (k1 cosine + k2 cosine
+        among temporally-matching, cosine backfill), keeping cosine ordering.
+        """
+        if self._temporal_query_planner is None or not deduped:
+            return deduped[:num_episodes_limit]
+
+        plan = await self._temporal_query_planner.plan(query)
+        match_scores = [
+            document_temporal_match_score(
+                plan.targets, temporal_anchors_from_segments(context.segments)
+            )
+            for _, context in deduped
+        ]
+        selected_indices = LongTermMemory._select_temporal_overfetch_indices(
+            match_scores,
+            limit=num_episodes_limit,
+            temporal_fraction=self._temporal_fraction,
+            match_threshold=self._temporal_match_threshold,
+        )
+        return [deduped[i] for i in selected_indices]
+
+    @staticmethod
+    def _select_temporal_overfetch_indices(
+        temporal_match_scores: Sequence[float],
+        *,
+        limit: int,
+        temporal_fraction: float,
+        match_threshold: float,
+    ) -> list[int]:
+        """Pick which candidates fill the final top-k under temporal overfetch.
+
+        Candidates must be supplied best-first by base (cosine) score, so a
+        candidate's index encodes its cosine rank. The final
+        ``k = min(limit, n)`` slots are filled with:
+
+        - ``k1 = k - k2`` candidates by base score alone (the strongest cosine
+          hits, taken unconditionally);
+        - ``k2 = round(k * temporal_fraction)`` further candidates that ALSO
+          clear the temporal match gate (match strictly greater than
+          ``match_threshold``), taken in base-score order;
+        - cosine backfill when fewer than ``k2`` candidates clear the gate.
+
+        Returns the selected indices in base-score order: overfetch changes only
+        WHICH candidates make the cut, not their relative ordering. A query with
+        no temporal targets yields all-zero match scores, so nothing clears the
+        gate and the result collapses to the top-k by cosine (a transparent
+        no-op).
+        """
+        n = len(temporal_match_scores)
+        k = min(limit, n)
+        if k <= 0:
+            return []
+        k2 = round(k * temporal_fraction)
+        k1 = k - k2
+
+        selected: set[int] = set()
+        # k1 strongest cosine hits, unconditionally.
+        for i in range(n):
+            if len(selected) >= k1:
+                break
+            selected.add(i)
+        # k2 further hits that also clear the temporal match gate.
+        gated = 0
+        for i in range(n):
+            if gated >= k2:
+                break
+            if i in selected:
+                continue
+            if temporal_match_scores[i] > match_threshold:
+                selected.add(i)
+                gated += 1
+        # Backfill by cosine to reach k when too few candidates cleared the gate.
+        for i in range(n):
+            if len(selected) >= k:
+                break
+            selected.add(i)
+        return sorted(selected)
 
     async def delete_episodes(self, uids: Iterable[str]) -> None:
         uids = list(uids)

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
@@ -12,12 +12,15 @@ from memmachine_server.common.configuration.episodic_config import (
     DeriverConf,
     DucklingTemporalExtractorConf,
     EventLongTermMemoryConf,
+    ExtractorTemporalQueryPlannerConf,
     LanguageModelTemporalExtractorConf,
+    LanguageModelTemporalQueryPlannerConf,
     LongTermMemoryConf,
     PassthroughSegmenterConf,
     SegmenterConf,
     SentenceTextDeriverConf,
     TemporalExtractorConf,
+    TemporalQueryPlannerConf,
     TemporalSegmenterConf,
     TextSegmenterConf,
     WholeTextDeriverConf,
@@ -56,9 +59,18 @@ from memmachine_server.temporal.extractor.duckling_temporal_extractor import (
     DucklingTemporalExtractor,
     DucklingTemporalExtractorParams,
 )
+from memmachine_server.temporal.extractor.extractor_temporal_query_planner import (
+    ExtractorTemporalQueryPlanner,
+    ExtractorTemporalQueryPlannerParams,
+)
 from memmachine_server.temporal.extractor.language_model_temporal_extractor import (
     LanguageModelTemporalExtractor,
     LanguageModelTemporalExtractorParams,
+)
+from memmachine_server.temporal.query_planner import TemporalQueryPlanner
+from memmachine_server.temporal.query_planner.language_model_temporal_query_planner import (
+    LanguageModelTemporalQueryPlanner,
+    LanguageModelTemporalQueryPlannerParams,
 )
 
 from .long_term_memory import (
@@ -166,7 +178,7 @@ async def _event_params(
     segmenter = await _build_segmenter(config.segmenter, resource_manager)
     deriver = _build_deriver(config.deriver)
 
-    return EventBackendParams(
+    event_params = EventBackendParams(
         session_id=config.session_id,
         vector_store=vector_store,
         vector_store_collection=collection,
@@ -181,6 +193,24 @@ async def _event_params(
         deriver=deriver,
         user_property_keys=frozenset(config.properties_schema),
     )
+
+    # Temporal retrieval is off unless configured; when configured, overlay the
+    # planner and its overfetch knobs (already validated by TemporalRetrievalConf).
+    temporal_retrieval = config.temporal_retrieval
+    if temporal_retrieval is not None:
+        event_params = event_params.model_copy(
+            update={
+                "temporal_query_planner": await _build_temporal_query_planner(
+                    temporal_retrieval.planner, resource_manager
+                ),
+                "temporal_overfetch_multiplier": (
+                    temporal_retrieval.overfetch_multiplier
+                ),
+                "temporal_fraction": temporal_retrieval.temporal_fraction,
+                "temporal_match_threshold": temporal_retrieval.match_threshold,
+            }
+        )
+    return event_params
 
 
 def partition_key_for_session(session_id: str) -> str:
@@ -282,6 +312,31 @@ async def _build_temporal_extractor(
         case _:
             raise NotImplementedError(
                 f"Unsupported temporal extractor config: {type(conf).__name__}"
+            )
+
+
+async def _build_temporal_query_planner(
+    conf: TemporalQueryPlannerConf,
+    resource_manager: InstanceOf[CommonResourceManager],
+) -> TemporalQueryPlanner:
+    match conf:
+        case LanguageModelTemporalQueryPlannerConf(language_model=language_model_id):
+            language_model = await resource_manager.get_language_model(
+                language_model_id, validate=True
+            )
+            return LanguageModelTemporalQueryPlanner(
+                LanguageModelTemporalQueryPlannerParams(language_model=language_model)
+            )
+        case ExtractorTemporalQueryPlannerConf(extractor=extractor_conf):
+            extractor = await _build_temporal_extractor(
+                extractor_conf, resource_manager
+            )
+            return ExtractorTemporalQueryPlanner(
+                ExtractorTemporalQueryPlannerParams(extractor=extractor)
+            )
+        case _:
+            raise NotImplementedError(
+                f"Unsupported temporal query planner config: {type(conf).__name__}"
             )
 
 

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
@@ -52,26 +52,7 @@ from memmachine_server.episodic_memory.event_memory.segmenter.text_segmenter imp
     TextSegmenter,
 )
 from memmachine_server.temporal.extractor import TemporalExtractor
-from memmachine_server.temporal.extractor.dateparser_temporal_extractor import (
-    DateparserTemporalExtractor,
-)
-from memmachine_server.temporal.extractor.duckling_temporal_extractor import (
-    DucklingTemporalExtractor,
-    DucklingTemporalExtractorParams,
-)
-from memmachine_server.temporal.extractor.extractor_temporal_query_planner import (
-    ExtractorTemporalQueryPlanner,
-    ExtractorTemporalQueryPlannerParams,
-)
-from memmachine_server.temporal.extractor.language_model_temporal_extractor import (
-    LanguageModelTemporalExtractor,
-    LanguageModelTemporalExtractorParams,
-)
 from memmachine_server.temporal.query_planner import TemporalQueryPlanner
-from memmachine_server.temporal.query_planner.language_model_temporal_query_planner import (
-    LanguageModelTemporalQueryPlanner,
-    LanguageModelTemporalQueryPlannerParams,
-)
 
 from .long_term_memory import (
     EVENT_BACKEND_SYSTEM_FIELDS,
@@ -293,8 +274,19 @@ async def _build_temporal_extractor(
 ) -> TemporalExtractor:
     match conf:
         case DateparserTemporalExtractorConf():
+            # Imported lazily: `dateparser` is an optional dependency, so the
+            # server must import without it unless this backend is configured.
+            from memmachine_server.temporal.extractor.dateparser_temporal_extractor import (
+                DateparserTemporalExtractor,
+            )
+
             return DateparserTemporalExtractor()
         case LanguageModelTemporalExtractorConf(language_model=language_model_id):
+            from memmachine_server.temporal.extractor.language_model_temporal_extractor import (
+                LanguageModelTemporalExtractor,
+                LanguageModelTemporalExtractorParams,
+            )
+
             language_model = await resource_manager.get_language_model(
                 language_model_id, validate=True
             )
@@ -302,6 +294,13 @@ async def _build_temporal_extractor(
                 LanguageModelTemporalExtractorParams(language_model=language_model)
             )
         case DucklingTemporalExtractorConf(url=url):
+            # Imported lazily: the Duckling backend's `httpx` is an optional
+            # dependency (the `duckling` extra).
+            from memmachine_server.temporal.extractor.duckling_temporal_extractor import (
+                DucklingTemporalExtractor,
+                DucklingTemporalExtractorParams,
+            )
+
             # Borrow the resource manager's shared HTTP client (bounded to one
             # per process and closed on shutdown) rather than opening a fresh
             # unowned client per extractor.
@@ -321,6 +320,11 @@ async def _build_temporal_query_planner(
 ) -> TemporalQueryPlanner:
     match conf:
         case LanguageModelTemporalQueryPlannerConf(language_model=language_model_id):
+            from memmachine_server.temporal.query_planner.language_model_temporal_query_planner import (
+                LanguageModelTemporalQueryPlanner,
+                LanguageModelTemporalQueryPlannerParams,
+            )
+
             language_model = await resource_manager.get_language_model(
                 language_model_id, validate=True
             )
@@ -328,6 +332,11 @@ async def _build_temporal_query_planner(
                 LanguageModelTemporalQueryPlannerParams(language_model=language_model)
             )
         case ExtractorTemporalQueryPlannerConf(extractor=extractor_conf):
+            from memmachine_server.temporal.extractor.extractor_temporal_query_planner import (
+                ExtractorTemporalQueryPlanner,
+                ExtractorTemporalQueryPlannerParams,
+            )
+
             extractor = await _build_temporal_extractor(
                 extractor_conf, resource_manager
             )

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
@@ -7,13 +7,18 @@ import re
 from pydantic import InstanceOf
 
 from memmachine_server.common.configuration.episodic_config import (
+    DateparserTemporalExtractorConf,
     DeclarativeLongTermMemoryConf,
     DeriverConf,
+    DucklingTemporalExtractorConf,
     EventLongTermMemoryConf,
+    LanguageModelTemporalExtractorConf,
     LongTermMemoryConf,
     PassthroughSegmenterConf,
     SegmenterConf,
     SentenceTextDeriverConf,
+    TemporalExtractorConf,
+    TemporalSegmenterConf,
     TextSegmenterConf,
     WholeTextDeriverConf,
 )
@@ -36,8 +41,24 @@ from memmachine_server.episodic_memory.event_memory.segmenter import Segmenter
 from memmachine_server.episodic_memory.event_memory.segmenter.passthrough_segmenter import (
     PassthroughSegmenter,
 )
+from memmachine_server.episodic_memory.event_memory.segmenter.temporal_segmenter import (
+    TemporalSegmenter,
+    TemporalSegmenterParams,
+)
 from memmachine_server.episodic_memory.event_memory.segmenter.text_segmenter import (
     TextSegmenter,
+)
+from memmachine_server.temporal.extractor import TemporalExtractor
+from memmachine_server.temporal.extractor.dateparser_temporal_extractor import (
+    DateparserTemporalExtractor,
+)
+from memmachine_server.temporal.extractor.duckling_temporal_extractor import (
+    DucklingTemporalExtractor,
+    DucklingTemporalExtractorParams,
+)
+from memmachine_server.temporal.extractor.language_model_temporal_extractor import (
+    LanguageModelTemporalExtractor,
+    LanguageModelTemporalExtractorParams,
 )
 
 from .long_term_memory import (
@@ -142,7 +163,7 @@ async def _event_params(
         SegmentStorePartitionConfig(),
     )
 
-    segmenter = _build_segmenter(config.segmenter)
+    segmenter = await _build_segmenter(config.segmenter, resource_manager)
     deriver = _build_deriver(config.deriver)
 
     return EventBackendParams(
@@ -210,15 +231,57 @@ def _resolve_user_properties_schema(
     return resolved
 
 
-def _build_segmenter(conf: SegmenterConf) -> Segmenter:
+async def _build_segmenter(
+    conf: SegmenterConf,
+    resource_manager: InstanceOf[CommonResourceManager],
+) -> Segmenter:
     match conf:
         case PassthroughSegmenterConf():
             return PassthroughSegmenter()
         case TextSegmenterConf(max_chunk_length=max_chunk_length):
             return TextSegmenter(max_chunk_length=max_chunk_length)
+        case TemporalSegmenterConf(extractor=extractor_conf, base_segmenter=base_conf):
+            extractor = await _build_temporal_extractor(
+                extractor_conf, resource_manager
+            )
+            base_segmenter = await _build_segmenter(base_conf, resource_manager)
+            return TemporalSegmenter(
+                TemporalSegmenterParams(
+                    temporal_extractor=extractor,
+                    base_segmenter=base_segmenter,
+                )
+            )
         case _:
             raise NotImplementedError(
                 f"Unsupported segmenter config: {type(conf).__name__}"
+            )
+
+
+async def _build_temporal_extractor(
+    conf: TemporalExtractorConf,
+    resource_manager: InstanceOf[CommonResourceManager],
+) -> TemporalExtractor:
+    match conf:
+        case DateparserTemporalExtractorConf():
+            return DateparserTemporalExtractor()
+        case LanguageModelTemporalExtractorConf(language_model=language_model_id):
+            language_model = await resource_manager.get_language_model(
+                language_model_id, validate=True
+            )
+            return LanguageModelTemporalExtractor(
+                LanguageModelTemporalExtractorParams(language_model=language_model)
+            )
+        case DucklingTemporalExtractorConf(url=url):
+            # Borrow the resource manager's shared HTTP client (bounded to one
+            # per process and closed on shutdown) rather than opening a fresh
+            # unowned client per extractor.
+            client = await resource_manager.get_http_client()
+            return DucklingTemporalExtractor(
+                DucklingTemporalExtractorParams(client=client, url=url)
+            )
+        case _:
+            raise NotImplementedError(
+                f"Unsupported temporal extractor config: {type(conf).__name__}"
             )
 
 

--- a/packages/server/src/memmachine_server/server/api_v2/router.py
+++ b/packages/server/src/memmachine_server/server/api_v2/router.py
@@ -88,6 +88,7 @@ from memmachine_server.server.api_v2.service import (
     _search_target_memories,
     _SessionData,
     get_memmachine,
+    provide_request_locale,
 )
 
 logger = logging.getLogger(__name__)
@@ -282,7 +283,12 @@ async def delete_project(
         raise RestError(code=500, message="Unable to delete project", ex=e) from e
 
 
-@router.post("/memories", description=RouterDoc.ADD_MEMORIES, tags=["Memories"])
+@router.post(
+    "/memories",
+    description=RouterDoc.ADD_MEMORIES,
+    tags=["Memories"],
+    dependencies=[Depends(provide_request_locale)],
+)
 async def add_memories(
     spec: AddMemoriesSpec,
     memmachine: Annotated[MemMachine, Depends(get_memmachine)],
@@ -301,6 +307,7 @@ async def add_memories(
     description=RouterDoc.SEARCH_MEMORIES,
     response_model_exclude_none=True,
     tags=["Memories"],
+    dependencies=[Depends(provide_request_locale)],
 )
 async def search_memories(
     spec: SearchMemoriesSpec,

--- a/packages/server/src/memmachine_server/server/api_v2/service.py
+++ b/packages/server/src/memmachine_server/server/api_v2/service.py
@@ -2,10 +2,12 @@
 
 import asyncio
 import logging
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from typing import cast
+from typing import Annotated, cast
 
-from fastapi import Request
+from babel import Locale, UnknownLocaleError
+from fastapi import Query, Request
 from memmachine_common.api import MemoryType as MemoryTypeE
 from memmachine_common.api.spec import (
     AddMemoriesSpec,
@@ -25,6 +27,11 @@ from pydantic import JsonValue
 
 from memmachine_server import MemMachine
 from memmachine_server.common.episode_store.episode_model import EpisodeEntry
+from memmachine_server.common.request_context import (
+    DEFAULT_LOCALE,
+    reset_request_locale,
+    set_request_locale,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +40,37 @@ logger = logging.getLogger(__name__)
 async def get_memmachine(request: Request) -> MemMachine:
     """Get session data manager instance."""
     return request.app.state.mem_machine
+
+
+def _parse_locale(value: str | None) -> Locale:
+    """Resolve a BCP-47 locale string to a ``Locale``.
+
+    An absent or unrecognized value falls back to ``DEFAULT_LOCALE`` so a bad
+    locale hint never fails the request it annotates.
+    """
+    if not value:
+        return DEFAULT_LOCALE
+    try:
+        return Locale.parse(value, sep="-")
+    except (UnknownLocaleError, ValueError):
+        return DEFAULT_LOCALE
+
+
+async def provide_request_locale(
+    locale: Annotated[
+        str | None,
+        Query(
+            description="Client locale as a BCP-47 tag (e.g. en-US) for "
+            "locale-sensitive date parsing; defaults to en-US.",
+        ),
+    ] = None,
+) -> AsyncIterator[None]:
+    """Bind the request's locale (from the ``locale`` query param) for its lifetime."""
+    token = set_request_locale(_parse_locale(locale))
+    try:
+        yield
+    finally:
+        reset_request_locale(token)
 
 
 @dataclass(frozen=True)

--- a/packages/server/src/memmachine_server/temporal/__init__.py
+++ b/packages/server/src/memmachine_server/temporal/__init__.py
@@ -1,0 +1,1 @@
+"""Temporal retrieval exports."""

--- a/packages/server/src/memmachine_server/temporal/extractor/__init__.py
+++ b/packages/server/src/memmachine_server/temporal/extractor/__init__.py
@@ -1,0 +1,7 @@
+"""Ingestion-side temporal extractors."""
+
+from .temporal_extractor import TemporalExtractor
+
+__all__ = [
+    "TemporalExtractor",
+]

--- a/packages/server/src/memmachine_server/temporal/extractor/dateparser_temporal_extractor.py
+++ b/packages/server/src/memmachine_server/temporal/extractor/dateparser_temporal_extractor.py
@@ -7,6 +7,7 @@ from typing import override
 from dateparser.date import DateDataParser
 from dateparser.search import search_dates
 
+from memmachine_server.common.request_context import get_request_locale
 from memmachine_server.common.utils import ensure_tz_aware
 from memmachine_server.temporal.time_range import TimeInterval, TimeRange
 
@@ -60,13 +61,15 @@ class DateparserTemporalExtractor(TemporalExtractor):
             "PREFER_DATES_FROM": "past",
         }
 
-    def _extract_time_ranges(self, text: str, ref_time: datetime) -> list[TimeRange]:
+    def _extract_time_ranges(
+        self, text: str, ref_time: datetime, languages: list[str]
+    ) -> list[TimeRange]:
         settings = self._settings(ref_time)
         # DateDataParser takes settings only at construction time, so we
         # build a fresh parser per call (its construction cost is small;
         # ``RELATIVE_BASE`` is the per-call signal).
-        parser = DateDataParser(languages=["en"], settings=settings)
-        candidates = search_dates(text, languages=["en"], settings=settings)
+        parser = DateDataParser(languages=languages, settings=settings)
+        candidates = search_dates(text, languages=languages, settings=settings)
         if not candidates:
             return []
         intervals: list[TimeInterval] = []
@@ -103,4 +106,6 @@ class DateparserTemporalExtractor(TemporalExtractor):
         if ref_time is None:
             ref_time = datetime.now(UTC)
 
-        return self._extract_time_ranges(text, ref_time)
+        # dateparser takes a language code (e.g. `en`); take it from the request locale.
+        language = get_request_locale().language
+        return self._extract_time_ranges(text, ref_time, [language])

--- a/packages/server/src/memmachine_server/temporal/extractor/dateparser_temporal_extractor.py
+++ b/packages/server/src/memmachine_server/temporal/extractor/dateparser_temporal_extractor.py
@@ -1,0 +1,106 @@
+"""Rule-based temporal extractor using dateparser."""
+
+import calendar
+from datetime import UTC, datetime, timedelta
+from typing import override
+
+from dateparser.date import DateDataParser
+from dateparser.search import search_dates
+
+from memmachine_server.common.utils import ensure_tz_aware
+from memmachine_server.temporal.time_range import TimeInterval, TimeRange
+
+from .temporal_extractor import TemporalExtractor
+
+_VALID_PERIODS = ("day", "week", "month", "year")
+
+
+def _interval_for(instant: datetime, period: str) -> TimeInterval | None:
+    """Expand a parsed ``instant`` into the interval containing it.
+
+    The returned ``[start, end)`` interval spans the ``period`` grain
+    (day / week / month / year) around ``instant``. Returns ``None`` for
+    unknown periods.
+    """
+    instant = ensure_tz_aware(instant).astimezone(UTC)
+    if period == "day":
+        start = instant.replace(hour=0, minute=0, second=0, microsecond=0)
+        end = start + timedelta(days=1)
+    elif period == "week":
+        # Expand to the ISO week containing ``instant`` (Monday-Sunday).
+        midnight = instant.replace(hour=0, minute=0, second=0, microsecond=0)
+        monday = midnight - timedelta(days=instant.weekday())
+        start = monday
+        end = monday + timedelta(days=7)
+    elif period == "month":
+        start = datetime(instant.year, instant.month, 1, tzinfo=UTC)
+        last_day = calendar.monthrange(instant.year, instant.month)[1]
+        end = datetime(instant.year, instant.month, last_day, tzinfo=UTC) + timedelta(
+            days=1
+        )
+    elif period == "year":
+        start = datetime(instant.year, 1, 1, tzinfo=UTC)
+        end = datetime(instant.year + 1, 1, 1, tzinfo=UTC)
+    else:
+        return None
+    return TimeInterval(start=start, end=end)
+
+
+class DateparserTemporalExtractor(TemporalExtractor):
+    """Rule-based ``TimeRange`` extractor (no LLM).
+
+    Configured with English language restriction and past-leaning
+    disambiguation, matching the LoCoMo-style "describe a past event"
+    profile.
+    """
+
+    def _settings(self, ref_time: datetime) -> dict:
+        return {
+            "RELATIVE_BASE": ensure_tz_aware(ref_time).astimezone(UTC),
+            "PREFER_DATES_FROM": "past",
+        }
+
+    def _extract_time_ranges(self, text: str, ref_time: datetime) -> list[TimeRange]:
+        settings = self._settings(ref_time)
+        # DateDataParser takes settings only at construction time, so we
+        # build a fresh parser per call (its construction cost is small;
+        # ``RELATIVE_BASE`` is the per-call signal).
+        parser = DateDataParser(languages=["en"], settings=settings)
+        candidates = search_dates(text, languages=["en"], settings=settings)
+        if not candidates:
+            return []
+        intervals: list[TimeInterval] = []
+        for matched, _instant in candidates:
+            data = parser.get_date_data(matched)
+            if data.date_obj is None:
+                continue
+            if data.period not in _VALID_PERIODS:
+                continue
+            interval = _interval_for(data.date_obj, data.period)
+            if interval is not None:
+                intervals.append(interval)
+        if not intervals:
+            return []
+        # Deduplicate exact-match intervals (the same date phrase can
+        # match multiple substrings) and emit each as its own reference.
+        seen: set[tuple] = set()
+        ranges: list[TimeRange] = []
+        for interval in intervals:
+            key = (
+                interval.start.isoformat() if interval.start else None,
+                interval.end.isoformat() if interval.end else None,
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            ranges.append(TimeRange(intervals=[interval]))
+        return ranges
+
+    @override
+    async def extract(
+        self, text: str, *, ref_time: datetime | None = None
+    ) -> list[TimeRange]:
+        if ref_time is None:
+            ref_time = datetime.now(UTC)
+
+        return self._extract_time_ranges(text, ref_time)

--- a/packages/server/src/memmachine_server/temporal/extractor/duckling_temporal_extractor.py
+++ b/packages/server/src/memmachine_server/temporal/extractor/duckling_temporal_extractor.py
@@ -1,0 +1,197 @@
+"""Duckling-based temporal extractor."""
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import override
+
+import httpx
+from pydantic import BaseModel, Field, InstanceOf
+
+from memmachine_server.common.utils import ensure_tz_aware
+from memmachine_server.temporal.time_range import TimeInterval, TimeRange
+
+from .temporal_extractor import TemporalExtractor
+
+
+def _parse_iso(value: str) -> datetime:
+    """Parse a Duckling ISO-8601 timestamp into a UTC-aware datetime."""
+    return ensure_tz_aware(datetime.fromisoformat(value)).astimezone(UTC)
+
+
+def _end_of(start: datetime, grain: str) -> datetime | None:
+    """End of the period containing ``start`` at the given ``grain``.
+
+    Returns ``None`` if the grain is unknown.
+    """
+    if grain == "second":
+        return start + timedelta(seconds=1)
+    if grain == "minute":
+        return start + timedelta(minutes=1)
+    if grain == "hour":
+        return start + timedelta(hours=1)
+    if grain == "day":
+        return start + timedelta(days=1)
+    if grain == "week":
+        # Duckling returns the week's start instant (Sunday for en_US,
+        # Monday for en_GB, etc.) -- add 7 days regardless of locale.
+        return start + timedelta(days=7)
+    if grain == "month":
+        first_next_month = (
+            datetime(start.year + 1, 1, 1, tzinfo=start.tzinfo)
+            if start.month == 12
+            else datetime(start.year, start.month + 1, 1, tzinfo=start.tzinfo)
+        )
+        # The boundary day at this grain is the first of the next month.
+        return first_next_month
+    if grain == "quarter":
+        # Quarter starts: 1, 4, 7, 10.
+        q_start_month = ((start.month - 1) // 3) * 3 + 1
+        end_month = q_start_month + 3
+        if end_month > 12:
+            return datetime(start.year + 1, end_month - 12, 1, tzinfo=start.tzinfo)
+        return datetime(start.year, end_month, 1, tzinfo=start.tzinfo)
+    if grain == "year":
+        return datetime(start.year + 1, 1, 1, tzinfo=start.tzinfo)
+    return None
+
+
+def _value_to_time_range(value: dict) -> TimeRange | None:
+    """Convert a Duckling ``type="value"`` (instant + grain) to a range."""
+    raw = value.get("value")
+    grain = value.get("grain", "day")
+    if raw is None:
+        return None
+    try:
+        start = _parse_iso(raw)
+    except ValueError:
+        return None
+    end = _end_of(start, grain)
+    if end is None or end <= start:
+        return None
+    return TimeRange(intervals=[TimeInterval(start=start, end=end)])
+
+
+def _interval_bound(part: dict | None) -> datetime | None:
+    """Parse one interval bound to UTC; ``None`` if the bound is absent.
+
+    Raises ``KeyError`` / ``ValueError`` if the bound is present but
+    malformed, so the caller can reject the whole interval.
+    """
+    if part is None:
+        return None
+    return _parse_iso(part["value"])
+
+
+def _interval_to_time_range(value: dict) -> TimeRange | None:
+    """Convert a Duckling ``type="interval"`` (from / to bounds) to a range.
+
+    Half-bounded intervals keep the missing side as ``None``.
+    """
+    try:
+        start = _interval_bound(value.get("from"))
+        end = _interval_bound(value.get("to"))
+    except (ValueError, KeyError):
+        return None
+    # Empty interval (no bounds at all) is meaningless.
+    if start is None and end is None:
+        return None
+    # Closed interval must be non-empty.
+    if start is not None and end is not None and end <= start:
+        return None
+    return TimeRange(intervals=[TimeInterval(start=start, end=end)])
+
+
+def _entity_to_time_range(entity: dict) -> TimeRange | None:
+    """Convert one Duckling ``dim=time`` entity into a ``TimeRange``.
+
+    Uses ONLY the primary value (``value.value`` or ``value.from`` /
+    ``value.to``); ignores the ``values[]`` alternatives.
+    """
+    value = entity.get("value") or {}
+    kind = value.get("type")
+    if kind == "value":
+        return _value_to_time_range(value)
+    if kind == "interval":
+        return _interval_to_time_range(value)
+    return None
+
+
+class DucklingTemporalExtractorParams(BaseModel):
+    """
+    Parameters for DucklingTemporalExtractor.
+
+    Attributes:
+        client (httpx.AsyncClient):
+            HTTP client used to call the Duckling server (caller-owned).
+        url (str):
+            Duckling parse endpoint URL.
+        locale (str):
+            Duckling locale (default: "en_US").
+    """
+
+    client: InstanceOf[httpx.AsyncClient] = Field(
+        ...,
+        description="HTTP client used to call the Duckling server (caller-owned)",
+    )
+    url: str = Field(
+        ...,
+        description="Duckling parse endpoint URL",
+    )
+    locale: str = Field(
+        default="en_US",
+        description="Duckling locale",
+    )
+
+
+class DucklingTemporalExtractor(TemporalExtractor):
+    """``TimeRange`` extractor backed by a local Duckling HTTP server."""
+
+    def __init__(self, params: DucklingTemporalExtractorParams) -> None:
+        """Initialize from parameters."""
+        self._client = params.client
+        self._url = params.url
+        self._locale = params.locale
+
+    @override
+    async def extract(
+        self, text: str, *, ref_time: datetime | None = None
+    ) -> list[TimeRange]:
+        if ref_time is None:
+            ref_time = datetime.now(UTC)
+
+        ref_time = ensure_tz_aware(ref_time)
+
+        # Duckling resolves local expressions in this tz; derive it from the
+        # input ref_time (its IANA name when available) rather than configuring
+        # it once.
+        timezone_name = (
+            getattr(ref_time.tzinfo, "key", None) or ref_time.tzname() or "UTC"
+        )
+        reftime_ms = int(ref_time.astimezone(UTC).timestamp() * 1000)
+        try:
+            response = await self._client.post(
+                self._url,
+                data={
+                    "locale": self._locale,
+                    "tz": timezone_name,
+                    "reftime": reftime_ms,
+                    "dims": json.dumps(["time"]),
+                    "text": text,
+                },
+            )
+        except httpx.HTTPError:
+            return []
+        if response.status_code != 200:
+            return []
+        try:
+            entities = response.json()
+        except ValueError:
+            return []
+        ranges: list[TimeRange] = []
+        for entity in entities:
+            if entity.get("dim") != "time":
+                continue
+            time_range = _entity_to_time_range(entity)
+            if time_range is not None:
+                ranges.append(time_range)
+        return ranges

--- a/packages/server/src/memmachine_server/temporal/extractor/duckling_temporal_extractor.py
+++ b/packages/server/src/memmachine_server/temporal/extractor/duckling_temporal_extractor.py
@@ -7,6 +7,7 @@ from typing import override
 import httpx
 from pydantic import BaseModel, Field, InstanceOf
 
+from memmachine_server.common.request_context import get_request_locale
 from memmachine_server.common.utils import ensure_tz_aware
 from memmachine_server.temporal.time_range import TimeInterval, TimeRange
 
@@ -125,8 +126,6 @@ class DucklingTemporalExtractorParams(BaseModel):
             HTTP client used to call the Duckling server (caller-owned).
         url (str):
             Duckling parse endpoint URL.
-        locale (str):
-            Duckling locale (default: "en_US").
     """
 
     client: InstanceOf[httpx.AsyncClient] = Field(
@@ -137,10 +136,6 @@ class DucklingTemporalExtractorParams(BaseModel):
         ...,
         description="Duckling parse endpoint URL",
     )
-    locale: str = Field(
-        default="en_US",
-        description="Duckling locale",
-    )
 
 
 class DucklingTemporalExtractor(TemporalExtractor):
@@ -150,7 +145,6 @@ class DucklingTemporalExtractor(TemporalExtractor):
         """Initialize from parameters."""
         self._client = params.client
         self._url = params.url
-        self._locale = params.locale
 
     @override
     async def extract(
@@ -168,11 +162,13 @@ class DucklingTemporalExtractor(TemporalExtractor):
             getattr(ref_time.tzinfo, "key", None) or ref_time.tzname() or "UTC"
         )
         reftime_ms = int(ref_time.astimezone(UTC).timestamp() * 1000)
+        # Duckling and babel both render locales as ``lang_REGION`` (``en_US``).
+        duckling_locale = str(get_request_locale())
         try:
             response = await self._client.post(
                 self._url,
                 data={
-                    "locale": self._locale,
+                    "locale": duckling_locale,
                     "tz": timezone_name,
                     "reftime": reftime_ms,
                     "dims": json.dumps(["time"]),

--- a/packages/server/src/memmachine_server/temporal/extractor/extractor_temporal_query_planner.py
+++ b/packages/server/src/memmachine_server/temporal/extractor/extractor_temporal_query_planner.py
@@ -1,0 +1,40 @@
+"""Temporal query planner backed by a temporal extractor."""
+
+from datetime import UTC, datetime
+from typing import override
+
+from pydantic import BaseModel, Field, InstanceOf
+
+from memmachine_server.temporal.query_planner import (
+    TemporalQueryPlan,
+    TemporalQueryPlanner,
+)
+
+from .temporal_extractor import TemporalExtractor
+
+
+class ExtractorTemporalQueryPlannerParams(BaseModel):
+    """Parameters for ExtractorTemporalQueryPlanner."""
+
+    extractor: InstanceOf[TemporalExtractor] = Field(
+        ...,
+        description="Temporal extractor used to resolve the query's dates into targets",
+    )
+
+
+class ExtractorTemporalQueryPlanner(TemporalQueryPlanner):
+    """Temporal query planner backed by an injected temporal extractor."""
+
+    def __init__(self, params: ExtractorTemporalQueryPlannerParams) -> None:
+        """Initialize with the injected extractor."""
+        self._extractor = params.extractor
+
+    @override
+    async def plan(
+        self, query: str, *, ref_time: datetime | None = None
+    ) -> TemporalQueryPlan:
+        if ref_time is None:
+            ref_time = datetime.now(UTC)
+
+        targets = await self._extractor.extract(query, ref_time=ref_time)
+        return TemporalQueryPlan(targets=targets)

--- a/packages/server/src/memmachine_server/temporal/extractor/language_model_temporal_extractor.py
+++ b/packages/server/src/memmachine_server/temporal/extractor/language_model_temporal_extractor.py
@@ -1,0 +1,338 @@
+"""LLM-based temporal extractor."""
+
+from datetime import UTC, datetime, timedelta
+from typing import override
+
+from pydantic import BaseModel, Field, InstanceOf
+
+from memmachine_server.common.language_model.language_model import LanguageModel
+from memmachine_server.common.utils import ensure_tz_aware
+from memmachine_server.temporal.time_range import TimeInterval, TimeRange
+
+from .temporal_extractor import TemporalExtractor
+
+
+def _parse_iso(s: str) -> datetime:
+    """Parse an ISO-8601 string into a UTC-aware datetime."""
+    return ensure_tz_aware(datetime.fromisoformat(s)).astimezone(UTC)
+
+
+def _deictic_context(ref_time: datetime) -> str:
+    """
+    Render a verbose deictic context relative to the reference time.
+
+    This allows the model to resolve deictic phrases more easily. The deictic
+    dates (today, yesterday, this week / month / quarter / year) are computed
+    in ``ref_time``'s own timezone, so "yesterday" is the reader's yesterday,
+    not UTC's; the rendered reference time carries its real offset. A naive
+    ``ref_time`` is treated as UTC.
+    """
+    ref_time = ensure_tz_aware(ref_time)
+    weekday = ref_time.strftime("%A")
+    iso_ref = ref_time.isoformat(timespec="seconds")
+    yesterday = ref_time - timedelta(days=1)
+    tomorrow = ref_time + timedelta(days=1)
+    iso_weekday = ref_time.isoweekday()
+    this_week_start = (ref_time - timedelta(days=iso_weekday - 1)).date()
+    this_week_end = this_week_start + timedelta(days=6)
+    last_week_start = this_week_start - timedelta(days=7)
+    last_week_end = last_week_start + timedelta(days=6)
+    next_week_start = this_week_start + timedelta(days=7)
+    next_week_end = next_week_start + timedelta(days=6)
+
+    def month_label(dt: datetime) -> str:
+        return dt.strftime("%B %Y")
+
+    this_month = month_label(ref_time)
+    if ref_time.month == 1:
+        last_month = ref_time.replace(year=ref_time.year - 1, month=12, day=1)
+    else:
+        last_month = ref_time.replace(month=ref_time.month - 1, day=1)
+    if ref_time.month == 12:
+        next_month = ref_time.replace(year=ref_time.year + 1, month=1, day=1)
+    else:
+        next_month = ref_time.replace(month=ref_time.month + 1, day=1)
+    this_quarter = (ref_time.month - 1) // 3 + 1
+    this_year = ref_time.year
+    return (
+        f"Reference time: {iso_ref} ({weekday}).\n"
+        f"Today = {ref_time.strftime('%A, %B %d, %Y')}. "
+        f"Yesterday = {yesterday.strftime('%A, %b %d, %Y')}. "
+        f"Tomorrow = {tomorrow.strftime('%A, %b %d, %Y')}.\n"
+        f"This week = {this_week_start.strftime('%b %d')}"
+        f"-{this_week_end.strftime('%b %d, %Y')} (Mon-Sun).\n"
+        f"Last week = {last_week_start.strftime('%b %d')}"
+        f"-{last_week_end.strftime('%b %d, %Y')}. "
+        f"Next week = {next_week_start.strftime('%b %d')}"
+        f"-{next_week_end.strftime('%b %d, %Y')}.\n"
+        f"This month = {this_month}. "
+        f"Last month = {month_label(last_month)}. "
+        f"Next month = {month_label(next_month)}.\n"
+        f"This quarter = Q{this_quarter} {this_year}. "
+        f"This year = {this_year}. Last year = {this_year - 1}. "
+        f"Next year = {this_year + 1}."
+    )
+
+
+_SYSTEM_PROMPT = """You are a temporal-anchor extractor.
+
+Your job: identify EVERY span in a passage that names a specific point,
+span, or recurring schedule of time, AND directly resolve each one
+into a temporal anchor (a half-open interval on the calendar).
+
+# Critical test before emitting anything
+
+Does the passage USE this phrase to locate a specific occurrence on
+the calendar -- one that the reader could later recall, search for,
+or reference by date? Or does the phrase describe a constraint, a
+requirement, a format placeholder, or a rule that applies generally
+across many possible occurrences?
+
+- Specific occurrence ("yesterday we deployed", "shipped on March 15",
+  "Q1 was rough", "during the pandemic", "every Thursday at 3pm I
+  have therapy") -> EMIT.
+- Constraint / rule / placeholder ("Policy: backups within the last
+  hour", "every release requires a 30-minute window", "Subject
+  format: [Date]") -> SKIP, even if temporal-shaped.
+
+This is the deciding test for borderline cases. The retriever's job
+is to surface timeless rule docs on non-temporal queries; anchoring
+a policy at the reference time defeats that.
+
+# What counts as a temporal anchor
+
+A span is a temporal anchor if and only if, given the reference
+time and any explicit anchoring in the passage, you could state WHEN
+it is on a calendar -- AND the critical test above puts it on the
+"specific occurrence" side:
+
+- Absolute dates: "March 5, 2026", "1986", "Q3 2025".
+- Relative deictics: "yesterday", "2 weeks ago", "next Thursday".
+- Approximations: "around 2010", "a few weeks ago", "recently".
+- Eras with a calendar anchor: "the 90s", "back in college", "during
+  the pandemic".
+- Recurring schedules tied to a real standing pattern: "every
+  Thursday at 3pm". Emit the first/nearest known occurrence.
+- Durations: emit ONLY if attached to a specific calendar anchor.
+  In particular, IMPACT-MAGNITUDE durations describe how long an
+  effect lasted, not when it was on the calendar -- skip them.
+  Examples: "over-reported for 6 weeks", "froze for 12 minutes",
+  "delayed 3 hours", "outage lasted 45 minutes". These are
+  measurements of an event's effect, not retrievable time anchors;
+  even when an anchor exists nearby (e.g. "Postmortem from May 12:
+  ... for 6 weeks"), the duration itself isn't a separately
+  retrievable anchor -- the date anchor ("May 12") is.
+
+# What does NOT count (skip)
+
+- Bare names of recurring annual events without a year-anchor:
+  "summer", "Christmas", "Easter", "graduation day". (EXCEPTION:
+  when the phrase IS the recurring schedule itself in a
+  standing-arrangement context -- "every summer we visit the lake".)
+- Vague descriptors: "recent", "modern", "old", "new", "ancient".
+- Bare frequency words: "often", "always", "sometimes", "rarely".
+- Bare approximators without concrete reference: "about", "around",
+  "roughly" used alone.
+
+# Policy / rule / template contexts -- skip everything inside
+
+When the surrounding sentence describes a generic policy, rule,
+convention, requirement, or format, even temporal-shaped phrases
+inside it are CONSTRAINTS or PLACEHOLDERS, not events. Cue patterns:
+
+- Explicit policy header: "policy:", "convention:", "rule:",
+  "guideline:", "standard:".
+- Prescriptive modals as main predicate: "must X", "should X",
+  "requires X", "never X without Y", "always X before Y".
+- Recurrence over an event-CLASS without naming a specific instance:
+  "every release", "every deploy", "every PR", "every sprint".
+- Template placeholders: "[Date]", "{date}", "<date>", "YYYY-MM-DD".
+
+If you skip on these cues, do not silently emit other temporal
+phrases from the same sentence either; the whole sentence is
+policy/rule content.
+
+# How to think about start / end
+
+- A pinpoint anchor (e.g. "March 15, 2024") -> single-day
+  interval: start = 2024-03-15T00:00:00Z, end = 2024-03-16T00:00:00Z.
+- A span ("Q1 2024") -> start = 2024-01-01T00:00:00Z, end =
+  2024-04-01T00:00:00Z.
+- A fuzzy anchor ("around 2008") -> widen by one unit: start
+  = 2006-01-01T00:00:00Z, end = 2011-01-01T00:00:00Z.
+- A relative anchor resolves against ref time. "yesterday" ->
+  day before ref. "last month" -> calendar month before ref. "the
+  90s" -> [1990-01-01, 2000-01-01).
+- A recurring phrase ("every Thursday at 3pm"): emit FIRST known
+  occurrence. If the passage anchors the schedule earlier ("every
+  Thursday since March"), use that start. Otherwise pick the
+  nearest past/upcoming occurrence from ref time.
+- A duration only counts if attached to an anchor ("for 3 weeks
+  starting June 1") -> [anchor, anchor+duration].
+
+# One anchor (multiple intervals) vs multiple anchors
+
+Most anchors are a single interval. Emit MULTIPLE intervals inside
+ONE anchor only when the passage frames them as ONE claim whose
+allowed moments form a set with holes:
+
+- A bounded period with an internal gap ("active all year except over
+  the break") -> one anchor, two intervals: the span before the
+  gap and the span after it.
+- A complement ("anytime except that one month") -> one anchor
+  covering the region outside the span. Endpoints are required, so
+  bound an open side with a far-past / far-future sentinel
+  (start 0001-01-01T00:00:00Z, end 9999-12-31T00:00:00Z).
+- An intrinsic disjunction stated as one fact ("only ever in the two
+  shoulder seasons") -> one anchor, one interval per piece.
+
+Emit SEPARATE anchors (each a single interval) when the passage
+reports DISTINCT occurrences -- separate events, even if they share a
+pattern ("shipped once early in the year and again late" -> two
+anchors).
+
+The litmus: would the passage call these "one thing with gaps" (one
+multi-interval anchor) or "several separate things" (several
+anchors)?
+
+# Rules
+
+- Use UTC ISO 8601 with "Z" suffix.
+- start is inclusive, end is exclusive (half-open).
+- For "about" / "around" / "roughly" / "a few" / "a couple", widen by
+  one granularity level (day -> week, month -> year, etc.).
+
+# Skip -- do not emit
+
+If you cannot place a surface on the calendar without falling back
+to ref time as a fabricated anchor, DO NOT emit it. Omit the
+anchor from your output entirely.
+
+This applies to:
+- Policy / rule constraints with no specific occurrence.
+- Generic recurrences over an event class with no named instance.
+- Template placeholders.
+- Phrases that look temporal but lack a calendar anchor (e.g.,
+  bare "the launch" or "grad school" without other context).
+
+In those cases, do not invent an interval around ref_time -- just
+skip the phrase.
+
+# Output
+
+A single JSON object: {"anchors": [...]}. Each anchor carries a list
+of one or more half-open intervals:
+{
+  "intervals": [
+    {
+      "start": ISO-8601 UTC datetime with "Z",
+      "end":   ISO-8601 UTC datetime with "Z"
+    }
+  ]
+}
+
+start is inclusive, end is exclusive. Use multiple intervals in
+one anchor ONLY for a single claim with internal structure (gap,
+complement, disjunction); otherwise one interval per anchor. If the
+passage has no temporal anchors that meet the bar, output
+{"anchors": []}.
+"""
+
+
+# Data models for structured outputs specification.
+
+
+# A half-open calendar interval as ISO-8601 UTC datetimes (with "Z").
+# No docstring on these schema models: a model docstring renders into the JSON
+# schema's "description" and would be sent to the LLM. The original hand-written
+# schema carried none.
+class _Interval(BaseModel):
+    start: str
+    end: str
+
+
+# One temporal anchor: a set of intervals treated as a single claim.
+class _Anchor(BaseModel):
+    intervals: list[_Interval] = Field(default_factory=list)
+
+
+# The extractor's structured output: the resolved temporal anchors.
+class _ExtractResponse(BaseModel):
+    anchors: list[_Anchor] = Field(default_factory=list)
+
+
+def _interval_to_time_interval(interval: dict) -> TimeInterval | None:
+    """Convert one ``{start, end}`` interval to a ``TimeInterval``.
+
+    Returns ``None`` for malformed or empty (``end <= start``) intervals
+    so the caller can drop them.
+    """
+    try:
+        start = _parse_iso(interval["start"])
+        end = _parse_iso(interval["end"])
+    except (KeyError, ValueError, TypeError):
+        return None
+    if end <= start:
+        return None
+    return TimeInterval(start=start, end=end)
+
+
+def _anchor_to_time_range(anchor: dict) -> TimeRange | None:
+    """Convert one anchor (a set of intervals) to a ``TimeRange``.
+
+    Drops malformed or empty intervals; returns ``None`` when none survive
+    so the caller can drop the whole anchor.
+    """
+    intervals = [
+        time_interval
+        for interval in anchor.get("intervals", [])
+        if (time_interval := _interval_to_time_interval(interval)) is not None
+    ]
+    if not intervals:
+        return None
+    return TimeRange(intervals=intervals)
+
+
+class LanguageModelTemporalExtractorParams(BaseModel):
+    """
+    Parameters for LanguageModelTemporalExtractor.
+
+    Attributes:
+        language_model (LanguageModel):
+            Language model used to extract time ranges.
+    """
+
+    language_model: InstanceOf[LanguageModel] = Field(
+        ...,
+        description="Language model used to extract time ranges",
+    )
+
+
+class LanguageModelTemporalExtractor(TemporalExtractor):
+    """LLM-based temporal extractor."""
+
+    def __init__(self, params: LanguageModelTemporalExtractorParams) -> None:
+        """Initialize from parameters."""
+        self._language_model = params.language_model
+
+    @override
+    async def extract(
+        self, text: str, *, ref_time: datetime | None = None
+    ) -> list[TimeRange]:
+        if ref_time is None:
+            ref_time = datetime.now(UTC)
+
+        deictic_context = _deictic_context(ref_time)
+        user_prompt = f"{deictic_context}\n\nPassage:\n{text}"
+        parsed = await self._language_model.generate_parsed_response(
+            output_format=_ExtractResponse,
+            system_prompt=_SYSTEM_PROMPT,
+            user_prompt=user_prompt,
+        )
+        if parsed is None:
+            return []
+        return [
+            time_range
+            for anchor in parsed.anchors
+            if (time_range := _anchor_to_time_range(anchor.model_dump())) is not None
+        ]

--- a/packages/server/src/memmachine_server/temporal/extractor/temporal_extractor.py
+++ b/packages/server/src/memmachine_server/temporal/extractor/temporal_extractor.py
@@ -1,0 +1,29 @@
+"""Abstract base class for a temporal extractor."""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+from memmachine_server.temporal.time_range import TimeRange
+
+
+class TemporalExtractor(ABC):
+    """Abstract base class for a temporal extractor."""
+
+    @abstractmethod
+    async def extract(
+        self, text: str, *, ref_time: datetime | None = None
+    ) -> list[TimeRange]:
+        """
+        Extract time ranges.
+
+        Args:
+            text (str):
+                The text to extract time ranges from.
+            ref_time (datetime):
+                The reference time for resolving relative time references.
+
+        Returns:
+            list[TimeRange]:
+                Time ranges extracted from the text.
+        """
+        raise NotImplementedError

--- a/packages/server/src/memmachine_server/temporal/query_planner/__init__.py
+++ b/packages/server/src/memmachine_server/temporal/query_planner/__init__.py
@@ -1,0 +1,8 @@
+"""Query-side temporal planners."""
+
+from .temporal_query_planner import TemporalQueryPlan, TemporalQueryPlanner
+
+__all__ = [
+    "TemporalQueryPlan",
+    "TemporalQueryPlanner",
+]

--- a/packages/server/src/memmachine_server/temporal/query_planner/language_model_temporal_query_planner.py
+++ b/packages/server/src/memmachine_server/temporal/query_planner/language_model_temporal_query_planner.py
@@ -1,0 +1,271 @@
+"""LLM-based temporal query planner."""
+
+from datetime import UTC, datetime
+from typing import override
+
+from pydantic import BaseModel, Field, InstanceOf
+
+from memmachine_server.common.language_model.language_model import LanguageModel
+from memmachine_server.temporal.time_range import TimeInterval, TimeRange
+
+from .temporal_query_planner import TemporalQueryPlan, TemporalQueryPlanner
+
+_PROMPT = """
+You translate a natural-language query into a TIME RANGE PLAN.
+
+A query describes WHAT MOMENTS IN TIME a matching document's date anchor
+should fall inside. You describe that set as a list of TARGETS. Each target
+is a SET of allowed moments expressed as one or more half-open intervals
+[start, end). Null endpoints mean unbounded (start=null is -infinity; end=null
+is +infinity).
+
+OUTPUT SHAPE
+============
+{{
+  "targets": [
+    {{"intervals": [{{"start": "YYYY-MM-DD"|null, "end": "YYYY-MM-DD"|null}}, ...]}}
+  ]
+}}
+
+`targets` are concrete time sets you have resolved. A doc anchor scores
+higher when it satisfies MORE targets -- mean of per-target overlap.
+
+KEY CONCEPTS
+============
+- An INTERVAL is half-open [start, end). end is EXCLUSIVE: "March 2024" =
+  start "2024-03-01", end "2024-04-01".
+- A TARGET is a SET of allowed moments. The doc anchor satisfies a target
+  if it falls in ANY of the target's intervals (intra-target OR via
+  multi-interval).
+- Multiple TARGETS = each target is a SEPARATE constraint. The doc is
+  scored by how many it satisfies (graded coverage).
+
+WHEN TO EMIT ONE TARGET (MULTI-INTERVAL) vs MULTIPLE TARGETS
+============================================================
+This is the planner's only structural decision.
+
+ONE target with multiple intervals -- use when the query describes a SINGLE
+allowed REGION that happens to have holes or discontinuities. The
+intervals are interchangeable: ANY ONE of them satisfies the user.
+  - "not in 2023" -> one target = (-inf, 2023) and (2024, +inf)
+  - "in 2024 not in summer" -> one target = [Jan-Jun 2024] and [Sep-Dec 2024]
+  - "between A and B" -> one target = [A.start, B.end)
+  - any single contiguous period ("in 2024", "after March 2020") -> one target
+
+MULTIPLE targets -- use when the query lists SEPARATE periods the doc should
+match independently. Coverage matters: matching both > matching one.
+  - "in 2020 and 2024" (colloquial, disjoint) -> two targets (one per year)
+  - "in 2020 or 2024" (explicit OR, disjoint) -> two targets (graded coverage)
+  - "in Q1 or Q4 of 2023" -> two targets (each quarter is its own period)
+
+The litmus: if a doc that mentions BOTH periods should rank higher than
+one that mentions ONE -> emit multiple targets. If they're interchangeable
+(any one is fine) -> emit one multi-interval target.
+
+REF_TIME is provided for resolving relative phrases ("recently", "two
+weeks ago", "last quarter"). For absolute dates you don't need it.
+
+VERB-POLARITY RULE -- CRITICAL
+==============================
+"not" / "didn't" / "did not" / "wasn't" attached to a VERB is EVENT
+POLARITY, not temporal scoping. IGNORE it. Emit the same plan as if the
+verb were affirmative. ONLY treat "not" as temporal scoping when it
+attaches DIRECTLY to a temporal preposition ("not in X", "not during Y",
+"not before Z").
+
+  "what did not happen in 2024" -- "not" attaches to the verb "happen",
+    NOT to "in 2024". Treat as: "what happened in 2024" -> one target [2024].
+  "what wasn't completed by March" -- "wasn't" is verb polarity. Treat as
+    "what was completed by March" -> one target (-inf, March).
+
+  Contrast with temporal-scoping negation:
+  "what happened NOT in 2024" -> complement of 2024 (rare phrasing).
+  "what happened outside 2024" -> complement of 2024.
+  "what happened excluding 2024" -> complement of 2024.
+
+COMPOSITION RULES (do these AT THE LLM LEVEL -- emit the composed result)
+========================================================================
+- "in X" -> ONE target = [X.start, X.end).
+- "after X" -> ONE target = [X.end, null). (X.end because "after X" excludes X.)
+- "before X" -> ONE target = [null, X.start).
+- "not in X" / "outside X" / "excluding X" -> ONE target = complement of [X]
+  = two intervals [null, X.start) and [X.end, null).
+- "in A not in B" (with B inside A) -> ONE target = A minus B = two intervals
+  [A.start, B.start) and [B.end, A.end).
+- "not in A or B" (A and B disjoint) -> ONE target = three intervals
+  [null, A.start), [A.end, B.start), [B.end, null).
+- "in A and B" (colloquial; A and B disjoint dates) -> TWO targets (one for
+  A, one for B). DO NOT intersect them -- the intersection is empty.
+- "in A or B" / "either A or B" -> TWO targets.
+- "between A and B" -> ONE target = [A.start, B.end) (inclusive of both endpoints).
+- "since X" / "starting X" / "from X onwards" -> ONE target = [X.start, null).
+- "until X" -> ONE target = [null, X.end).
+
+EMPTY OUTPUT
+============
+If the query has NO temporal scope at all (e.g., "how do I plan my
+morning?", "lessons from the launch", "how did the migration go?") emit
+{{"targets": []}}.
+
+"What did I do recently" / "show me what happened lately" -> deictic;
+resolve to a recent window (e.g. last 60-90 days from REF_TIME) as a
+target.
+
+DEICTIC RESOLUTION
+==================
+Resolve deictic phrases against REF_TIME and emit them as targets.
+
+Resolutions:
+- "this year" -> [Jan 1 of ref_time year, Jan 1 of next year)
+- "last year" -> year before
+- "this quarter" / "last quarter" / "next quarter" -> corresponding calendar quarter
+- "this month" / "last month" / "next month" -> corresponding calendar month
+- "yesterday" -> 1-day interval before ref_time's date
+- "today" -> ref_time's date (1-day)
+- "this week" / "last week" / "next week" -> Mon-Sun week-of
+- "two weeks ago" / "three months ago" -> resolve arithmetically
+
+EXAMPLES
+========
+
+Query: "in March 2024"
+{{"targets":[{{"intervals":[{{"start":"2024-03-01","end":"2024-04-01"}}]}}]}}
+
+Query: "after 2020"
+{{"targets":[{{"intervals":[{{"start":"2021-01-01","end":null}}]}}]}}
+
+Query: "not in 2023"
+{{"targets":[{{"intervals":[{{"start":null,"end":"2023-01-01"}},{{"start":"2024-01-01","end":null}}]}}]}}
+
+Query: "in Q1 or Q4 of 2023"
+{{"targets":[
+  {{"intervals":[{{"start":"2023-01-01","end":"2023-04-01"}}]}},
+  {{"intervals":[{{"start":"2023-10-01","end":"2024-01-01"}}]}}
+]}}
+
+Query: "between 2020 and 2024"
+{{"targets":[{{"intervals":[{{"start":"2020-01-01","end":"2025-01-01"}}]}}]}}
+
+Query: "How do I plan my morning?"
+{{"targets":[]}}
+
+RETRIEVAL ORIENTATION
+=====================
+You are translating queries for a SEARCH/RETRIEVAL system over a memory
+of PAST events. When a query asks about recurring or ambiguous-direction
+patterns ("what do I do on Thursdays?", "when do I exercise?"),
+enumerate PAST occurrences (looking back from REF_TIME), not future
+ones. Future-tense queries ("what is scheduled for next Thursday") of
+course remain future-oriented.
+
+NOW PRODUCE THE PLAN FOR:
+
+Query: {query}
+Reference time: {ref_time}
+"""
+
+
+# Data models for structured outputs specification.
+
+
+class _Interval(BaseModel):
+    start: str | None = None
+    end: str | None = None
+
+
+class _Target(BaseModel):
+    intervals: list[_Interval] = Field(default_factory=list)
+
+
+class _PlanResponse(BaseModel):
+    targets: list[_Target] = Field(default_factory=list)
+
+
+def _iso_to_datetime(s: str) -> datetime:
+    """Parse an ISO date/datetime into a UTC-aware datetime."""
+    try:
+        dt = datetime.fromisoformat(s)
+    except (ValueError, TypeError) as e:
+        raise ValueError(f"Cannot parse date {s!r}: {e}") from e
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _json_intervals_to_time_range(json_intervals: list[dict]) -> TimeRange:
+    """Convert the LLM's interval JSON into one ``TimeRange`` (a union).
+
+    A ``null`` endpoint maps to an unbounded (``None``) endpoint; invalid
+    (``start >= end``) intervals are dropped.
+    """
+    intervals: list[TimeInterval] = []
+    for entry in json_intervals:
+        start_raw = entry.get("start")
+        end_raw = entry.get("end")
+        try:
+            start = None if start_raw is None else _iso_to_datetime(start_raw)
+            end = None if end_raw is None else _iso_to_datetime(end_raw)
+        except ValueError:
+            continue
+        if start is not None and end is not None and start >= end:
+            continue
+        intervals.append(TimeInterval(start=start, end=end))
+    return TimeRange(intervals=intervals)
+
+
+def _json_to_targets(json_targets: list[dict]) -> list[TimeRange]:
+    """Convert the LLM's target list into a flat list of ``TimeRange`` targets."""
+    out: list[TimeRange] = []
+    for entry in json_targets:
+        target = _json_intervals_to_time_range(entry.get("intervals", []))
+        if target.intervals:
+            out.append(target)
+    return out
+
+
+class LanguageModelTemporalQueryPlannerParams(BaseModel):
+    """
+    Parameters for LanguageModelTemporalQueryPlanner.
+
+    Attributes:
+        language_model (LanguageModel):
+            Language model used to resolve the query into time range targets.
+    """
+
+    language_model: InstanceOf[LanguageModel] = Field(
+        ...,
+        description="Language model used to resolve the query into time range targets",
+    )
+
+
+class LanguageModelTemporalQueryPlanner(TemporalQueryPlanner):
+    """LLM-based temporal query planner."""
+
+    def __init__(self, params: LanguageModelTemporalQueryPlannerParams) -> None:
+        """Initialize from parameters."""
+        self._language_model = params.language_model
+
+    @override
+    async def plan(
+        self, query: str, *, ref_time: datetime | None = None
+    ) -> TemporalQueryPlan:
+        if ref_time is None:
+            ref_time = datetime.now(UTC)
+        prompt = _PROMPT.format(query=query, ref_time=ref_time.isoformat())
+        try:
+            parsed = await self._language_model.generate_parsed_response(
+                output_format=_PlanResponse,
+                user_prompt=prompt,
+            )
+        except Exception:
+            # Produce an empty plan on failure.
+            return TemporalQueryPlan()
+
+        if parsed is None:
+            return TemporalQueryPlan()
+
+        return TemporalQueryPlan(
+            targets=_json_to_targets(
+                [target.model_dump() for target in parsed.targets]
+            ),
+        )

--- a/packages/server/src/memmachine_server/temporal/query_planner/temporal_query_planner.py
+++ b/packages/server/src/memmachine_server/temporal/query_planner/temporal_query_planner.py
@@ -1,0 +1,37 @@
+"""Temporal query planning."""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from memmachine_server.temporal.time_range import TimeRange
+
+
+class TemporalQueryPlan(BaseModel):
+    """Temporal query plan."""
+
+    targets: list[TimeRange] = Field(default_factory=list)
+
+
+class TemporalQueryPlanner(ABC):
+    """Abstract base class for a temporal query planner."""
+
+    @abstractmethod
+    async def plan(
+        self, query: str, *, ref_time: datetime | None = None
+    ) -> TemporalQueryPlan:
+        """
+        Make a temporal query plan for the query.
+
+        Args:
+            query (str):
+                The query to make a plan for.
+            ref_time (str):
+                The reference time for resolving relative time references.
+
+        Returns:
+            TemporalQueryPlan:
+                The temporal query plan.
+        """
+        raise NotImplementedError

--- a/packages/server/src/memmachine_server/temporal/scoring.py
+++ b/packages/server/src/memmachine_server/temporal/scoring.py
@@ -2,7 +2,7 @@
 
 import math
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .query_planner import TemporalQueryPlan
 from .time_range import TimeRange
@@ -77,8 +77,27 @@ class TemporalScoringResult(BaseModel):
     temporal_match_score: float
 
 
+class TemporalScorerParams(BaseModel):
+    """
+    Parameters for TemporalScorer.
+
+    Attributes:
+        match_weight (float):
+            Weight on the temporal match term in the additive fusion.
+    """
+
+    match_weight: float = Field(
+        default=1.0,
+        description=("Weight on the temporal match term in the additive fusion"),
+    )
+
+
 class TemporalScorer:
     """Temporal scorer."""
+
+    def __init__(self, params: TemporalScorerParams) -> None:
+        """Initialize from parameters."""
+        self._match_weight = params.match_weight
 
     def score(
         self,
@@ -111,7 +130,8 @@ class TemporalScorer:
 
         return [
             TemporalScoringResult(
-                final_score=base_scores[i] + match_scores[i] * pool_spread,
+                final_score=base_scores[i]
+                + self._match_weight * match_scores[i] * pool_spread,
                 temporal_match_score=match_scores[i],
             )
             for i in range(len(candidates))

--- a/packages/server/src/memmachine_server/temporal/scoring.py
+++ b/packages/server/src/memmachine_server/temporal/scoring.py
@@ -1,0 +1,118 @@
+"""Temporal scoring."""
+
+import math
+
+from pydantic import BaseModel
+
+from .query_planner import TemporalQueryPlan
+from .time_range import TimeRange
+
+
+def temporal_match_score(target: TimeRange, anchor: TimeRange) -> float:
+    """Return the temporal match score between a target and an anchor."""
+    intersection_measure = (target & anchor).measure_seconds
+    if intersection_measure <= 0.0:
+        return 0.0
+
+    target_measure = target.measure_seconds
+    anchor_measure = anchor.measure_seconds
+
+    if math.isinf(target_measure) and math.isinf(anchor_measure):
+        return 1.0
+
+    denominator = min(target_measure, anchor_measure)
+    if denominator <= 0.0:
+        return 0.0
+
+    return min(intersection_measure / denominator, 1.0)
+
+
+def document_temporal_match_score(
+    targets: list[TimeRange],
+    anchors: list[TimeRange],
+) -> float:
+    """
+    Return the temporal match score for a document.
+
+    The temporal match score for a document
+    is the arithmetic mean over the query's targets
+    of the max over the document's anchors of the
+    per-pair match score between one target and one anchor.
+    """
+    if not targets:
+        return 0.0
+
+    return sum(
+        max(
+            (temporal_match_score(target, anchor) for anchor in anchors),
+            default=0.0,
+        )
+        for target in targets
+    ) / len(targets)
+
+
+class TemporalScoringCandidate(BaseModel):
+    """
+    Temporal scoring candidate.
+
+    Attributes:
+        base_score (float): Base relevance score.
+        anchors (list[TimeRange]): Anchor time ranges.
+    """
+
+    base_score: float
+    anchors: list[TimeRange]
+
+
+class TemporalScoringResult(BaseModel):
+    """
+    Temporal scoring result.
+
+    Attributes:
+        final_score (float): Final score for ordering candidates.
+        temporal_match_score (float): Temporal match score.
+    """
+
+    final_score: float
+    temporal_match_score: float
+
+
+class TemporalScorer:
+    """Temporal scorer."""
+
+    def score(
+        self,
+        plan: TemporalQueryPlan,
+        candidates: list[TemporalScoringCandidate],
+    ) -> list[TemporalScoringResult]:
+        """
+        Score candidates against a temporal query plan.
+
+        Args:
+            plan (TemporalQueryPlan):
+                Temporal query plan for scoring candidates.
+            candidates (list[TemporalScoringCandidate]):
+                Candidates for temporal scoring.
+        """
+        if not candidates:
+            return []
+
+        base_scores = [candidate.base_score for candidate in candidates]
+        match_scores = [
+            document_temporal_match_score(plan.targets, candidate.anchors)
+            for candidate in candidates
+        ]
+
+        # Scale the temporal match score by the pool's base score spread so the
+        # base-match balance is stable across pools.
+        pool_spread = (max(base_scores) - min(base_scores)) if base_scores else 1.0
+        if pool_spread <= 0:
+            pool_spread = 1.0
+
+        return [
+            TemporalScoringResult(
+                final_score=base_scores[i] + match_scores[i] * pool_spread,
+                temporal_match_score=match_scores[i],
+            )
+            for i in range(len(candidates))
+        ]

--- a/packages/server/src/memmachine_server/temporal/time_range.py
+++ b/packages/server/src/memmachine_server/temporal/time_range.py
@@ -1,0 +1,116 @@
+"""Time range types."""
+
+import math
+from collections.abc import Iterable
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+
+def epoch_seconds(moment: datetime) -> float:
+    """Seconds since the Unix epoch (naive datetimes are treated as UTC)."""
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=UTC)
+    return moment.timestamp()
+
+
+class TimeInterval(BaseModel):
+    """
+    A time interval.
+
+    The interval is half-open when start and end are not None: [start, end).
+    No lower bound when start is None.
+    No upper bound when end is None.
+    """
+
+    start: datetime | None = None
+    end: datetime | None = None
+
+    @property
+    def lower_endpoint(self) -> float:
+        """Lower endpoint as a comparable real (`-inf` when unbounded)."""
+        return -math.inf if self.start is None else epoch_seconds(self.start)
+
+    @property
+    def upper_endpoint(self) -> float:
+        """Upper endpoint as a comparable real (`+inf` when unbounded)."""
+        return math.inf if self.end is None else epoch_seconds(self.end)
+
+    @property
+    def measure_seconds(self) -> float:
+        """Measure of the interval in seconds (`inf` if unbounded)."""
+        return self.upper_endpoint - self.lower_endpoint
+
+    def __and__(self, other: "TimeInterval") -> "TimeRange":
+        """Intersection with another interval, as a time range."""
+        intersection = _intersect(self, other)
+        intervals = [intersection] if intersection is not None else []
+        return TimeRange(intervals=intervals)
+
+    def __or__(self, other: "TimeInterval") -> "TimeRange":
+        """Union with another interval, as a time range."""
+        return TimeRange(intervals=[self, other])
+
+
+def _intersect(a: TimeInterval, b: TimeInterval) -> TimeInterval | None:
+    """Intersection of two intervals as one interval, or `None` if disjoint."""
+    start = a.start if a.lower_endpoint >= b.lower_endpoint else b.start
+    end = a.end if a.upper_endpoint <= b.upper_endpoint else b.end
+    intersection = TimeInterval(start=start, end=end)
+    if intersection.lower_endpoint < intersection.upper_endpoint:
+        return intersection
+    return None
+
+
+def _merge_intervals(intervals: Iterable[TimeInterval]) -> list[TimeInterval]:
+    """Sort and merge intervals into a union of disjoint, non-adjacent time intervals, in chronological order."""
+    endpoints_keyed_intervals = [
+        (interval.lower_endpoint, interval.upper_endpoint, interval)
+        for interval in intervals
+        if interval.lower_endpoint < interval.upper_endpoint
+    ]
+    endpoints_keyed_intervals.sort(key=lambda item: (item[0], item[1]))
+
+    merged: list[TimeInterval] = []
+    run_upper = -math.inf
+    for lower, upper, interval in endpoints_keyed_intervals:
+        if merged and lower <= run_upper:
+            # Overlap or adjacency: extend the run's end if this reaches further.
+            if upper > run_upper:
+                merged[-1] = TimeInterval(start=merged[-1].start, end=interval.end)
+                run_upper = upper
+        else:
+            merged.append(interval)
+            run_upper = upper
+    return merged
+
+
+class TimeRange(BaseModel):
+    """A union of disjoint, non-adjacent time intervals, in chronological order."""
+
+    intervals: list[TimeInterval] = Field(default_factory=list)
+
+    @field_validator("intervals", mode="after")
+    @classmethod
+    def _canonicalize(cls, intervals: list[TimeInterval]) -> list[TimeInterval]:
+        """Merge intervals into a disjoint, chronologically ordered union."""
+        return _merge_intervals(intervals)
+
+    @property
+    def measure_seconds(self) -> float:
+        """Measure of the range in seconds (`inf` if unbounded)."""
+        return sum(interval.measure_seconds for interval in self.intervals)
+
+    def __and__(self, other: "TimeRange") -> "TimeRange":
+        """Set intersection with another range."""
+        intersections: list[TimeInterval] = []
+        for a in self.intervals:
+            for b in other.intervals:
+                intersection = _intersect(a, b)
+                if intersection is not None:
+                    intersections.append(intersection)
+        return TimeRange(intervals=intersections)
+
+    def __or__(self, other: "TimeRange") -> "TimeRange":
+        """Set union with another range."""
+        return TimeRange(intervals=[*self.intervals, *other.intervals])

--- a/uv.lock
+++ b/uv.lock
@@ -724,6 +724,21 @@ wheels = [
 ]
 
 [[package]]
+name = "dateparser"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/2d/a0ccdb78788064fa0dc901b8524e50615c42be1d78b78d646d0b28d09180/dateparser-1.4.0.tar.gz", hash = "sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4", size = 321512, upload-time = "2026-03-26T09:56:10.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/0b/3c3bb7cbe757279e693a0be6049048012f794d01f81099609ecd53b899f0/dateparser-1.4.0-py3-none-any.whl", hash = "sha256:7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378", size = 300379, upload-time = "2026-03-26T09:56:08.409Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1941,6 +1956,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+dateparser = [
+    { name = "dateparser" },
+]
+duckling = [
+    { name = "httpx" },
+]
 gpu = [
     { name = "sentence-transformers" },
 ]
@@ -1966,11 +1987,13 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.40.40" },
     { name = "boto3-stubs", specifier = "==1.43.13" },
     { name = "cohere", specifier = ">=5.20.0" },
+    { name = "dateparser", marker = "extra == 'dateparser'", specifier = ">=1.4.0" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "greenlet", specifier = ">=3.2.4" },
     { name = "hnswlib", marker = "extra == 'hnswlib'", specifier = ">=0.8.0" },
+    { name = "httpx", marker = "extra == 'duckling'", specifier = ">=0.27.0" },
     { name = "instructor", extras = ["bedrock"], specifier = ">=1.12.0" },
     { name = "json-repair", specifier = ">=0.54" },
     { name = "langchain-aws", specifier = ">=0.2.33" },
@@ -1996,7 +2019,7 @@ requires-dist = [
     { name = "usearch", specifier = ">=2.25.1" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
-provides-extras = ["gpu", "hnswlib", "nebula", "qdrant", "litellm"]
+provides-extras = ["gpu", "hnswlib", "nebula", "qdrant", "litellm", "dateparser", "duckling"]
 
 [[package]]
 name = "minijinja"
@@ -4031,6 +4054,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,7 @@ name = "blis"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/d0/d8cc8c9a4488a787e7fa430f6055e5bd1ddb22c340a751d9e901b82e2efe/blis-1.3.3.tar.gz", hash = "sha256:034d4560ff3cc43e8aa37e188451b0440e3261d989bb8a42ceee865607715ecd", size = 2644873, upload-time = "2025-11-17T12:28:30.511Z" }
 wheels = [
@@ -839,7 +839,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -870,43 +870,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -973,28 +973,18 @@ wheels = [
 ]
 
 [[package]]
-name = "datasets"
-version = "5.0.0"
+name = "dateparser"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill" },
-    { name = "filelock" },
-    { name = "fsspec", extra = ["http"] },
-    { name = "httpx" },
-    { name = "huggingface-hub" },
-    { name = "multiprocess" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "xxhash" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/85/ce4f780c32f7e36d71257f1c27e8ba898ebe379cb54f211f5f2013f2c219/datasets-5.0.0.tar.gz", hash = "sha256:83dbbbdb07a33b82192b8c419deb18739b138ee2ce1a322d55ce6b100954ec1a", size = 631708, upload-time = "2026-06-05T13:18:26.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/6a/9f06999c4f27e9192c5eb38bfffadc2e6752df8178e97e88b10b9eb4c682/dateparser-1.4.2.tar.gz", hash = "sha256:bed2a3fd9bad8f2fb2d72b57748bada260b3a9349a264c22ffc23c3249d7049a", size = 338363, upload-time = "2026-08-04T12:11:03.201Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/66/73034ad30b59f13439b75e620989dacba4c047256e358ba7c2e9ec98ea22/datasets-5.0.0-py3-none-any.whl", hash = "sha256:7dd34927a0fd7046e98aad5cb9430e699c373238a15befa7b9bf22b991a7fee6", size = 555084, upload-time = "2026-06-05T13:18:24.435Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1b/349e07ad184d64e81109e85a3557d7e05631fa3d05344169114ba743c4d3/dateparser-1.4.2-py3-none-any.whl", hash = "sha256:752f3d49d477cf7f60a7a9c8bcb19c882496ede0e377d5a3d80014cdfeca7050", size = 316546, upload-time = "2026-08-04T12:11:01.396Z" },
 ]
 
 [[package]]
@@ -1004,15 +994,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
-]
-
-[[package]]
-name = "dill"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
 ]
 
 [[package]]
@@ -1393,11 +1374,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
-]
-
-[package.optional-dependencies]
-http = [
-    { name = "aiohttp" },
 ]
 
 [[package]]
@@ -2246,7 +2222,6 @@ dependencies = [
     { name = "boto3" },
     { name = "boto3-stubs" },
     { name = "cohere" },
-    { name = "datasets" },
     { name = "dotenv" },
     { name = "fastapi" },
     { name = "fastmcp" },
@@ -2274,6 +2249,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+dateparser = [
+    { name = "dateparser" },
+]
+duckling = [
+    { name = "httpx" },
+]
 gpu = [
     { name = "sentence-transformers" },
 ]
@@ -2303,12 +2284,13 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.40.40" },
     { name = "boto3-stubs", specifier = "==1.43.13" },
     { name = "cohere", specifier = ">=5.20.0" },
-    { name = "datasets", specifier = ">=5.0.0" },
+    { name = "dateparser", marker = "extra == 'dateparser'", specifier = ">=1.4.0" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "greenlet", specifier = ">=3.2.4" },
     { name = "hnswlib", marker = "extra == 'hnswlib'", specifier = ">=0.8.0" },
+    { name = "httpx", marker = "extra == 'duckling'", specifier = ">=0.27.0" },
     { name = "instructor", extras = ["bedrock"], specifier = ">=1.12.0" },
     { name = "json-repair", specifier = ">=0.54" },
     { name = "langchain-aws", specifier = ">=0.2.33" },
@@ -2336,7 +2318,7 @@ requires-dist = [
     { name = "usearch", specifier = ">=2.25.1" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
-provides-extras = ["gpu", "hnswlib", "nebula", "qdrant", "milvus", "litellm"]
+provides-extras = ["gpu", "hnswlib", "nebula", "qdrant", "milvus", "litellm", "dateparser", "duckling"]
 
 [[package]]
 name = "milvus-lite"
@@ -2487,23 +2469,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
-]
-
-[[package]]
-name = "multiprocess"
-version = "0.70.19"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dill" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/45/8004d1e6b9185c1a444d6b55ac5682acf9d98035e54386d967366035a03a/multiprocess-0.70.19-py310-none-any.whl", hash = "sha256:97404393419dcb2a8385910864eedf47a3cadf82c66345b44f036420eb0b5d87", size = 134948, upload-time = "2026-01-19T06:47:32.325Z" },
-    { url = "https://files.pythonhosted.org/packages/86/c2/dec9722dc3474c164a0b6bcd9a7ed7da542c98af8cabce05374abab35edd/multiprocess-0.70.19-py311-none-any.whl", hash = "sha256:928851ae7973aea4ce0eaf330bbdafb2e01398a91518d5c8818802845564f45c", size = 144457, upload-time = "2026-01-19T06:47:33.711Z" },
-    { url = "https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl", hash = "sha256:3a56c0e85dd5025161bac5ce138dcac1e49174c7d8e74596537e729fd5c53c28", size = 150281, upload-time = "2026-01-19T06:47:35.037Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/74/d2c27e03cb84251dfe7249b8e82923643c6d48fa4883b9476b025e7dc7eb/multiprocess-0.70.19-py313-none-any.whl", hash = "sha256:8d5eb4ec5017ba2fab4e34a747c6d2c2b6fecfe9e7236e77988db91580ada952", size = 156414, upload-time = "2026-01-19T06:47:35.915Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl", hash = "sha256:e8cc7fbdff15c0613f0a1f1f8744bef961b0a164c0ca29bdff53e9d2d93c5e5f", size = 160318, upload-time = "2026-01-19T06:47:37.497Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
 ]
 
 [[package]]
@@ -2752,7 +2717,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2791,7 +2756,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2803,7 +2768,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2833,9 +2798,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2847,7 +2812,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3115,8 +3080,8 @@ name = "preshed"
 version = "3.0.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cymem" },
-    { name = "murmurhash" },
+    { name = "cymem", marker = "python_full_version < '3.14'" },
+    { name = "murmurhash", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/75/fe6b7bbd0dea530a001b0e24c331b21a0be2786e402abf3c57f5dce43d4b/preshed-3.0.13.tar.gz", hash = "sha256:d75f718bbfd97e992f7827e0fa7faf6a91bdd9c922d5baa4b50d62731396cb89", size = 18338, upload-time = "2026-03-23T08:57:31.378Z" }
 wheels = [
@@ -4135,8 +4100,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -4194,7 +4159,7 @@ name = "smart-open"
 version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt" },
+    { name = "wrapt", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/3e/79fd5fd2375a8a500b9ec2f6a0762fc1ac33e35582d4a87483a78d19408f/smart_open-8.0.0.tar.gz", hash = "sha256:5a2008d60688bd3b33c52e2ef666d3c60cf956e73e215de8c7b242cf56fdd1b2", size = 61520, upload-time = "2026-06-27T16:28:11.894Z" }
 wheels = [
@@ -4215,25 +4180,25 @@ name = "spacy"
 version = "3.8.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "catalogue" },
-    { name = "confection" },
-    { name = "cymem" },
-    { name = "jinja2" },
-    { name = "murmurhash" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "preshed" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "setuptools" },
-    { name = "spacy-legacy" },
-    { name = "spacy-loggers" },
-    { name = "srsly" },
-    { name = "thinc" },
-    { name = "tqdm" },
-    { name = "typer" },
-    { name = "wasabi" },
-    { name = "weasel" },
+    { name = "catalogue", marker = "python_full_version < '3.14'" },
+    { name = "confection", marker = "python_full_version < '3.14'" },
+    { name = "cymem", marker = "python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version < '3.14'" },
+    { name = "murmurhash", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "preshed", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "setuptools", marker = "python_full_version < '3.14'" },
+    { name = "spacy-legacy", marker = "python_full_version < '3.14'" },
+    { name = "spacy-loggers", marker = "python_full_version < '3.14'" },
+    { name = "srsly", marker = "python_full_version < '3.14'" },
+    { name = "thinc", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "typer", marker = "python_full_version < '3.14'" },
+    { name = "wasabi", marker = "python_full_version < '3.14'" },
+    { name = "weasel", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/78/e4f2ae19a791cae756cd0e801204953eaec4e9ab75a60ad39f671dbb8d5a/spacy-3.8.14-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:726f02c60a2c6b0029167370d22d51731172a053d29c7e2ea6190db6de3ab483", size = 6218335, upload-time = "2026-03-29T10:40:46.298Z" },
@@ -4329,7 +4294,7 @@ name = "srsly"
 version = "2.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "catalogue" },
+    { name = "catalogue", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/db/f794f219a6c788b881252d2536a8c4a97d2bdaadc690391e1cb53d123d71/srsly-2.5.3.tar.gz", hash = "sha256:08f98dbecbff3a31466c4ae7c833131f59d3655a0ad8ac749e6e2c149e2b0680", size = 490881, upload-time = "2026-03-23T11:56:59.865Z" }
 wheels = [
@@ -4443,18 +4408,18 @@ name = "thinc"
 version = "8.3.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "blis" },
-    { name = "catalogue" },
-    { name = "confection" },
-    { name = "cymem" },
-    { name = "murmurhash" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "preshed" },
-    { name = "pydantic" },
-    { name = "setuptools" },
-    { name = "srsly" },
-    { name = "wasabi" },
+    { name = "blis", marker = "python_full_version < '3.14'" },
+    { name = "catalogue", marker = "python_full_version < '3.14'" },
+    { name = "confection", marker = "python_full_version < '3.14'" },
+    { name = "cymem", marker = "python_full_version < '3.14'" },
+    { name = "murmurhash", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "preshed", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "setuptools", marker = "python_full_version < '3.14'" },
+    { name = "srsly", marker = "python_full_version < '3.14'" },
+    { name = "wasabi", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/46/76df95f2c327f9a9cef30c1523bf285627897097163584dcf5f77b2ebce2/thinc-8.3.13.tar.gz", hash = "sha256:68e658549fc1eb3ff92aed5147fcbb9c15d6e9cc0e623b4d0998d16522ffb4f9", size = 194640, upload-time = "2026-03-23T07:22:36.41Z" }
 wheels = [
@@ -4798,6 +4763,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tzlocal"
+version = "5.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/5b/879b2f932adfa7a053c360d50bc896c977fa6426109185f7c12ebdd0cb9d/tzlocal-5.4.4.tar.gz", hash = "sha256:8dbb8660838688a7b6ba4fed31d18dedf842afb4d47ca050d6d891c2c15f3be4", size = 31170, upload-time = "2026-06-29T08:03:40.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/a4/017a7a6cbe387d961a688ec31364ae60a5c4e22c96ae9921b79a947c855d/tzlocal-5.4.4-py3-none-any.whl", hash = "sha256:aae09f0126a8a86fa736be266eb4a471380d26a0de3bc14844e7821fee3e2a15", size = 18115, upload-time = "2026-06-29T08:03:38.666Z" },
+]
+
+[[package]]
 name = "uncalled-for"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4947,7 +4924,7 @@ name = "wasabi"
 version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/054e6e2f1071e963b5e746b48d1e3727470b2a490834d18ad92364929db3/wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878", size = 30391, upload-time = "2024-05-31T16:56:18.99Z" }
 wheels = [
@@ -5045,15 +5022,15 @@ name = "weasel"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cloudpathlib" },
-    { name = "confection" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "smart-open" },
-    { name = "srsly" },
-    { name = "typer" },
-    { name = "wasabi" },
+    { name = "cloudpathlib", marker = "python_full_version < '3.14'" },
+    { name = "confection", marker = "python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "smart-open", marker = "python_full_version < '3.14'" },
+    { name = "srsly", marker = "python_full_version < '3.14'" },
+    { name = "typer", marker = "python_full_version < '3.14'" },
+    { name = "wasabi", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/e5/e272bb9a045105a1fdf4b798d8086f5932a178f4d738f17a74f5c9e0ae9a/weasel-1.0.0.tar.gz", hash = "sha256:7b129b44c90cc543b760532974ca1e4eb30dad2aa2026f57bdce66354ae610fc", size = 38682, upload-time = "2026-03-20T08:10:25.266Z" }
 wheels = [


### PR DESCRIPTION
### Purpose of the change

Improve ability to process temporal retrieval signals.

### Description

Make Context composable. Use Context to hold temporal information.

Does not really stack with reranker or #1444 on locomo.
Temporal match score component weight must be tuned for the embedder.

Approach works on synthetic data with harder temporal queries (works well for deictics, complex time ranges).

Recency/proximity not included (design less finalized). Temporal signal for introducing candidates to the pool not well-explored (requires new tables and indexing).

Add temporal extractors and query planners.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

Tested on synthetically generated data with more difficult temporal problems.

- [ ] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [x] Manual verification (list step-by-step instructions)

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected