### PR TITLE
Feat: Add Hybrid Search (Vector + FTS)

### DIFF
--- a/packages/client/src/memmachine_client/memory.py
+++ b/packages/client/src/memmachine_client/memory.py
@@ -444,6 +444,7 @@ class Memory:
             filter=filter_str,
             set_metadata=set_metadata,
             types=[MemoryType.Episodic, MemoryType.Semantic],  # Search both types
+            use_fts=False,
         )
         v2_search_data = spec.model_dump(mode="json", exclude_none=True)
 

--- a/packages/client/src/memmachine_client/memory.py
+++ b/packages/client/src/memmachine_client/memory.py
@@ -36,6 +36,7 @@ from memmachine_common.api.spec import (
     DeleteSemanticTagSpec,
     DisableSemanticCategorySpec,
     EpisodicMemoryConfigEntry,
+    FtsMode,
     GetEpisodicMemoryConfigSpec,
     GetFeatureSpec,
     GetSemanticCategorySetIdsResponse,
@@ -370,6 +371,8 @@ class Memory:
         filter: str | None = None,  # noqa: A002 — matches API field name in `SearchMemoriesSpec.filter`
         set_metadata: dict[str, JsonValue] | None = None,
         agent_mode: bool = False,
+        use_fts: FtsMode = False,
+        append_n: int = 10,
     ) -> SearchResult:
         """
         Search for memories.
@@ -401,6 +404,10 @@ class Memory:
                     `filter_dict` filters, all filters are combined with AND.
             set_metadata: Optional metadata key-value pairs used to select semantic sets.
             agent_mode: Whether to enable top-level retrieval-agent orchestration.
+            use_fts: Full-Text Search (keyword) mode combined with Vector Search.
+                    False: vector only; True or 'rrf': RRF fusion; 'append':
+                    append FTS results after vector results.
+            append_n: Number of FTS results to append (only used when use_fts='append').
 
         Returns:
             SearchResult object containing search results from both episodic and semantic memory
@@ -444,7 +451,8 @@ class Memory:
             filter=filter_str,
             set_metadata=set_metadata,
             types=[MemoryType.Episodic, MemoryType.Semantic],  # Search both types
-            use_fts=False,
+            use_fts=use_fts,
+            append_n=append_n,
         )
         v2_search_data = spec.model_dump(mode="json", exclude_none=True)
 

--- a/packages/common/src/memmachine_common/api/spec.py
+++ b/packages/common/src/memmachine_common/api/spec.py
@@ -621,6 +621,14 @@ class SearchMemoriesSpec(_WithOrgAndProj):
         ),
     ]
 
+    # Flags for using Hybrid Search(Vector + Full-Text Search)
+    use_fts: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="Use Full-Text Search (keyword search) with Vector Search",
+        ),
+    ]
 
 class DeleteMemoriesSpec(_WithOrgAndProj):
     """Specification model for deleting memories."""

--- a/packages/common/src/memmachine_common/api/spec.py
+++ b/packages/common/src/memmachine_common/api/spec.py
@@ -26,6 +26,19 @@ UTC = timezone.utc
 PropertyValue = bool | int | float | str | datetime
 """Type for stored property values (duplicated here to avoid server dependency)."""
 
+# FTS (Full-Text Search) hybrid search configuration.
+# use_fts modes:
+#   False           -> vector search only
+#   True / "rrf"    -> hybrid search fused via Reciprocal Rank Fusion (returns top_k)
+#   "append"        -> hybrid search that appends FTS results after vector results
+FtsMode = Literal["rrf", "append"] | bool
+
+# RRF score formula constant (1 / (RRF_K + rank)); NOT a result-count.
+RRF_K = 60
+
+# Default number of FTS results appended in "append" mode.
+FTS_APPEND_COUNT_DEFAULT = 10
+
 # Canonical type-name set accepted in `properties_schema`. Mirrors
 # `memmachine_server.common.data_types.PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE` but
 # lives here so the API contract validates types at request time rather than
@@ -623,10 +636,30 @@ class SearchMemoriesSpec(_WithOrgAndProj):
 
     # Flags for using Hybrid Search(Vector + Full-Text Search)
     use_fts: Annotated[
-        bool,
+        FtsMode,
         Field(
             default=False,
-            description="Use Full-Text Search (keyword search) with Vector Search",
+            description=(
+                "Full-Text Search (keyword) mode combined with Vector Search. "
+                "False: vector search only; "
+                "True or 'rrf': hybrid search fused via Reciprocal Rank Fusion "
+                "(vector and FTS each ranked then fused, returns top_k); "
+                "'append': hybrid search that appends FTS results after vector "
+                "results (deduplicated, no reranking; count set by append_n)."
+            ),
+            examples=[False, True, "rrf", "append"],
+        ),
+    ]
+    append_n: Annotated[
+        int,
+        Field(
+            default=FTS_APPEND_COUNT_DEFAULT,
+            ge=1,
+            description=(
+                "Number of FTS (keyword) results to append after vector results. "
+                "Only used when use_fts='append'. Ignored for 'rrf' and False."
+            ),
+            examples=[10, 5],
         ),
     ]
 

--- a/packages/common/src/memmachine_common/api/spec.py
+++ b/packages/common/src/memmachine_common/api/spec.py
@@ -220,6 +220,39 @@ class _WithOrgAndProj(BaseModel):
     ]
 
 
+class EnableFtsIndexSpec(_WithOrgAndProj):
+    """Specification model for manually creating the FTS index.
+
+    The FTS index is auto-created at session creation by default (see
+    `DeclarativeLongTermMemoryConf.fts_enabled`). This request creates it on
+    demand — useful when FTS was disabled at creation time, or when an
+    existing Neo4j vector store should gain FTS without re-ingesting.
+    """
+
+
+class EnableFtsIndexResponse(BaseModel):
+    """Response model for the FTS index creation request."""
+
+    status: Annotated[
+        str,
+        Field(
+            description=(
+                "Result status: 'created' when the index is now online "
+                "(newly created or already existed — the operation is "
+                "idempotent); 'unsupported' when the backend has no FTS "
+                "(e.g. Nebula / event backend)."
+            ),
+        ),
+    ]
+    index_name: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Name of the FTS index, or None if unsupported.",
+        ),
+    ]
+
+
 class ProjectConfig(BaseModel):
     """
     Project configuration model.

--- a/packages/common/src/memmachine_common/api/spec.py
+++ b/packages/common/src/memmachine_common/api/spec.py
@@ -630,6 +630,7 @@ class SearchMemoriesSpec(_WithOrgAndProj):
         ),
     ]
 
+
 class DeleteMemoriesSpec(_WithOrgAndProj):
     """Specification model for deleting memories."""
 

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_fts_index_creation.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_fts_index_creation.py
@@ -1,0 +1,140 @@
+"""Unit tests for `LongTermMemory.create_fts_index` and the EpisodicMemory proxy.
+
+`create_fts_index` is the explicit, user-triggered command that creates the
+Neo4j Full-Text Search index on demand (e.g. for a project whose FTS was
+disabled at creation time, or an existing Neo4j-backed project that should gain
+keyword search without re-ingesting data). Unlike `initialize_fts` (a silent
+no-op on unsupported backends), this command reports whether the backend
+supports FTS by returning a `(status, index_name)` tuple.
+
+These tests do NOT require a live Neo4j instance. The `VectorGraphStore` is
+mocked, so we verify only the dispatch logic — whether the FTS index-creation
+call is made or skipped — not the real Cypher.
+
+Cases (LongTermMemory.create_fts_index):
+- declarative + Neo4j store -> ("created", fts_<collection>_content)
+- declarative + non-Neo4j (e.g. Nebula) store -> ("unsupported", None)
+- event backend -> ("unsupported", None)
+
+Cases (EpisodicMemory.create_fts_index proxy):
+- long_term_memory is None -> ("unsupported", None)
+- long_term_memory present -> delegates through
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from memmachine_server.common.vector_graph_store.neo4j_vector_graph_store import (
+    Neo4jVectorGraphStore,
+)
+from memmachine_server.episodic_memory.episodic_memory import EpisodicMemory
+from memmachine_server.episodic_memory.long_term_memory import LongTermMemory
+
+
+def _declarative_ltm(*, vector_graph_store) -> LongTermMemory:
+    """Build a declarative-backed LongTermMemory without running __init__.
+
+    `create_fts_index` only touches `self._backend`, `self._declarative_memory`
+    (and the declarative memory's `_vector_graph_store` /
+    `_derivative_collection`), so we set those attributes directly instead of
+    constructing the full dependency graph.
+    """
+    ltm = LongTermMemory.__new__(LongTermMemory)
+    ltm._backend = "declarative"
+
+    declarative_memory = MagicMock()
+    declarative_memory._vector_graph_store = vector_graph_store
+    declarative_memory._derivative_collection = "Derivative_test-session"
+    ltm._declarative_memory = declarative_memory
+    return ltm
+
+
+@pytest.mark.asyncio
+async def test_create_fts_index_creates_index_on_neo4j():
+    """On a Neo4j store, the index is created and its name returned.
+
+    `create_fts_index` runs regardless of `fts_enabled` (it is the explicit
+    user command), so unlike `initialize_fts` it does not consult
+    `self._fts_enabled`.
+    """
+    store = MagicMock(spec=Neo4jVectorGraphStore)
+    store._sanitize_name = MagicMock(return_value="Derivative_test_session")
+    store._create_fts_index_if_not_exists = AsyncMock()
+
+    ltm = _declarative_ltm(vector_graph_store=store)
+
+    status, index_name = await ltm.create_fts_index()
+
+    store._create_fts_index_if_not_exists.assert_awaited_once_with(
+        sanitized_collection="Derivative_test_session",
+    )
+    assert status == "created"
+    assert index_name == "fts_Derivative_test_session_content"
+
+
+@pytest.mark.asyncio
+async def test_create_fts_index_unsupported_on_non_neo4j_store():
+    """A non-Neo4j store (e.g. Nebula) returns ``("unsupported", None)``.
+
+    Unlike `initialize_fts` (which skips silently), the explicit command
+    reports the unsupported backend so the API layer can surface a
+    consistent response without try/except branching.
+    """
+    # A plain MagicMock is not a Neo4jVectorGraphStore, so the isinstance
+    # guard treats it as an unsupported backend.
+    store = MagicMock()
+    store._create_fts_index_if_not_exists = AsyncMock()
+
+    ltm = _declarative_ltm(vector_graph_store=store)
+
+    status, index_name = await ltm.create_fts_index()
+
+    store._create_fts_index_if_not_exists.assert_not_awaited()
+    assert status == "unsupported"
+    assert index_name is None
+
+
+@pytest.mark.asyncio
+async def test_create_fts_index_unsupported_on_event_backend():
+    """The event backend has no FTS, so the command reports ``unsupported``."""
+    ltm = LongTermMemory.__new__(LongTermMemory)
+    ltm._backend = "event"
+    ltm._declarative_memory = None  # event backend has no declarative memory
+
+    status, index_name = await ltm.create_fts_index()
+
+    assert status == "unsupported"
+    assert index_name is None
+
+
+@pytest.mark.asyncio
+async def test_episodic_memory_proxy_returns_unsupported_when_ltm_is_none():
+    """The EpisodicMemory proxy returns unsupported when LTM is not wired.
+
+    This covers the path where `EpisodicMemory.create_fts_index` short-
+    circuits before delegating to `LongTermMemory.create_fts_index`.
+    """
+    episodic_memory = EpisodicMemory.__new__(EpisodicMemory)
+    episodic_memory._long_term_memory = None
+
+    status, index_name = await episodic_memory.create_fts_index()
+
+    assert status == "unsupported"
+    assert index_name is None
+
+
+@pytest.mark.asyncio
+async def test_episodic_memory_proxy_delegates_to_ltm():
+    """The EpisodicMemory proxy delegates to its LongTermMemory when present."""
+    ltm = MagicMock()
+    ltm.create_fts_index = AsyncMock(return_value=("created", "fts_xyz_content"))
+
+    episodic_memory = EpisodicMemory.__new__(EpisodicMemory)
+    episodic_memory._long_term_memory = ltm
+
+    status, index_name = await episodic_memory.create_fts_index()
+
+    ltm.create_fts_index.assert_awaited_once()
+    assert status == "created"
+    assert index_name == "fts_xyz_content"

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_fts_initialization.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_fts_initialization.py
@@ -1,0 +1,116 @@
+"""Unit tests for `LongTermMemory.initialize_fts`.
+
+`initialize_fts` creates the Neo4j Full-Text Search index up front at session
+creation so the first ingest is immediately searchable via hybrid search.
+
+These tests do NOT require a live Neo4j instance. The `VectorGraphStore` is
+mocked, so we verify only the dispatch logic — whether the FTS index-creation
+call is made or skipped — not the real Cypher.
+
+Cases:
+- declarative + fts_enabled + Neo4j store -> creates the index
+- declarative + fts_enabled=False -> skips (no call)
+- declarative + non-Neo4j (e.g. Nebula) store -> skips with a warning
+- event backend -> skips (FTS is declarative-only)
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from memmachine_server.common.vector_graph_store.neo4j_vector_graph_store import (
+    Neo4jVectorGraphStore,
+)
+from memmachine_server.episodic_memory.long_term_memory import LongTermMemory
+
+
+def _declarative_ltm(*, fts_enabled: bool, vector_graph_store) -> LongTermMemory:
+    """Build a declarative-backed LongTermMemory without running __init__.
+
+    `initialize_fts` only touches `self._fts_enabled`, `self._backend`,
+    `self._declarative_memory` (and the declarative memory's
+    `_vector_graph_store` / `_derivative_collection`), so we set those
+    attributes directly instead of constructing the full dependency graph.
+    """
+    ltm = LongTermMemory.__new__(LongTermMemory)
+    ltm._backend = "declarative"
+    ltm._fts_enabled = fts_enabled
+
+    declarative_memory = MagicMock()
+    declarative_memory._vector_graph_store = vector_graph_store
+    declarative_memory._derivative_collection = "Derivative_test-session"
+    ltm._declarative_memory = declarative_memory
+    return ltm
+
+
+@pytest.mark.asyncio
+async def test_initialize_fts_creates_index_on_neo4j():
+    """With FTS enabled and a Neo4j store, the index is created up front."""
+    store = MagicMock(spec=Neo4jVectorGraphStore)
+    store._sanitize_name = MagicMock(return_value="Derivative_test_session")
+    store._create_fts_index_if_not_exists = AsyncMock()
+
+    ltm = _declarative_ltm(fts_enabled=True, vector_graph_store=store)
+
+    await ltm.initialize_fts()
+
+    store._create_fts_index_if_not_exists.assert_awaited_once_with(
+        sanitized_collection="Derivative_test_session",
+    )
+
+
+@pytest.mark.asyncio
+async def test_initialize_fts_skips_when_disabled():
+    """When `fts_enabled=False`, no FTS index is created."""
+    store = MagicMock(spec=Neo4jVectorGraphStore)
+    store._create_fts_index_if_not_exists = AsyncMock()
+
+    ltm = _declarative_ltm(fts_enabled=False, vector_graph_store=store)
+
+    await ltm.initialize_fts()
+
+    store._create_fts_index_if_not_exists.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_initialize_fts_skips_non_neo4j_store(caplog):
+    """A non-Neo4j store (e.g. Nebula) is skipped with a warning, not an error.
+
+    FTS initialization is opt-in and must not break session creation on
+    backends without FTS, so `initialize_fts` returns silently instead of
+    raising `NotImplementedError` (unlike `_search_fts`, which raises because
+    the caller explicitly asked for FTS).
+    """
+    # A plain MagicMock is not a Neo4jVectorGraphStore, so the isinstance
+    # guard treats it as an unsupported backend.
+    store = MagicMock()
+    store._create_fts_index_if_not_exists = AsyncMock()
+
+    ltm = _declarative_ltm(fts_enabled=True, vector_graph_store=store)
+
+    with caplog.at_level(
+        "WARNING",
+        logger="memmachine_server.episodic_memory.long_term_memory.long_term_memory",
+    ):
+        await ltm.initialize_fts()
+
+    store._create_fts_index_if_not_exists.assert_not_awaited()
+    assert any("not Neo4j" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_initialize_fts_skips_on_event_backend():
+    """The event backend has no FTS, so initialization is a no-op.
+
+    The event backend sets `_fts_enabled=False` in __init__; we replicate
+    that state here to confirm `initialize_fts` short-circuits before
+    touching any store.
+    """
+    ltm = LongTermMemory.__new__(LongTermMemory)
+    ltm._backend = "event"
+    ltm._fts_enabled = False
+    ltm._declarative_memory = None  # event backend has no declarative memory
+
+    # Must not raise (no assert on _declarative_memory fires) and must not
+    # touch any store.
+    await ltm.initialize_fts()

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_hybrid_search.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_hybrid_search.py
@@ -1,0 +1,329 @@
+"""Unit tests for the hybrid search merge logic in `LongTermMemory`.
+
+These tests do NOT require a live Neo4j instance. They patch
+`_search_scored_declarative` and `_search_fts` to return canned results and
+verify the merge/dedup/fusion behavior of `_search_scored_hybrid` directly:
+
+- append mode respects `append_n`
+- append mode deduplicates by episode uid
+- RRF mode (True / "rrf") fuses vector + FTS by rank, selects top-k, then
+  re-sorts by timestamp
+- an invalid `use_fts` value raises ValueError
+- score threshold is applied after the merge/fusion
+"""
+
+from contextlib import ExitStack
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from memmachine_server.common.episode_store import Episode
+from memmachine_server.episodic_memory.long_term_memory import LongTermMemory
+
+
+def _episode(
+    uid: str, content: str = "", *, created_at: datetime | None = None
+) -> Episode:
+    """Build a minimal Episode for testing."""
+    return Episode(
+        uid=uid,
+        content=content,
+        session_key="",
+        created_at=created_at or datetime.now(UTC),
+        producer_id="",
+        producer_role="",
+    )
+
+
+def _make_long_term_memory() -> LongTermMemory:
+    """Construct a LongTermMemory without running its full __init__.
+
+    `_search_scored_hybrid` only touches `self._declarative_memory` (asserted
+    non-None), so we bypass __init__ and set that attribute directly.
+    """
+    ltm = LongTermMemory.__new__(LongTermMemory)
+    ltm._declarative_memory = object()  # truthy; satisfies the assert
+    return ltm
+
+
+@pytest.mark.asyncio
+async def test_append_mode_respects_append_n():
+    """Append mode returns at most `append_n` unique FTS results after vector."""
+    vector_results = [
+        (0.9, _episode("v1", "vector hit one")),
+        (0.8, _episode("v2", "vector hit two")),
+    ]
+    # FTS returns 50 candidates (over-fetch); append_n=5 should slice to 5.
+    fts_results = [(float(i), _episode(f"f{i}", f"fts hit {i}")) for i in range(50)]
+
+    ltm = _make_long_term_memory()
+    with (
+        patch.object(
+            ltm,
+            "_search_scored_declarative",
+            new=AsyncMock(return_value=vector_results),
+        ),
+        patch.object(
+            ltm,
+            "_search_fts",
+            new=AsyncMock(return_value=fts_results),
+        ) as fts_mock,
+    ):
+        merged = await ltm._search_scored_hybrid(
+            "query",
+            num_episodes_limit=10,
+            expand_context=0,
+            score_threshold=None,
+            property_filter=None,
+            use_fts="append",
+            append_n=5,
+        )
+
+    # 2 vector results + 5 appended FTS results = 7
+    assert len(merged) == 7
+    uids = [ep.uid for _, ep in merged]
+    assert uids[:2] == ["v1", "v2"]
+    # The 5 appended come from the first 5 FTS results (highest score).
+    assert uids[2:] == ["f0", "f1", "f2", "f3", "f4"]
+
+    # FTS is called with num_episodes_limit (used for over-fetch sizing), not append_n.
+    fts_mock.assert_awaited_once()
+    assert fts_mock.call_args.kwargs["num_episodes_limit"] == 10
+
+
+@pytest.mark.asyncio
+async def test_append_mode_dedups_by_uid():
+    """FTS results whose uid already exists in vector results are skipped."""
+    vector_results = [(0.9, _episode("shared", "in both"))]
+    fts_results = [
+        (0.7, _episode("shared", "duplicate uid")),
+        (0.6, _episode("unique", "only in fts")),
+    ]
+
+    ltm = _make_long_term_memory()
+    with (
+        patch.object(
+            ltm,
+            "_search_scored_declarative",
+            new=AsyncMock(return_value=vector_results),
+        ),
+        patch.object(
+            ltm,
+            "_search_fts",
+            new=AsyncMock(return_value=fts_results),
+        ),
+    ):
+        merged = await ltm._search_scored_hybrid(
+            "query",
+            num_episodes_limit=10,
+            expand_context=0,
+            score_threshold=None,
+            property_filter=None,
+            use_fts="append",
+            append_n=10,
+        )
+
+    uids = [ep.uid for _, ep in merged]
+    # "shared" appears once (vector), "unique" appended once.
+    assert uids == ["shared", "unique"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_fts", [True, "rrf"])
+async def test_rrf_mode_fuses_and_sorts_by_timestamp(use_fts):
+    """RRF fuses vector + FTS ranks, selects top-k, then sorts by timestamp.
+
+    Setup: vector ranks v1(1) > v2(2); FTS ranks f1(1) > v1(2) > f2(3).
+    v1 appears in both lists → highest RRF score. Final output is re-sorted by
+    timestamp, not by RRF score.
+    """
+    now = datetime.now(UTC)
+    # Deliberate timestamps that do NOT match relevance rank, so we can confirm
+    # the final ordering is by timestamp, not RRF score.
+    v1 = _episode("v1", "vector one", created_at=now + timedelta(seconds=20))
+    v2 = _episode("v2", "vector two", created_at=now + timedelta(seconds=10))
+    f1 = _episode("f1", "fts one", created_at=now + timedelta(seconds=5))
+    f2 = _episode("f2", "fts two", created_at=now + timedelta(seconds=0))
+
+    vector_results = [(0.9, v1), (0.8, v2)]  # ranks 1, 2
+    fts_results = [(0.9, f1), (0.7, v1), (0.6, f2)]  # ranks 1, 2, 3
+
+    ltm = _make_long_term_memory()
+    with (
+        patch.object(
+            ltm,
+            "_search_scored_declarative",
+            new=AsyncMock(return_value=vector_results),
+        ),
+        patch.object(
+            ltm,
+            "_search_fts",
+            new=AsyncMock(return_value=fts_results),
+        ),
+    ):
+        merged = await ltm._search_scored_hybrid(
+            "query",
+            num_episodes_limit=10,
+            expand_context=0,
+            score_threshold=None,
+            property_filter=None,
+            use_fts=use_fts,
+            append_n=10,
+        )
+
+    # All 4 distinct uids are selected (limit 10). v1 (in both lists) must be
+    # present. Final order must be by timestamp ascending (oldest first).
+    uids = [ep.uid for _, ep in merged]
+    assert set(uids) == {"v1", "v2", "f1", "f2"}
+    assert uids == ["f2", "f1", "v2", "v1"]  # timestamp ascending
+
+    # v1 must have the highest RRF score (appears in both rankings).
+    score_by_uid = {ep.uid: score for score, ep in merged}
+    assert score_by_uid["v1"] > score_by_uid["f1"]
+    assert score_by_uid["v1"] > score_by_uid["v2"]
+
+
+@pytest.mark.asyncio
+async def test_rrf_mode_respects_top_k_limit():
+    """RRF returns at most `num_episodes_limit` candidates (top-k selection)."""
+    vector_results = [(float(10 - i), _episode(f"v{i}")) for i in range(8)]
+    fts_results = [(float(10 - i), _episode(f"f{i}")) for i in range(8)]
+
+    ltm = _make_long_term_memory()
+    with (
+        patch.object(
+            ltm,
+            "_search_scored_declarative",
+            new=AsyncMock(return_value=vector_results),
+        ),
+        patch.object(
+            ltm,
+            "_search_fts",
+            new=AsyncMock(return_value=fts_results),
+        ),
+    ):
+        merged = await ltm._search_scored_hybrid(
+            "query",
+            num_episodes_limit=5,
+            expand_context=0,
+            score_threshold=None,
+            property_filter=None,
+            use_fts=True,
+            append_n=10,
+        )
+
+    assert len(merged) == 5
+
+
+@pytest.mark.asyncio
+async def test_rrf_mode_dedups_across_lists():
+    """An episode appearing in both vector and FTS contributes RRF from both."""
+    shared = _episode("shared", "in both")
+    vector_results = [(0.9, shared)]  # rank 1 -> 1/(60+1)
+    fts_results = [(0.8, shared)]  # rank 1 -> 1/(60+1)
+
+    ltm = _make_long_term_memory()
+    with (
+        patch.object(
+            ltm,
+            "_search_scored_declarative",
+            new=AsyncMock(return_value=vector_results),
+        ),
+        patch.object(
+            ltm,
+            "_search_fts",
+            new=AsyncMock(return_value=fts_results),
+        ),
+    ):
+        merged = await ltm._search_scored_hybrid(
+            "query",
+            num_episodes_limit=10,
+            expand_context=0,
+            score_threshold=None,
+            property_filter=None,
+            use_fts="rrf",
+            append_n=10,
+        )
+
+    # Only one entry despite appearing in both lists.
+    assert len(merged) == 1
+    score, ep = merged[0]
+    assert ep.uid == "shared"
+    # 1/(60+1) + 1/(60+1) == 2/61
+    assert score == pytest.approx(2.0 / 61.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_value", ["rrf2", "RRF", "unknown", 1, "true"])
+async def test_invalid_use_fts_raises_value_error(bad_value):
+    """An invalid `use_fts` value must raise ValueError, not fall through."""
+    ltm = _make_long_term_memory()
+    # Use ExitStack so the two patches and pytest.raises live as three
+    # independent enter_context calls under one `with`, instead of nested
+    # `with` statements that ruff's SIM117 would try to merge (merging them
+    # turns the patches into a tuple, which has no context-manager protocol).
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(
+                ltm,
+                "_search_scored_declarative",
+                new=AsyncMock(return_value=[]),
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                ltm,
+                "_search_fts",
+                new=AsyncMock(return_value=[]),
+            )
+        )
+        with pytest.raises(ValueError, match="Invalid use_fts value"):
+            await ltm._search_scored_hybrid(
+                "query",
+                num_episodes_limit=10,
+                expand_context=0,
+                score_threshold=None,
+                property_filter=None,
+                use_fts=bad_value,  # type: ignore[arg-type]
+                append_n=10,
+            )
+
+
+@pytest.mark.asyncio
+async def test_append_mode_applies_score_threshold():
+    """Score threshold filters merged results (drops below threshold)."""
+    vector_results = [
+        (0.9, _episode("v1")),
+        (0.3, _episode("v2")),  # below threshold
+    ]
+    fts_results = [
+        (0.8, _episode("f1")),
+        (0.2, _episode("f2")),  # below threshold
+    ]
+
+    ltm = _make_long_term_memory()
+    with (
+        patch.object(
+            ltm,
+            "_search_scored_declarative",
+            new=AsyncMock(return_value=vector_results),
+        ),
+        patch.object(
+            ltm,
+            "_search_fts",
+            new=AsyncMock(return_value=fts_results),
+        ),
+    ):
+        merged = await ltm._search_scored_hybrid(
+            "query",
+            num_episodes_limit=10,
+            expand_context=0,
+            score_threshold=0.5,
+            property_filter=None,
+            use_fts="append",
+            append_n=10,
+        )
+
+    uids = [ep.uid for _, ep in merged]
+    assert uids == ["v1", "f1"]

--- a/packages/server/server_tests/memmachine_server/retrieval_agent/test_retrieval_agent.py
+++ b/packages/server/server_tests/memmachine_server/retrieval_agent/test_retrieval_agent.py
@@ -92,6 +92,7 @@ class FakeEpisodicMemory(EpisodicMemory):
         expand_context: int = 0,
         score_threshold: float = -float("inf"),
         property_filter: Any | None = None,
+        use_fts: bool = False,
         mode: EpisodicMemory.QueryMode = EpisodicMemory.QueryMode.BOTH,
     ) -> EpisodicMemory.QueryResponse | None:
         self.queries.append(query)
@@ -102,6 +103,7 @@ class FakeEpisodicMemory(EpisodicMemory):
                 "expand_context": expand_context,
                 "score_threshold": score_threshold,
                 "property_filter": property_filter,
+                "use_fts": use_fts,
                 "mode": mode,
             }
         )
@@ -202,6 +204,7 @@ async def test_memmachine_agent_queries_long_term_memory_only(
             "expand_context": 2,
             "score_threshold": 0.55,
             "property_filter": None,
+            "use_fts": False,
             "mode": EpisodicMemory.QueryMode.LONG_TERM_ONLY,
         }
     ]

--- a/packages/server/server_tests/memmachine_server/retrieval_agent/test_retrieval_agent.py
+++ b/packages/server/server_tests/memmachine_server/retrieval_agent/test_retrieval_agent.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
+from memmachine_common.api.spec import FtsMode
 
 from memmachine_server.common.episode_store import Episode, EpisodeResponse
 from memmachine_server.common.language_model.language_model import LanguageModel
@@ -92,7 +93,8 @@ class FakeEpisodicMemory(EpisodicMemory):
         expand_context: int = 0,
         score_threshold: float = -float("inf"),
         property_filter: Any | None = None,
-        use_fts: bool = False,
+        use_fts: FtsMode = False,
+        append_n: int = 10,
         mode: EpisodicMemory.QueryMode = EpisodicMemory.QueryMode.BOTH,
     ) -> EpisodicMemory.QueryResponse | None:
         self.queries.append(query)

--- a/packages/server/src/memmachine_server/common/configuration/episodic_config.py
+++ b/packages/server/src/memmachine_server/common/configuration/episodic_config.py
@@ -196,6 +196,18 @@ class DeclarativeLongTermMemoryConf(BaseModel):
         False,
         description="Whether to chunk message episodes into sentences for embedding",
     )
+    fts_enabled: bool = Field(
+        True,
+        description=(
+            "Whether to auto-create the Neo4j Full-Text Search (FTS) index for "
+            "this session at session creation. Default True: the FTS index is "
+            "created up front so the first ingest is immediately searchable via "
+            "hybrid (Vector+FTS) search. Set False to skip FTS initialization "
+            "(e.g. on a non-Neo4j backend or when FTS is not wanted). Only "
+            "effective with the declarative backend; silently ignored on the "
+            "event backend."
+        ),
+    )
 
 
 class EventLongTermMemoryConf(BaseModel):
@@ -282,6 +294,14 @@ class LongTermMemoryConfPartial(BaseModel):
     message_sentence_chunking: bool | None = Field(
         default=None,
         description="Sentence-chunk message episodes (declarative backend only)",
+    )
+    fts_enabled: bool | None = Field(
+        default=None,
+        description=(
+            "Whether to auto-create the FTS index at session creation "
+            "(declarative backend only). None defers to the resolved default "
+            "(True). Set False to skip FTS initialization."
+        ),
     )
 
     # Event-backend fields.

--- a/packages/server/src/memmachine_server/common/vector_graph_store/neo4j_vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/neo4j_vector_graph_store.py
@@ -148,7 +148,7 @@ class Neo4jVectorGraphStoreParams(BaseModel):
         ),
     )
     range_index_creation_threshold: int = Field(
-        10_000,
+        1_000, # [10k→1k] Enable range index creation for small-to-medium datasets (< 10k nodes)
         description=(
             "Threshold number of entities "
             "in a collection or having a relation "
@@ -156,7 +156,7 @@ class Neo4jVectorGraphStoreParams(BaseModel):
         ),
     )
     vector_index_creation_threshold: int = Field(
-        10_000,
+        1_000, # [10k→1k] Enable vector index creation for small-to-medium datasets (< 10k nodes)
         description=(
             "Threshold number of entities "
             "in a collection or having a relation "

--- a/packages/server/src/memmachine_server/common/vector_graph_store/neo4j_vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/neo4j_vector_graph_store.py
@@ -303,6 +303,16 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                     )
                 )
 
+                # Create FTS Index (for all NODE collections)
+                self._track_task(
+                    asyncio.create_task(
+                        self._create_fts_index_if_not_exists(
+                            entity_type=EntityType.NODE,      
+                            sanitized_collection_or_relation=sanitized_collection,
+                        ),
+                    )
+                )
+
             if (
                 self._collection_node_counts[collection]
                 >= self._vector_index_creation_threshold
@@ -1060,6 +1070,66 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                 range_index_name,
                 create_index_awaitable,
             )
+
+    async def _create_fts_index_if_not_exists(
+        self,
+        entity_type: EntityType,
+        sanitized_collection_or_relation: str,
+    ) -> None:
+        """Create a Full-Text Search (FTS) index if missing and wait for it to be online."""
+        async with self._tracker("create_fts_index_if_not_exists"):
+            logger.info(f"Creating FTS index for '{sanitized_collection_or_relation}'...")
+            await self._populate_index_state_cache()
+
+            fts_index_name = f"fts_{sanitized_collection_or_relation}_content"
+            logger.info(f"FTS index name: '{fts_index_name}'")
+
+            cached_index_state = self._index_state_cache.get(fts_index_name)
+            logger.info(f"Cached index state: {cached_index_state}")
+
+            match cached_index_state:
+                case Neo4jVectorGraphStore.CacheIndexState.CREATING:
+                    # Wait for the index to be online.
+                    logger.info(f"FTS index is already being created, waiting...")
+                    await self._await_create_index_if_not_exists(
+                        fts_index_name,
+                        asyncio.sleep(0),
+                    )
+                    return
+                case Neo4jVectorGraphStore.CacheIndexState.ONLINE:
+                    logger.info(f"FTS index is already online")
+                    return
+
+            # Code is synchronous between the cache read and this write,
+            # so it is effectively atomic in the asynchronous framework.
+            self._index_state_cache[fts_index_name] = (
+                Neo4jVectorGraphStore.CacheIndexState.CREATING
+            )
+
+            # FTS only supports NODE entities; use 'n' alias to match ON EACH clause.
+            query_index_for_expression = f"(n:{sanitized_collection_or_relation})"
+
+            logger.info(f"Executing CREATE FULLTEXT INDEX query...")
+            create_index_awaitable = self._driver.execute_query(
+                _neo4j_query(
+                    f"CREATE FULLTEXT INDEX {fts_index_name}\n"
+                    "IF NOT EXISTS\n"
+                    f"FOR {query_index_for_expression}\n"
+                    f"ON EACH [n.{Neo4jVectorGraphStore._sanitize_name(mangle_property_name('content'))}]\n"
+                    "OPTIONS {\n"
+                    "    indexConfig: {\n"
+                    "        `fulltext.analyzer`: 'standard'\n"
+                    "    }\n"
+                    "}"
+                ),
+            )
+
+            logger.info(f"Waiting for FTS index to be online...")
+            await self._await_create_index_if_not_exists(
+                fts_index_name,
+                create_index_awaitable,
+            )
+            logger.info(f"FTS index '{fts_index_name}' is now online")
 
     async def _create_vector_index_if_not_exists(
         self,

--- a/packages/server/src/memmachine_server/common/vector_graph_store/neo4j_vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/neo4j_vector_graph_store.py
@@ -148,7 +148,7 @@ class Neo4jVectorGraphStoreParams(BaseModel):
         ),
     )
     range_index_creation_threshold: int = Field(
-        1_000, # [10k→1k] Enable range index creation for small-to-medium datasets (< 10k nodes)
+        1_000,  # [10k→1k] Enable range index creation for small-to-medium datasets (< 10k nodes)
         description=(
             "Threshold number of entities "
             "in a collection or having a relation "
@@ -156,7 +156,7 @@ class Neo4jVectorGraphStoreParams(BaseModel):
         ),
     )
     vector_index_creation_threshold: int = Field(
-        1_000, # [10k→1k] Enable vector index creation for small-to-medium datasets (< 10k nodes)
+        1_000,  # [10k→1k] Enable vector index creation for small-to-medium datasets (< 10k nodes)
         description=(
             "Threshold number of entities "
             "in a collection or having a relation "
@@ -307,8 +307,7 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                 self._track_task(
                     asyncio.create_task(
                         self._create_fts_index_if_not_exists(
-                            entity_type=EntityType.NODE,      
-                            sanitized_collection_or_relation=sanitized_collection,
+                            sanitized_collection=sanitized_collection,
                         ),
                     )
                 )
@@ -1073,31 +1072,33 @@ class Neo4jVectorGraphStore(VectorGraphStore):
 
     async def _create_fts_index_if_not_exists(
         self,
-        entity_type: EntityType,
-        sanitized_collection_or_relation: str,
+        sanitized_collection: str,
     ) -> None:
-        """Create a Full-Text Search (FTS) index if missing and wait for it to be online."""
+        """Create a Full-Text Search (FTS) index if missing and wait for it to be online.
+
+        FTS indexes are only supported for nodes, so no entity type is accepted.
+        """
         async with self._tracker("create_fts_index_if_not_exists"):
-            logger.info(f"Creating FTS index for '{sanitized_collection_or_relation}'...")
+            logger.info("Creating FTS index for '%s'...", sanitized_collection)
             await self._populate_index_state_cache()
 
-            fts_index_name = f"fts_{sanitized_collection_or_relation}_content"
-            logger.info(f"FTS index name: '{fts_index_name}'")
+            fts_index_name = f"fts_{sanitized_collection}_content"
+            logger.info("FTS index name: '%s'", fts_index_name)
 
             cached_index_state = self._index_state_cache.get(fts_index_name)
-            logger.info(f"Cached index state: {cached_index_state}")
+            logger.info("Cached index state: %s", cached_index_state)
 
             match cached_index_state:
                 case Neo4jVectorGraphStore.CacheIndexState.CREATING:
                     # Wait for the index to be online.
-                    logger.info(f"FTS index is already being created, waiting...")
+                    logger.info("FTS index is already being created, waiting...")
                     await self._await_create_index_if_not_exists(
                         fts_index_name,
                         asyncio.sleep(0),
                     )
                     return
                 case Neo4jVectorGraphStore.CacheIndexState.ONLINE:
-                    logger.info(f"FTS index is already online")
+                    logger.info("FTS index is already online")
                     return
 
             # Code is synchronous between the cache read and this write,
@@ -1107,9 +1108,9 @@ class Neo4jVectorGraphStore(VectorGraphStore):
             )
 
             # FTS only supports NODE entities; use 'n' alias to match ON EACH clause.
-            query_index_for_expression = f"(n:{sanitized_collection_or_relation})"
+            query_index_for_expression = f"(n:{sanitized_collection})"
 
-            logger.info(f"Executing CREATE FULLTEXT INDEX query...")
+            logger.info("Executing CREATE FULLTEXT INDEX query...")
             create_index_awaitable = self._driver.execute_query(
                 _neo4j_query(
                     f"CREATE FULLTEXT INDEX {fts_index_name}\n"
@@ -1124,12 +1125,12 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                 ),
             )
 
-            logger.info(f"Waiting for FTS index to be online...")
+            logger.info("Waiting for FTS index to be online...")
             await self._await_create_index_if_not_exists(
                 fts_index_name,
                 create_index_awaitable,
             )
-            logger.info(f"FTS index '{fts_index_name}' is now online")
+            logger.info("FTS index '%s' is now online", fts_index_name)
 
     async def _create_vector_index_if_not_exists(
         self,

--- a/packages/server/src/memmachine_server/episodic_memory/episodic_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/episodic_memory.py
@@ -336,6 +336,7 @@ class EpisodicMemory:
         expand_context: int,
         score_threshold: float,
         property_filter: FilterExpr | None,
+        use_fts: bool = False, # Full-Text Search flag for hybrid search
     ) -> list[tuple[float, Episode]]:
         """Query long-term memory or return an empty result if unavailable."""
         if self._long_term_memory is None:
@@ -347,6 +348,7 @@ class EpisodicMemory:
             expand_context=expand_context,
             score_threshold=score_threshold,
             property_filter=property_filter,
+            use_fts=use_fts, # Full-Text Search flag for hybrid search
         )
 
     async def query_memory(
@@ -357,6 +359,7 @@ class EpisodicMemory:
         expand_context: int = 0,
         score_threshold: float = -float("inf"),
         property_filter: FilterExpr | None = None,
+        use_fts: bool = False, # Full-Text Search flag for hybrid search
         mode: QueryMode = QueryMode.BOTH,
     ) -> QueryResponse | None:
         """
@@ -400,6 +403,7 @@ class EpisodicMemory:
                     expand_context=expand_context,
                     score_threshold=score_threshold,
                     property_filter=property_filter,
+                    use_fts=use_fts, # Full-Text Search flag for hybrid search
                 )
             elif self._long_term_memory is None:
                 short_episode, short_summary = await self._query_short_term_memory(
@@ -421,6 +425,7 @@ class EpisodicMemory:
                         expand_context=expand_context,
                         score_threshold=score_threshold,
                         property_filter=property_filter,
+                        use_fts=use_fts, # Full-Text Search flag for hybrid search
                     ),
                 )
                 short_episode, short_summary = session_result
@@ -431,6 +436,7 @@ class EpisodicMemory:
                 expand_context=expand_context,
                 score_threshold=score_threshold,
                 property_filter=property_filter,
+                use_fts=use_fts, # Full-Text Search flag for hybrid search
             )
         elif mode is EpisodicMemory.QueryMode.SHORT_TERM_ONLY:
             short_episode, short_summary = await self._query_short_term_memory(

--- a/packages/server/src/memmachine_server/episodic_memory/episodic_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/episodic_memory.py
@@ -336,7 +336,7 @@ class EpisodicMemory:
         expand_context: int,
         score_threshold: float,
         property_filter: FilterExpr | None,
-        use_fts: bool = False, # Full-Text Search flag for hybrid search
+        use_fts: bool = False,  # Full-Text Search flag for hybrid search
     ) -> list[tuple[float, Episode]]:
         """Query long-term memory or return an empty result if unavailable."""
         if self._long_term_memory is None:
@@ -348,7 +348,7 @@ class EpisodicMemory:
             expand_context=expand_context,
             score_threshold=score_threshold,
             property_filter=property_filter,
-            use_fts=use_fts, # Full-Text Search flag for hybrid search
+            use_fts=use_fts,  # Full-Text Search flag for hybrid search
         )
 
     async def query_memory(
@@ -359,7 +359,7 @@ class EpisodicMemory:
         expand_context: int = 0,
         score_threshold: float = -float("inf"),
         property_filter: FilterExpr | None = None,
-        use_fts: bool = False, # Full-Text Search flag for hybrid search
+        use_fts: bool = False,  # Full-Text Search flag for hybrid search
         mode: QueryMode = QueryMode.BOTH,
     ) -> QueryResponse | None:
         """
@@ -378,6 +378,7 @@ class EpisodicMemory:
                             around each matched episode from long term memory.
             score_threshold: Minimum score to consider a match.
             property_filter: Properties to filter declarative memory searches.
+            use_fts: Full-Text Search flag for hybrid search
             mode: Which memory backends to query.
 
         Returns:
@@ -403,7 +404,7 @@ class EpisodicMemory:
                     expand_context=expand_context,
                     score_threshold=score_threshold,
                     property_filter=property_filter,
-                    use_fts=use_fts, # Full-Text Search flag for hybrid search
+                    use_fts=use_fts,  # Full-Text Search flag for hybrid search
                 )
             elif self._long_term_memory is None:
                 short_episode, short_summary = await self._query_short_term_memory(
@@ -425,7 +426,7 @@ class EpisodicMemory:
                         expand_context=expand_context,
                         score_threshold=score_threshold,
                         property_filter=property_filter,
-                        use_fts=use_fts, # Full-Text Search flag for hybrid search
+                        use_fts=use_fts,  # Full-Text Search flag for hybrid search
                     ),
                 )
                 short_episode, short_summary = session_result
@@ -436,7 +437,7 @@ class EpisodicMemory:
                 expand_context=expand_context,
                 score_threshold=score_threshold,
                 property_filter=property_filter,
-                use_fts=use_fts, # Full-Text Search flag for hybrid search
+                use_fts=use_fts,  # Full-Text Search flag for hybrid search
             )
         elif mode is EpisodicMemory.QueryMode.SHORT_TERM_ONLY:
             short_episode, short_summary = await self._query_short_term_memory(

--- a/packages/server/src/memmachine_server/episodic_memory/episodic_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/episodic_memory.py
@@ -206,6 +206,21 @@ class EpisodicMemory:
         """
         return self._session_key
 
+    async def create_fts_index(self) -> tuple[str, str | None]:
+        """Manually create the FTS index for this session's long-term memory.
+
+        Delegates to `LongTermMemory.create_fts_index`. Returns ``("unsupported",
+        None)`` when long-term memory is disabled or has no FTS backend, so the
+        API layer can report a consistent status without branching.
+
+        Returns:
+            A `(status, index_name)` tuple (see `LongTermMemory.create_fts_index`).
+
+        """
+        if self._long_term_memory is None:
+            return ("unsupported", None)
+        return await self._long_term_memory.create_fts_index()
+
     async def add_memory_episodes(self, episodes: list[Episode]) -> None:
         """
         Add a new memory episode to both session and declarative memory.

--- a/packages/server/src/memmachine_server/episodic_memory/episodic_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/episodic_memory.py
@@ -23,6 +23,7 @@ from collections.abc import Coroutine, Iterable
 from enum import StrEnum
 from typing import cast, get_args
 
+from memmachine_common.api.spec import FtsMode
 from pydantic import BaseModel, Field, InstanceOf, model_validator
 
 from memmachine_server.common.data_types import PropertyValue
@@ -336,7 +337,8 @@ class EpisodicMemory:
         expand_context: int,
         score_threshold: float,
         property_filter: FilterExpr | None,
-        use_fts: bool = False,  # Full-Text Search flag for hybrid search
+        use_fts: FtsMode = False,  # Full-Text Search flag for hybrid search
+        append_n: int = 10,  # Number of FTS results to append (append mode)
     ) -> list[tuple[float, Episode]]:
         """Query long-term memory or return an empty result if unavailable."""
         if self._long_term_memory is None:
@@ -349,6 +351,7 @@ class EpisodicMemory:
             score_threshold=score_threshold,
             property_filter=property_filter,
             use_fts=use_fts,  # Full-Text Search flag for hybrid search
+            append_n=append_n,  # Number of FTS results to append (append mode)
         )
 
     async def query_memory(
@@ -359,7 +362,8 @@ class EpisodicMemory:
         expand_context: int = 0,
         score_threshold: float = -float("inf"),
         property_filter: FilterExpr | None = None,
-        use_fts: bool = False,  # Full-Text Search flag for hybrid search
+        use_fts: FtsMode = False,  # Full-Text Search flag for hybrid search
+        append_n: int = 10,  # Number of FTS results to append (append mode)
         mode: QueryMode = QueryMode.BOTH,
     ) -> QueryResponse | None:
         """
@@ -379,6 +383,7 @@ class EpisodicMemory:
             score_threshold: Minimum score to consider a match.
             property_filter: Properties to filter declarative memory searches.
             use_fts: Full-Text Search flag for hybrid search
+            append_n: Number of FTS results to append (only used in 'append' mode)
             mode: Which memory backends to query.
 
         Returns:
@@ -405,6 +410,7 @@ class EpisodicMemory:
                     score_threshold=score_threshold,
                     property_filter=property_filter,
                     use_fts=use_fts,  # Full-Text Search flag for hybrid search
+                    append_n=append_n,  # Number of FTS results to append (append mode)
                 )
             elif self._long_term_memory is None:
                 short_episode, short_summary = await self._query_short_term_memory(
@@ -427,6 +433,7 @@ class EpisodicMemory:
                         score_threshold=score_threshold,
                         property_filter=property_filter,
                         use_fts=use_fts,  # Full-Text Search flag for hybrid search
+                        append_n=append_n,  # Number of FTS results to append (append mode)
                     ),
                 )
                 short_episode, short_summary = session_result
@@ -438,6 +445,7 @@ class EpisodicMemory:
                 score_threshold=score_threshold,
                 property_filter=property_filter,
                 use_fts=use_fts,  # Full-Text Search flag for hybrid search
+                append_n=append_n,  # Number of FTS results to append (append mode)
             )
         elif mode is EpisodicMemory.QueryMode.SHORT_TERM_ONLY:
             short_episode, short_summary = await self._query_short_term_memory(

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -1,7 +1,9 @@
 """Long-term memory facade with declarative + event backends."""
 
+import asyncio # For parallel execution in Hybrid Search
 import datetime
 import logging
+from datetime import timezone # For FTS Episode created_at default value (UTC)
 from collections.abc import Iterable
 from typing import Annotated, Literal, cast
 from uuid import UUID, uuid4, uuid5
@@ -24,6 +26,8 @@ from memmachine_server.common.filter.filter_parser import (
 )
 from memmachine_server.common.reranker import Reranker
 from memmachine_server.common.vector_graph_store import VectorGraphStore
+# Converts content to SANITIZED_property_u5f_content
+from memmachine_server.common.vector_graph_store.data_types import mangle_property_name
 from memmachine_server.common.vector_store import (
     VectorStore,
     VectorStoreCollection,
@@ -251,6 +255,7 @@ class LongTermMemory:
         expand_context: int = 0,
         score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
+        use_fts: bool = False,  # Full-Text Search flag for hybrid search
     ) -> list[tuple[float, Episode]]:
         """Score-thresholded query.
 
@@ -262,6 +267,16 @@ class LongTermMemory:
         which silently inverted to "drop everything" under euclidean.
         """
         if self._backend == "declarative":
+            # Full-Text Search is enabled
+            if use_fts:
+                # Perform hybrid search: Vector + Full-Text Search with dedup
+                return await self._search_scored_hybrid(
+                    query,
+                    num_episodes_limit=num_episodes_limit,
+                    expand_context=expand_context,
+                    score_threshold=score_threshold,
+                    property_filter=property_filter,
+                )
             return await self._search_scored_declarative(
                 query,
                 num_episodes_limit=num_episodes_limit,
@@ -276,6 +291,173 @@ class LongTermMemory:
             score_threshold=score_threshold,
             property_filter=property_filter,
         )
+
+    async def _search_scored_hybrid(
+        self,
+        query: str,
+        *,
+        num_episodes_limit: int,
+        expand_context: int,
+        score_threshold: float | None,
+        property_filter: FilterExpr | None,
+    ) -> list[tuple[float, Episode]]:
+        """Hybrid search: Vector (reranked via RRF) + FTS Top-10 with dedup.
+
+        Vector search results (already reranked with RRF by _search_scored_declarative)
+        are combined with FTS Top-10 results after removing duplicates (by episode uid).
+
+        Returns up to num_episodes_limit + 10 results (e.g., 50 + 10 = 60 max).
+        """
+        assert self._declarative_memory is not None
+
+        # 1. Run Vector Search and FTS in parallel
+        # _search_scored_declarative already returns RRF reranked results
+        # _search_fts over-fetches 5x for FTS Top-10 (50 items)
+        vector_results, fts_results_full = await asyncio.gather(
+            self._search_scored_declarative(
+                query,
+                num_episodes_limit=num_episodes_limit,
+                expand_context=expand_context,
+                score_threshold=None, # Apply threshold after merge
+                property_filter=property_filter,
+            ),
+            self._search_fts(
+                query,
+                num_episodes_limit=10,  # FTS Top-10 (over-fetch 5x = 50 internally)
+            ),
+        )
+
+        # 2. Limit FTS results to Top-10 by score (descending order)
+        fts_top_10 = fts_results_full[:10]
+
+        # 3. Merge FTS Top-10 into Vector results with dedup by episode uid
+        # Preserve vector result order, append unique FTS results
+        merged_results = list(vector_results)
+        seen_uids = {ep.uid for _, ep in merged_results}
+
+        for score, episode in fts_top_10:
+            if episode.uid not in seen_uids:
+                merged_results.append((score, episode))
+                seen_uids.add(episode.uid)
+
+        # 4. Apply score threshold
+        if score_threshold is not None:
+            merged_results = [
+                (score, episode) for score, episode in merged_results
+                if score >= score_threshold
+            ]
+        return merged_results
+
+    @staticmethod
+    def _escape_lucene_query(query: str) -> str:
+        r"""
+        Escape Lucene special characters in FTS query.
+        Lucene special characters: + - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /
+        """
+        lucene_special_chars = ['+', '-', '=', '&', '|', '>', '<', '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '\\', '/']
+        escaped_query = query
+        for char in lucene_special_chars:
+            escaped_query = escaped_query.replace(char, f'\\{char}')
+        return escaped_query
+
+    async def _search_fts(
+        self,
+        query: str,
+        *,
+        num_episodes_limit: int,
+    ) -> list[tuple[float, Episode]]:
+        """Search using Neo4j Full-Text Search only."""
+        assert self._declarative_memory is not None
+
+        long_term_memory = self._declarative_memory
+        vector_graph_store = long_term_memory._vector_graph_store
+        derivative_collection = long_term_memory._derivative_collection
+
+        # Generate FTS index name (auto-created during ingest)
+        sanitized_derivative_collection = vector_graph_store._sanitize_name(derivative_collection)
+        fts_index_name = f"fts_{sanitized_derivative_collection}_content"
+
+        logger.info(f"FTS Search: index={fts_index_name}, query={query}")
+
+        # Neo4j FTS query
+        driver = vector_graph_store._driver
+        fts_query_terms = query.lower().split()
+        # Escape Lucene special characters
+        fts_query_string = " ".join(self._escape_lucene_query(term) for term in fts_query_terms)
+
+        # Use sanitized property name
+        # FTS index is on content field, stored as SANITIZED_property_u5f_content after mangle_property_name
+        sanitized_content = vector_graph_store._sanitize_name(mangle_property_name("content"))
+
+        # FTS query: Follow DERIVED_FROM relation to get Episode Node uid directly
+        # Returns same Episode.uid as Vector Search for correct dedup
+        derivative_episode_relation = long_term_memory._derived_from_relation
+        sanitized_derived_from_relation = vector_graph_store._sanitize_name(derivative_episode_relation)
+        # Episode label also needs sanitization (same as collection name)
+        sanitized_episode_collection = vector_graph_store._sanitize_name(long_term_memory._episode_collection)
+
+        records, _, _ = await driver.execute_query(
+            f"""
+            CALL db.index.fulltext.queryNodes(
+                '{fts_index_name}',
+                $query,
+                {{ limit: $limit }}
+            )
+            YIELD node AS derivative, score
+            MATCH (derivative)-[:{sanitized_derived_from_relation}]->(episode:{sanitized_episode_collection})
+            RETURN episode.uid AS uid,
+                   derivative.{sanitized_content} AS content,
+                   derivative.SANITIZED_property_u5f_filterable_u5f_metadata_u2e_lme_u5f_session_u5f_id AS lme_session_id,
+                   derivative.SANITIZED_property_u5f_filterable_u5f_metadata_u2e_lme_u5f_turn_u5f_idx AS lme_turn_idx,
+                   score
+            ORDER BY score DESC
+            """,
+            query=fts_query_string,
+            limit=num_episodes_limit * 5,
+        )
+
+        # Convert to Episode objects
+        # FTS returns only content, so timestamp and producer_id are set to empty/default values
+        fts_episodes = []
+        for record in records:
+            uid = record.get("uid")
+            if uid:
+                content = record.get("content", "")
+                # Get metadata explicitly from Neo4j (using sanitized property names)
+                lme_session_id = record.get("lme_session_id")
+                lme_turn_idx = record.get("lme_turn_idx")
+                metadata = {}
+                if lme_session_id is not None and lme_turn_idx is not None:
+                    metadata["lme_session_id"] = lme_session_id
+                    metadata["lme_turn_idx"] = lme_turn_idx
+                # Extract source from content (format: "User: ..." or "Assistant: ...")
+                producer_id = ""
+                producer_role = ""
+                if content.startswith("User:"):
+                    producer_id = "User"
+                    producer_role = "user"
+                elif content.startswith("Assistant:"):
+                    producer_id = "Assistant"
+                    producer_role = "assistant"
+
+                episode = Episode(
+                    uid=uid,  # Now Episode Node uid (session_id:turn_idx format)
+                    sequence_num=0,
+                    session_key="",
+                    episode_type=EpisodeType.MESSAGE,
+                    content_type=ContentType.STRING,
+                    content=content,
+                    created_at=datetime.datetime.now(timezone.utc),  # FTS has no timestamp info (use current time)
+                    producer_id=producer_id,
+                    producer_role=producer_role,
+                    produced_for_id=None,
+                    metadata=metadata,  # Use metadata from Neo4j
+                    filterable_metadata=None,
+                )
+                fts_episodes.append((record.get("score", 0.0), episode))
+
+        logger.info(f"FTS returned {len(fts_episodes)} results")
+        return fts_episodes
 
     async def _search_scored_declarative(
         self,

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -124,6 +124,13 @@ class DeclarativeBackendParams(BaseModel):
     embedder: InstanceOf[Embedder] = Field(...)
     reranker: InstanceOf[Reranker] = Field(...)
     message_sentence_chunking: bool = Field(False)
+    fts_enabled: bool = Field(
+        True,
+        description=(
+            "Whether to auto-create the Neo4j FTS index for this session at "
+            "session creation. Default True. Ignored on non-declarative backends."
+        ),
+    )
 
 
 class EventBackendParams(BaseModel):
@@ -217,6 +224,7 @@ class LongTermMemory:
                         message_sentence_chunking=params.message_sentence_chunking,
                     ),
                 )
+                self._fts_enabled: bool = params.fts_enabled
             case EventBackendParams():
                 self._event_memory = EventMemory(
                     EventMemoryParams(
@@ -238,6 +246,103 @@ class LongTermMemory:
                     or params.vector_store_collection.config.similarity_metric.higher_is_better
                 )
                 self._user_property_keys = params.user_property_keys
+                # FTS is a declarative-backend-only feature; the event backend
+                # has no Neo4j derivative collection to index.
+                self._fts_enabled = False
+
+    async def initialize_fts(self) -> None:
+        """Create the FTS index up front, at session creation.
+
+        Creates the Neo4j Full-Text Search index on the derivative collection so
+        that the very first ingest is immediately searchable via hybrid
+        (Vector+FTS) search, instead of waiting for the node-count threshold
+        that triggers lazy index creation inside `add_nodes`.
+
+        No-op when FTS is disabled (`fts_enabled=False`), on the event backend,
+        or on a non-Neo4j `VectorGraphStore` (e.g. Nebula, which has no FTS).
+        Never raises on the unsupported cases — skipping is the desired
+        behavior, mirroring how `_search_fts` guards its own Neo4j assumption.
+        """
+        if not self._fts_enabled or self._backend != "declarative":
+            return
+        assert self._declarative_memory is not None
+
+        vector_graph_store = self._declarative_memory._vector_graph_store  # noqa: SLF001
+        if not isinstance(vector_graph_store, Neo4jVectorGraphStore):
+            # Nebula (or any non-Neo4j store): FTS is not supported. Skip
+            # silently rather than raising — FTS initialization is opt-in and
+            # must not break session creation on backends without FTS.
+            logger.warning(
+                "Skipping FTS initialization: backend %s is not Neo4j.",
+                type(vector_graph_store).__name__,
+            )
+            return
+
+        derivative_collection = self._declarative_memory._derivative_collection  # noqa: SLF001
+        sanitized_collection = vector_graph_store._sanitize_name(  # noqa: SLF001
+            derivative_collection
+        )
+        await vector_graph_store._create_fts_index_if_not_exists(  # noqa: SLF001
+            sanitized_collection=sanitized_collection,
+        )
+        logger.info(
+            "FTS index initialized at session creation for collection '%s'.",
+            derivative_collection,
+        )
+
+    async def create_fts_index(self) -> tuple[str, str | None]:
+        """Manually create the FTS index on demand.
+
+        Unlike `initialize_fts` (which runs at session creation and skips
+        silently on unsupported backends), this is the explicit user-triggered
+        command. It creates the index regardless of `fts_enabled` and reports
+        whether the backend supports FTS.
+
+        Returns:
+            A `(status, index_name)` tuple where `status` is one of:
+            - ``"created"``: the index is now online (newly created or already
+              existed — `_create_fts_index_if_not_exists` is idempotent).
+            - ``"unsupported"``: the backend has no FTS (event backend or a
+              non-Neo4j store such as Nebula). `index_name` is ``None``.
+
+        Raises:
+            NotImplementedError: never — unsupported backends return the
+            ``"unsupported"`` status instead of raising, so the API layer can
+            surface a consistent response without try/except branching.
+        """
+        if self._backend != "declarative":
+            logger.info(
+                "create_fts_index: event backend has no FTS; returning 'unsupported'."
+            )
+            return ("unsupported", None)
+        assert self._declarative_memory is not None
+
+        vector_graph_store = self._declarative_memory._vector_graph_store  # noqa: SLF001
+        if not isinstance(vector_graph_store, Neo4jVectorGraphStore):
+            logger.info(
+                "create_fts_index: backend %s is not Neo4j; returning 'unsupported'.",
+                type(vector_graph_store).__name__,
+            )
+            return ("unsupported", None)
+
+        derivative_collection = self._declarative_memory._derivative_collection  # noqa: SLF001
+        sanitized_collection = vector_graph_store._sanitize_name(  # noqa: SLF001
+            derivative_collection
+        )
+        fts_index_name = f"fts_{sanitized_collection}_content"
+
+        # `_create_fts_index_if_not_exists` is idempotent: it short-circuits
+        # when the index is already online, so calling this on an existing
+        # index is a safe no-op that still reports "created".
+        await vector_graph_store._create_fts_index_if_not_exists(  # noqa: SLF001
+            sanitized_collection=sanitized_collection,
+        )
+        logger.info(
+            "create_fts_index: index=%s online, collection=%s",
+            fts_index_name,
+            derivative_collection,
+        )
+        return ("created", fts_index_name)
 
     async def add_episodes(self, episodes: Iterable[Episode]) -> None:
         episodes = list(episodes)

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -28,6 +28,10 @@ from memmachine_server.common.vector_graph_store import VectorGraphStore
 
 # Converts content to SANITIZED_property_u5f_content
 from memmachine_server.common.vector_graph_store.data_types import mangle_property_name
+from memmachine_server.common.vector_graph_store.neo4j_vector_graph_store import (
+    Neo4jVectorGraphStore,
+    _neo4j_query,
+)
 from memmachine_server.common.vector_store import (
     VectorStore,
     VectorStoreCollection,
@@ -393,11 +397,13 @@ class LongTermMemory:
         """Search using Neo4j Full-Text Search only."""
         assert self._declarative_memory is not None
 
-        # There is no full-text search API on the DeclarativeMemory or
-        # VectorGraphStore interfaces yet, so the collection/relation names,
-        # the Neo4j driver, and the name sanitizer are read directly here.
         declarative_memory = self._declarative_memory
         vector_graph_store = declarative_memory._vector_graph_store  # noqa: SLF001
+
+        # FTS is Neo4j-only
+        if not isinstance(vector_graph_store, Neo4jVectorGraphStore):
+            raise NotImplementedError("FTS is only supported with the Neo4j backend")
+
         derivative_collection = declarative_memory._derivative_collection  # noqa: SLF001
         episode_collection = declarative_memory._episode_collection  # noqa: SLF001
         derivative_episode_relation = declarative_memory._derived_from_relation  # noqa: SLF001
@@ -426,7 +432,7 @@ class LongTermMemory:
         sanitized_episode_collection = sanitize_name(episode_collection)
 
         records, _, _ = await driver.execute_query(
-            f"""
+            _neo4j_query(f"""
             CALL db.index.fulltext.queryNodes(
                 '{fts_index_name}',
                 $query,
@@ -440,7 +446,7 @@ class LongTermMemory:
                    derivative.SANITIZED_property_u5f_filterable_u5f_metadata_u2e_lme_u5f_turn_u5f_idx AS lme_turn_idx,
                    score
             ORDER BY score DESC
-            """,
+            """),
             query=fts_query_string,
             limit=num_episodes_limit * 5,
         )

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -1,9 +1,8 @@
 """Long-term memory facade with declarative + event backends."""
 
-import asyncio # For parallel execution in Hybrid Search
+import asyncio  # For parallel execution in Hybrid Search
 import datetime
 import logging
-from datetime import timezone # For FTS Episode created_at default value (UTC)
 from collections.abc import Iterable
 from typing import Annotated, Literal, cast
 from uuid import UUID, uuid4, uuid5
@@ -26,6 +25,7 @@ from memmachine_server.common.filter.filter_parser import (
 )
 from memmachine_server.common.reranker import Reranker
 from memmachine_server.common.vector_graph_store import VectorGraphStore
+
 # Converts content to SANITIZED_property_u5f_content
 from memmachine_server.common.vector_graph_store.data_types import mangle_property_name
 from memmachine_server.common.vector_store import (
@@ -318,7 +318,7 @@ class LongTermMemory:
                 query,
                 num_episodes_limit=num_episodes_limit,
                 expand_context=expand_context,
-                score_threshold=None, # Apply threshold after merge
+                score_threshold=None,  # Apply threshold after merge
                 property_filter=property_filter,
             ),
             self._search_fts(
@@ -343,21 +343,45 @@ class LongTermMemory:
         # 4. Apply score threshold
         if score_threshold is not None:
             merged_results = [
-                (score, episode) for score, episode in merged_results
+                (score, episode)
+                for score, episode in merged_results
                 if score >= score_threshold
             ]
         return merged_results
 
     @staticmethod
     def _escape_lucene_query(query: str) -> str:
-        r"""
-        Escape Lucene special characters in FTS query.
+        r"""Escape Lucene special characters in an FTS query.
+
         Lucene special characters: + - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /
         """
-        lucene_special_chars = ['+', '-', '=', '&', '|', '>', '<', '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '\\', '/']
+        lucene_special_chars = [
+            "+",
+            "-",
+            "=",
+            "&",
+            "|",
+            ">",
+            "<",
+            "!",
+            "(",
+            ")",
+            "{",
+            "}",
+            "[",
+            "]",
+            "^",
+            '"',
+            "~",
+            "*",
+            "?",
+            ":",
+            "\\",
+            "/",
+        ]
         escaped_query = query
         for char in lucene_special_chars:
-            escaped_query = escaped_query.replace(char, f'\\{char}')
+            escaped_query = escaped_query.replace(char, f"\\{char}")
         return escaped_query
 
     async def _search_fts(
@@ -369,32 +393,37 @@ class LongTermMemory:
         """Search using Neo4j Full-Text Search only."""
         assert self._declarative_memory is not None
 
-        long_term_memory = self._declarative_memory
-        vector_graph_store = long_term_memory._vector_graph_store
-        derivative_collection = long_term_memory._derivative_collection
+        # There is no full-text search API on the DeclarativeMemory or
+        # VectorGraphStore interfaces yet, so the collection/relation names,
+        # the Neo4j driver, and the name sanitizer are read directly here.
+        declarative_memory = self._declarative_memory
+        vector_graph_store = declarative_memory._vector_graph_store  # noqa: SLF001
+        derivative_collection = declarative_memory._derivative_collection  # noqa: SLF001
+        episode_collection = declarative_memory._episode_collection  # noqa: SLF001
+        derivative_episode_relation = declarative_memory._derived_from_relation  # noqa: SLF001
+        driver = vector_graph_store._driver  # noqa: SLF001
+        sanitize_name = vector_graph_store._sanitize_name  # noqa: SLF001
 
         # Generate FTS index name (auto-created during ingest)
-        sanitized_derivative_collection = vector_graph_store._sanitize_name(derivative_collection)
-        fts_index_name = f"fts_{sanitized_derivative_collection}_content"
+        fts_index_name = f"fts_{sanitize_name(derivative_collection)}_content"
 
-        logger.info(f"FTS Search: index={fts_index_name}, query={query}")
+        logger.info("FTS Search: index=%s, query=%s", fts_index_name, query)
 
-        # Neo4j FTS query
-        driver = vector_graph_store._driver
         fts_query_terms = query.lower().split()
         # Escape Lucene special characters
-        fts_query_string = " ".join(self._escape_lucene_query(term) for term in fts_query_terms)
+        fts_query_string = " ".join(
+            self._escape_lucene_query(term) for term in fts_query_terms
+        )
 
         # Use sanitized property name
         # FTS index is on content field, stored as SANITIZED_property_u5f_content after mangle_property_name
-        sanitized_content = vector_graph_store._sanitize_name(mangle_property_name("content"))
+        sanitized_content = sanitize_name(mangle_property_name("content"))
 
         # FTS query: Follow DERIVED_FROM relation to get Episode Node uid directly
         # Returns same Episode.uid as Vector Search for correct dedup
-        derivative_episode_relation = long_term_memory._derived_from_relation
-        sanitized_derived_from_relation = vector_graph_store._sanitize_name(derivative_episode_relation)
+        sanitized_derived_from_relation = sanitize_name(derivative_episode_relation)
         # Episode label also needs sanitization (same as collection name)
-        sanitized_episode_collection = vector_graph_store._sanitize_name(long_term_memory._episode_collection)
+        sanitized_episode_collection = sanitize_name(episode_collection)
 
         records, _, _ = await driver.execute_query(
             f"""
@@ -447,7 +476,9 @@ class LongTermMemory:
                     episode_type=EpisodeType.MESSAGE,
                     content_type=ContentType.STRING,
                     content=content,
-                    created_at=datetime.datetime.now(timezone.utc),  # FTS has no timestamp info (use current time)
+                    created_at=datetime.datetime.now(
+                        datetime.UTC
+                    ),  # FTS has no timestamp info (use current time)
                     producer_id=producer_id,
                     producer_role=producer_role,
                     produced_for_id=None,
@@ -456,7 +487,7 @@ class LongTermMemory:
                 )
                 fts_episodes.append((record.get("score", 0.0), episode))
 
-        logger.info(f"FTS returned {len(fts_episodes)} results")
+        logger.info("FTS returned %d results", len(fts_episodes))
         return fts_episodes
 
     async def _search_scored_declarative(

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 from typing import Annotated, Literal, cast
 from uuid import UUID, uuid4, uuid5
 
+from memmachine_common.api.spec import FTS_APPEND_COUNT_DEFAULT, RRF_K, FtsMode
 from pydantic import BaseModel, Field, InstanceOf, JsonValue
 
 from memmachine_server.common.data_types import PropertyValue
@@ -259,7 +260,8 @@ class LongTermMemory:
         expand_context: int = 0,
         score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
-        use_fts: bool = False,  # Full-Text Search flag for hybrid search
+        use_fts: FtsMode = False,  # Full-Text Search flag for hybrid search
+        append_n: int = FTS_APPEND_COUNT_DEFAULT,  # FTS results to append (append mode)
     ) -> list[tuple[float, Episode]]:
         """Score-thresholded query.
 
@@ -273,13 +275,15 @@ class LongTermMemory:
         if self._backend == "declarative":
             # Full-Text Search is enabled
             if use_fts:
-                # Perform hybrid search: Vector + Full-Text Search with dedup
+                # Perform hybrid search: Vector + Full-Text Search
                 return await self._search_scored_hybrid(
                     query,
                     num_episodes_limit=num_episodes_limit,
                     expand_context=expand_context,
                     score_threshold=score_threshold,
                     property_filter=property_filter,
+                    use_fts=use_fts,
+                    append_n=append_n,
                 )
             return await self._search_scored_declarative(
                 query,
@@ -304,19 +308,30 @@ class LongTermMemory:
         expand_context: int,
         score_threshold: float | None,
         property_filter: FilterExpr | None,
+        use_fts: FtsMode = True,
+        append_n: int = FTS_APPEND_COUNT_DEFAULT,
     ) -> list[tuple[float, Episode]]:
-        """Hybrid search: Vector (reranked via RRF) + FTS Top-10 with dedup.
+        """Hybrid search combining Vector results with FTS (keyword) results.
 
-        Vector search results (already reranked with RRF by _search_scored_declarative)
-        are combined with FTS Top-10 results after removing duplicates (by episode uid).
+        Modes (selected via `use_fts`):
+        - True / "rrf": Reciprocal Rank Fusion — vector and FTS results are each
+          ranked, then fused by RRF score 1/(RRF_K + rank); returns top
+          `num_episodes_limit` results, re-sorted by timestamp (the default
+          MemMachine ordering) to match the vector-only path.
+        - "append": Appends up to `append_n` FTS results (deduplicated by episode
+          uid) after the vector results; no reranking. Returns up to
+          `num_episodes_limit + append_n` results.
 
-        Returns up to num_episodes_limit + 10 results (e.g., 50 + 10 = 60 max).
+        Any other value raises ValueError.
+
+        Vector results are already reranked (e.g. via RRFHybridReranker) by
+        `_search_scored_declarative`; only their rank order is used here.
         """
         assert self._declarative_memory is not None
 
-        # 1. Run Vector Search and FTS in parallel
-        # _search_scored_declarative already returns RRF reranked results
-        # _search_fts over-fetches 5x for FTS Top-10 (50 items)
+        # Both RRF and append modes need vector + FTS results; fetch them in
+        # parallel. The threshold is applied *after* the merge/fusion so that
+        # the two result sets are compared on a common footing.
         vector_results, fts_results_full = await asyncio.gather(
             self._search_scored_declarative(
                 query,
@@ -325,33 +340,109 @@ class LongTermMemory:
                 score_threshold=None,  # Apply threshold after merge
                 property_filter=property_filter,
             ),
-            self._search_fts(
-                query,
-                num_episodes_limit=10,  # FTS Top-10 (over-fetch 5x = 50 internally)
-            ),
+            self._search_fts(query, num_episodes_limit=num_episodes_limit),
         )
 
-        # 2. Limit FTS results to Top-10 by score (descending order)
-        fts_top_10 = fts_results_full[:10]
+        # RRF fusion mode: rank vector + FTS results, fuse by 1/(RRF_K + rank),
+        # take the top `num_episodes_limit`, then re-sort by timestamp (the
+        # MemMachine-default ordering, matching the vector-only path).
+        if use_fts is True or use_fts == "rrf":
+            return self._fuse_rrf(
+                vector_results,
+                fts_results_full,
+                num_episodes_limit=num_episodes_limit,
+                score_threshold=score_threshold,
+            )
 
-        # 3. Merge FTS Top-10 into Vector results with dedup by episode uid
-        # Preserve vector result order, append unique FTS results
-        merged_results = list(vector_results)
-        seen_uids = {ep.uid for _, ep in merged_results}
+        # Append mode: keep vector results (timestamp order) and append up to
+        # `append_n` unique FTS (keyword) results after them, deduplicated by
+        # uid. No re-ordering — vector-first then FTS, not a global sort.
+        if use_fts == "append":
+            fts_top_n = fts_results_full[:append_n]
 
-        for score, episode in fts_top_10:
-            if episode.uid not in seen_uids:
-                merged_results.append((score, episode))
-                seen_uids.add(episode.uid)
+            merged_results = list(vector_results)
+            seen_uids = {ep.uid for _, ep in merged_results}
+            for score, episode in fts_top_n:
+                if episode.uid not in seen_uids:
+                    merged_results.append((score, episode))
+                    seen_uids.add(episode.uid)
 
-        # 4. Apply score threshold
+            # Apply score threshold
+            if score_threshold is not None:
+                merged_results = [
+                    (score, episode)
+                    for score, episode in merged_results
+                    if score >= score_threshold
+                ]
+            return merged_results
+
+        # Unreachable under FtsMode typing, but guards against unexpected runtime
+        # values that bypass the type system (e.g. via MCP/HTTP string args).
+        raise ValueError(
+            f"Invalid use_fts value: {use_fts!r}. Expected True, 'rrf', or 'append'."
+        )
+
+    @staticmethod
+    def _fuse_rrf(
+        vector_results: list[tuple[float, Episode]],
+        fts_results: list[tuple[float, Episode]],
+        *,
+        num_episodes_limit: int,
+        score_threshold: float | None,
+    ) -> list[tuple[float, Episode]]:
+        """Fuse vector and FTS result lists via Reciprocal Rank Fusion.
+
+        Each input list is treated as a ranking (highest-relevance first). For
+        every candidate, RRF accumulates `1/(RRF_K + rank)` across the lists it
+        appears in. Candidates seen in both lists therefore score higher than
+        those seen in only one — the fusion reward for agreement.
+
+        After fusion:
+        1. Take the top `num_episodes_limit` candidates by RRF score.
+        2. Re-sort those top candidates by (timestamp, uid) — the default
+           MemMachine ordering, matching the vector-only path. The RRF score is
+           only used to *select* the winners, not to order the final output.
+        3. Apply `score_threshold` to the RRF score (higher-is-better).
+
+        Deduplication is by episode uid: if the same episode appears in both
+        lists, its RRF contributions are summed under one entry.
+
+        Note: the RRF score lives on a small fixed scale (a single hit at rank 1
+        is `1/(RRF_K + 1)` ≈ 0.0164; a hit in both lists tops out near `2/61` ≈
+        0.0328). A `score_threshold` calibrated for the 0-1 vector/reranker
+        scale will therefore filter *every* RRF candidate out — callers using
+        RRF should pass `score_threshold=None` or rescale accordingly.
+        """
+        rrf_scores: dict[str, float] = {}
+        episodes_by_uid: dict[str, Episode] = {}
+
+        def add_ranking(ranking: list[tuple[float, Episode]]) -> None:
+            for rank, (_score, episode) in enumerate(ranking, start=1):
+                uid = episode.uid
+                episodes_by_uid.setdefault(uid, episode)
+                rrf_scores[uid] = rrf_scores.get(uid, 0.0) + 1.0 / (RRF_K + rank)
+
+        add_ranking(vector_results)
+        add_ranking(fts_results)
+
+        # Select the top candidates by RRF score (descending). Ties broken by
+        # uid for determinism.
+        ranked = sorted(
+            rrf_scores.items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+        top = ranked[:num_episodes_limit]
+
+        # Drop below threshold (RRF score is higher-is-better).
         if score_threshold is not None:
-            merged_results = [
-                (score, episode)
-                for score, episode in merged_results
-                if score >= score_threshold
-            ]
-        return merged_results
+            top = [(uid, score) for uid, score in top if score >= score_threshold]
+
+        # Final ordering: timestamp then uid (the MemMachine default), not RRF.
+        fused = [(score, episodes_by_uid[uid]) for uid, score in top]
+        fused.sort(
+            key=lambda scored: (scored[1].created_at, scored[1].uid),
+        )
+        return fused
 
     @staticmethod
     def _escape_lucene_query(query: str) -> str:
@@ -424,6 +515,11 @@ class LongTermMemory:
         # Use sanitized property name
         # FTS index is on content field, stored as SANITIZED_property_u5f_content after mangle_property_name
         sanitized_content = sanitize_name(mangle_property_name("content"))
+        # Timestamp is stored on every node (episode + derivative) under the same
+        # mangled+sanitized key as content. Reading it here lets FTS results carry
+        # the SAME timestamp as the vector-search path, so RRF/append can sort by
+        # timestamp just like vector-only results do.
+        sanitized_timestamp = sanitize_name(mangle_property_name("timestamp"))
 
         # FTS query: Follow DERIVED_FROM relation to get Episode Node uid directly
         # Returns same Episode.uid as Vector Search for correct dedup
@@ -442,6 +538,7 @@ class LongTermMemory:
             MATCH (derivative)-[:{sanitized_derived_from_relation}]->(episode:{sanitized_episode_collection})
             RETURN episode.uid AS uid,
                    derivative.{sanitized_content} AS content,
+                   derivative.{sanitized_timestamp} AS timestamp,
                    derivative.SANITIZED_property_u5f_filterable_u5f_metadata_u2e_lme_u5f_session_u5f_id AS lme_session_id,
                    derivative.SANITIZED_property_u5f_filterable_u5f_metadata_u2e_lme_u5f_turn_u5f_idx AS lme_turn_idx,
                    score
@@ -452,12 +549,25 @@ class LongTermMemory:
         )
 
         # Convert to Episode objects
-        # FTS returns only content, so timestamp and producer_id are set to empty/default values
+        # FTS now returns the stored timestamp (same value as vector-search uses),
+        # so results can be sorted by timestamp consistently across hybrid modes.
         fts_episodes = []
         for record in records:
             uid = record.get("uid")
             if uid:
                 content = record.get("content", "")
+                # Timestamp stored on the derivative node; falls back to now()
+                # only if the node somehow lacks the property (shouldn't happen).
+                timestamp = record.get("timestamp")
+                if timestamp is None:
+                    timestamp = datetime.datetime.now(datetime.UTC)
+                elif hasattr(timestamp, "to_native"):
+                    # The Neo4j driver returns neo4j.time.DateTime for stored
+                    # timestamps. Convert it to a native python datetime so
+                    # pydantic's Episode.created_at accepts it (the vector path
+                    # already gets a native datetime via the declarative-memory
+                    # layer's dm.timestamp).
+                    timestamp = timestamp.to_native()
                 # Get metadata explicitly from Neo4j (using sanitized property names)
                 lme_session_id = record.get("lme_session_id")
                 lme_turn_idx = record.get("lme_turn_idx")
@@ -482,9 +592,7 @@ class LongTermMemory:
                     episode_type=EpisodeType.MESSAGE,
                     content_type=ContentType.STRING,
                     content=content,
-                    created_at=datetime.datetime.now(
-                        datetime.UTC
-                    ),  # FTS has no timestamp info (use current time)
+                    created_at=timestamp,  # Stored timestamp, same as vector path
                     producer_id=producer_id,
                     producer_role=producer_role,
                     produced_for_id=None,

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
@@ -86,6 +86,7 @@ async def _declarative_params(
         embedder=embedder,
         reranker=reranker,
         message_sentence_chunking=config.message_sentence_chunking,
+        fts_enabled=config.fts_enabled,
     )
 
 

--- a/packages/server/src/memmachine_server/episodic_memory/service_locator.py
+++ b/packages/server/src/memmachine_server/episodic_memory/service_locator.py
@@ -28,6 +28,10 @@ async def episodic_memory_params_from_config(
             resource_manager,
         )
         long_term_memory = LongTermMemory(long_term_memory_params)
+        # Create the FTS index up front (default) so the first ingest is
+        # immediately searchable via hybrid search. No-op when `fts_enabled`
+        # is False or the backend has no FTS (event backend / Nebula).
+        await long_term_memory.initialize_fts()
 
     short_term_memory: ShortTermMemory | None = None
     if config.short_term_memory and config.short_term_memory_enabled:

--- a/packages/server/src/memmachine_server/main/memmachine.py
+++ b/packages/server/src/memmachine_server/main/memmachine.py
@@ -749,6 +749,7 @@ class MemMachine:
         score_threshold: float = -float("inf"),
         search_filter: FilterExpr | None = None,
         retrieval_agent: AgentToolBase | None = None,
+        use_fts: bool = False, # Full-Text Search flag for hybrid search
     ) -> EpisodicMemory.QueryResponse | None:
         """
         Query episodic memory for relevant episodes.
@@ -783,6 +784,7 @@ class MemMachine:
                     expand_context=expand_context,
                     score_threshold=score_threshold,
                     property_filter=search_filter,
+                    use_fts=use_fts, # Full-Text Search flag for hybrid search
                 )
             else:
                 response = await self._query_episodic_with_retrieval_agent(
@@ -957,6 +959,7 @@ class MemMachine:
         score_threshold: float = -float("inf"),
         search_filter: str | None = None,
         agent_mode: bool = False,
+        use_fts: bool = False,  # Full-Text Search flag for hybrid search
     ) -> SearchResponse:
         """
         Search across enabled memory types using a query string.
@@ -991,6 +994,7 @@ class MemMachine:
                     score_threshold=score_threshold,
                     search_filter=property_filter,
                     retrieval_agent=retrieval_agent,
+                    use_fts=use_fts, # Full-Text Search flag for hybrid search
                 )
             )
 

--- a/packages/server/src/memmachine_server/main/memmachine.py
+++ b/packages/server/src/memmachine_server/main/memmachine.py
@@ -8,6 +8,7 @@ from collections.abc import Callable, Coroutine, Iterable, Mapping
 from typing import Any, Final, Protocol
 
 from memmachine_common.api import MemoryType
+from memmachine_common.api.spec import FtsMode
 from pydantic import BaseModel, InstanceOf, JsonValue, ValidationError
 
 from memmachine_server.common.configuration import Configuration
@@ -749,7 +750,8 @@ class MemMachine:
         score_threshold: float = -float("inf"),
         search_filter: FilterExpr | None = None,
         retrieval_agent: AgentToolBase | None = None,
-        use_fts: bool = False,  # Full-Text Search flag for hybrid search
+        use_fts: FtsMode = False,  # Full-Text Search flag for hybrid search
+        append_n: int = 10,  # Number of FTS results to append (append mode)
     ) -> EpisodicMemory.QueryResponse | None:
         """
         Query episodic memory for relevant episodes.
@@ -763,6 +765,7 @@ class MemMachine:
             score_threshold: Optional minimum score threshold for results.
             retrieval_agent: Optional top-level retrieval agent for long-term search.
             use_fts: Full-Text Search flag for hybrid search
+            append_n: Number of FTS results to append (only used in 'append' mode)
 
         Returns:
             Episodic memory query response, if episodic memory is enabled.
@@ -786,6 +789,7 @@ class MemMachine:
                     score_threshold=score_threshold,
                     property_filter=search_filter,
                     use_fts=use_fts,  # Full-Text Search flag for hybrid search
+                    append_n=append_n,  # Number of FTS results to append (append mode)
                 )
             else:
                 response = await self._query_episodic_with_retrieval_agent(
@@ -960,7 +964,8 @@ class MemMachine:
         score_threshold: float = -float("inf"),
         search_filter: str | None = None,
         agent_mode: bool = False,
-        use_fts: bool = False,  # Full-Text Search flag for hybrid search
+        use_fts: FtsMode = False,  # Full-Text Search flag for hybrid search
+        append_n: int = 10,  # Number of FTS results to append (append mode)
     ) -> SearchResponse:
         """
         Search across enabled memory types using a query string.
@@ -976,6 +981,7 @@ class MemMachine:
             score_threshold: Optional minimum score threshold for results.
             agent_mode: Whether to enable top-level retrieval-agent orchestration.
             use_fts: Full-Text Search flag for hybrid search
+            append_n: Number of FTS results to append (only used in 'append' mode)
 
         Returns:
             Aggregated search results across memory types.
@@ -997,6 +1003,7 @@ class MemMachine:
                     search_filter=property_filter,
                     retrieval_agent=retrieval_agent,
                     use_fts=use_fts,  # Full-Text Search flag for hybrid search
+                    append_n=append_n,  # Number of FTS results to append (append mode)
                 )
             )
 

--- a/packages/server/src/memmachine_server/main/memmachine.py
+++ b/packages/server/src/memmachine_server/main/memmachine.py
@@ -678,6 +678,36 @@ class MemMachine:
             return left
         return FilterAnd(left=left, right=right)
 
+    async def create_fts_index(
+        self,
+        session_data: InstanceOf[SessionData],
+    ) -> tuple[str, str | None]:
+        """Manually create the FTS index for a session's long-term memory.
+
+        Opens (or creates) the session's episodic memory and delegates to
+        `EpisodicMemory.create_fts_index`. Useful when FTS was disabled at
+        session creation or when an existing Neo4j vector store should gain
+        FTS without re-ingesting.
+
+        Args:
+            session_data: Session context identifying the target project.
+
+        Returns:
+            A `(status, index_name)` tuple where `status` is ``"created"`` or
+            ``"unsupported"`` (see `LongTermMemory.create_fts_index`).
+
+        """
+        episodic_memory_manager = await self._resources.get_episodic_memory_manager()
+        async with episodic_memory_manager.open_or_create_episodic_memory(
+            session_key=session_data.session_key,
+            description="",
+            episodic_memory_config=self._with_default_episodic_memory_conf(
+                session_key=session_data.session_key
+            ),
+            metadata={},
+        ) as episodic_session:
+            return await episodic_session.create_fts_index()
+
     async def add_episodes(
         self,
         session_data: InstanceOf[SessionData],

--- a/packages/server/src/memmachine_server/main/memmachine.py
+++ b/packages/server/src/memmachine_server/main/memmachine.py
@@ -749,7 +749,7 @@ class MemMachine:
         score_threshold: float = -float("inf"),
         search_filter: FilterExpr | None = None,
         retrieval_agent: AgentToolBase | None = None,
-        use_fts: bool = False, # Full-Text Search flag for hybrid search
+        use_fts: bool = False,  # Full-Text Search flag for hybrid search
     ) -> EpisodicMemory.QueryResponse | None:
         """
         Query episodic memory for relevant episodes.
@@ -762,6 +762,7 @@ class MemMachine:
             search_filter: Optional property filter for narrowing results.
             score_threshold: Optional minimum score threshold for results.
             retrieval_agent: Optional top-level retrieval agent for long-term search.
+            use_fts: Full-Text Search flag for hybrid search
 
         Returns:
             Episodic memory query response, if episodic memory is enabled.
@@ -784,7 +785,7 @@ class MemMachine:
                     expand_context=expand_context,
                     score_threshold=score_threshold,
                     property_filter=search_filter,
-                    use_fts=use_fts, # Full-Text Search flag for hybrid search
+                    use_fts=use_fts,  # Full-Text Search flag for hybrid search
                 )
             else:
                 response = await self._query_episodic_with_retrieval_agent(
@@ -974,6 +975,7 @@ class MemMachine:
             search_filter: Optional filter string applied to each memory query.
             score_threshold: Optional minimum score threshold for results.
             agent_mode: Whether to enable top-level retrieval-agent orchestration.
+            use_fts: Full-Text Search flag for hybrid search
 
         Returns:
             Aggregated search results across memory types.
@@ -994,7 +996,7 @@ class MemMachine:
                     score_threshold=score_threshold,
                     search_filter=property_filter,
                     retrieval_agent=retrieval_agent,
-                    use_fts=use_fts, # Full-Text Search flag for hybrid search
+                    use_fts=use_fts,  # Full-Text Search flag for hybrid search
                 )
             )
 

--- a/packages/server/src/memmachine_server/retrieval_agent/agents/memmachine_retriever.py
+++ b/packages/server/src/memmachine_server/retrieval_agent/agents/memmachine_retriever.py
@@ -64,6 +64,7 @@ class MemMachineAgent(AgentToolBase):
             expand_context=query.expand_context,
             score_threshold=query.score_threshold,
             property_filter=query.property_filter,
+            use_fts=query.use_fts,  # Full-Text Search flag for hybrid search 
             mode=EpisodicMemory.QueryMode.LONG_TERM_ONLY,
         )
         if query_response is None:

--- a/packages/server/src/memmachine_server/retrieval_agent/agents/memmachine_retriever.py
+++ b/packages/server/src/memmachine_server/retrieval_agent/agents/memmachine_retriever.py
@@ -64,7 +64,7 @@ class MemMachineAgent(AgentToolBase):
             expand_context=query.expand_context,
             score_threshold=query.score_threshold,
             property_filter=query.property_filter,
-            use_fts=query.use_fts,  # Full-Text Search flag for hybrid search 
+            use_fts=query.use_fts,  # Full-Text Search flag for hybrid search
             mode=EpisodicMemory.QueryMode.LONG_TERM_ONLY,
         )
         if query_response is None:

--- a/packages/server/src/memmachine_server/retrieval_agent/agents/memmachine_retriever.py
+++ b/packages/server/src/memmachine_server/retrieval_agent/agents/memmachine_retriever.py
@@ -65,6 +65,7 @@ class MemMachineAgent(AgentToolBase):
             score_threshold=query.score_threshold,
             property_filter=query.property_filter,
             use_fts=query.use_fts,  # Full-Text Search flag for hybrid search
+            append_n=query.append_n,  # Number of FTS results to append (append mode)
             mode=EpisodicMemory.QueryMode.LONG_TERM_ONLY,
         )
         if query_response is None:

--- a/packages/server/src/memmachine_server/retrieval_agent/common/agent_api.py
+++ b/packages/server/src/memmachine_server/retrieval_agent/common/agent_api.py
@@ -42,6 +42,7 @@ class QueryParam(BaseModel):
     score_threshold: float = -float("inf")
     property_filter: FilterExpr | None = None
     memory: InstanceOf[EpisodicMemory]
+    use_fts: bool = False   # Full-Text Search flag for hybrid search 
 
 
 class AgentToolBaseParam(BaseModel):

--- a/packages/server/src/memmachine_server/retrieval_agent/common/agent_api.py
+++ b/packages/server/src/memmachine_server/retrieval_agent/common/agent_api.py
@@ -42,7 +42,7 @@ class QueryParam(BaseModel):
     score_threshold: float = -float("inf")
     property_filter: FilterExpr | None = None
     memory: InstanceOf[EpisodicMemory]
-    use_fts: bool = False   # Full-Text Search flag for hybrid search 
+    use_fts: bool = False  # Full-Text Search flag for hybrid search
 
 
 class AgentToolBaseParam(BaseModel):

--- a/packages/server/src/memmachine_server/retrieval_agent/common/agent_api.py
+++ b/packages/server/src/memmachine_server/retrieval_agent/common/agent_api.py
@@ -7,6 +7,7 @@ import logging
 from abc import abstractmethod
 from typing import Any
 
+from memmachine_common.api.spec import FTS_APPEND_COUNT_DEFAULT, FtsMode
 from pydantic import BaseModel, ConfigDict, InstanceOf
 
 from memmachine_server.common.episode_store import Episode
@@ -42,7 +43,8 @@ class QueryParam(BaseModel):
     score_threshold: float = -float("inf")
     property_filter: FilterExpr | None = None
     memory: InstanceOf[EpisodicMemory]
-    use_fts: bool = False  # Full-Text Search flag for hybrid search
+    use_fts: FtsMode = False  # Full-Text Search flag for hybrid search
+    append_n: int = FTS_APPEND_COUNT_DEFAULT  # FTS results to append (append mode)
 
 
 class AgentToolBaseParam(BaseModel):

--- a/packages/server/src/memmachine_server/server/api_v2/mcp.py
+++ b/packages/server/src/memmachine_server/server/api_v2/mcp.py
@@ -18,6 +18,7 @@ from memmachine_common.api.spec import (
     DeleteMemoriesSpec,
     EpisodeIdT,
     FeatureIdT,
+    FtsMode,
     MemoryMessage,
     SearchMemoriesSpec,
     SearchResult,
@@ -221,6 +222,8 @@ class Params(BaseModel):
         expand_context: int = 0,
         score_threshold: float | None = None,
         agent_mode: bool = False,
+        use_fts: FtsMode = False,
+        append_n: int = 10,
     ) -> SearchMemoriesSpec:
         """Convert to SearchMemoriesParam."""
         return SearchMemoriesSpec(
@@ -234,7 +237,8 @@ class Params(BaseModel):
             set_metadata=None,
             types=ALL_MEMORY_TYPES,
             agent_mode=agent_mode,
-            use_fts=False,
+            use_fts=use_fts,
+            append_n=append_n,
         )
 
     def to_delete_memories_spec(
@@ -493,6 +497,8 @@ async def mcp_search_memory(
     proj_id: str = "",
     user_id: str = "",
     top_k: int = 20,
+    use_fts: FtsMode = False,
+    append_n: int = 10,
 ) -> McpResponse | SearchResult:
     """
     Search memory for the specified user.
@@ -507,6 +513,10 @@ async def mcp_search_memory(
         user_id: The unique identifier of the user (flat style).
         query: The current user message or topic of discussion (flat style).
         top_k: The maximum number of memory entries to retrieve (flat style). Defaults to 5.
+        use_fts: Full-Text Search (keyword) mode combined with Vector Search
+            (flat style). False: vector only; True or 'rrf': RRF fusion;
+            'append': append FTS results after vector results.
+        append_n: Number of FTS results to append (only used when use_fts='append').
 
     Returns:
         McpResponse on failure, or SearchResult on success
@@ -524,7 +534,12 @@ async def mcp_search_memory(
             proj_id=proj_id,
             user_id=user_id,
         )
-        spec = param.to_search_memories_spec(query, top_k)
+        spec = param.to_search_memories_spec(
+            query,
+            top_k,
+            use_fts=use_fts,
+            append_n=append_n,
+        )
         return await _search_target_memories(
             target_memories=ALL_MEMORY_TYPES, spec=spec, memmachine=mem_machine
         )

--- a/packages/server/src/memmachine_server/server/api_v2/mcp.py
+++ b/packages/server/src/memmachine_server/server/api_v2/mcp.py
@@ -16,6 +16,7 @@ from fastmcp.server.http import StarletteWithLifespan
 from memmachine_common.api.spec import (
     AddMemoriesSpec,
     DeleteMemoriesSpec,
+    EnableFtsIndexResponse,
     EpisodeIdT,
     FeatureIdT,
     FtsMode,
@@ -38,6 +39,7 @@ from memmachine_server.server.api_v2.service import (
     _delete_memories,
     _search_target_memories,
     _session_key_to_session_data,
+    enable_fts_index,
 )
 from memmachine_server.server.diagnostics import dump_traceback, install_sigusr1_handler
 
@@ -546,6 +548,51 @@ async def mcp_search_memory(
     except Exception as e:
         status_code = status.HTTP_422_UNPROCESSABLE_CONTENT
         logger.exception("Failed to search memory")
+        return McpResponse(status=status_code, message=str(e))
+
+
+@mcp.tool(
+    name="enable_fts_index",
+    description=(
+        "Create the Neo4j Full-Text Search (FTS) index for a project's "
+        "long-term memory on demand. The FTS index is normally auto-created "
+        "when a session starts, so this is only needed when FTS was disabled "
+        "at creation time or when an existing Neo4j-backed project should "
+        "gain keyword (FTS) search without re-ingesting data. Returns "
+        "status='created' on success, or 'unsupported' when the backend has "
+        "no FTS (e.g. Nebula or the event backend). "
+        "\n\n**Parameters**: Supports flat style with org_id and proj_id."
+    ),
+)
+async def mcp_enable_fts_index(
+    org_id: str = "",
+    proj_id: str = "",
+) -> McpResponse | EnableFtsIndexResponse:
+    """Create the FTS index for the specified project.
+
+    Args:
+        org_id: The organization ID (optional, flat style).
+        proj_id: The project ID (optional, flat style).
+
+    Returns:
+        McpResponse on failure, or EnableFtsIndexResponse on success.
+
+    """
+    global mem_machine
+    if mem_machine is None:
+        return McpResponse(
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            message="MemMachine is not initialized",
+        )
+    try:
+        return await enable_fts_index(
+            spec_org_id=org_id,
+            spec_project_id=proj_id,
+            memmachine=mem_machine,
+        )
+    except Exception as e:
+        status_code = status.HTTP_422_UNPROCESSABLE_CONTENT
+        logger.exception("Failed to create FTS index")
         return McpResponse(status=status_code, message=str(e))
 
 

--- a/packages/server/src/memmachine_server/server/api_v2/mcp.py
+++ b/packages/server/src/memmachine_server/server/api_v2/mcp.py
@@ -234,6 +234,7 @@ class Params(BaseModel):
             set_metadata=None,
             types=ALL_MEMORY_TYPES,
             agent_mode=agent_mode,
+            use_fts=False,
         )
 
     def to_delete_memories_spec(

--- a/packages/server/src/memmachine_server/server/api_v2/router.py
+++ b/packages/server/src/memmachine_server/server/api_v2/router.py
@@ -29,6 +29,8 @@ from memmachine_common.api.spec import (
     DeleteSemanticSetTypeSpec,
     DeleteSemanticTagSpec,
     DisableSemanticCategorySpec,
+    EnableFtsIndexResponse,
+    EnableFtsIndexSpec,
     EpisodeCountResponse,
     EpisodicMemoryConfigEntry,
     GetEpisodicMemoryConfigSpec,
@@ -87,6 +89,7 @@ from memmachine_server.server.api_v2.service import (
     _list_target_memories,
     _search_target_memories,
     _SessionData,
+    enable_fts_index,
     get_memmachine,
 )
 
@@ -240,6 +243,32 @@ async def get_episode_count(
     except Exception as e:
         raise RestError(code=500, message="Internal server error", ex=e) from e
     return EpisodeCountResponse(count=count)
+
+
+@router.post(
+    "/fts-index/enable",
+    description="Create the FTS index for a project's long-term memory on demand.",
+    tags=["Projects"],
+)
+async def enable_fts_index_endpoint(
+    spec: EnableFtsIndexSpec,
+    memmachine: Annotated[MemMachine, Depends(get_memmachine)],
+) -> EnableFtsIndexResponse:
+    """Manually create the Neo4j Full-Text Search index.
+
+    The FTS index is auto-created at session creation by default. This endpoint
+    creates it on demand — for example when FTS was disabled at creation time
+    or when an existing Neo4j vector store should gain FTS without re-ingesting.
+    Returns ``status='unsupported'`` for backends without FTS (Nebula / event).
+    """
+    try:
+        return await enable_fts_index(
+            spec_org_id=spec.org_id,
+            spec_project_id=spec.project_id,
+            memmachine=memmachine,
+        )
+    except Exception as e:
+        raise RestError(code=500, message="Unable to create FTS index", ex=e) from e
 
 
 @router.post("/projects/list", description=RouterDoc.LIST_PROJECTS, tags=["Projects"])

--- a/packages/server/src/memmachine_server/server/api_v2/service.py
+++ b/packages/server/src/memmachine_server/server/api_v2/service.py
@@ -118,6 +118,7 @@ async def _search_target_memories(
         if spec.score_threshold is not None
         else -float("inf"),
         agent_mode=spec.agent_mode,
+        use_fts=spec.use_fts, # Full-Text Search flag for hybrid search
     )
     content = SearchResultContent(
         episodic_memory=None,

--- a/packages/server/src/memmachine_server/server/api_v2/service.py
+++ b/packages/server/src/memmachine_server/server/api_v2/service.py
@@ -119,6 +119,7 @@ async def _search_target_memories(
         else -float("inf"),
         agent_mode=spec.agent_mode,
         use_fts=spec.use_fts,  # Full-Text Search flag for hybrid search
+        append_n=spec.append_n,  # Number of FTS results to append (append mode)
     )
     content = SearchResultContent(
         episodic_memory=None,

--- a/packages/server/src/memmachine_server/server/api_v2/service.py
+++ b/packages/server/src/memmachine_server/server/api_v2/service.py
@@ -118,7 +118,7 @@ async def _search_target_memories(
         if spec.score_threshold is not None
         else -float("inf"),
         agent_mode=spec.agent_mode,
-        use_fts=spec.use_fts, # Full-Text Search flag for hybrid search
+        use_fts=spec.use_fts,  # Full-Text Search flag for hybrid search
     )
     content = SearchResultContent(
         episodic_memory=None,

--- a/packages/server/src/memmachine_server/server/api_v2/service.py
+++ b/packages/server/src/memmachine_server/server/api_v2/service.py
@@ -11,6 +11,7 @@ from memmachine_common.api.spec import (
     AddMemoriesSpec,
     AddMemoryResult,
     DeleteMemoriesSpec,
+    EnableFtsIndexResponse,
     Episode,
     EpisodicSearchResult,
     ListMemoriesSpec,
@@ -175,3 +176,28 @@ async def _list_target_memories(
         status=0,
         content=content,
     )
+
+
+async def enable_fts_index(
+    spec_org_id: str,
+    spec_project_id: str,
+    memmachine: MemMachine,
+) -> EnableFtsIndexResponse:
+    """Manually create the FTS index for a project's long-term memory.
+
+    Args:
+        spec_org_id: Organization ID from the request spec.
+        spec_project_id: Project ID from the request spec.
+        memmachine: The MemMachine instance.
+
+    Returns:
+        An `EnableFtsIndexResponse` carrying the creation status and index name.
+
+    """
+    status, index_name = await memmachine.create_fts_index(
+        session_data=_SessionData(
+            org_id=spec_org_id,
+            project_id=spec_project_id,
+        ),
+    )
+    return EnableFtsIndexResponse(status=status, index_name=index_name)


### PR DESCRIPTION
### Purpose of the change

This PR introduces **Hybrid Search** capability to MemMachine, combining vector similarity search with keyword-based Full-Text Search (FTS) to significantly improve retrieval accuracy. The implementation addresses the fundamental limitation of pure vector search where exact keyword matches (error messages, model names, technical terms, identifiers) are often missed due to semantic embedding dilution.

This PR enables clients to opt-in to hybrid retrieval via a simple use_fts flag without changing query patterns.

### Description

**1. API Extension** - Added `use_fts: bool` parameter across the API stack to enable hybrid search mode. Default `false` maintains backward compatibility.

**2. FTS Index Setup** - FTS indexes are auto-created during ingest. The index name follows the pattern `fts_{sanitized_derivative_collection}_content` and is indexed on the Derivative node's content field. No manual index creation is required; the index is ready for use when hybrid search is enabled.

**3. FTS Search Implementation** - New `_search_fts()` method (`packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py:363-460`) executes Neo4j Full-Text Search queries on Derivative nodes using `db.index.fulltext.queryNodes()`. It follows the `DERIVED_FROM` relation to retrieve Episode nodes, returning FTS scores and Episode objects with metadata extracted from Neo4j.

**4. Hybrid Search Orchestration** - New `_search_scored_hybrid()` method (`packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py:295-349`) runs Vector Search and FTS in parallel via `asyncio.gather()` (no latency overhead). Results are merged with UID-based deduplication: Vector results (top-k, RRF-reranked) are preserved in order, and unique FTS results (top-10) are appended. Returns up to `top-k + 10` episodes.

**5. Query Escaping Utility** - Static method `_escape_lucene_query()` (`packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py:351-361`) escapes Lucene special characters (`+ - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /`) to prevent query syntax errors on user input containing special characters.

**Motivation:** Vector search excels at semantic similarity but struggles with exact keyword matches (error messages like `CUDA_ERROR_OUT_OF_MEMORY`, model names like `RTX-4090`, acronyms like `API/HTTP`, function/class names). FTS complements vector search by providing precise term matching.

**Dependencies:** No new external dependencies. Uses existing Neo4j FTS indexes (auto-created on ingest), asyncio, and vector search infrastructure.

### Summary of Changes

This PR adds Hybrid Search functionality by integrating Neo4j Full-Text Search (FTS) indexes with existing vector search infrastructure. The key changes include:

### Fixes/Closes

N/A (New feature)

### Type of change

[Please delete options that are not relevant.]

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

**Test Environment:**
- **Benchmark**: LongMemEval_M (500 questions, 896 gold turns)
- **Dataset**: `longmemeval_m_cleaned.json`
- **Configuration**: Qwen3-Embedding-4B + Qwen3.5-397B-A17B-NVFP4

[Please delete options that are not relevant.]

- [ ] Unit Test
- [ ] Integration Test
- [ ] End-to-end Test
- [ ] Test Script (please provide)
- [x] Manual verification (list step-by-step instructions)

**Usage Example:**

When data is ingested, FTS indexes are automatically created. To enable hybrid search, pass `use_fts=True` in the `QueryParam` when calling the search function:

```python
from memmachine_server.retrieval_agent.common.agent_api import QueryParam

# Hybrid search enabled
results = await do_query(
    QueryParam(
        query="CUDA_ERROR_OUT_OF_MEMORY",
        limit=50,
        memory=memory,
        use_fts=True,  # Enable Hybrid Search (Vector + FTS)
    )
)
```

**Test Results:** [Attach logs, screenshots, or relevant output]

| Method | top-k | Overall Recall | Improvement |
|--------|-------|----------------|-------------|
| Vector (baseline) | 50 | 0.8811 | - |
| Vector | 60 | 0.9006 | +1.95% |
| Vector | 70 | 0.8945 | +1.34% |
| Vector | 80 | 0.9010 | +1.99% |
| **Hybrid (Vector+FTS)** | **50** | **0.9108** | **+2.97%** |

**Key Findings:**
- Hybrid Search achieves **+2.97% improvement** over Vector-only (top-k=50)
- Outperforms Vector top-k=80 (0.9010) while fetching fewer total results
- **Single-session-user queries**: +7.8% improvement (largest gain)
- **Temporal-reasoning queries**: +3.9% improvement

### Checklist

[Please delete options that are not relevant.]

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A (Backend feature - no UI changes)

### Further comments

**Known Limitations:**
1. Hybrid search currently only supported on declarative backend (Neo4j - VectorGraphStore), not event backend (VectorStore)
2. FTS returns limited metadata (timestamp/producer_id set to defaults)
3. FTS uses BM25 scores while vector uses cosine/euclidean; threshold semantics differ