### PR TITLE
Updating Color profile to match main website

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,16 +3,21 @@
   "theme": "palm",
   "name": "MemMachine Documentation",
   "colors": {
-    "primary": "#005eb9",
-    "light": "#429cf1",
-    "dark": "#a8bacb"
+    "primary": "#9B63E6",
+    "light": "#CE63C8",
+    "dark": "#120919"
+  },
+  "background": {
+    "decoration": "windows",
+    "color": {
+      "dark": "#0D0713"
+    }
   },
   "integrations": {
     "gtm": {
       "tagId": "GTM-WDX7ZBC7"
     }
   },
-  
   "favicon": "favicon.ico",
   "navigation": {
     "tabs": [


### PR DESCRIPTION
### Purpose of the change

Updating the color profile to match that of the primary memmachine.ai website.

### Description

We had different color palettes between the primary site and the docs site for memmachine.  This PR serves to match the two.

### Fixes/Closes

NA

### Type of change

- [X] Documentation update


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [X] Manual verification (tested rendering in `mint dev` environment)

**Test Results:** 
Dark Version:
<img width="2010" height="1132" alt="Screenshot 2026-08-06 at 2 42 07 PM" src="https://github.com/user-attachments/assets/06cd76fb-6af8-4ff0-b34c-240056db0c00" />

Light Version:
<img width="2010" height="1132" alt="Screenshot 2026-08-06 at 2 42 38 PM" src="https://github.com/user-attachments/assets/e0e88f78-5261-4908-991b-a2639b886027" />


### Checklist


- [X] I have signed the commit(s) within this pull request
- [X] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

See Screen shots above.

### Further comments
NA
