### PR TITLE
fix: stop coercing omitted score_threshold to -inf

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4730,7 +4730,7 @@
               }
             ],
             "title": "Score Threshold",
-            "description": "\n    The minimum score for a memory to be included in the search results. Defaults\n    to -inf (no threshold) represented as None. Meaningful only for certain ranking methods.\n    ",
+            "description": "\n    The minimum score for a memory to be included in the search results. Defaults\n    to None (no threshold). Meaningful only for certain ranking methods. Do not\n    send -inf: under lower-is-better metrics that sentinel drops every hit.\n    ",
             "examples": [
               0.0,
               0.5,

--- a/packages/common/src/memmachine_common/api/doc.py
+++ b/packages/common/src/memmachine_common/api/doc.py
@@ -217,7 +217,8 @@ class SpecDoc:
 
     SCORE_THRESHOLD = """
     The minimum score for a memory to be included in the search results. Defaults
-    to -inf (no threshold) represented as None. Meaningful only for certain ranking methods.
+    to None (no threshold). Meaningful only for certain ranking methods. Do not
+    send -inf: under lower-is-better metrics that sentinel drops every hit.
     """
 
     QUERY = """

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
@@ -14,7 +14,7 @@ drop_session_partition all dispatch correctly through the event backend.
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import override
-from unittest.mock import create_autospec
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 
@@ -28,9 +28,14 @@ from memmachine_server.common.episode_store import (
 from memmachine_server.common.filter.filter_parser import (
     Comparison as FilterComparison,
 )
+from memmachine_server.common.metrics_factory import MetricsFactory
 from memmachine_server.common.vector_store import VectorStore
 from memmachine_server.common.vector_store.data_types import (
     VectorStoreCollectionConfig,
+)
+from memmachine_server.episodic_memory.episodic_memory import (
+    EpisodicMemory,
+    EpisodicMemoryParams,
 )
 from memmachine_server.episodic_memory.event_memory.deriver.text_deriver import (
     WholeTextDeriver,
@@ -587,3 +592,51 @@ async def test_score_threshold_none_keeps_all_results_under_euclidean():
 
     scored = await ltm.search_scored("abc", num_episodes_limit=10)
     assert [ep.uid for _, ep in scored] == ["only"]
+
+
+async def test_score_threshold_neg_inf_sentinel_drops_all_under_euclidean():
+    """Upper layers historically passed `-inf` to mean "no threshold". Under
+    euclidean (lower-is-better) that sentinel becomes `score <= -inf` and drops
+    every hit. Callers must pass `None` instead.
+    """
+    episodes = [_episode("only", "abc")]
+    ltm = _make_ltm_with_metric(SimilarityMetric.EUCLIDEAN, episodes)
+    await ltm.add_episodes(episodes)
+
+    scored = await ltm.search_scored(
+        "abc",
+        num_episodes_limit=10,
+        score_threshold=-float("inf"),
+    )
+    assert scored == []
+
+
+async def test_episodic_query_memory_default_keeps_euclidean_results():
+    """Default score_threshold on EpisodicMemory.query_memory must mean
+    "no threshold" under euclidean event-backed LTM. Injecting `-inf` empties
+    long-term results even when matches exist.
+    """
+    episodes = [_episode("only", "abc")]
+    ltm = _make_ltm_with_metric(SimilarityMetric.EUCLIDEAN, episodes)
+    await ltm.add_episodes(episodes)
+
+    metrics = MagicMock(spec=MetricsFactory)
+    metrics.get_summary.return_value = MagicMock()
+    metrics.get_counter.return_value = MagicMock()
+
+    memory = EpisodicMemory(
+        EpisodicMemoryParams(
+            session_key="sess1",
+            metrics_factory=metrics,
+            short_term_memory=None,
+            long_term_memory=ltm,
+            enabled=True,
+        )
+    )
+
+    response = await memory.query_memory(
+        "abc",
+        mode=EpisodicMemory.QueryMode.LONG_TERM_ONLY,
+    )
+    assert response is not None
+    assert [ep.uid for ep in response.long_term_memory.episodes] == ["only"]

--- a/packages/server/server_tests/memmachine_server/main/test_memmachine_mock.py
+++ b/packages/server/server_tests/memmachine_server/main/test_memmachine_mock.py
@@ -458,7 +458,7 @@ async def test_query_episodic_with_retrieval_agent_searches_long_then_short(
         query="hello world",
         limit=5,
         expand_context=0,
-        score_threshold=-float("inf"),
+        score_threshold=None,
         search_filter=None,
     )
 
@@ -534,7 +534,7 @@ async def test_query_episodic_with_retrieval_agent_skips_short_term_when_disable
         query="hello world",
         limit=5,
         expand_context=0,
-        score_threshold=-float("inf"),
+        score_threshold=None,
         search_filter=None,
     )
 

--- a/packages/server/server_tests/memmachine_server/retrieval_agent/test_retrieval_agent.py
+++ b/packages/server/server_tests/memmachine_server/retrieval_agent/test_retrieval_agent.py
@@ -90,7 +90,7 @@ class FakeEpisodicMemory(EpisodicMemory):
         *,
         limit: int | None = None,
         expand_context: int = 0,
-        score_threshold: float = -float("inf"),
+        score_threshold: float | None = None,
         property_filter: Any | None = None,
         mode: EpisodicMemory.QueryMode = EpisodicMemory.QueryMode.BOTH,
     ) -> EpisodicMemory.QueryResponse | None:

--- a/packages/server/server_tests/memmachine_server/server/api_v2/test_service.py
+++ b/packages/server/server_tests/memmachine_server/server/api_v2/test_service.py
@@ -126,6 +126,47 @@ async def test_search_target_memories_other_fields_still_passed():
     assert call_kwargs["query"] == "my query"
     assert call_kwargs["limit"] == 5
     assert call_kwargs["set_metadata"] == {"user_id": "u1"}
+    assert call_kwargs["score_threshold"] is None
+
+
+@pytest.mark.asyncio
+async def test_search_target_memories_omitted_score_threshold_is_none():
+    """Omitted score_threshold must stay None — not coerced to -inf.
+
+    Under euclidean (lower-is-better) event-backed LTM, `-inf` means
+    `score <= -inf` and empties the result set.
+    """
+    spec = SearchMemoriesSpec.model_validate({"query": "test query"})
+    assert spec.score_threshold is None
+
+    memmachine = _make_empty_memmachine()
+
+    await _search_target_memories(
+        target_memories=[MemoryType.Episodic],
+        spec=spec,
+        memmachine=memmachine,
+    )
+
+    call_kwargs = memmachine.query_search.call_args[1]
+    assert call_kwargs["score_threshold"] is None
+
+
+@pytest.mark.asyncio
+async def test_search_target_memories_passes_explicit_score_threshold():
+    """Explicit numeric score_threshold is forwarded unchanged."""
+    spec = SearchMemoriesSpec.model_validate(
+        {"query": "test query", "score_threshold": 0.25}
+    )
+    memmachine = _make_empty_memmachine()
+
+    await _search_target_memories(
+        target_memories=[MemoryType.Episodic],
+        spec=spec,
+        memmachine=memmachine,
+    )
+
+    call_kwargs = memmachine.query_search.call_args[1]
+    assert call_kwargs["score_threshold"] == 0.25
 
 
 # ---------------------------------------------------------------------------

--- a/packages/server/src/memmachine_server/episodic_memory/episodic_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/episodic_memory.py
@@ -334,7 +334,7 @@ class EpisodicMemory:
         query: str,
         limit: int,
         expand_context: int,
-        score_threshold: float,
+        score_threshold: float | None,
         property_filter: FilterExpr | None,
     ) -> list[tuple[float, Episode]]:
         """Query long-term memory or return an empty result if unavailable."""
@@ -355,7 +355,7 @@ class EpisodicMemory:
         *,
         limit: int | None = None,
         expand_context: int = 0,
-        score_threshold: float = -float("inf"),
+        score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
         mode: QueryMode = QueryMode.BOTH,
     ) -> QueryResponse | None:
@@ -373,7 +373,9 @@ class EpisodicMemory:
                    value is 20.
             expand_context: The number of additional episodes to include
                             around each matched episode from long term memory.
-            score_threshold: Minimum score to consider a match.
+            score_threshold: Minimum score to consider a match. ``None``
+                (default) means no threshold. Do not pass ``-inf``: under
+                lower-is-better metrics that sentinel drops every hit.
             property_filter: Properties to filter declarative memory searches.
             mode: Which memory backends to query.
 
@@ -480,7 +482,7 @@ class EpisodicMemory:
         query: str,
         limit: int | None = None,
         expand_context: int = 0,
-        score_threshold: float = -float("inf"),
+        score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
     ) -> str:
         """
@@ -494,7 +496,8 @@ class EpisodicMemory:
             limit: The maximum number of episodes to include in the context.
             expand_context: The number of additional episodes to include
                             around each matched episode from long term memory.
-            score_threshold: Minimum score to include in the context.
+            score_threshold: Minimum score to include in the context. ``None``
+                means no threshold.
             property_filter: Properties to filter the search.
 
         Returns:

--- a/packages/server/src/memmachine_server/main/memmachine.py
+++ b/packages/server/src/memmachine_server/main/memmachine.py
@@ -746,7 +746,7 @@ class MemMachine:
         query: str,
         limit: int | None = None,
         expand_context: int = 0,
-        score_threshold: float = -float("inf"),
+        score_threshold: float | None = None,
         search_filter: FilterExpr | None = None,
         retrieval_agent: AgentToolBase | None = None,
     ) -> EpisodicMemory.QueryResponse | None:
@@ -760,6 +760,7 @@ class MemMachine:
             expand_context: Number of surrounding episodes to return with each match.
             search_filter: Optional property filter for narrowing results.
             score_threshold: Optional minimum score threshold for results.
+                ``None`` means no threshold.
             retrieval_agent: Optional top-level retrieval agent for long-term search.
 
         Returns:
@@ -805,7 +806,7 @@ class MemMachine:
         query: str,
         limit: int | None,
         expand_context: int,
-        score_threshold: float,
+        score_threshold: float | None,
         search_filter: FilterExpr | None,
     ) -> EpisodicMemory.QueryResponse | None:
         """Build episodic query response using retrieval-agent long-term search."""
@@ -865,7 +866,7 @@ class MemMachine:
         query: str,
         limit: int,
         expand_context: int,
-        score_threshold: float,
+        score_threshold: float | None,
         search_filter: FilterExpr | None,
     ) -> list[Episode]:
         if episodic_session.long_term_memory is None:
@@ -899,7 +900,7 @@ class MemMachine:
         query: str,
         limit: int,
         expand_context: int,
-        score_threshold: float,
+        score_threshold: float | None,
         search_filter: FilterExpr | None,
     ) -> EpisodicMemory.QueryResponse.ShortTermMemoryResponse:
         if episodic_session.short_term_memory is None:
@@ -928,12 +929,12 @@ class MemMachine:
         *,
         normalized_long_episodes: list[Episode],
         short_response: EpisodicMemory.QueryResponse.ShortTermMemoryResponse,
-        score_threshold: float,
+        score_threshold: float | None,
     ) -> list[tuple[float, Episode]]:
         scored_long_episodes = [
             (1.0, episode)
             for episode in normalized_long_episodes
-            if score_threshold <= 1.0
+            if score_threshold is None or score_threshold <= 1.0
         ]
         episode_uid_set = {episode.uid for episode in short_response.episodes}
         unique_scored_long_episodes: list[tuple[float, Episode]] = []
@@ -954,7 +955,7 @@ class MemMachine:
         limit: int
         | None = None,  # TODO: Define if limit is per memory or is global limit
         expand_context: int = 0,
-        score_threshold: float = -float("inf"),
+        score_threshold: float | None = None,
         search_filter: str | None = None,
         agent_mode: bool = False,
     ) -> SearchResponse:
@@ -970,6 +971,8 @@ class MemMachine:
             expand_context: Number of surrounding episodes to return with each match.
             search_filter: Optional filter string applied to each memory query.
             score_threshold: Optional minimum score threshold for results.
+                ``None`` means no threshold. Do not pass ``-inf``: under
+                lower-is-better metrics that sentinel drops every hit.
             agent_mode: Whether to enable top-level retrieval-agent orchestration.
 
         Returns:

--- a/packages/server/src/memmachine_server/retrieval_agent/common/agent_api.py
+++ b/packages/server/src/memmachine_server/retrieval_agent/common/agent_api.py
@@ -39,7 +39,7 @@ class QueryParam(BaseModel):
     query: str
     limit: int = 0
     expand_context: int = 0
-    score_threshold: float = -float("inf")
+    score_threshold: float | None = None
     property_filter: FilterExpr | None = None
     memory: InstanceOf[EpisodicMemory]
 

--- a/packages/server/src/memmachine_server/server/api_v2/service.py
+++ b/packages/server/src/memmachine_server/server/api_v2/service.py
@@ -114,9 +114,7 @@ async def _search_target_memories(
         search_filter=spec.filter,
         limit=spec.top_k,
         expand_context=spec.expand_context,
-        score_threshold=spec.score_threshold
-        if spec.score_threshold is not None
-        else -float("inf"),
+        score_threshold=spec.score_threshold,
         agent_mode=spec.agent_mode,
     )
     content = SearchResultContent(


### PR DESCRIPTION
### Purpose of the change

Fix empty long-term search results when `score_threshold` is omitted under euclidean (lower-is-better) event-backed LongTermMemory. Upper layers were still injecting `-inf` after LongTermMemory switched to `None` as the “no threshold” sentinel.

Fixes #1489

### Description

`LongTermMemory.search_scored` already documents and tests that `score_threshold=None` means “no threshold”, and that the old `-inf` sentinel silently drops every hit under euclidean with no reranker (`score <= -inf`).

Callers had not been updated:

* `api_v2/service.py` converted `None` → `-inf`
* `MemMachine.query_search` / `_search_episodic_memory` defaulted to `-inf`
* `EpisodicMemory.query_memory` / `formalize_query_with_context` defaulted to `-inf`
* retrieval-agent `QueryParam` defaulted to `-inf`

This change passes `None` through the search call chain, keeps numeric thresholds unchanged, and updates API docs / OpenAPI description accordingly.

### Fixes/Closes

Fixes #1489

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Unit Test

**Commands and results:**

```bash
# Pre-fix reproduction (on upstream main): failed with [] instead of ["only"]
uv run pytest packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py::test_episodic_query_memory_default_keeps_euclidean_results -vv

# Post-fix focused + affected modules
uv run pytest packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py packages/server/server_tests/memmachine_server/episodic_memory/test_episodic_memory.py packages/server/server_tests/memmachine_server/server/api_v2/test_service.py packages/server/server_tests/memmachine_server/main/test_memmachine_mock.py packages/server/server_tests/memmachine_server/retrieval_agent/test_retrieval_agent.py -q
# 74 passed

uv run pytest packages/server/server_tests/memmachine_server/server/api_v2/ -q
# 257 passed

uv run pytest packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/ -q
# 36 passed, 1 skipped, 6 deselected

uv run ruff check <touched files>
uv run ruff format --check <touched files>
uv run ty check <touched production files>
git diff --check
```

All listed checks passed locally. Focused euclidean regression was run 3 times successfully.

**Not run:** full `uv run pytest` suite and Docker/integration tests (`-m integration`) — not required for this unit-level call-chain fix; no paid model/API credentials used.

**Test Results:** Deterministic FakeEmbedder + in-memory vector/segment stores. Pre-fix: default `query_memory` returned empty LTM under euclidean. Post-fix: returns the ingested episode. Service layer now forwards omitted `score_threshold` as `None`.

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

**Root cause:** Incomplete propagation of the LTM `None` sentinel. Service/MemMachine/EpisodicMemory still used `-inf`.

**Why minimal:** Only replace the harmful sentinel with `None` along the search path; metric-aware numeric filtering in `_score_passes_threshold` is unchanged.

**Compatibility:** Callers that already pass numeric thresholds are unchanged. Callers that explicitly pass `-inf` still get the empty-result behavior under euclidean (documented and covered by a regression test); omit the field or pass `None` instead.

**Non-goals:** No storage backend changes, no dependency updates, no expand_context / limit=0 / client changes.

**Analyzed revision:** `18f1211290c50ae30e9960b90bbe57d89bf68600`