### PR TITLE
Let a filtered-out seed still anchor its segment context

### DIFF
--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
@@ -11,7 +11,7 @@ import pytest_asyncio
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from memmachine_server.common.filter.filter_parser import Comparison
+from memmachine_server.common.filter.filter_parser import Comparison, parse_filter
 from memmachine_server.common.payload_codec.payload_codec_config import (
     PlaintextPayloadCodecConfig,
 )
@@ -325,6 +325,44 @@ async def test_contexts_clamp_at_boundaries(
     assert len(ctx) == 3
     uuids = [s.uuid for s in ctx]
     assert uuids == [segs[0].uuid, segs[1].uuid, segs[2].uuid]
+
+
+@pytest.mark.asyncio
+async def test_contexts_filter_excludes_the_seed_but_keeps_its_window(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    """A seed anchors its window whether or not it passes; it is returned only if it does."""
+    ep = uuid4()
+    s0 = _seg(event_uuid=ep, offset=0, ts_offset_seconds=0, properties={"tag": "a"})
+    s1 = _seg(event_uuid=ep, offset=1, ts_offset_seconds=1, properties={"tag": "b"})
+    s2 = _seg(event_uuid=ep, offset=2, ts_offset_seconds=2, properties={"tag": "a"})
+    await partition.add_segments(_links(s0, s1, s2))
+
+    result = await partition.get_segment_contexts(
+        [s1.uuid],
+        max_backward_segments=5,
+        max_forward_segments=5,
+        property_filter=parse_filter("m.tag = 'a'"),
+    )
+    # Previously the filtered-out seed discarded the whole window.
+    assert [s.uuid for s in result[s1.uuid]] == [s0.uuid, s2.uuid]
+
+
+@pytest.mark.asyncio
+async def test_contexts_absent_when_the_whole_window_is_filtered_away(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    """A seed with nothing left to show is absent from the map, not an empty list."""
+    seed = _seg(properties={"tag": "b"})
+    await partition.add_segments(_links(seed))
+
+    result = await partition.get_segment_contexts(
+        [seed.uuid],
+        max_backward_segments=5,
+        max_forward_segments=5,
+        property_filter=parse_filter("m.tag = 'a'"),
+    )
+    assert seed.uuid not in result
 
 
 @pytest.mark.asyncio

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
@@ -755,10 +755,17 @@ class EventMemory:
                 unified.update(context)
             else:
                 # Prioritize segments near the seed segment.
+                # The seed anchors its own context but need not be IN it — a
+                # property filter can exclude the very segment the window was
+                # built around — so fall back to the start of the context, which
+                # degrades this to chronological order rather than raising.
                 seed_index = next(
-                    index
-                    for index, segment in enumerate(context)
-                    if segment.uuid == scored_context.seed_segment_uuid
+                    (
+                        index
+                        for index, segment in enumerate(context)
+                        if segment.uuid == scored_context.seed_segment_uuid
+                    ),
+                    0,
                 )
 
                 for segment in sorted(

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
@@ -313,19 +313,22 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
             self._tracker("get_segment_contexts"),
             self._create_session() as session,
         ):
-            seed_segments_query = select(SegmentRow).where(
-                SegmentRow.uuid.in_(seed_segment_uuids),
-                SegmentRow.partition_key == self._partition_key,
-            )
-            if property_filter is not None:
-                seed_segments_query = seed_segments_query.where(
-                    compile_sql_filter(
-                        property_filter,
-                        SQLAlchemySegmentStorePartition._resolve_segment_field,
+            # The seed is an ADDRESS, not a candidate: look it up unfiltered so it
+            # can anchor its window wherever it is, then filter it like every other
+            # segment on the way out. Filtering the lookup instead discarded the
+            # whole window, so a filter that merely excluded the seed's own kind
+            # returned nothing at all rather than the neighbours that do match.
+            seed_segment_rows = (
+                (
+                    await session.execute(
+                        select(SegmentRow).where(
+                            SegmentRow.uuid.in_(seed_segment_uuids),
+                            SegmentRow.partition_key == self._partition_key,
+                        )
                     )
                 )
-            seed_segment_rows = (
-                (await session.execute(seed_segments_query)).scalars().all()
+                .scalars()
+                .all()
             )
 
             seed_segment_rows_by_uuid: dict[UUID, SegmentRow] = {
@@ -333,6 +336,9 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
             }
             if not seed_segment_rows_by_uuid:
                 return {}
+            seeds_passing_filter = await self._seeds_passing_filter(
+                session, seed_segment_rows_by_uuid.keys(), property_filter
+            )
 
             # Short-circuit: no context needed.
             if max_backward_segments <= 0 and max_forward_segments <= 0:
@@ -343,6 +349,7 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
                         )
                     ]
                     for seed_segment_uuid, seed_segment_row in seed_segment_rows_by_uuid.items()
+                    if seed_segment_uuid in seeds_passing_filter
                 }
 
             # Get backward/forward context rows.
@@ -369,12 +376,41 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
                 backward_rows, forward_rows = context_rows_by_seed.get(
                     seed_uuid, ([], [])
                 )
-                segments_by_seed[seed_uuid] = [
-                    self._segment_from_segment_row(row)
-                    for row in [*reversed(backward_rows), seed_row, *forward_rows]
-                ]
+                middle = [seed_row] if seed_uuid in seeds_passing_filter else []
+                context = [*reversed(backward_rows), *middle, *forward_rows]
+                if context:
+                    segments_by_seed[seed_uuid] = [
+                        self._segment_from_segment_row(row) for row in context
+                    ]
 
             return segments_by_seed
+
+    async def _seeds_passing_filter(
+        self,
+        session: AsyncSession,
+        seed_uuids: Iterable[UUID],
+        property_filter: FilterExpr | None,
+    ) -> set[UUID]:
+        """Which seeds the filter would keep, if they were ordinary context rows.
+
+        One indexed lookup over the seeds alone, and only when there is a filter.
+        The seeds are fetched unfiltered so they can anchor their windows; this
+        decides separately whether each is also something the caller asked to see.
+        """
+        seed_uuids = set(seed_uuids)
+        if property_filter is None:
+            return seed_uuids
+        rows = await session.execute(
+            select(SegmentRow.uuid).where(
+                SegmentRow.uuid.in_(seed_uuids),
+                SegmentRow.partition_key == self._partition_key,
+                compile_sql_filter(
+                    property_filter,
+                    SQLAlchemySegmentStorePartition._resolve_segment_field,
+                ),
+            )
+        )
+        return {row[0] for row in rows}
 
     async def _get_context_rows_lateral(
         self,


### PR DESCRIPTION
## Problem

`get_segment_contexts` applies `property_filter` to the **seed lookup** itself. A seed that does not match the filter is dropped before its window is built, so the caller gets nothing back for it — not even the neighbouring segments that *do* match.

The practical effect: a filter that excludes only the seed's own kind answers "no context" rather than "here is the surrounding context, of the kind you asked for". Asking to see the tool results around a message returns nothing, because the message is not a tool result.

## Change

The seed is an address, not a candidate. It is looked up unfiltered so it can anchor its window wherever it is, and the filter is applied to it like any other row on the way out:

- returned when it passes, omitted when it does not;
- a seed whose entire window is filtered away stays **absent** from the returned mapping rather than mapping to an empty list, which the `dict[UUID, list[Segment]]` return already expresses unambiguously for multiple seeds.

Deciding whether each seed passes costs one indexed lookup over the seeds alone, and only when a filter is present.

## Caller that assumed otherwise

`EventMemory.build_query_result_context` located the seed inside its own context with a bare `next(...)`, which would now raise `StopIteration`. It falls back to the start of the context, degrading seed-proximity ordering to chronological order for that context.

I checked the rest of the tree for the same assumption; this was the only place.

## Tests

Two new cases — the filtered-out seed keeps its window, and an entirely filtered window leaves the seed absent — running against **SQLite and PostgreSQL**, since both must have the same semantics.

Full `event_memory` suite, with and without the change, fails exactly the same 8 tests on this machine (all missing NLTK `punkt_tab` data, unrelated), and passes 4 more with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)