### PR TITLE
Add VectorSearchEngine backed by turbovec

### DIFF
--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -74,6 +74,9 @@ milvus = [
 litellm = [
     "litellm>=1.63.0,<1.86",
 ]
+turbovec = [
+    "turbovec>=0.7.0",
+]
 
 [project.scripts]
 memmachine-server = "memmachine_server.server.app:main"

--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -75,7 +75,7 @@ litellm = [
     "litellm>=1.63.0,<1.86",
 ]
 turbovec = [
-    "turbovec>=0.7.0",
+    "turbovec>=1.0.0",
 ]
 
 [project.scripts]

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -2,7 +2,6 @@
 
 import math
 from datetime import UTC, datetime, timedelta, timezone
-from pathlib import Path
 from uuid import UUID, uuid4
 
 import pytest
@@ -31,9 +30,6 @@ from memmachine_server.common.vector_store.sqlite_vector_store import (
     SQLiteVectorStoreParams,
     _CollectionRow,
     _PendingOperationRow,
-)
-from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
-    published_index_path,
 )
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
@@ -1343,16 +1339,6 @@ async def _get_index_saved(engine, namespace, name) -> bool | None:
         ).scalar_one_or_none()
 
 
-def _delete_file(path: str) -> None:
-    """Remove a file from under a running store."""
-    Path(path).unlink()
-
-
-def _overwrite_file(path: str, contents: bytes) -> None:
-    """Replace a file's contents from under a running store."""
-    Path(path).write_bytes(contents)
-
-
 class TestIndexFileDurability:
     """Once the index has been saved, the file is part of the durable contract."""
 
@@ -1418,14 +1404,11 @@ class TestIndexFileDurability:
         await store1.shutdown()
         await engine1.dispose()
 
-        # Operator deletes the published index out from under us, leaving the
-        # generation record that names it.
+        # Operator deletes the index file out from under us.
         index_dir = tmp_path / "indexes"
-        bases = {p.with_suffix("") for p in index_dir.glob("*.idx.[01]")}
-        assert len(bases) == 1
-        published = published_index_path(str(next(iter(bases))))
-        assert published is not None
-        _delete_file(published)
+        idx_files = list(index_dir.glob("*.idx"))
+        assert len(idx_files) == 1
+        idx_files[0].unlink()
 
         # Restart: open_collection must surface the failure, not return an
         # engine silently rebuilt empty.
@@ -1453,46 +1436,15 @@ class TestIndexFileDurability:
         await engine1.dispose()
 
         index_dir = tmp_path / "indexes"
-        bases = {p.with_suffix("") for p in index_dir.glob("*.idx.[01]")}
-        assert len(bases) == 1
-        published = published_index_path(str(next(iter(bases))))
-        assert published is not None
-        _overwrite_file(published, b"not a valid index file")
+        idx_files = list(index_dir.glob("*.idx"))
+        assert len(idx_files) == 1
+        idx_files[0].write_bytes(b"not a valid index file")
 
         store2, engine2 = await _fresh_store(db_path, tmp_path)
         with pytest.raises(IndexLoadError) as exc_info:
             await store2.open_collection(namespace=NAMESPACE, name=NAME)
         assert exc_info.value.namespace == NAMESPACE
         assert exc_info.value.name == NAME
-        assert exc_info.value.__cause__ is not None
-
-        await store2.shutdown()
-        await engine2.dispose()
-
-    @pytest.mark.asyncio
-    async def test_nothing_published_when_saved_raises(self, tmp_path):
-        """A saved collection whose engine publishes nothing is a fault."""
-        db_path = tmp_path / "test.db"
-        store1, engine1 = await _fresh_store(db_path, tmp_path)
-
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
-        await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
-        await store1.shutdown()
-        await engine1.dispose()
-
-        # Both generation records lost: the slots may still hold indexes, but
-        # nothing names one, and an unnamed index is not a publication.
-        index_dir = tmp_path / "indexes"
-        records = list(index_dir.glob("*.gen"))
-        assert records
-        for record in records:
-            _delete_file(str(record))
-
-        store2, engine2 = await _fresh_store(db_path, tmp_path)
-        with pytest.raises(IndexLoadError) as exc_info:
-            await store2.open_collection(namespace=NAMESPACE, name=NAME)
         assert exc_info.value.__cause__ is not None
 
         await store2.shutdown()
@@ -1528,6 +1480,57 @@ class TestIndexFileDurability:
             query_vectors=[_normalize([1.0, 0.0, 0.0])], limit=10
         )
         assert len(results[0].matches) == 2
+
+        await store2.shutdown()
+        await engine2.dispose()
+
+    @pytest.mark.asyncio
+    async def test_a_reverted_publication_costs_search_not_records(self, tmp_path):
+        """A publication lost to power failure leaves records unsearchable.
+
+        The swap is atomic, not durable, so a power failure can revert the last
+        publication after the trim behind it has committed. Restoring the
+        previous index bytes reconstructs exactly that state, deterministically
+        rather than by pulling a plug, and pins the direction it fails in: the
+        record survives and still resolves by uuid, it simply cannot be found
+        by search until it is upserted again.
+        """
+        db_path = tmp_path / "test.db"
+        store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=1)
+
+        coll = await store1.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        r1 = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
+        await coll.upsert(records=[r1])
+
+        index_dir = tmp_path / "indexes"
+        idx_files = list(index_dir.glob("*.idx"))
+        assert len(idx_files) == 1
+        published_without_r2 = idx_files[0].read_bytes()
+
+        # Publishes an index holding both, then trims r2's only other copy.
+        r2 = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+        await coll.upsert(records=[r2])
+        assert await _pending_operation_count(engine1) == 0
+
+        await store1.shutdown()
+        await engine1.dispose()
+
+        # Power failure: the publication that held r2 never reached the disk.
+        idx_files[0].write_bytes(published_without_r2)
+
+        store2, engine2 = await _fresh_store(db_path, tmp_path)
+        coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        assert coll2 is not None
+
+        # The record is still a record.
+        fetched = await coll2.get(record_uuids=[r2.uuid])
+        assert [record.uuid for record in fetched] == [r2.uuid]
+
+        # The index just cannot find it any more.
+        results = await coll2.query(query_vectors=[r2.vector], limit=10)
+        assert [match.record.uuid for match in results[0].matches] == [r1.uuid]
 
         await store2.shutdown()
         await engine2.dispose()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -2,6 +2,7 @@
 
 import math
 from datetime import UTC, datetime, timedelta, timezone
+from pathlib import Path
 from uuid import UUID, uuid4
 
 import pytest
@@ -30,6 +31,9 @@ from memmachine_server.common.vector_store.sqlite_vector_store import (
     SQLiteVectorStoreParams,
     _CollectionRow,
     _PendingOperationRow,
+)
+from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
+    published_index_path,
 )
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
@@ -1339,6 +1343,16 @@ async def _get_index_saved(engine, namespace, name) -> bool | None:
         ).scalar_one_or_none()
 
 
+def _delete_file(path: str) -> None:
+    """Remove a file from under a running store."""
+    Path(path).unlink()
+
+
+def _overwrite_file(path: str, contents: bytes) -> None:
+    """Replace a file's contents from under a running store."""
+    Path(path).write_bytes(contents)
+
+
 class TestIndexFileDurability:
     """Once the index has been saved, the file is part of the durable contract."""
 
@@ -1404,11 +1418,14 @@ class TestIndexFileDurability:
         await store1.shutdown()
         await engine1.dispose()
 
-        # Operator deletes the index file out from under us.
+        # Operator deletes the published index out from under us, leaving the
+        # generation record that names it.
         index_dir = tmp_path / "indexes"
-        idx_files = list(index_dir.glob("*.idx"))
-        assert len(idx_files) == 1
-        idx_files[0].unlink()
+        bases = {p.with_suffix("") for p in index_dir.glob("*.idx.[01]")}
+        assert len(bases) == 1
+        published = published_index_path(str(next(iter(bases))))
+        assert published is not None
+        _delete_file(published)
 
         # Restart: open_collection must surface the failure, not return an
         # engine silently rebuilt empty.
@@ -1436,15 +1453,46 @@ class TestIndexFileDurability:
         await engine1.dispose()
 
         index_dir = tmp_path / "indexes"
-        idx_files = list(index_dir.glob("*.idx"))
-        assert len(idx_files) == 1
-        idx_files[0].write_bytes(b"not a valid index file")
+        bases = {p.with_suffix("") for p in index_dir.glob("*.idx.[01]")}
+        assert len(bases) == 1
+        published = published_index_path(str(next(iter(bases))))
+        assert published is not None
+        _overwrite_file(published, b"not a valid index file")
 
         store2, engine2 = await _fresh_store(db_path, tmp_path)
         with pytest.raises(IndexLoadError) as exc_info:
             await store2.open_collection(namespace=NAMESPACE, name=NAME)
         assert exc_info.value.namespace == NAMESPACE
         assert exc_info.value.name == NAME
+        assert exc_info.value.__cause__ is not None
+
+        await store2.shutdown()
+        await engine2.dispose()
+
+    @pytest.mark.asyncio
+    async def test_nothing_published_when_saved_raises(self, tmp_path):
+        """A saved collection whose engine publishes nothing is a fault."""
+        db_path = tmp_path / "test.db"
+        store1, engine1 = await _fresh_store(db_path, tmp_path)
+
+        coll = await store1.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
+        await store1.shutdown()
+        await engine1.dispose()
+
+        # Both generation records lost: the slots may still hold indexes, but
+        # nothing names one, and an unnamed index is not a publication.
+        index_dir = tmp_path / "indexes"
+        records = list(index_dir.glob("*.gen"))
+        assert records
+        for record in records:
+            _delete_file(str(record))
+
+        store2, engine2 = await _fresh_store(db_path, tmp_path)
+        with pytest.raises(IndexLoadError) as exc_info:
+            await store2.open_collection(namespace=NAMESPACE, name=NAME)
         assert exc_info.value.__cause__ is not None
 
         await store2.shutdown()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
@@ -362,6 +362,42 @@ class TestPersistence:
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=3)
         assert {m.key for m in result.matches} == {1, 3}
 
+    @pytest.mark.asyncio
+    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
+        engine = HnswlibVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine.add({1: _normalize([1, 0, 0])})
+
+        path = tmp_path / "test.hnswlib"
+        await engine.save(str(path))
+
+        assert path.exists()
+        assert not (tmp_path / "test.hnswlib.tmp").exists()
+
+    @pytest.mark.asyncio
+    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+        engine = HnswlibVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
+
+        path = tmp_path / "test.hnswlib"
+        await engine.save(str(path))
+
+        # A temp file left behind by a previously interrupted save.
+        stale_temp = tmp_path / "test.hnswlib.tmp"
+        stale_temp.write_text("STALE")
+
+        engine2 = HnswlibVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine2.load(str(path))
+
+        assert not stale_temp.exists()
+        result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
+        assert {m.key for m in result.matches} == {1, 2}
+
 
 # -- allow_replace_deleted=True (slot reclamation) --
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
@@ -21,9 +21,6 @@ from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.vector_store.vector_search_engine.hnswlib_engine import (
     HnswlibVectorSearchEngine,
 )
-from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
-    published_index_path,
-)
 
 NDIM = 3
 
@@ -366,47 +363,38 @@ class TestPersistence:
         assert {m.key for m in result.matches} == {1, 3}
 
     @pytest.mark.asyncio
-    async def test_save_publishes_under_the_base_path(self, tmp_path: Path):
+    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
         engine = HnswlibVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
         await engine.add({1: _normalize([1, 0, 0])})
 
-        base = tmp_path / "test.hnswlib"
-        await engine.save(str(base))
+        path = tmp_path / "test.hnswlib"
+        await engine.save(str(path))
 
-        # The base path is a name, not a file: the engine owns what sits under
-        # it, and something is published there.
-        assert not base.exists()
-        assert published_index_path(str(base)) is not None
+        assert path.exists()
+        assert not (tmp_path / "test.hnswlib.tmp").exists()
 
     @pytest.mark.asyncio
-    async def test_load_without_a_published_index_raises(self, tmp_path: Path):
+    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
         engine = HnswlibVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
+        await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
-        with pytest.raises(OSError, match="No published index"):
-            await engine.load(str(tmp_path / "test.hnswlib"))
+        path = tmp_path / "test.hnswlib"
+        await engine.save(str(path))
 
-    @pytest.mark.asyncio
-    async def test_load_sees_the_latest_checkpoint(self, tmp_path: Path):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
-        base = tmp_path / "test.hnswlib"
-
-        await engine.add({1: _normalize([1, 0, 0])})
-        await engine.save(str(base))
-        # A second checkpoint lands in the other slot; the load must follow it.
-        await engine.add({2: _normalize([0, 1, 0])})
-        await engine.save(str(base))
+        # A temp file left behind by a previously interrupted save.
+        stale_temp = tmp_path / "test.hnswlib.tmp"
+        stale_temp.write_text("STALE")
 
         engine2 = HnswlibVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
-        await engine2.load(str(base))
+        await engine2.load(str(path))
 
+        assert not stale_temp.exists()
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
@@ -21,6 +21,9 @@ from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.vector_store.vector_search_engine.hnswlib_engine import (
     HnswlibVectorSearchEngine,
 )
+from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
+    published_index_path,
+)
 
 NDIM = 3
 
@@ -363,38 +366,47 @@ class TestPersistence:
         assert {m.key for m in result.matches} == {1, 3}
 
     @pytest.mark.asyncio
-    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
+    async def test_save_publishes_under_the_base_path(self, tmp_path: Path):
         engine = HnswlibVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
         await engine.add({1: _normalize([1, 0, 0])})
 
-        path = tmp_path / "test.hnswlib"
-        await engine.save(str(path))
+        base = tmp_path / "test.hnswlib"
+        await engine.save(str(base))
 
-        assert path.exists()
-        assert not (tmp_path / "test.hnswlib.tmp").exists()
+        # The base path is a name, not a file: the engine owns what sits under
+        # it, and something is published there.
+        assert not base.exists()
+        assert published_index_path(str(base)) is not None
 
     @pytest.mark.asyncio
-    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+    async def test_load_without_a_published_index_raises(self, tmp_path: Path):
         engine = HnswlibVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
-        await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
-        path = tmp_path / "test.hnswlib"
-        await engine.save(str(path))
+        with pytest.raises(OSError, match="No published index"):
+            await engine.load(str(tmp_path / "test.hnswlib"))
 
-        # A temp file left behind by a previously interrupted save.
-        stale_temp = tmp_path / "test.hnswlib.tmp"
-        stale_temp.write_text("STALE")
+    @pytest.mark.asyncio
+    async def test_load_sees_the_latest_checkpoint(self, tmp_path: Path):
+        engine = HnswlibVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        base = tmp_path / "test.hnswlib"
+
+        await engine.add({1: _normalize([1, 0, 0])})
+        await engine.save(str(base))
+        # A second checkpoint lands in the other slot; the load must follow it.
+        await engine.add({2: _normalize([0, 1, 0])})
+        await engine.save(str(base))
 
         engine2 = HnswlibVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
-        await engine2.load(str(path))
+        await engine2.load(str(base))
 
-        assert not stale_temp.exists()
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -1,0 +1,97 @@
+"""Tests for the shared atomic index persistence helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
+    atomic_index_write,
+    clear_stale_index_temp,
+)
+
+
+class TestAtomicIndexWrite:
+    def test_swaps_temp_into_place_on_success(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        path.write_text("OLD")
+
+        with atomic_index_write(str(path)) as temp:
+            Path(temp).write_text("NEW")
+            # Until the context exits, the target still holds the old contents.
+            assert path.read_text() == "OLD"
+
+        assert path.read_text() == "NEW"
+        assert not (tmp_path / "index.idx.tmp").exists()
+
+    def test_creates_target_when_missing(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+
+        with atomic_index_write(str(path)) as temp:
+            Path(temp).write_text("NEW")
+
+        assert path.read_text() == "NEW"
+
+    def test_preserves_existing_index_on_failure(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        path.write_text("GOOD")
+
+        def write_then_fail() -> None:
+            with atomic_index_write(str(path)) as temp:
+                Path(temp).write_text("PARTIAL")
+                raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            write_then_fail()
+
+        # The existing index is untouched and the temp file is cleaned up.
+        assert path.read_text() == "GOOD"
+        assert not (tmp_path / "index.idx.tmp").exists()
+
+    def test_does_not_create_target_on_failure(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+
+        def write_then_fail() -> None:
+            with atomic_index_write(str(path)) as temp:
+                Path(temp).write_text("PARTIAL")
+                raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            write_then_fail()
+
+        assert not path.exists()
+        assert not (tmp_path / "index.idx.tmp").exists()
+
+    def test_clears_stale_temp_before_writing(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        # A temp file left by a previously interrupted save.
+        (tmp_path / "index.idx.tmp").write_text("STALE")
+
+        with atomic_index_write(str(path)) as temp:
+            assert not Path(temp).exists()
+            Path(temp).write_text("NEW")
+
+        assert path.read_text() == "NEW"
+
+
+class TestClearStaleIndexTemp:
+    def test_removes_leftover_temp(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        temp = tmp_path / "index.idx.tmp"
+        temp.write_text("STALE")
+
+        clear_stale_index_temp(str(path))
+
+        assert not temp.exists()
+
+    def test_no_temp_is_noop(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        # Must not raise when there is nothing to clear.
+        clear_stale_index_temp(str(path))
+
+    def test_leaves_index_file_untouched(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        path.write_text("GOOD")
+
+        clear_stale_index_temp(str(path))
+
+        assert path.read_text() == "GOOD"

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -1,275 +1,97 @@
-"""
-Tests for crash-safe index publication.
+"""Tests for the shared atomic index persistence helpers."""
 
-The anomaly tests walk the crash points in the publish sequence by constructing
-the on-disk state each one would leave — stricter than killing a process, since
-every state is produced deterministically. The one property construction cannot
-observe is the *ordering* itself: a generation record written before its index
-would satisfy every state-based test here, so
-`test_a_failed_index_write_publishes_nothing` pins it separately.
-"""
-
-import errno
-import os
-import stat
-import struct
-import sys
 from pathlib import Path
 
 import pytest
 
-from memmachine_server.common.vector_store.vector_search_engine import (
-    index_persistence,
-)
 from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
-    index_artifact_paths,
-    publish_index,
-    published_index_path,
+    atomic_index_write,
+    clear_stale_index_temp,
 )
 
-_MASK = 0xFFFFFFFFFFFFFFFF
 
+class TestAtomicIndexWrite:
+    def test_swaps_temp_into_place_on_success(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        path.write_text("OLD")
 
-def _write_index(base: str, contents: str) -> str:
-    """Publish `contents` as the next index generation, returning its slot."""
-    with publish_index(base) as slot:
-        Path(slot).write_text(contents)
-    return slot
+        with atomic_index_write(str(path)) as temp:
+            Path(temp).write_text("NEW")
+            # Until the context exits, the target still holds the old contents.
+            assert path.read_text() == "OLD"
 
+        assert path.read_text() == "NEW"
+        assert not (tmp_path / "index.idx.tmp").exists()
 
-def _record(base: str, slot: int) -> Path:
-    return Path(f"{base}.{slot}.gen")
+    def test_creates_target_when_missing(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
 
+        with atomic_index_write(str(path)) as temp:
+            Path(temp).write_text("NEW")
 
-def _slot(base: str, slot: int) -> Path:
-    return Path(f"{base}.{slot}")
+        assert path.read_text() == "NEW"
 
+    def test_preserves_existing_index_on_failure(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        path.write_text("GOOD")
 
-def _generation(base: str, slot: int) -> int | None:
-    """The generation stored in a record, ignoring the complement check."""
-    data = _record(base, slot).read_bytes()
-    if len(data) != 16:
-        return None
-    return struct.unpack("<QQ", data)[0]
-
-
-class TestPublish:
-    def test_nothing_is_published_before_the_first_save(self, tmp_path: Path):
-        assert published_index_path(str(tmp_path / "index.idx")) is None
-
-    def test_publishes_and_reads_back(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-
-        _write_index(base, "FIRST")
-
-        published = published_index_path(base)
-        assert published is not None
-        assert Path(published).read_text() == "FIRST"
-
-    def test_alternates_slots_across_checkpoints(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-
-        first = _write_index(base, "FIRST")
-        second = _write_index(base, "SECOND")
-        third = _write_index(base, "THIRD")
-
-        assert first != second
-        assert third == first
-        published = published_index_path(base)
-        assert published is not None
-        assert Path(published).read_text() == "THIRD"
-
-    def test_empties_the_retired_slot(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-
-        retired = _write_index(base, "FIRST")
-        _write_index(base, "SECOND")
-
-        # The spare costs no disk at rest, and its record no longer publishes.
-        assert Path(retired).stat().st_size == 0
-        retired_slot = int(retired[-1])
-        assert _record(base, retired_slot).stat().st_size == 0
-
-    def test_creates_its_files_once(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-
-        _write_index(base, "FIRST")
-
-        assert sorted(p.name for p in tmp_path.iterdir()) == sorted(
-            p.name for p in index_artifact_paths(base)
-        )
-
-
-class TestCrashPoints:
-    def test_a_torn_index_write_is_invisible(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-        _write_index(base, "GOOD")
-        live = published_index_path(base)
-        assert live is not None
-
-        # Crash during step 1: the damaged file is the slot nobody reads.
-        free = 1 - int(live[-1])
-        _slot(base, free).write_text("HALF-WRITTEN")
-
-        assert published_index_path(base) == live
-        assert Path(live).read_text() == "GOOD"
-
-    def test_an_unpublished_index_is_invisible(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-        _write_index(base, "GOOD")
-        live = published_index_path(base)
-        assert live is not None
-
-        # Crash between steps 1 and 2: a complete new index that nothing named.
-        free = 1 - int(live[-1])
-        _slot(base, free).write_text("COMPLETE BUT UNPUBLISHED")
-
-        assert published_index_path(base) == live
-
-    def test_a_torn_record_reads_as_absent(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-        _write_index(base, "GOOD")
-        live = published_index_path(base)
-        assert live is not None
-        live_slot = int(live[-1])
-        free = 1 - live_slot
-
-        # Crash during step 2: halves from different writes. The higher
-        # generation is present but unbelievable, so the live slot still wins.
-        _slot(base, free).write_text("NEWER")
-        torn = struct.pack("<QQ", 2, 1 ^ _MASK)
-        _record(base, free).write_bytes(torn)
-
-        assert published_index_path(base) == live
-        assert Path(live).read_text() == "GOOD"
-
-    def test_a_short_record_reads_as_absent(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-        _write_index(base, "GOOD")
-        live = published_index_path(base)
-        assert live is not None
-        free = 1 - int(live[-1])
-
-        _slot(base, free).write_text("NEWER")
-        _record(base, free).write_bytes(struct.pack("<Q", 2))
-
-        assert published_index_path(base) == live
-
-    def test_the_higher_generation_wins(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-        first = _write_index(base, "FIRST")
-        second = _write_index(base, "SECOND")
-
-        # Crash between steps 2 and 3: both records valid, retired not yet
-        # emptied. Reconstruct that state by republishing the older record.
-        first_slot = int(first[-1])
-        _slot(base, first_slot).write_text("FIRST")
-        _record(base, first_slot).write_bytes(struct.pack("<QQ", 1, 1 ^ _MASK))
-
-        assert _generation(base, first_slot) == 1
-        assert published_index_path(base) == second
-
-    def test_a_failed_index_write_publishes_nothing(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-        _write_index(base, "GOOD")
-        live = published_index_path(base)
-        assert live is not None
-
-        # The ordering itself: no state-based test can see a record written
-        # before its index, because the end state is identical either way.
         def write_then_fail() -> None:
-            with publish_index(base) as slot:
-                Path(slot).write_text("PARTIAL")
-                raise RuntimeError("engine exploded")
+            with atomic_index_write(str(path)) as temp:
+                Path(temp).write_text("PARTIAL")
+                raise RuntimeError("boom")
 
-        with pytest.raises(RuntimeError, match="engine exploded"):
+        with pytest.raises(RuntimeError, match="boom"):
             write_then_fail()
 
-        assert published_index_path(base) == live
-        assert Path(live).read_text() == "GOOD"
+        # The existing index is untouched and the temp file is cleaned up.
+        assert path.read_text() == "GOOD"
+        assert not (tmp_path / "index.idx.tmp").exists()
 
-    def test_a_failed_flush_publishes_nothing(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        base = str(tmp_path / "index.idx")
-        _write_index(base, "GOOD")
-        live = published_index_path(base)
-        assert live is not None
-
-        def fail(_fd: int) -> None:
-            raise OSError(errno.EIO, "Input/output error")
-
-        monkeypatch.setattr(index_persistence, "_fsync", fail)
-
-        # A flush that fails must fail the save: the caller trims its log on the
-        # strength of it, and EIO means the writeback already failed.
-        def write_index() -> None:
-            with publish_index(base) as slot:
-                Path(slot).write_text("NEWER")
-
-        with pytest.raises(OSError, match="Input/output error"):
-            write_index()
-
-        assert published_index_path(base) == live
-
-
-class TestDurability:
-    def test_flushes_the_index_before_the_record(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        base = str(tmp_path / "index.idx")
-        real_fsync = index_persistence._fsync
-        flushed: list[str] = []
-
-        def record(fd: int) -> None:
-            mode = os.fstat(fd).st_mode
-            flushed.append("dir" if stat.S_ISDIR(mode) else f"{os.fstat(fd).st_size}")
-            real_fsync(fd)
-
-        monkeypatch.setattr(index_persistence, "_fsync", record)
-
-        _write_index(base, "FIRST")
-
-        # A one-time parent flush for the created files (POSIX only), then the
-        # index, then the 16-byte record that publishes it.
-        assert flushed[-2:] == ["5", "16"]
-        if os.name != "nt":
-            assert flushed[0] == "dir"
-
-    @pytest.mark.skipif(
-        sys.platform != "darwin", reason="F_FULLFSYNC only exists on macOS"
-    )
-    def test_falls_back_when_full_fsync_is_unsupported(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ):
-        fcntl = pytest.importorskip("fcntl")
-        calls: list[str] = []
-
-        def unsupported(_fd: int, _cmd: int) -> None:
-            calls.append("full_fsync")
-            raise OSError(errno.ENOTSUP, "Operation not supported")
-
-        monkeypatch.setattr(fcntl, "fcntl", unsupported)
-        monkeypatch.setattr(os, "fsync", lambda fd: calls.append("fsync"))
-
+    def test_does_not_create_target_on_failure(self, tmp_path: Path):
         path = tmp_path / "index.idx"
-        path.write_text("DATA")
-        fd = os.open(str(path), os.O_RDWR)
-        try:
-            index_persistence._fsync(fd)
-        finally:
-            os.close(fd)
 
-        assert calls == ["full_fsync", "fsync"]
+        def write_then_fail() -> None:
+            with atomic_index_write(str(path)) as temp:
+                Path(temp).write_text("PARTIAL")
+                raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            write_then_fail()
+
+        assert not path.exists()
+        assert not (tmp_path / "index.idx.tmp").exists()
+
+    def test_clears_stale_temp_before_writing(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        # A temp file left by a previously interrupted save.
+        (tmp_path / "index.idx.tmp").write_text("STALE")
+
+        with atomic_index_write(str(path)) as temp:
+            assert not Path(temp).exists()
+            Path(temp).write_text("NEW")
+
+        assert path.read_text() == "NEW"
 
 
-class TestIndexArtifactPaths:
-    def test_lists_every_file_the_base_expands_into(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
+class TestClearStaleIndexTemp:
+    def test_removes_leftover_temp(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        temp = tmp_path / "index.idx.tmp"
+        temp.write_text("STALE")
 
-        assert sorted(p.name for p in index_artifact_paths(base)) == [
-            "index.idx.0",
-            "index.idx.0.gen",
-            "index.idx.1",
-            "index.idx.1.gen",
-        ]
+        clear_stale_index_temp(str(path))
+
+        assert not temp.exists()
+
+    def test_no_temp_is_noop(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        # Must not raise when there is nothing to clear.
+        clear_stale_index_temp(str(path))
+
+    def test_leaves_index_file_untouched(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        path.write_text("GOOD")
+
+        clear_stale_index_temp(str(path))
+
+        assert path.read_text() == "GOOD"

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -1,9 +1,16 @@
 """Tests for the shared atomic index persistence helpers."""
 
+import errno
+import os
+import stat
+import sys
 from pathlib import Path
 
 import pytest
 
+from memmachine_server.common.vector_store.vector_search_engine import (
+    index_persistence,
+)
 from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
     atomic_index_write,
     clear_stale_index_temp,
@@ -71,6 +78,103 @@ class TestAtomicIndexWrite:
             Path(temp).write_text("NEW")
 
         assert path.read_text() == "NEW"
+
+
+class TestDurability:
+    def test_flushes_the_file_then_the_parent_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        real_fsync = index_persistence._fsync
+        # True for a directory fd, False for a regular file.
+        flushed: list[bool] = []
+
+        def record(fd: int) -> None:
+            flushed.append(stat.S_ISDIR(os.fstat(fd).st_mode))
+            real_fsync(fd)
+
+        monkeypatch.setattr(index_persistence, "_fsync", record)
+
+        path = tmp_path / "index.idx"
+        with atomic_index_write(str(path)) as temp:
+            Path(temp).write_text("NEW")
+
+        if os.name == "nt":
+            # Windows cannot open a directory to flush it; the swap's
+            # durability follows NTFS metadata journaling instead.
+            assert flushed == [False]
+        else:
+            # The bytes first, then the directory entry the swap created.
+            assert flushed == [False, True]
+
+    def test_file_flush_failure_fails_the_save(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        def fail(fd: int) -> None:
+            raise OSError(errno.EIO, "Input/output error")
+
+        monkeypatch.setattr(index_persistence, "_fsync", fail)
+
+        path = tmp_path / "index.idx"
+        path.write_text("GOOD")
+
+        def write_index() -> None:
+            with atomic_index_write(str(path)) as temp:
+                Path(temp).write_text("NEW")
+
+        # Reported as a failure rather than swallowed: the caller trims its
+        # pending log on the strength of this save.
+        with pytest.raises(OSError, match="Input/output error"):
+            write_index()
+
+        assert path.read_text() == "GOOD"
+        assert not (tmp_path / "index.idx.tmp").exists()
+
+    def test_parent_directory_flush_failure_is_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        real_fsync = index_persistence._fsync
+
+        def fail_for_directories(fd: int) -> None:
+            if stat.S_ISDIR(os.fstat(fd).st_mode):
+                raise OSError(errno.EINVAL, "Invalid argument")
+            real_fsync(fd)
+
+        monkeypatch.setattr(index_persistence, "_fsync", fail_for_directories)
+
+        path = tmp_path / "index.idx"
+        # Filesystems that refuse a directory fsync must not fail every save.
+        with atomic_index_write(str(path)) as temp:
+            Path(temp).write_text("NEW")
+
+        assert path.read_text() == "NEW"
+
+
+class TestFsync:
+    @pytest.mark.skipif(
+        sys.platform != "darwin", reason="F_FULLFSYNC only exists on macOS"
+    )
+    def test_falls_back_when_full_fsync_is_unsupported(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        fcntl = pytest.importorskip("fcntl")
+        calls: list[str] = []
+
+        def unsupported(_fd: int, _cmd: int) -> None:
+            calls.append("full_fsync")
+            raise OSError(errno.ENOTSUP, "Operation not supported")
+
+        monkeypatch.setattr(fcntl, "fcntl", unsupported)
+        monkeypatch.setattr(os, "fsync", lambda fd: calls.append("fsync"))
+
+        path = tmp_path / "index.idx"
+        path.write_text("DATA")
+        fd = os.open(str(path), os.O_RDWR)
+        try:
+            index_persistence._fsync(fd)
+        finally:
+            os.close(fd)
+
+        assert calls == ["full_fsync", "fsync"]
 
 
 class TestClearStaleIndexTemp:

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -1,8 +1,18 @@
-"""Tests for the shared atomic index persistence helpers."""
+"""
+Tests for crash-safe index publication.
+
+The anomaly tests walk the crash points in the publish sequence by constructing
+the on-disk state each one would leave — stricter than killing a process, since
+every state is produced deterministically. The one property construction cannot
+observe is the *ordering* itself: a generation record written before its index
+would satisfy every state-based test here, so
+`test_a_failed_index_write_publishes_nothing` pins it separately.
+"""
 
 import errno
 import os
 import stat
+import struct
 import sys
 from pathlib import Path
 
@@ -12,144 +22,220 @@ from memmachine_server.common.vector_store.vector_search_engine import (
     index_persistence,
 )
 from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
-    atomic_index_write,
-    clear_stale_index_temp,
+    index_artifact_paths,
+    publish_index,
+    published_index_path,
 )
 
+_MASK = 0xFFFFFFFFFFFFFFFF
 
-class TestAtomicIndexWrite:
-    def test_swaps_temp_into_place_on_success(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-        path.write_text("OLD")
 
-        with atomic_index_write(str(path)) as temp:
-            Path(temp).write_text("NEW")
-            # Until the context exits, the target still holds the old contents.
-            assert path.read_text() == "OLD"
+def _write_index(base: str, contents: str) -> str:
+    """Publish `contents` as the next index generation, returning its slot."""
+    with publish_index(base) as slot:
+        Path(slot).write_text(contents)
+    return slot
 
-        assert path.read_text() == "NEW"
-        assert not (tmp_path / "index.idx.tmp").exists()
 
-    def test_creates_target_when_missing(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
+def _record(base: str, slot: int) -> Path:
+    return Path(f"{base}.{slot}.gen")
 
-        with atomic_index_write(str(path)) as temp:
-            Path(temp).write_text("NEW")
 
-        assert path.read_text() == "NEW"
+def _slot(base: str, slot: int) -> Path:
+    return Path(f"{base}.{slot}")
 
-    def test_preserves_existing_index_on_failure(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-        path.write_text("GOOD")
 
+def _generation(base: str, slot: int) -> int | None:
+    """The generation stored in a record, ignoring the complement check."""
+    data = _record(base, slot).read_bytes()
+    if len(data) != 16:
+        return None
+    return struct.unpack("<QQ", data)[0]
+
+
+class TestPublish:
+    def test_nothing_is_published_before_the_first_save(self, tmp_path: Path):
+        assert published_index_path(str(tmp_path / "index.idx")) is None
+
+    def test_publishes_and_reads_back(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+
+        _write_index(base, "FIRST")
+
+        published = published_index_path(base)
+        assert published is not None
+        assert Path(published).read_text() == "FIRST"
+
+    def test_alternates_slots_across_checkpoints(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+
+        first = _write_index(base, "FIRST")
+        second = _write_index(base, "SECOND")
+        third = _write_index(base, "THIRD")
+
+        assert first != second
+        assert third == first
+        published = published_index_path(base)
+        assert published is not None
+        assert Path(published).read_text() == "THIRD"
+
+    def test_empties_the_retired_slot(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+
+        retired = _write_index(base, "FIRST")
+        _write_index(base, "SECOND")
+
+        # The spare costs no disk at rest, and its record no longer publishes.
+        assert Path(retired).stat().st_size == 0
+        retired_slot = int(retired[-1])
+        assert _record(base, retired_slot).stat().st_size == 0
+
+    def test_creates_its_files_once(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+
+        _write_index(base, "FIRST")
+
+        assert sorted(p.name for p in tmp_path.iterdir()) == sorted(
+            p.name for p in index_artifact_paths(base)
+        )
+
+
+class TestCrashPoints:
+    def test_a_torn_index_write_is_invisible(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+        _write_index(base, "GOOD")
+        live = published_index_path(base)
+        assert live is not None
+
+        # Crash during step 1: the damaged file is the slot nobody reads.
+        free = 1 - int(live[-1])
+        _slot(base, free).write_text("HALF-WRITTEN")
+
+        assert published_index_path(base) == live
+        assert Path(live).read_text() == "GOOD"
+
+    def test_an_unpublished_index_is_invisible(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+        _write_index(base, "GOOD")
+        live = published_index_path(base)
+        assert live is not None
+
+        # Crash between steps 1 and 2: a complete new index that nothing named.
+        free = 1 - int(live[-1])
+        _slot(base, free).write_text("COMPLETE BUT UNPUBLISHED")
+
+        assert published_index_path(base) == live
+
+    def test_a_torn_record_reads_as_absent(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+        _write_index(base, "GOOD")
+        live = published_index_path(base)
+        assert live is not None
+        live_slot = int(live[-1])
+        free = 1 - live_slot
+
+        # Crash during step 2: halves from different writes. The higher
+        # generation is present but unbelievable, so the live slot still wins.
+        _slot(base, free).write_text("NEWER")
+        torn = struct.pack("<QQ", 2, 1 ^ _MASK)
+        _record(base, free).write_bytes(torn)
+
+        assert published_index_path(base) == live
+        assert Path(live).read_text() == "GOOD"
+
+    def test_a_short_record_reads_as_absent(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+        _write_index(base, "GOOD")
+        live = published_index_path(base)
+        assert live is not None
+        free = 1 - int(live[-1])
+
+        _slot(base, free).write_text("NEWER")
+        _record(base, free).write_bytes(struct.pack("<Q", 2))
+
+        assert published_index_path(base) == live
+
+    def test_the_higher_generation_wins(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+        first = _write_index(base, "FIRST")
+        second = _write_index(base, "SECOND")
+
+        # Crash between steps 2 and 3: both records valid, retired not yet
+        # emptied. Reconstruct that state by republishing the older record.
+        first_slot = int(first[-1])
+        _slot(base, first_slot).write_text("FIRST")
+        _record(base, first_slot).write_bytes(struct.pack("<QQ", 1, 1 ^ _MASK))
+
+        assert _generation(base, first_slot) == 1
+        assert published_index_path(base) == second
+
+    def test_a_failed_index_write_publishes_nothing(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+        _write_index(base, "GOOD")
+        live = published_index_path(base)
+        assert live is not None
+
+        # The ordering itself: no state-based test can see a record written
+        # before its index, because the end state is identical either way.
         def write_then_fail() -> None:
-            with atomic_index_write(str(path)) as temp:
-                Path(temp).write_text("PARTIAL")
-                raise RuntimeError("boom")
+            with publish_index(base) as slot:
+                Path(slot).write_text("PARTIAL")
+                raise RuntimeError("engine exploded")
 
-        with pytest.raises(RuntimeError, match="boom"):
+        with pytest.raises(RuntimeError, match="engine exploded"):
             write_then_fail()
 
-        # The existing index is untouched and the temp file is cleaned up.
-        assert path.read_text() == "GOOD"
-        assert not (tmp_path / "index.idx.tmp").exists()
+        assert published_index_path(base) == live
+        assert Path(live).read_text() == "GOOD"
 
-    def test_does_not_create_target_on_failure(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-
-        def write_then_fail() -> None:
-            with atomic_index_write(str(path)) as temp:
-                Path(temp).write_text("PARTIAL")
-                raise RuntimeError("boom")
-
-        with pytest.raises(RuntimeError):
-            write_then_fail()
-
-        assert not path.exists()
-        assert not (tmp_path / "index.idx.tmp").exists()
-
-    def test_clears_stale_temp_before_writing(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-        # A temp file left by a previously interrupted save.
-        (tmp_path / "index.idx.tmp").write_text("STALE")
-
-        with atomic_index_write(str(path)) as temp:
-            assert not Path(temp).exists()
-            Path(temp).write_text("NEW")
-
-        assert path.read_text() == "NEW"
-
-
-class TestDurability:
-    def test_flushes_the_file_then_the_parent_directory(
+    def test_a_failed_flush_publishes_nothing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
-        real_fsync = index_persistence._fsync
-        # True for a directory fd, False for a regular file.
-        flushed: list[bool] = []
+        base = str(tmp_path / "index.idx")
+        _write_index(base, "GOOD")
+        live = published_index_path(base)
+        assert live is not None
 
-        def record(fd: int) -> None:
-            flushed.append(stat.S_ISDIR(os.fstat(fd).st_mode))
-            real_fsync(fd)
-
-        monkeypatch.setattr(index_persistence, "_fsync", record)
-
-        path = tmp_path / "index.idx"
-        with atomic_index_write(str(path)) as temp:
-            Path(temp).write_text("NEW")
-
-        if os.name == "nt":
-            # Windows cannot open a directory to flush it; the swap's
-            # durability follows NTFS metadata journaling instead.
-            assert flushed == [False]
-        else:
-            # The bytes first, then the directory entry the swap created.
-            assert flushed == [False, True]
-
-    def test_file_flush_failure_fails_the_save(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        def fail(fd: int) -> None:
+        def fail(_fd: int) -> None:
             raise OSError(errno.EIO, "Input/output error")
 
         monkeypatch.setattr(index_persistence, "_fsync", fail)
 
-        path = tmp_path / "index.idx"
-        path.write_text("GOOD")
-
+        # A flush that fails must fail the save: the caller trims its log on the
+        # strength of it, and EIO means the writeback already failed.
         def write_index() -> None:
-            with atomic_index_write(str(path)) as temp:
-                Path(temp).write_text("NEW")
+            with publish_index(base) as slot:
+                Path(slot).write_text("NEWER")
 
-        # Reported as a failure rather than swallowed: the caller trims its
-        # pending log on the strength of this save.
         with pytest.raises(OSError, match="Input/output error"):
             write_index()
 
-        assert path.read_text() == "GOOD"
-        assert not (tmp_path / "index.idx.tmp").exists()
+        assert published_index_path(base) == live
 
-    def test_parent_directory_flush_failure_is_ignored(
+
+class TestDurability:
+    def test_flushes_the_index_before_the_record(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
+        base = str(tmp_path / "index.idx")
         real_fsync = index_persistence._fsync
+        flushed: list[str] = []
 
-        def fail_for_directories(fd: int) -> None:
-            if stat.S_ISDIR(os.fstat(fd).st_mode):
-                raise OSError(errno.EINVAL, "Invalid argument")
+        def record(fd: int) -> None:
+            mode = os.fstat(fd).st_mode
+            flushed.append("dir" if stat.S_ISDIR(mode) else f"{os.fstat(fd).st_size}")
             real_fsync(fd)
 
-        monkeypatch.setattr(index_persistence, "_fsync", fail_for_directories)
+        monkeypatch.setattr(index_persistence, "_fsync", record)
 
-        path = tmp_path / "index.idx"
-        # Filesystems that refuse a directory fsync must not fail every save.
-        with atomic_index_write(str(path)) as temp:
-            Path(temp).write_text("NEW")
+        _write_index(base, "FIRST")
 
-        assert path.read_text() == "NEW"
+        # A one-time parent flush for the created files (POSIX only), then the
+        # index, then the 16-byte record that publishes it.
+        assert flushed[-2:] == ["5", "16"]
+        if os.name != "nt":
+            assert flushed[0] == "dir"
 
-
-class TestFsync:
     @pytest.mark.skipif(
         sys.platform != "darwin", reason="F_FULLFSYNC only exists on macOS"
     )
@@ -177,25 +263,13 @@ class TestFsync:
         assert calls == ["full_fsync", "fsync"]
 
 
-class TestClearStaleIndexTemp:
-    def test_removes_leftover_temp(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-        temp = tmp_path / "index.idx.tmp"
-        temp.write_text("STALE")
+class TestIndexArtifactPaths:
+    def test_lists_every_file_the_base_expands_into(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
 
-        clear_stale_index_temp(str(path))
-
-        assert not temp.exists()
-
-    def test_no_temp_is_noop(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-        # Must not raise when there is nothing to clear.
-        clear_stale_index_temp(str(path))
-
-    def test_leaves_index_file_untouched(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-        path.write_text("GOOD")
-
-        clear_stale_index_temp(str(path))
-
-        assert path.read_text() == "GOOD"
+        assert sorted(p.name for p in index_artifact_paths(base)) == [
+            "index.idx.0",
+            "index.idx.0.gen",
+            "index.idx.1",
+            "index.idx.1.gen",
+        ]

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -1,0 +1,440 @@
+"""Tests for TurboVecVectorSearchEngine.
+
+turbovec stores TurboQuant-compressed vectors, so scores are approximate: a
+self-match lands near (and may slightly exceed) the exact value, and orthogonal
+pairs land near zero rather than exactly zero. Tests therefore assert ranking
+and membership (robust under quantization) and only loosely assert score
+magnitudes.
+"""
+
+import math
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("turbovec")
+
+from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.vector_store.vector_search_engine.turbovec_engine import (
+    TurboVecVectorSearchEngine,
+)
+
+NDIM = 8
+
+QUANT_ABS = 0.05
+
+
+def _normalize(v: list[float]) -> list[float]:
+    magnitude = math.sqrt(sum(x * x for x in v))
+    return [x / magnitude for x in v]
+
+
+def _one_hot(index: int, value: float = 1.0) -> list[float]:
+    """A length-NDIM vector with `value` at `index`, zeros elsewhere."""
+    vector = [0.0] * NDIM
+    vector[index] = value
+    return vector
+
+
+async def _search_one(engine, vector, limit=10, **kwargs):
+    """Helper: search a single vector, return the one SearchResult."""
+    results = await engine.search([vector], limit=limit, **kwargs)
+    return results[0]
+
+
+def _make_engine(metric=SimilarityMetric.COSINE, **kwargs):
+    return TurboVecVectorSearchEngine(
+        num_dimensions=NDIM, similarity_metric=metric, **kwargs
+    )
+
+
+# -- Construction --
+
+
+class TestConstruction:
+    def test_supported_metrics(self):
+        for metric in (SimilarityMetric.COSINE, SimilarityMetric.DOT):
+            _make_engine(metric)
+
+    def test_unsupported_metric_raises(self):
+        for metric in (SimilarityMetric.EUCLIDEAN, SimilarityMetric.MANHATTAN):
+            with pytest.raises(NotImplementedError, match="does not support"):
+                _make_engine(metric)
+
+    def test_valid_bit_widths(self):
+        for bit_width in (2, 3, 4):
+            _make_engine(bit_width=bit_width)
+
+    def test_invalid_bit_width_raises(self):
+        with pytest.raises(ValueError, match="bit_width"):
+            _make_engine(bit_width=5)
+
+    def test_dimensions_must_be_multiple_of_8(self):
+        with pytest.raises(ValueError, match="multiple of 8"):
+            TurboVecVectorSearchEngine(
+                num_dimensions=7, similarity_metric=SimilarityMetric.COSINE
+            )
+
+
+# -- Add --
+
+
+class TestAdd:
+    @pytest.mark.asyncio
+    async def test_add_single(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches[0].key == 1
+
+    @pytest.mark.asyncio
+    async def test_add_batch(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                10: _normalize(_one_hot(0)),
+                20: _normalize(_one_hot(1)),
+                30: _normalize(_one_hot(2)),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        assert {m.key for m in result.matches} == {10, 20, 30}
+
+    @pytest.mark.asyncio
+    async def test_add_empty(self):
+        engine = _make_engine()
+        await engine.add({})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_remove_then_add_replaces_key(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        await engine.remove([1])
+        await engine.add({1: _normalize(_one_hot(1))})
+        result = await _search_one(engine, _normalize(_one_hot(1)), limit=1)
+        assert result.matches[0].key == 1
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_repeated_reupsert_of_same_key(self):
+        engine = _make_engine()
+        for index in range(NDIM):
+            await engine.remove([7])
+            await engine.add({7: _normalize(_one_hot(index))})
+        result = await _search_one(engine, _normalize(_one_hot(NDIM - 1)), limit=1)
+        assert result.matches[0].key == 7
+
+
+# -- Remove --
+
+
+class TestRemove:
+    @pytest.mark.asyncio
+    async def test_remove_existing(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        await engine.remove([1])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=2)
+        keys = {m.key for m in result.matches}
+        assert 1 not in keys
+        assert 2 in keys
+
+    @pytest.mark.asyncio
+    async def test_remove_missing_is_ignored(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        await engine.remove([99, 100])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches[0].key == 1
+
+    @pytest.mark.asyncio
+    async def test_remove_all(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize(_one_hot(2)),
+            }
+        )
+        await engine.remove([1, 2, 3])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_remove_empty_iterable(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        await engine.remove([])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches[0].key == 1
+
+
+# -- Search: Cosine --
+
+
+class TestSearchCosine:
+    @pytest.mark.asyncio
+    async def test_basic_knn(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize([1, 1, 0, 0, 0, 0, 0, 0]),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        assert len(result.matches) == 3
+        assert result.matches[0].key == 1
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[1].key == 3
+        assert result.matches[2].key == 2
+
+    @pytest.mark.asyncio
+    async def test_orthogonal_scores_near_zero(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=2)
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[1].score == pytest.approx(0.0, abs=0.1)
+
+    @pytest.mark.asyncio
+    async def test_scores_ordered_best_first(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize([1, 1, 0, 0, 0, 0, 0, 0]),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        for i in range(len(result.matches) - 1):
+            assert result.matches[i].score >= result.matches[i + 1].score
+
+    @pytest.mark.asyncio
+    async def test_k_larger_than_index(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=10)
+        assert len(result.matches) == 1
+
+    @pytest.mark.asyncio
+    async def test_search_empty_index(self):
+        engine = _make_engine()
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=5)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_limit_zero_returns_empty(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=0)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_empty_query_list(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        results = await engine.search([], limit=3)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_batched_search(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        results = await engine.search(
+            [_normalize(_one_hot(0)), _normalize(_one_hot(1))], limit=1
+        )
+        assert len(results) == 2
+        assert results[0].matches[0].key == 1
+        assert results[1].matches[0].key == 2
+
+
+# -- Search: Dot product --
+
+
+class TestSearchDot:
+    @pytest.mark.asyncio
+    async def test_self_match_highest(self):
+        engine = _make_engine(SimilarityMetric.DOT)
+        v1 = _normalize(_one_hot(0))
+        v2 = _normalize(_one_hot(1))
+        await engine.add({1: v1, 2: v2})
+        result = await _search_one(engine, v1, limit=2)
+        assert result.matches[0].key == 1
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[1].score == pytest.approx(0.0, abs=0.1)
+
+    @pytest.mark.asyncio
+    async def test_scores_ordered_best_first(self):
+        engine = _make_engine(SimilarityMetric.DOT)
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize([1, 1, 0, 0, 0, 0, 0, 0]),
+                3: _normalize(_one_hot(1)),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        for i in range(len(result.matches) - 1):
+            assert result.matches[i].score >= result.matches[i + 1].score
+
+
+# -- Search: allowed_keys filtering --
+
+
+class TestSearchFiltered:
+    @pytest.mark.asyncio
+    async def test_allowed_keys_restricts_results(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize(_one_hot(2)),
+                4: _normalize(_one_hot(3)),
+            }
+        )
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=4, allowed_keys={2, 3}
+        )
+        assert {m.key for m in result.matches} == {2, 3}
+
+    @pytest.mark.asyncio
+    async def test_allowed_keys_excludes_best_match(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize(_one_hot(2)),
+            }
+        )
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=1, allowed_keys={2, 3}
+        )
+        assert len(result.matches) == 1
+        assert result.matches[0].key in {2, 3}
+
+    @pytest.mark.asyncio
+    async def test_allowed_keys_empty_returns_nothing(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=2, allowed_keys=set()
+        )
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_allowed_keys_found_beyond_overfetch_window(self):
+        engine = _make_engine()
+        vectors = {
+            index: _normalize(_one_hot(index % NDIM, value=1.0 + index))
+            for index in range(2 * NDIM)
+        }
+        await engine.add(vectors)
+        target = 2 * NDIM - 1
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=1, allowed_keys={target}
+        )
+        assert [m.key for m in result.matches] == [target]
+
+
+# -- get_vectors --
+
+
+class TestGetVectors:
+    @pytest.mark.asyncio
+    async def test_get_vectors_raises(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        with pytest.raises(NotImplementedError, match="cannot be retrieved"):
+            await engine.get_vectors([1])
+
+
+# -- Persistence --
+
+
+class TestPersistence:
+    @pytest.mark.asyncio
+    async def test_save_and_load(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        engine2 = _make_engine()
+        await engine2.load(path)
+
+        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=2)
+        assert {m.key for m in result.matches} == {1, 2}
+        assert result.matches[0].key == 1
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
+
+        assert path.exists()
+        assert not (tmp_path / "test.idx.tmp").exists()
+
+    @pytest.mark.asyncio
+    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
+
+        stale_temp = tmp_path / "test.idx.tmp"
+        stale_temp.write_text("STALE")
+
+        engine2 = _make_engine()
+        await engine2.load(str(path))
+
+        assert not stale_temp.exists()
+        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=2)
+        assert {m.key for m in result.matches} == {1, 2}
+
+    @pytest.mark.asyncio
+    async def test_load_replaces_existing_index(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        engine2 = _make_engine()
+        await engine2.add({2: _normalize(_one_hot(1))})
+        await engine2.load(path)
+
+        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=5)
+        keys = {m.key for m in result.matches}
+        assert keys == {1}
+
+
+# -- SearchResult types --
+
+
+class TestSearchResultTypes:
+    @pytest.mark.asyncio
+    async def test_keys_are_ints(self):
+        engine = _make_engine()
+        await engine.add({42: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert isinstance(result.matches[0].key, int)
+
+    @pytest.mark.asyncio
+    async def test_scores_are_floats(self):
+        engine = _make_engine()
+        await engine.add({42: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert isinstance(result.matches[0].score, float)

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -36,6 +36,18 @@ def _one_hot(index: int, value: float = 1.0) -> list[float]:
     return vector
 
 
+def _entry_names(directory: Path) -> list[str]:
+    """Names of everything in `directory`. Sync: the tests calling it are not."""
+    return [entry.name for entry in directory.iterdir()]
+
+
+def _spread(seed: int) -> list[float]:
+    """A deterministic unit vector, distinct per `seed`."""
+    return _normalize(
+        [math.cos(seed * (axis + 1) * 0.7 + axis) for axis in range(NDIM)]
+    )
+
+
 async def _search_one(engine, vector, limit=10, **kwargs):
     """Helper: search a single vector, return the one SearchResult."""
     results = await engine.search([vector], limit=limit, **kwargs)
@@ -384,26 +396,27 @@ class TestPersistence:
         path = tmp_path / "test.idx"
         await engine.save(str(path))
 
-        assert path.exists()
-        assert not (tmp_path / "test.idx.tmp").exists()
+        assert _entry_names(tmp_path) == ["test.idx"]
 
     @pytest.mark.asyncio
-    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+    async def test_checkpoint_carries_adds_and_mass_removals(self, tmp_path: Path):
         engine = _make_engine()
-        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        await engine.add({key: _spread(key) for key in range(1, 2001)})
 
-        path = tmp_path / "test.idx"
-        await engine.save(str(path))
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
 
-        stale_temp = tmp_path / "test.idx.tmp"
-        stale_temp.write_text("STALE")
+        doomed = [key for key in range(1, 2001) if key % 4 != 0]
+        await engine.remove(doomed)
+        await engine.add({key: _spread(key) for key in range(10_001, 10_033)})
+        await engine.save(path)
 
         engine2 = _make_engine()
-        await engine2.load(str(path))
+        await engine2.load(path)
 
-        assert not stale_temp.exists()
-        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=2)
-        assert {m.key for m in result.matches} == {1, 2}
+        expected = set(range(4, 2001, 4)) | set(range(10_001, 10_033))
+        result = await _search_one(engine2, _spread(1), limit=len(expected) + 10)
+        assert {match.key for match in result.matches} == expected
 
     @pytest.mark.asyncio
     async def test_load_replaces_existing_index(self, tmp_path: Path):

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -1,10 +1,10 @@
 """Tests for TurboVecVectorSearchEngine.
 
 turbovec stores TurboQuant-compressed vectors, so scores are approximate: a
-self-match lands near (and may slightly exceed) the exact value, and orthogonal
-pairs land near zero rather than exactly zero. Tests therefore assert ranking
-and membership (robust under quantization) and only loosely assert score
-magnitudes.
+self-match lands near the exact value, and orthogonal pairs land near zero
+rather than exactly zero. Tests therefore assert ranking and membership (robust
+under quantization) and only loosely assert score magnitudes. The one exact
+bound is the cosine range, which the engine clamps.
 """
 
 import math
@@ -435,6 +435,27 @@ class TestPersistence:
 
 
 # -- SearchResult types --
+
+
+class TestScoreRange:
+    @pytest.mark.asyncio
+    async def test_cosine_scores_stay_within_range(self):
+        engine = _make_engine()
+        vectors = {key: _spread(key) for key in range(1, 51)}
+        await engine.add(vectors)
+
+        for vector in vectors.values():
+            result = await _search_one(engine, vector, limit=5)
+            for match in result.matches:
+                assert -1.0 <= match.score <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_dot_scores_are_not_clamped(self):
+        engine = _make_engine(SimilarityMetric.DOT)
+        await engine.add({1: [4.0] + [0.0] * (NDIM - 1)})
+
+        result = await _search_one(engine, [4.0] + [0.0] * (NDIM - 1), limit=1)
+        assert result.matches[0].score > 1.0
 
 
 class TestSearchResultTypes:

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -81,11 +81,10 @@ class TestConstruction:
         with pytest.raises(ValueError, match="bit_width"):
             _make_engine(bit_width=5)
 
-    def test_dimensions_must_be_multiple_of_8(self):
-        with pytest.raises(ValueError, match="multiple of 8"):
-            TurboVecVectorSearchEngine(
-                num_dimensions=7, similarity_metric=SimilarityMetric.COSINE
-            )
+    def test_unaligned_dimensions_are_accepted(self):
+        TurboVecVectorSearchEngine(
+            num_dimensions=7, similarity_metric=SimilarityMetric.COSINE
+        )
 
 
 # -- Add --
@@ -435,6 +434,52 @@ class TestPersistence:
 
 
 # -- SearchResult types --
+
+
+class TestUnalignedDimensions:
+    @pytest.mark.asyncio
+    async def test_search_at_an_unaligned_width(self):
+        engine = TurboVecVectorSearchEngine(
+            num_dimensions=5, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine.add(
+            {
+                1: [1.0, 0.0, 0.0, 0.0, 0.0],
+                2: [0.0, 1.0, 0.0, 0.0, 0.0],
+            }
+        )
+
+        results = await engine.search([[1.0, 0.0, 0.0, 0.0, 0.0]], limit=2)
+        matches = results[0].matches
+        assert [match.key for match in matches] == [1, 2]
+        assert matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert matches[1].score == pytest.approx(0.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_save_and_load_at_an_unaligned_width(self, tmp_path: Path):
+        def make_engine():
+            return TurboVecVectorSearchEngine(
+                num_dimensions=5, similarity_metric=SimilarityMetric.COSINE
+            )
+
+        engine = make_engine()
+        await engine.add({1: [1.0, 0.0, 0.0, 0.0, 0.0]})
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        loaded = make_engine()
+        await loaded.load(path)
+
+        results = await loaded.search([[1.0, 0.0, 0.0, 0.0, 0.0]], limit=1)
+        assert [match.key for match in results[0].matches] == [1]
+
+    @pytest.mark.asyncio
+    async def test_wrong_width_vector_is_rejected(self):
+        engine = TurboVecVectorSearchEngine(
+            num_dimensions=5, similarity_metric=SimilarityMetric.COSINE
+        )
+        with pytest.raises(ValueError, match="must have 5 dimensions"):
+            await engine.add({1: [1.0, 0.0, 0.0]})
 
 
 class TestScoreRange:

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
@@ -296,6 +296,42 @@ class TestPersistence:
         assert result.matches[0].key == 1
         assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
 
+    @pytest.mark.asyncio
+    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
+        engine = USearchVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine.add({1: _normalize([1, 0, 0])})
+
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
+
+        assert path.exists()
+        assert not (tmp_path / "test.idx.tmp").exists()
+
+    @pytest.mark.asyncio
+    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+        engine = USearchVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
+
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
+
+        # A temp file left behind by a previously interrupted save.
+        stale_temp = tmp_path / "test.idx.tmp"
+        stale_temp.write_text("STALE")
+
+        engine2 = USearchVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine2.load(str(path))
+
+        assert not stale_temp.exists()
+        result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
+        assert {m.key for m in result.matches} == {1, 2}
+
 
 # -- SearchResult types --
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
@@ -6,9 +6,6 @@ from pathlib import Path
 import pytest
 
 from memmachine_server.common.data_types import SimilarityMetric
-from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
-    published_index_path,
-)
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
 )
@@ -300,47 +297,38 @@ class TestPersistence:
         assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
-    async def test_save_publishes_under_the_base_path(self, tmp_path: Path):
+    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
         engine = USearchVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
         await engine.add({1: _normalize([1, 0, 0])})
 
-        base = tmp_path / "test.idx"
-        await engine.save(str(base))
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
 
-        # The base path is a name, not a file: the engine owns what sits under
-        # it, and something is published there.
-        assert not base.exists()
-        assert published_index_path(str(base)) is not None
+        assert path.exists()
+        assert not (tmp_path / "test.idx.tmp").exists()
 
     @pytest.mark.asyncio
-    async def test_load_without_a_published_index_raises(self, tmp_path: Path):
+    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
         engine = USearchVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
+        await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
-        with pytest.raises(OSError, match="No published index"):
-            await engine.load(str(tmp_path / "test.idx"))
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
 
-    @pytest.mark.asyncio
-    async def test_load_sees_the_latest_checkpoint(self, tmp_path: Path):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
-        base = tmp_path / "test.idx"
-
-        await engine.add({1: _normalize([1, 0, 0])})
-        await engine.save(str(base))
-        # A second checkpoint lands in the other slot; the load must follow it.
-        await engine.add({2: _normalize([0, 1, 0])})
-        await engine.save(str(base))
+        # A temp file left behind by a previously interrupted save.
+        stale_temp = tmp_path / "test.idx.tmp"
+        stale_temp.write_text("STALE")
 
         engine2 = USearchVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
-        await engine2.load(str(base))
+        await engine2.load(str(path))
 
+        assert not stale_temp.exists()
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
@@ -6,6 +6,9 @@ from pathlib import Path
 import pytest
 
 from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
+    published_index_path,
+)
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
 )
@@ -297,38 +300,47 @@ class TestPersistence:
         assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
-    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
+    async def test_save_publishes_under_the_base_path(self, tmp_path: Path):
         engine = USearchVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
         await engine.add({1: _normalize([1, 0, 0])})
 
-        path = tmp_path / "test.idx"
-        await engine.save(str(path))
+        base = tmp_path / "test.idx"
+        await engine.save(str(base))
 
-        assert path.exists()
-        assert not (tmp_path / "test.idx.tmp").exists()
+        # The base path is a name, not a file: the engine owns what sits under
+        # it, and something is published there.
+        assert not base.exists()
+        assert published_index_path(str(base)) is not None
 
     @pytest.mark.asyncio
-    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+    async def test_load_without_a_published_index_raises(self, tmp_path: Path):
         engine = USearchVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
-        await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
-        path = tmp_path / "test.idx"
-        await engine.save(str(path))
+        with pytest.raises(OSError, match="No published index"):
+            await engine.load(str(tmp_path / "test.idx"))
 
-        # A temp file left behind by a previously interrupted save.
-        stale_temp = tmp_path / "test.idx.tmp"
-        stale_temp.write_text("STALE")
+    @pytest.mark.asyncio
+    async def test_load_sees_the_latest_checkpoint(self, tmp_path: Path):
+        engine = USearchVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        base = tmp_path / "test.idx"
+
+        await engine.add({1: _normalize([1, 0, 0])})
+        await engine.save(str(base))
+        # A second checkpoint lands in the other slot; the load must follow it.
+        await engine.add({2: _normalize([0, 1, 0])})
+        await engine.save(str(base))
 
         engine2 = USearchVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
-        await engine2.load(str(path))
+        await engine2.load(str(base))
 
-        assert not stale_temp.exists()
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
 

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -4,6 +4,23 @@ Vector store backed by SQLite + pluggable vector search engine.
 Each logical collection gets its own records table and vector search engine.
 A pending operations table tracks search engine operations for crash recovery:
 on startup, unfinalized operations are replayed.
+
+What survives a crash
+---------------------
+
+`upsert` and `delete` commit to SQLite before they return, so a process crash
+loses nothing: the pending log carries every operation the search engine has
+not been checkpointed with, and startup replays it.
+
+A power failure is weaker, and callers should size their expectations to it.
+The index is published atomically but not durably (see
+`vector_search_engine.index_persistence`), so a power failure can revert the
+last publication while the records table -- and the trim that ran behind that
+publication -- stay committed. The result is records whose vectors are missing
+from the index: `get` still returns them, `query` cannot find them, and
+re-upserting them is the repair. Callers that need every record searchable
+after a power failure must be able to re-ingest; nothing here detects the gap
+for them.
 """
 
 import logging
@@ -59,17 +76,16 @@ from .data_types import (
 )
 from .utils import validate_filter, validate_identifier
 from .vector_search_engine import VectorSearchEngine
-from .vector_search_engine.index_persistence import index_artifact_paths
 from .vector_store import VectorStore, VectorStoreCollection
 
 logger = logging.getLogger(__name__)
 
 
 class IndexLoadError(RuntimeError):
-    """Raised when a collection's on-disk index cannot be loaded."""
+    """Raised when a collection's on-disk index file cannot be loaded."""
 
     def __init__(self, namespace: str, name: str, path: Path) -> None:
-        """Initialize with the collection namespace, name, and index base path."""
+        """Initialize with the collection namespace, name, and index file path."""
         self.namespace = namespace
         self.name = name
         self.path = path
@@ -91,10 +107,9 @@ class _CollectionRow(BaseSQLiteVectorStore):
     config_json: MappedColumn[dict[str, JsonValue]] = mapped_column(
         JSON, nullable=False
     )
-    # Flips to True after the first successful index save. Bookkeeping about the
-    # collection's own lifecycle rather than the engine's layout: once True, an
-    # engine reporting nothing published is a fault to raise on, not an empty
-    # collection to serve.
+    # Flips to True after the first successful index save.
+    # Once True, the on-disk index file is part of the durable contract:
+    # missing or corrupt is treated as an error rather than silently rebuilt empty.
     index_saved: MappedColumn[bool] = mapped_column(
         Boolean, nullable=False, default=False
     )
@@ -142,13 +157,16 @@ async def _save_collection_index(
     search_engine: VectorSearchEngine,
     path: str,
 ) -> None:
-    """Save a collection's index to disk."""
-    # The one rule this checkpoint rests on: never trim the log past what the
-    # engine says is durable. `save` returning is that statement — a later
-    # `load` produces this index even if the machine loses power on the next
-    # instruction — so these two steps need no shared transaction, only this
-    # order. A crash between them costs a replay of operations the index
-    # already holds, and replay is idempotent.
+    """Publish a collection's index to disk and trim the operations it holds.
+
+    The order is the whole protocol. The pending log is the only other copy of
+    these vectors -- the records table has no vector column -- so an applied row
+    may be deleted only once the index that holds it has been published.
+    `save` returning is that statement, and no more than that: publication is
+    atomic, not durable, so a power failure can revert it after this trim has
+    committed. See the module docstring for what that leaves behind.
+    """
+    # Write index to path.
     await search_engine.save(path)
 
     # Delete applied pending operations and flip index_saved to True.
@@ -231,7 +249,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         namespace: str,
         name: str,
         config: VectorStoreCollectionConfig,
-        index_base_path: str | None,
+        index_path: str | None,
         save_threshold: int,
     ) -> None:
         """Initialize a collection handle."""
@@ -245,7 +263,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
         self._config = config
 
-        self._index_base_path = index_base_path
+        self._index_path = index_path
         self._save_threshold = save_threshold
 
     @property
@@ -255,7 +273,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
     async def _maybe_save_index(self) -> None:
         """Save the index to disk if applied pending operations exceed the threshold."""
-        if self._index_base_path is None:
+        if self._index_path is None:
             return
 
         async with self._create_session() as session:
@@ -275,7 +293,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 namespace=self._namespace,
                 name=self._name,
                 search_engine=self._search_engine,
-                path=self._index_base_path,
+                path=self._index_path,
             )
 
     @override
@@ -794,7 +812,7 @@ class SQLiteVectorStore(VectorStore):
         self._require_started()
         if self._index_directory is not None:
             for (namespace, name), search_engine in self._search_engines.items():
-                path = self._index_base_path(namespace, name)
+                path = self._index_path(namespace, name)
                 assert path is not None
                 await _save_collection_index(
                     create_session=self._create_session,
@@ -845,7 +863,7 @@ class SQLiteVectorStore(VectorStore):
         if not validate_identifier(namespace) or not validate_identifier(name):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
 
-        index_base_path = self._index_base_path(namespace, name)
+        index_path = self._index_path(namespace, name)
 
         async with self._create_session() as session, session.begin():
             existing_config = await self._get_stored_config(session, namespace, name)
@@ -865,9 +883,7 @@ class SQLiteVectorStore(VectorStore):
                     namespace=namespace,
                     name=name,
                     config=existing_config,
-                    index_base_path=(
-                        str(index_base_path) if index_base_path is not None else None
-                    ),
+                    index_path=str(index_path) if index_path is not None else None,
                     save_threshold=self._save_threshold,
                 )
 
@@ -891,9 +907,7 @@ class SQLiteVectorStore(VectorStore):
             namespace=namespace,
             name=name,
             config=config,
-            index_base_path=(
-                str(index_base_path) if index_base_path is not None else None
-            ),
+            index_path=str(index_path) if index_path is not None else None,
             save_threshold=self._save_threshold,
         )
 
@@ -918,7 +932,7 @@ class SQLiteVectorStore(VectorStore):
             namespace, name, existing
         )
 
-        index_base_path = self._index_base_path(namespace, name)
+        index_path = self._index_path(namespace, name)
         return SQLiteVectorStoreCollection(
             create_session=self._create_session,
             sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
@@ -927,9 +941,7 @@ class SQLiteVectorStore(VectorStore):
             namespace=namespace,
             name=name,
             config=existing,
-            index_base_path=(
-                str(index_base_path) if index_base_path is not None else None
-            ),
+            index_path=str(index_path) if index_path is not None else None,
             save_threshold=self._save_threshold,
         )
 
@@ -966,7 +978,9 @@ class SQLiteVectorStore(VectorStore):
 
         # If unlink fails, the orphan is harmless.
         # _clear_search_engine_state will clean it up if a new collection with the same name is created.
-        self._remove_index_files(namespace, name)
+        index_path = self._index_path(namespace, name)
+        if index_path is not None and index_path.exists():
+            index_path.unlink()
         self._search_engines.pop((namespace, name), None)
 
     # Helpers.
@@ -987,30 +1001,18 @@ class SQLiteVectorStore(VectorStore):
             extend_existing=True,
         )
 
-    def _index_base_path(self, namespace: str, name: str) -> Path | None:
-        """
-        Return a collection's index base path, or None if in-memory.
-
-        A base name, not a file: what an engine keeps under it — one file, two
-        slots, a set of segments — is the engine's business, and no caller may
-        hold this believing it is the index.
-        """
+    def _index_path(self, namespace: str, name: str) -> Path | None:
+        """Return the on-disk index path for a collection, or None if in-memory."""
         if self._index_directory is None:
             return None
         return self._index_directory / f"{self._collection_prefix(namespace, name)}.idx"
 
-    def _remove_index_files(self, namespace: str, name: str) -> None:
-        """Discard a collection's index, whatever the engine keeps under it."""
-        index_base_path = self._index_base_path(namespace, name)
-        if index_base_path is None:
-            return
-        for path in index_artifact_paths(str(index_base_path)):
-            path.unlink(missing_ok=True)
-
     def _clear_search_engine_state(self, namespace: str, name: str) -> None:
         """Remove any in-memory engine and on-disk index for a collection."""
         self._search_engines.pop((namespace, name), None)
-        self._remove_index_files(namespace, name)
+        index_path = self._index_path(namespace, name)
+        if index_path is not None and index_path.exists():
+            index_path.unlink()
 
     async def _get_stored_config(
         self,
@@ -1044,8 +1046,8 @@ class SQLiteVectorStore(VectorStore):
             config.vector_dimensions, config.similarity_metric
         )
 
-        index_base_path = self._index_base_path(namespace, name)
-        if index_base_path is not None:
+        index_path = self._index_path(namespace, name)
+        if index_path is not None:
             async with self._create_session() as session:
                 saved = (
                     await session.execute(
@@ -1060,9 +1062,9 @@ class SQLiteVectorStore(VectorStore):
                 # The engine just propagates whatever its backend raises.
                 # Wrap any failure as IndexLoadError so callers see one type.
                 try:
-                    await search_engine.load(str(index_base_path))
+                    await search_engine.load(str(index_path))
                 except Exception as e:
-                    raise IndexLoadError(namespace, name, index_base_path) from e
+                    raise IndexLoadError(namespace, name, index_path) from e
 
         self._search_engines[cache_key] = search_engine
         return search_engine

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -59,16 +59,17 @@ from .data_types import (
 )
 from .utils import validate_filter, validate_identifier
 from .vector_search_engine import VectorSearchEngine
+from .vector_search_engine.index_persistence import index_artifact_paths
 from .vector_store import VectorStore, VectorStoreCollection
 
 logger = logging.getLogger(__name__)
 
 
 class IndexLoadError(RuntimeError):
-    """Raised when a collection's on-disk index file cannot be loaded."""
+    """Raised when a collection's on-disk index cannot be loaded."""
 
     def __init__(self, namespace: str, name: str, path: Path) -> None:
-        """Initialize with the collection namespace, name, and index file path."""
+        """Initialize with the collection namespace, name, and index base path."""
         self.namespace = namespace
         self.name = name
         self.path = path
@@ -90,9 +91,10 @@ class _CollectionRow(BaseSQLiteVectorStore):
     config_json: MappedColumn[dict[str, JsonValue]] = mapped_column(
         JSON, nullable=False
     )
-    # Flips to True after the first successful index save.
-    # Once True, the on-disk index file is part of the durable contract:
-    # missing or corrupt is treated as an error rather than silently rebuilt empty.
+    # Flips to True after the first successful index save. Bookkeeping about the
+    # collection's own lifecycle rather than the engine's layout: once True, an
+    # engine reporting nothing published is a fault to raise on, not an empty
+    # collection to serve.
     index_saved: MappedColumn[bool] = mapped_column(
         Boolean, nullable=False, default=False
     )
@@ -141,7 +143,12 @@ async def _save_collection_index(
     path: str,
 ) -> None:
     """Save a collection's index to disk."""
-    # Write index to path.
+    # The one rule this checkpoint rests on: never trim the log past what the
+    # engine says is durable. `save` returning is that statement — a later
+    # `load` produces this index even if the machine loses power on the next
+    # instruction — so these two steps need no shared transaction, only this
+    # order. A crash between them costs a replay of operations the index
+    # already holds, and replay is idempotent.
     await search_engine.save(path)
 
     # Delete applied pending operations and flip index_saved to True.
@@ -224,7 +231,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         namespace: str,
         name: str,
         config: VectorStoreCollectionConfig,
-        index_path: str | None,
+        index_base_path: str | None,
         save_threshold: int,
     ) -> None:
         """Initialize a collection handle."""
@@ -238,7 +245,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
         self._config = config
 
-        self._index_path = index_path
+        self._index_base_path = index_base_path
         self._save_threshold = save_threshold
 
     @property
@@ -248,7 +255,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
     async def _maybe_save_index(self) -> None:
         """Save the index to disk if applied pending operations exceed the threshold."""
-        if self._index_path is None:
+        if self._index_base_path is None:
             return
 
         async with self._create_session() as session:
@@ -268,7 +275,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 namespace=self._namespace,
                 name=self._name,
                 search_engine=self._search_engine,
-                path=self._index_path,
+                path=self._index_base_path,
             )
 
     @override
@@ -787,7 +794,7 @@ class SQLiteVectorStore(VectorStore):
         self._require_started()
         if self._index_directory is not None:
             for (namespace, name), search_engine in self._search_engines.items():
-                path = self._index_path(namespace, name)
+                path = self._index_base_path(namespace, name)
                 assert path is not None
                 await _save_collection_index(
                     create_session=self._create_session,
@@ -838,7 +845,7 @@ class SQLiteVectorStore(VectorStore):
         if not validate_identifier(namespace) or not validate_identifier(name):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
 
-        index_path = self._index_path(namespace, name)
+        index_base_path = self._index_base_path(namespace, name)
 
         async with self._create_session() as session, session.begin():
             existing_config = await self._get_stored_config(session, namespace, name)
@@ -858,7 +865,9 @@ class SQLiteVectorStore(VectorStore):
                     namespace=namespace,
                     name=name,
                     config=existing_config,
-                    index_path=str(index_path) if index_path is not None else None,
+                    index_base_path=(
+                        str(index_base_path) if index_base_path is not None else None
+                    ),
                     save_threshold=self._save_threshold,
                 )
 
@@ -882,7 +891,9 @@ class SQLiteVectorStore(VectorStore):
             namespace=namespace,
             name=name,
             config=config,
-            index_path=str(index_path) if index_path is not None else None,
+            index_base_path=(
+                str(index_base_path) if index_base_path is not None else None
+            ),
             save_threshold=self._save_threshold,
         )
 
@@ -907,7 +918,7 @@ class SQLiteVectorStore(VectorStore):
             namespace, name, existing
         )
 
-        index_path = self._index_path(namespace, name)
+        index_base_path = self._index_base_path(namespace, name)
         return SQLiteVectorStoreCollection(
             create_session=self._create_session,
             sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
@@ -916,7 +927,9 @@ class SQLiteVectorStore(VectorStore):
             namespace=namespace,
             name=name,
             config=existing,
-            index_path=str(index_path) if index_path is not None else None,
+            index_base_path=(
+                str(index_base_path) if index_base_path is not None else None
+            ),
             save_threshold=self._save_threshold,
         )
 
@@ -953,9 +966,7 @@ class SQLiteVectorStore(VectorStore):
 
         # If unlink fails, the orphan is harmless.
         # _clear_search_engine_state will clean it up if a new collection with the same name is created.
-        index_path = self._index_path(namespace, name)
-        if index_path is not None and index_path.exists():
-            index_path.unlink()
+        self._remove_index_files(namespace, name)
         self._search_engines.pop((namespace, name), None)
 
     # Helpers.
@@ -976,18 +987,30 @@ class SQLiteVectorStore(VectorStore):
             extend_existing=True,
         )
 
-    def _index_path(self, namespace: str, name: str) -> Path | None:
-        """Return the on-disk index path for a collection, or None if in-memory."""
+    def _index_base_path(self, namespace: str, name: str) -> Path | None:
+        """
+        Return a collection's index base path, or None if in-memory.
+
+        A base name, not a file: what an engine keeps under it — one file, two
+        slots, a set of segments — is the engine's business, and no caller may
+        hold this believing it is the index.
+        """
         if self._index_directory is None:
             return None
         return self._index_directory / f"{self._collection_prefix(namespace, name)}.idx"
 
+    def _remove_index_files(self, namespace: str, name: str) -> None:
+        """Discard a collection's index, whatever the engine keeps under it."""
+        index_base_path = self._index_base_path(namespace, name)
+        if index_base_path is None:
+            return
+        for path in index_artifact_paths(str(index_base_path)):
+            path.unlink(missing_ok=True)
+
     def _clear_search_engine_state(self, namespace: str, name: str) -> None:
         """Remove any in-memory engine and on-disk index for a collection."""
         self._search_engines.pop((namespace, name), None)
-        index_path = self._index_path(namespace, name)
-        if index_path is not None and index_path.exists():
-            index_path.unlink()
+        self._remove_index_files(namespace, name)
 
     async def _get_stored_config(
         self,
@@ -1021,8 +1044,8 @@ class SQLiteVectorStore(VectorStore):
             config.vector_dimensions, config.similarity_metric
         )
 
-        index_path = self._index_path(namespace, name)
-        if index_path is not None:
+        index_base_path = self._index_base_path(namespace, name)
+        if index_base_path is not None:
             async with self._create_session() as session:
                 saved = (
                     await session.execute(
@@ -1037,9 +1060,9 @@ class SQLiteVectorStore(VectorStore):
                 # The engine just propagates whatever its backend raises.
                 # Wrap any failure as IndexLoadError so callers see one type.
                 try:
-                    await search_engine.load(str(index_path))
+                    await search_engine.load(str(index_base_path))
                 except Exception as e:
-                    raise IndexLoadError(namespace, name, index_path) from e
+                    raise IndexLoadError(namespace, name, index_base_path) from e
 
         self._search_engines[cache_key] = search_engine
         return search_engine

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -12,6 +12,7 @@ import numpy as np
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
+from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -321,7 +322,8 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        self._index.save_index(path)
+        with atomic_index_write(path) as temp_path:
+            self._index.save_index(temp_path)
         # Reconcile _known_labels with hnswlib's label_lookup_.
         if self._allow_replace_deleted:
             self._known_labels = {int(k) for k in self._index.get_ids_list()}
@@ -332,6 +334,7 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> None:
+        clear_stale_index_temp(path)
         self._index = hnswlib.Index(space=self._space, dim=self._num_dimensions)
         self._index.load_index(path, allow_replace_deleted=self._allow_replace_deleted)
         self._index.set_ef(self._ef_search)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -12,7 +12,7 @@ import numpy as np
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
-from .index_persistence import publish_index, published_index_path
+from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -322,8 +322,8 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        with publish_index(path) as slot_path:
-            self._index.save_index(slot_path)
+        with atomic_index_write(path) as temp_path:
+            self._index.save_index(temp_path)
         # Reconcile _known_labels with hnswlib's label_lookup_.
         if self._allow_replace_deleted:
             self._known_labels = {int(k) for k in self._index.get_ids_list()}
@@ -334,13 +334,9 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> None:
-        published = published_index_path(path)
-        if published is None:
-            raise FileNotFoundError(f"No published index for {path}")
+        clear_stale_index_temp(path)
         self._index = hnswlib.Index(space=self._space, dim=self._num_dimensions)
-        self._index.load_index(
-            published, allow_replace_deleted=self._allow_replace_deleted
-        )
+        self._index.load_index(path, allow_replace_deleted=self._allow_replace_deleted)
         self._index.set_ef(self._ef_search)
         # Reconcile _known_labels with hnswlib's label_lookup_.
         if self._allow_replace_deleted:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -12,7 +12,7 @@ import numpy as np
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
-from .index_persistence import atomic_index_write, clear_stale_index_temp
+from .index_persistence import publish_index, published_index_path
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -322,8 +322,8 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        with atomic_index_write(path) as temp_path:
-            self._index.save_index(temp_path)
+        with publish_index(path) as slot_path:
+            self._index.save_index(slot_path)
         # Reconcile _known_labels with hnswlib's label_lookup_.
         if self._allow_replace_deleted:
             self._known_labels = {int(k) for k in self._index.get_ids_list()}
@@ -334,9 +334,13 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> None:
-        clear_stale_index_temp(path)
+        published = published_index_path(path)
+        if published is None:
+            raise FileNotFoundError(f"No published index for {path}")
         self._index = hnswlib.Index(space=self._space, dim=self._num_dimensions)
-        self._index.load_index(path, allow_replace_deleted=self._allow_replace_deleted)
+        self._index.load_index(
+            published, allow_replace_deleted=self._allow_replace_deleted
+        )
         self._index.set_ef(self._ef_search)
         # Reconcile _known_labels with hnswlib's label_lookup_.
         if self._allow_replace_deleted:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -1,0 +1,92 @@
+"""
+Atomic on-disk index persistence helpers, shared by vector search engines.
+
+Each engine owns its index file layout, so the atomic-swap logic lives here
+(shared by the engines) rather than in the vector store: the index save
+location and the number of files written differ across engine implementations.
+
+The core guarantee is that a reader never observes a partially written index at
+the target path. The index is written to a sibling temp file and swapped into
+place with ``Path.replace`` (``os.replace``), which is atomic on POSIX and
+Windows when source and destination share a filesystem (guaranteed here, since
+the temp file is a sibling of the target). A save that is interrupted (crash,
+exception) therefore leaves the previous index untouched rather than corrupting
+it, which matters because the vector store treats a saved-but-unloadable index
+as a hard error rather than silently rebuilding it empty.
+"""
+
+import contextlib
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+# Deterministic suffix so a crash leaves at most one stale temp per index file.
+# The next save overwrites it and load clears it, rather than accumulating
+# uniquely named leftovers.
+_TEMP_SUFFIX = ".tmp"
+
+
+def _temp_path(path: str) -> str:
+    """Return the sibling temp path used while writing the index at `path`."""
+    return f"{path}{_TEMP_SUFFIX}"
+
+
+def clear_stale_index_temp(path: str) -> None:
+    """
+    Remove a temp file left behind by a previously interrupted save.
+
+    Call this on load/startup so a save that crashed before the atomic swap
+    does not leak a temp file across restarts. A missing temp file is a no-op.
+
+    Args:
+        path (str):
+            The index file path whose sibling temp file should be cleared.
+    """
+    Path(_temp_path(path)).unlink(missing_ok=True)
+
+
+@contextlib.contextmanager
+def atomic_index_write(path: str) -> Iterator[str]:
+    """
+    Write an index to a temp file, then atomically swap it into `path`.
+
+    Yields a sibling temp path for the caller to write the index to. On normal
+    exit the temp file is flushed and atomically renamed onto `path`, so a
+    reader sees either the old index or the new one, never a partial write. If
+    the body raises, the temp file is removed and the exception propagates,
+    leaving any existing index at `path` intact.
+
+    Args:
+        path (str):
+            The final index file path to swap the written index into.
+
+    Yields:
+        str:
+            The temp path to write the index to.
+    """
+    temp = _temp_path(path)
+    # Clear any temp left by a previously interrupted save before reusing it.
+    Path(temp).unlink(missing_ok=True)
+    try:
+        yield temp
+        _flush_to_disk(temp)
+        Path(temp).replace(path)
+    except BaseException:
+        Path(temp).unlink(missing_ok=True)
+        raise
+
+
+def _flush_to_disk(path: str) -> None:
+    """
+    Best-effort fsync so the temp file's bytes are durable before the swap.
+
+    Guards against a crash where the rename is durable but the data behind it
+    is not. Failures are ignored: durability is a bonus on top of the atomic
+    swap, which is the actual correctness guarantee.
+    """
+    with contextlib.suppress(OSError):
+        fd = os.open(path, os.O_RDWR)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -4,21 +4,65 @@ Atomic on-disk index persistence helpers, shared by vector search engines.
 Each engine owns its index file layout, so the atomic-swap logic lives here
 (shared by the engines) rather than in the vector store: the index save
 location and the number of files written differ across engine implementations.
+An engine whose backend implements this protocol natively can satisfy
+`VectorSearchEngine.save` by delegating to it and skip these helpers.
 
-The core guarantee is that a reader never observes a partially written index at
-the target path. The index is written to a sibling temp file and swapped into
-place with ``Path.replace`` (``os.replace``), which is atomic on POSIX and
-Windows when source and destination share a filesystem (guaranteed here, since
-the temp file is a sibling of the target). A save that is interrupted (crash,
-exception) therefore leaves the previous index untouched rather than corrupting
-it, which matters because the vector store treats a saved-but-unloadable index
-as a hard error rather than silently rebuilding it empty.
+The two guarantees fail differently, which is why they are separated below:
+
+- **Atomic.** A reader never observes a partially written index at the target
+  path. The index is written to a sibling temp file and swapped into place with
+  ``Path.replace`` (``os.replace``), which is atomic on POSIX and Windows when
+  source and destination share a filesystem (guaranteed here, since the temp
+  file is a sibling of the target). A save that is interrupted (crash,
+  exception) leaves the previous index untouched rather than corrupting it,
+  which matters because the vector store treats a saved-but-unloadable index as
+  a hard error rather than silently rebuilding it empty.
+- **Durable.** A save that returns has put the new index on stable storage, and
+  on POSIX the swap itself too. This is not a bonus on top of the atomicity:
+  the vector store trims its pending-operation log — the only other copy of
+  these vectors — once ``save`` returns, so a swap that quietly fails to reach
+  disk costs data rather than performance.
+
+Durability is platform-limited in one place. On POSIX the swap is made durable
+by fsyncing the parent directory, since ``rename(2)`` leaves the new directory
+entry in the page cache. Windows has no equivalent operation: the swap is
+atomic through NTFS metadata journaling, but that journal record is not
+necessarily flushed when the call returns, so power loss (a process crash is
+not enough) within a sub-second window can roll it back. The residue is bounded
+— the previous index reappears, and the records whose vectors that checkpoint
+added are still in SQLite but no longer in the index, so they stop matching
+queries rather than matching them wrongly.
 """
 
 import contextlib
 import os
+import sys
 from collections.abc import Iterator
 from pathlib import Path
+
+if sys.platform == "darwin":
+    import fcntl
+
+    def _fsync(fd: int) -> None:
+        """
+        Flush `fd` to stable storage, through the drive's write cache.
+
+        macOS ``fsync`` only pushes the data to the drive, which may hold it in
+        a volatile write cache; ``F_FULLFSYNC`` is the documented request for
+        the stronger flush. Not every filesystem implements it, so a refusal
+        falls back to ``fsync`` rather than failing the caller.
+        """
+        try:
+            fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
+        except OSError:
+            os.fsync(fd)
+
+else:
+
+    def _fsync(fd: int) -> None:
+        """Flush `fd` to stable storage, as far as the platform allows."""
+        os.fsync(fd)
+
 
 # Deterministic suffix so a crash leaves at most one stale temp per index file.
 # The next save overwrites it and load clears it, rather than accumulating
@@ -51,10 +95,14 @@ def atomic_index_write(path: str) -> Iterator[str]:
     Write an index to a temp file, then atomically swap it into `path`.
 
     Yields a sibling temp path for the caller to write the index to. On normal
-    exit the temp file is flushed and atomically renamed onto `path`, so a
-    reader sees either the old index or the new one, never a partial write. If
-    the body raises, the temp file is removed and the exception propagates,
-    leaving any existing index at `path` intact.
+    exit the temp file is flushed, atomically renamed onto `path`, and the
+    rename itself flushed where the platform allows — so a reader sees either
+    the old index or the new one, never a partial write, and a return means the
+    new index is on disk. If the body raises, the temp file is removed and the
+    exception propagates, leaving any existing index at `path` intact.
+
+    The rename is the commit point: nothing after it may raise, or a caller
+    would roll back against an index that has already been replaced.
 
     Args:
         path (str):
@@ -71,6 +119,7 @@ def atomic_index_write(path: str) -> Iterator[str]:
         yield temp
         _flush_to_disk(temp)
         Path(temp).replace(path)
+        _flush_parent_dir(path)
     except BaseException:
         Path(temp).unlink(missing_ok=True)
         raise
@@ -78,15 +127,48 @@ def atomic_index_write(path: str) -> Iterator[str]:
 
 def _flush_to_disk(path: str) -> None:
     """
-    Best-effort fsync so the temp file's bytes are durable before the swap.
+    Flush the temp file's bytes to disk before the swap. Errors propagate.
 
-    Guards against a crash where the rename is durable but the data behind it
-    is not. Failures are ignored: durability is a bonus on top of the atomic
-    swap, which is the actual correctness guarantee.
+    The vector store trims its pending-operation log — its only other copy of
+    these vectors — once the save returns, so a failed flush has to fail the
+    save rather than be reported as success. ``EIO`` here is not hypothetical:
+    a writeback error is reported to ``fsync`` once and the dirty pages are
+    then dropped, which is exactly when the save must not be treated as
+    committed. `atomic_index_write` removes the temp file and leaves the
+    previous index in place, so the next save retries. (SQLite draws the same
+    line: a file fsync failure raises ``SQLITE_IOERR_FSYNC``, while a directory
+    fsync failure is ignored — see `_flush_parent_dir`.)
+    """
+    # O_RDWR rather than O_RDONLY: os.fsync is `_commit` on Windows, which
+    # needs a writable handle. Opening for write does not truncate.
+    fd = os.open(path, os.O_RDWR)
+    try:
+        _fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _flush_parent_dir(path: str) -> None:
+    """
+    Flush the directory holding `path`, making the swap itself durable.
+
+    Without this the swap is atomic but not durable: POSIX ``rename(2)`` leaves
+    the new directory entry in the page cache, so power loss can roll it back to
+    the previous file.
+
+    Best-effort, matching SQLite's ``unixSync``, which fsyncs the directory
+    holding a journal for exactly this reason and treats a directory it cannot
+    open as success. A filesystem that refuses this gives the SQLite database
+    beside the index no guarantee either, so hardening the index alone would
+    buy nothing, and failing the save would instead grow the pending log
+    without bound. Windows cannot open a directory this way at all, so this is
+    a no-op there and the swap's durability follows NTFS metadata journaling.
     """
     with contextlib.suppress(OSError):
-        fd = os.open(path, os.O_RDWR)
+        # `.parent` before `.resolve()`: the entry the swap created lives in the
+        # directory the path names, not in a symlink target's directory.
+        fd = os.open(Path(path).parent.resolve(), os.O_RDONLY)
         try:
-            os.fsync(fd)
+            _fsync(fd)
         finally:
             os.close(fd)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -1,306 +1,125 @@
 """
-Crash-safe index publication, shared by vector search engines.
+Atomic on-disk index publication, shared by vector search engines.
 
-An engine's `save` may only return once a later `load` would produce that index
-even if the machine lost power on the next instruction, because the vector store
-trims its pending-operation log — the only other copy of those vectors — as soon
-as it returns. This module implements that guarantee for engines whose backend
-writes an index to a path.
+Each engine owns its index file layout, so the atomic-swap logic lives here
+(shared by the engines) rather than in the vector store: the index save
+location and the number of files written differ across engine implementations.
 
-Why not the obvious protocol
-----------------------------
+What a save guarantees
+----------------------
 
-Writing a temp file and renaming it over the destination is atomic, but the
-rename cannot be made durable. A rename changes a *directory entry*, and the two
-kinds of state have very different guarantees:
+A reader never observes a partially written index at the target path. The index
+is written to a sibling temp file and swapped into place with ``Path.replace``
+(``os.replace``), which is atomic on POSIX and Windows when source and
+destination share a filesystem (guaranteed here, since the temp file is a
+sibling of the target). A save that is interrupted (crash, exception) therefore
+leaves the previous index untouched rather than corrupting it, which matters
+because the vector store treats a saved-but-unloadable index as a hard error
+rather than silently rebuilding it empty.
 
-===================  ==========================================  ==============
-state                make it durable                             available
-===================  ==========================================  ==============
-file contents        ``fsync`` / ``F_FULLFSYNC`` / FlushFileBuffers  everywhere
-directory entry      ``fsync`` on a directory file descriptor     POSIX only
-===================  ==========================================  ==============
+What it does not
+----------------
 
-On POSIX a parent-directory fsync closes the gap, but only best-effort — network
-and FUSE filesystems refuse it. Windows has no equivalent at all: you cannot open
-a directory as a file, and `MOVEFILE_WRITE_THROUGH` does not help, since its
-documented guarantee is scoped to moves performed as a copy and delete. The
-decisive evidence is SQLite's own: its VFS threads a directory-sync flag through
-every commit-relevant directory operation, honors it in ``unixDelete``, and
-declares it ``/* Not used on win32 */`` in ``winDelete``. So the rename could
-return, the store's trim could commit durably behind it, and a power cut could
-still roll the rename back — leaving the mapping forward, the index back, and no
-copy of the difference anywhere.
+The publication is atomic, not durable. A rename changes a *directory entry*,
+and a directory entry cannot be flushed portably: POSIX needs an fsync on a
+directory file descriptor, which network and FUSE filesystems may refuse, and
+Windows has no equivalent at all. SQLite's own VFS is the precedent -- it
+threads a directory-sync flag through every commit-relevant directory
+operation, honors it in ``unixDelete``, and declares it
+``/* Not used on win32 */`` in ``winDelete``.
 
-What we do instead
-------------------
+So a power failure can roll a save back to the previously published index even
+though ``save`` returned, while the SQLite side -- including the
+pending-operation trim that ran behind that save -- stays committed. What that
+leaves is records whose vectors are missing from the index: they still resolve
+by uuid, but they cannot be found by search until they are re-upserted.
 
-SQLite's answer was not to harden the directory operation but to stop using one
-as a commit point: ``PERSIST`` commits by zeroing a journal header, ``TRUNCATE``
-by truncating, WAL by appending frames. This module does the same.
-
-A base path expands into four files — two index slots and a generation record
-for each — created once and thereafter only overwritten. A checkpoint is:
-
-1. Write the index over the inactive slot and flush it. In-place file data,
-   which every platform can make durable.
-2. Write that slot's generation record and flush it. **This is the commit
-   point**, and it is a write into a file that already exists.
-3. Empty the retired slot and its record, so the spare costs no disk at rest.
-
-`load` reads both records, keeps the ones whose halves agree, and takes the
-higher generation. That comparison is the entire bookkeeping: no pointer,
-manifest, or generation is kept anywhere else, so nothing about this layout
-leaks into the vector store.
-
-The record is 16 bytes — a generation and its bitwise complement. That is what
-makes step 2 atomic without asking the hardware for single-sector-write
-atomicity: every byte of a torn write comes from either the new record or the
-slot's previous one, so the result is the new generation, the old one (which
-loses to the live slot, correctly, since the caller had not trimmed), or a mix
-whose halves disagree and is rejected. A torn record reads as *absent*, never as
-some other generation.
-
-Every crash window is benign:
-
-- **during step 1** — the damaged file is the inactive slot, which nothing
-  reads. The older record still wins and the log is intact.
-- **between steps 1 and 2** — a complete new index exists and is invisible,
-  because nothing published it. Correct: the caller has not trimmed either.
-- **during step 2** — torn record, reads as absent, previous generation wins.
-- **after step 2** — the index it names was flushed before it was written.
-- **between steps 2 and 3** — two valid records; the higher generation wins.
-
-There is no directory operation anywhere in this after the four files exist,
-which is the whole point.
+That is the direction this store tolerates, and it is a deliberate trade. A
+stronger guarantee needs a commit protocol that never uses a directory
+operation as its commit point (two index slots plus a generation record, or an
+equivalent), which every engine would then have to implement and maintain. The
+failure it buys out is bounded -- search recall for at most the records applied
+since the last checkpoint, repaired by re-ingesting them -- so the machinery
+costs more than it saves.
 """
 
 import contextlib
 import os
-import struct
-import sys
 from collections.abc import Iterator
 from pathlib import Path
 
-if sys.platform == "darwin":
-    import fcntl
-
-    def _fsync(fd: int) -> None:
-        """
-        Flush `fd` to stable storage, through the drive's write cache.
-
-        macOS ``fsync`` only pushes the data to the drive, which may hold it in
-        a volatile write cache; ``F_FULLFSYNC`` is the documented request for
-        the stronger flush. Not every filesystem implements it, so a refusal
-        falls back to ``fsync`` rather than failing the caller.
-        """
-        try:
-            fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
-        except OSError:
-            os.fsync(fd)
-
-else:
-
-    def _fsync(fd: int) -> None:
-        """Flush `fd` to stable storage, as far as the platform allows."""
-        os.fsync(fd)
+# Deterministic suffix so a crash leaves at most one stale temp per index file.
+# The next save overwrites it and load clears it, rather than accumulating
+# uniquely named leftovers.
+_TEMP_SUFFIX = ".tmp"
 
 
-_SLOTS = (0, 1)
-
-# Generation, then its bitwise complement.
-_RECORD_FORMAT = "<QQ"
-_RECORD_SIZE = struct.calcsize(_RECORD_FORMAT)
-_COMPLEMENT_MASK = 0xFFFFFFFFFFFFFFFF
+def _temp_path(path: str) -> str:
+    """Return the sibling temp path used while writing the index at `path`."""
+    return f"{path}{_TEMP_SUFFIX}"
 
 
-def _slot_path(base: str, slot: int) -> Path:
-    """Path of an index slot under `base`."""
-    return Path(f"{base}.{slot}")
-
-
-def _record_path(base: str, slot: int) -> Path:
-    """Path of a slot's generation record."""
-    return Path(f"{base}.{slot}.gen")
-
-
-def index_artifact_paths(base: str) -> list[Path]:
+def clear_stale_index_temp(path: str) -> None:
     """
-    Every file `base` expands into.
+    Remove a temp file left behind by a previously interrupted save.
 
-    The vector store uses this to discard a collection's index without having to
-    know how many files an engine keeps or what they are called.
+    Call this on load/startup so a save that crashed before the atomic swap
+    does not leak a temp file across restarts. A missing temp file is a no-op.
 
     Args:
-        base (str):
-            The index base path.
-
-    Returns:
-        list[Path]:
-            The slot and generation-record paths, in no particular order.
+        path (str):
+            The index file path whose sibling temp file should be cleared.
     """
-    return [
-        path
-        for slot in _SLOTS
-        for path in (_slot_path(base, slot), _record_path(base, slot))
-    ]
-
-
-def published_index_path(base: str) -> str | None:
-    """
-    The index a `load` should read, or None if nothing has been published.
-
-    Reads both generation records, discards any whose halves disagree — a torn
-    or absent record — and returns the slot holding the higher generation.
-
-    A caller must **not** fall back to the other slot when the returned index
-    fails to parse. The log was trimmed against the published one, so the other
-    is stale by exactly the operations that can no longer be replayed; failing
-    loudly is right, and quietly serving the previous generation would be data
-    loss dressed as success.
-
-    Args:
-        base (str):
-            The index base path.
-
-    Returns:
-        str | None:
-            Path of the published index slot, or None if there is none.
-    """
-    published = _published_slot(base)
-    return None if published is None else str(_slot_path(base, published[0]))
+    Path(_temp_path(path)).unlink(missing_ok=True)
 
 
 @contextlib.contextmanager
-def publish_index(base: str) -> Iterator[str]:
+def atomic_index_write(path: str) -> Iterator[str]:
     """
-    Write an index into the free slot and publish it.
+    Write an index to a temp file, then atomically swap it into `path`.
 
-    Yields the path of the slot that is not currently published, for the caller
-    to write the index to. On normal exit that slot is flushed, its generation
-    record is written and flushed — the commit — and the retired slot is
-    emptied.
+    Yields a sibling temp path for the caller to write the index to. On normal
+    exit the temp file is flushed and atomically renamed onto `path`, so a
+    reader sees either the old index or the new one, never a partial write. If
+    the body raises, the temp file is removed and the exception propagates,
+    leaving any existing index at `path` intact.
 
-    If the body raises, nothing is published and the exception propagates: the
-    previously published index stays live, and the half-written slot is
-    invisible until the next checkpoint overwrites it. The same holds for a
-    failed flush, which is why flush errors are not suppressed — the store trims
-    its log on the strength of this call, and ``EIO`` from ``fsync`` means the
-    writeback already failed and the dirty pages were dropped.
+    The swap is atomic, not durable: after a power failure the index at `path`
+    may be the previous one. See the module docstring for what that costs.
 
     Args:
-        base (str):
-            The index base path.
+        path (str):
+            The final index file path to swap the written index into.
 
     Yields:
         str:
-            Path of the slot to write the index to.
+            The temp path to write the index to.
     """
-    live = _published_slot(base)
-    if live is None:
-        target, generation = _SLOTS[0], 1
-    else:
-        live_slot, live_generation = live
-        target, generation = 1 - live_slot, live_generation + 1
-
-    _create_artifacts(base)
-
-    yield str(_slot_path(base, target))
-
-    # 1. The index itself, durable before anything names it.
-    _flush_file(_slot_path(base, target))
-    # 2. The commit point.
-    _write_generation(base, target, generation)
-    # 3. Reclaim the retired pair. Best-effort: this runs after the commit, so
-    #    it must not fail the save, and a slot left full is harmless — its
-    #    record holds the lower generation and loses the comparison.
-    if live is not None:
-        _empty_slot(base, live[0])
-
-
-def _published_slot(base: str) -> tuple[int, int] | None:
-    """The (slot, generation) with the highest believable generation, if any."""
-    published = [
-        (generation, slot)
-        for slot in _SLOTS
-        if (generation := _read_generation(base, slot)) is not None
-    ]
-    if not published:
-        return None
-    generation, slot = max(published)
-    return slot, generation
-
-
-def _read_generation(base: str, slot: int) -> int | None:
-    """The generation published in `slot`, or None if no believable record."""
+    temp = _temp_path(path)
+    # Clear any temp left by a previously interrupted save before reusing it.
+    Path(temp).unlink(missing_ok=True)
     try:
-        record = _record_path(base, slot).read_bytes()
-    except OSError:
-        return None
-    if len(record) != _RECORD_SIZE:
-        return None
-    generation, complement = struct.unpack(_RECORD_FORMAT, record)
-    # Generations start at 1, so an all-zero record is never a publication.
-    if generation == 0 or complement != generation ^ _COMPLEMENT_MASK:
-        return None
-    return generation
+        yield temp
+        _flush_to_disk(temp)
+        Path(temp).replace(path)
+    except BaseException:
+        Path(temp).unlink(missing_ok=True)
+        raise
 
 
-def _write_generation(base: str, slot: int, generation: int) -> None:
-    """Publish `slot` by writing and flushing its generation record."""
-    record = struct.pack(_RECORD_FORMAT, generation, generation ^ _COMPLEMENT_MASK)
-    fd = os.open(_record_path(base, slot), os.O_RDWR)
-    try:
-        os.write(fd, record)
-        _fsync(fd)
-    finally:
-        os.close(fd)
-
-
-def _empty_slot(base: str, slot: int) -> None:
-    """Unpublish a slot and reclaim its space, best-effort."""
-    # The record first: no valid record may ever name an emptied slot.
-    for path in (_record_path(base, slot), _slot_path(base, slot)):
-        with contextlib.suppress(OSError):
-            os.truncate(path, 0)
-
-
-def _flush_file(path: Path) -> None:
-    """Flush a file's contents to stable storage. Errors propagate."""
-    # O_RDWR rather than O_RDONLY: os.fsync is `_commit` on Windows, which needs
-    # a writable handle. Opening for write does not truncate.
-    fd = os.open(path, os.O_RDWR)
-    try:
-        _fsync(fd)
-    finally:
-        os.close(fd)
-
-
-def _create_artifacts(base: str) -> None:
+def _flush_to_disk(path: str) -> None:
     """
-    Create any missing slot or record files, once per collection.
+    Best-effort fsync so the temp file's bytes are durable before the swap.
 
-    This is the only directory operation in the protocol, and it happens when
-    there is nothing to lose: before anything has been published, the store's
-    log still holds every vector. The parent directory is flushed afterwards so
-    that even this is durable where the platform allows it — a POSIX-only,
-    best-effort step, and the one place where a filesystem that refuses it costs
-    nothing more than a loud missing-index error at the next open.
+    Guards against a crash where the rename is durable but the data behind it
+    is not, which is the direction that costs: a published index that will not
+    parse is a hard error, while a publication that reverts is only missing
+    vectors. Failures are ignored -- this narrows a window rather than closing
+    one, since the swap itself is not durable either.
     """
-    created = False
-    for path in index_artifact_paths(base):
-        try:
-            os.close(os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644))
-        except FileExistsError:
-            continue
-        created = True
-
-    if not created:
-        return
-
     with contextlib.suppress(OSError):
-        fd = os.open(Path(base).parent.resolve(), os.O_RDONLY)
+        fd = os.open(path, os.O_RDWR)
         try:
-            _fsync(fd)
+            os.fsync(fd)
         finally:
             os.close(fd)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -1,41 +1,83 @@
 """
-Atomic on-disk index persistence helpers, shared by vector search engines.
+Crash-safe index publication, shared by vector search engines.
 
-Each engine owns its index file layout, so the atomic-swap logic lives here
-(shared by the engines) rather than in the vector store: the index save
-location and the number of files written differ across engine implementations.
-An engine whose backend implements this protocol natively can satisfy
-`VectorSearchEngine.save` by delegating to it and skip these helpers.
+An engine's `save` may only return once a later `load` would produce that index
+even if the machine lost power on the next instruction, because the vector store
+trims its pending-operation log — the only other copy of those vectors — as soon
+as it returns. This module implements that guarantee for engines whose backend
+writes an index to a path.
 
-The two guarantees fail differently, which is why they are separated below:
+Why not the obvious protocol
+----------------------------
 
-- **Atomic.** A reader never observes a partially written index at the target
-  path. The index is written to a sibling temp file and swapped into place with
-  ``Path.replace`` (``os.replace``), which is atomic on POSIX and Windows when
-  source and destination share a filesystem (guaranteed here, since the temp
-  file is a sibling of the target). A save that is interrupted (crash,
-  exception) leaves the previous index untouched rather than corrupting it,
-  which matters because the vector store treats a saved-but-unloadable index as
-  a hard error rather than silently rebuilding it empty.
-- **Durable.** A save that returns has put the new index on stable storage, and
-  on POSIX the swap itself too. This is not a bonus on top of the atomicity:
-  the vector store trims its pending-operation log — the only other copy of
-  these vectors — once ``save`` returns, so a swap that quietly fails to reach
-  disk costs data rather than performance.
+Writing a temp file and renaming it over the destination is atomic, but the
+rename cannot be made durable. A rename changes a *directory entry*, and the two
+kinds of state have very different guarantees:
 
-Durability is platform-limited in one place. On POSIX the swap is made durable
-by fsyncing the parent directory, since ``rename(2)`` leaves the new directory
-entry in the page cache. Windows has no equivalent operation: the swap is
-atomic through NTFS metadata journaling, but that journal record is not
-necessarily flushed when the call returns, so power loss (a process crash is
-not enough) within a sub-second window can roll it back. The residue is bounded
-— the previous index reappears, and the records whose vectors that checkpoint
-added are still in SQLite but no longer in the index, so they stop matching
-queries rather than matching them wrongly.
+===================  ==========================================  ==============
+state                make it durable                             available
+===================  ==========================================  ==============
+file contents        ``fsync`` / ``F_FULLFSYNC`` / FlushFileBuffers  everywhere
+directory entry      ``fsync`` on a directory file descriptor     POSIX only
+===================  ==========================================  ==============
+
+On POSIX a parent-directory fsync closes the gap, but only best-effort — network
+and FUSE filesystems refuse it. Windows has no equivalent at all: you cannot open
+a directory as a file, and `MOVEFILE_WRITE_THROUGH` does not help, since its
+documented guarantee is scoped to moves performed as a copy and delete. The
+decisive evidence is SQLite's own: its VFS threads a directory-sync flag through
+every commit-relevant directory operation, honors it in ``unixDelete``, and
+declares it ``/* Not used on win32 */`` in ``winDelete``. So the rename could
+return, the store's trim could commit durably behind it, and a power cut could
+still roll the rename back — leaving the mapping forward, the index back, and no
+copy of the difference anywhere.
+
+What we do instead
+------------------
+
+SQLite's answer was not to harden the directory operation but to stop using one
+as a commit point: ``PERSIST`` commits by zeroing a journal header, ``TRUNCATE``
+by truncating, WAL by appending frames. This module does the same.
+
+A base path expands into four files — two index slots and a generation record
+for each — created once and thereafter only overwritten. A checkpoint is:
+
+1. Write the index over the inactive slot and flush it. In-place file data,
+   which every platform can make durable.
+2. Write that slot's generation record and flush it. **This is the commit
+   point**, and it is a write into a file that already exists.
+3. Empty the retired slot and its record, so the spare costs no disk at rest.
+
+`load` reads both records, keeps the ones whose halves agree, and takes the
+higher generation. That comparison is the entire bookkeeping: no pointer,
+manifest, or generation is kept anywhere else, so nothing about this layout
+leaks into the vector store.
+
+The record is 16 bytes — a generation and its bitwise complement. That is what
+makes step 2 atomic without asking the hardware for single-sector-write
+atomicity: every byte of a torn write comes from either the new record or the
+slot's previous one, so the result is the new generation, the old one (which
+loses to the live slot, correctly, since the caller had not trimmed), or a mix
+whose halves disagree and is rejected. A torn record reads as *absent*, never as
+some other generation.
+
+Every crash window is benign:
+
+- **during step 1** — the damaged file is the inactive slot, which nothing
+  reads. The older record still wins and the log is intact.
+- **between steps 1 and 2** — a complete new index exists and is invisible,
+  because nothing published it. Correct: the caller has not trimmed either.
+- **during step 2** — torn record, reads as absent, previous generation wins.
+- **after step 2** — the index it names was flushed before it was written.
+- **between steps 2 and 3** — two valid records; the higher generation wins.
+
+There is no directory operation anywhere in this after the four files exist,
+which is the whole point.
 """
 
 import contextlib
 import os
+import struct
 import sys
 from collections.abc import Iterator
 from pathlib import Path
@@ -64,83 +106,169 @@ else:
         os.fsync(fd)
 
 
-# Deterministic suffix so a crash leaves at most one stale temp per index file.
-# The next save overwrites it and load clears it, rather than accumulating
-# uniquely named leftovers.
-_TEMP_SUFFIX = ".tmp"
+_SLOTS = (0, 1)
+
+# Generation, then its bitwise complement.
+_RECORD_FORMAT = "<QQ"
+_RECORD_SIZE = struct.calcsize(_RECORD_FORMAT)
+_COMPLEMENT_MASK = 0xFFFFFFFFFFFFFFFF
 
 
-def _temp_path(path: str) -> str:
-    """Return the sibling temp path used while writing the index at `path`."""
-    return f"{path}{_TEMP_SUFFIX}"
+def _slot_path(base: str, slot: int) -> Path:
+    """Path of an index slot under `base`."""
+    return Path(f"{base}.{slot}")
 
 
-def clear_stale_index_temp(path: str) -> None:
+def _record_path(base: str, slot: int) -> Path:
+    """Path of a slot's generation record."""
+    return Path(f"{base}.{slot}.gen")
+
+
+def index_artifact_paths(base: str) -> list[Path]:
     """
-    Remove a temp file left behind by a previously interrupted save.
+    Every file `base` expands into.
 
-    Call this on load/startup so a save that crashed before the atomic swap
-    does not leak a temp file across restarts. A missing temp file is a no-op.
+    The vector store uses this to discard a collection's index without having to
+    know how many files an engine keeps or what they are called.
 
     Args:
-        path (str):
-            The index file path whose sibling temp file should be cleared.
+        base (str):
+            The index base path.
+
+    Returns:
+        list[Path]:
+            The slot and generation-record paths, in no particular order.
     """
-    Path(_temp_path(path)).unlink(missing_ok=True)
+    return [
+        path
+        for slot in _SLOTS
+        for path in (_slot_path(base, slot), _record_path(base, slot))
+    ]
+
+
+def published_index_path(base: str) -> str | None:
+    """
+    The index a `load` should read, or None if nothing has been published.
+
+    Reads both generation records, discards any whose halves disagree — a torn
+    or absent record — and returns the slot holding the higher generation.
+
+    A caller must **not** fall back to the other slot when the returned index
+    fails to parse. The log was trimmed against the published one, so the other
+    is stale by exactly the operations that can no longer be replayed; failing
+    loudly is right, and quietly serving the previous generation would be data
+    loss dressed as success.
+
+    Args:
+        base (str):
+            The index base path.
+
+    Returns:
+        str | None:
+            Path of the published index slot, or None if there is none.
+    """
+    published = _published_slot(base)
+    return None if published is None else str(_slot_path(base, published[0]))
 
 
 @contextlib.contextmanager
-def atomic_index_write(path: str) -> Iterator[str]:
+def publish_index(base: str) -> Iterator[str]:
     """
-    Write an index to a temp file, then atomically swap it into `path`.
+    Write an index into the free slot and publish it.
 
-    Yields a sibling temp path for the caller to write the index to. On normal
-    exit the temp file is flushed, atomically renamed onto `path`, and the
-    rename itself flushed where the platform allows — so a reader sees either
-    the old index or the new one, never a partial write, and a return means the
-    new index is on disk. If the body raises, the temp file is removed and the
-    exception propagates, leaving any existing index at `path` intact.
+    Yields the path of the slot that is not currently published, for the caller
+    to write the index to. On normal exit that slot is flushed, its generation
+    record is written and flushed — the commit — and the retired slot is
+    emptied.
 
-    The rename is the commit point: nothing after it may raise, or a caller
-    would roll back against an index that has already been replaced.
+    If the body raises, nothing is published and the exception propagates: the
+    previously published index stays live, and the half-written slot is
+    invisible until the next checkpoint overwrites it. The same holds for a
+    failed flush, which is why flush errors are not suppressed — the store trims
+    its log on the strength of this call, and ``EIO`` from ``fsync`` means the
+    writeback already failed and the dirty pages were dropped.
 
     Args:
-        path (str):
-            The final index file path to swap the written index into.
+        base (str):
+            The index base path.
 
     Yields:
         str:
-            The temp path to write the index to.
+            Path of the slot to write the index to.
     """
-    temp = _temp_path(path)
-    # Clear any temp left by a previously interrupted save before reusing it.
-    Path(temp).unlink(missing_ok=True)
+    live = _published_slot(base)
+    if live is None:
+        target, generation = _SLOTS[0], 1
+    else:
+        live_slot, live_generation = live
+        target, generation = 1 - live_slot, live_generation + 1
+
+    _create_artifacts(base)
+
+    yield str(_slot_path(base, target))
+
+    # 1. The index itself, durable before anything names it.
+    _flush_file(_slot_path(base, target))
+    # 2. The commit point.
+    _write_generation(base, target, generation)
+    # 3. Reclaim the retired pair. Best-effort: this runs after the commit, so
+    #    it must not fail the save, and a slot left full is harmless — its
+    #    record holds the lower generation and loses the comparison.
+    if live is not None:
+        _empty_slot(base, live[0])
+
+
+def _published_slot(base: str) -> tuple[int, int] | None:
+    """The (slot, generation) with the highest believable generation, if any."""
+    published = [
+        (generation, slot)
+        for slot in _SLOTS
+        if (generation := _read_generation(base, slot)) is not None
+    ]
+    if not published:
+        return None
+    generation, slot = max(published)
+    return slot, generation
+
+
+def _read_generation(base: str, slot: int) -> int | None:
+    """The generation published in `slot`, or None if no believable record."""
     try:
-        yield temp
-        _flush_to_disk(temp)
-        Path(temp).replace(path)
-        _flush_parent_dir(path)
-    except BaseException:
-        Path(temp).unlink(missing_ok=True)
-        raise
+        record = _record_path(base, slot).read_bytes()
+    except OSError:
+        return None
+    if len(record) != _RECORD_SIZE:
+        return None
+    generation, complement = struct.unpack(_RECORD_FORMAT, record)
+    # Generations start at 1, so an all-zero record is never a publication.
+    if generation == 0 or complement != generation ^ _COMPLEMENT_MASK:
+        return None
+    return generation
 
 
-def _flush_to_disk(path: str) -> None:
-    """
-    Flush the temp file's bytes to disk before the swap. Errors propagate.
+def _write_generation(base: str, slot: int, generation: int) -> None:
+    """Publish `slot` by writing and flushing its generation record."""
+    record = struct.pack(_RECORD_FORMAT, generation, generation ^ _COMPLEMENT_MASK)
+    fd = os.open(_record_path(base, slot), os.O_RDWR)
+    try:
+        os.write(fd, record)
+        _fsync(fd)
+    finally:
+        os.close(fd)
 
-    The vector store trims its pending-operation log — its only other copy of
-    these vectors — once the save returns, so a failed flush has to fail the
-    save rather than be reported as success. ``EIO`` here is not hypothetical:
-    a writeback error is reported to ``fsync`` once and the dirty pages are
-    then dropped, which is exactly when the save must not be treated as
-    committed. `atomic_index_write` removes the temp file and leaves the
-    previous index in place, so the next save retries. (SQLite draws the same
-    line: a file fsync failure raises ``SQLITE_IOERR_FSYNC``, while a directory
-    fsync failure is ignored — see `_flush_parent_dir`.)
-    """
-    # O_RDWR rather than O_RDONLY: os.fsync is `_commit` on Windows, which
-    # needs a writable handle. Opening for write does not truncate.
+
+def _empty_slot(base: str, slot: int) -> None:
+    """Unpublish a slot and reclaim its space, best-effort."""
+    # The record first: no valid record may ever name an emptied slot.
+    for path in (_record_path(base, slot), _slot_path(base, slot)):
+        with contextlib.suppress(OSError):
+            os.truncate(path, 0)
+
+
+def _flush_file(path: Path) -> None:
+    """Flush a file's contents to stable storage. Errors propagate."""
+    # O_RDWR rather than O_RDONLY: os.fsync is `_commit` on Windows, which needs
+    # a writable handle. Opening for write does not truncate.
     fd = os.open(path, os.O_RDWR)
     try:
         _fsync(fd)
@@ -148,26 +276,30 @@ def _flush_to_disk(path: str) -> None:
         os.close(fd)
 
 
-def _flush_parent_dir(path: str) -> None:
+def _create_artifacts(base: str) -> None:
     """
-    Flush the directory holding `path`, making the swap itself durable.
+    Create any missing slot or record files, once per collection.
 
-    Without this the swap is atomic but not durable: POSIX ``rename(2)`` leaves
-    the new directory entry in the page cache, so power loss can roll it back to
-    the previous file.
-
-    Best-effort, matching SQLite's ``unixSync``, which fsyncs the directory
-    holding a journal for exactly this reason and treats a directory it cannot
-    open as success. A filesystem that refuses this gives the SQLite database
-    beside the index no guarantee either, so hardening the index alone would
-    buy nothing, and failing the save would instead grow the pending log
-    without bound. Windows cannot open a directory this way at all, so this is
-    a no-op there and the swap's durability follows NTFS metadata journaling.
+    This is the only directory operation in the protocol, and it happens when
+    there is nothing to lose: before anything has been published, the store's
+    log still holds every vector. The parent directory is flushed afterwards so
+    that even this is durable where the platform allows it — a POSIX-only,
+    best-effort step, and the one place where a filesystem that refuses it costs
+    nothing more than a loud missing-index error at the next open.
     """
+    created = False
+    for path in index_artifact_paths(base):
+        try:
+            os.close(os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644))
+        except FileExistsError:
+            continue
+        created = True
+
+    if not created:
+        return
+
     with contextlib.suppress(OSError):
-        # `.parent` before `.resolve()`: the entry the swap created lives in the
-        # directory the path names, not in a symlink target's directory.
-        fd = os.open(Path(path).parent.resolve(), os.O_RDONLY)
+        fd = os.open(Path(base).parent.resolve(), os.O_RDONLY)
         try:
             _fsync(fd)
         finally:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -72,7 +72,6 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
         keys = np.array(list(vectors.keys()), dtype=np.uint64)
         array = self._prepare_vectors(list(vectors.values()))
         self._index.add_with_ids(array, keys)
-        self._index.prepare()
 
     @override
     async def search(

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -10,7 +10,6 @@ from turbovec import IdMapIndex
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
-from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -162,8 +161,7 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        with atomic_index_write(path) as temp_path:
-            self._index.write(temp_path)
+        self._index.sync(path)
 
     @override
     async def load(self, path: str) -> None:
@@ -171,5 +169,4 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             self._index = await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> IdMapIndex:
-        clear_stale_index_temp(path)
         return IdMapIndex.load(path)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -1,0 +1,175 @@
+"""turbovec (TurboQuant) implementation of VectorSearchEngine."""
+
+import asyncio
+from collections.abc import Container, Iterable, Mapping, Sequence
+from typing import ClassVar, override
+
+import numpy as np
+from turbovec import IdMapIndex
+
+from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.rw_locks import AsyncRWLock
+
+from .index_persistence import atomic_index_write, clear_stale_index_temp
+from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
+
+
+class TurboVecVectorSearchEngine(VectorSearchEngine):
+    """Vector search engine backed by turbovec."""
+
+    _SUPPORTED_METRICS: ClassVar[frozenset[SimilarityMetric]] = frozenset(
+        {SimilarityMetric.COSINE, SimilarityMetric.DOT}
+    )
+
+    _VALID_BIT_WIDTHS: ClassVar[frozenset[int]] = frozenset({2, 3, 4})
+    _DEFAULT_BIT_WIDTH: ClassVar[int] = 4
+
+    _OVERFETCH_BASE: ClassVar[int] = 4
+
+    def __init__(
+        self,
+        *,
+        num_dimensions: int,
+        similarity_metric: SimilarityMetric,
+        bit_width: int = _DEFAULT_BIT_WIDTH,
+    ) -> None:
+        """Initialize."""
+        if similarity_metric not in self._SUPPORTED_METRICS:
+            supported = ", ".join(metric.value for metric in self._SUPPORTED_METRICS)
+            raise NotImplementedError(
+                f"turbovec does not support {similarity_metric.value!r} "
+                f"(inner-product index only). Supported: {supported}"
+            )
+
+        if bit_width not in self._VALID_BIT_WIDTHS:
+            raise ValueError(
+                f"turbovec bit_width must be one of "
+                f"{sorted(self._VALID_BIT_WIDTHS)}, got {bit_width}"
+            )
+
+        self._similarity_metric = similarity_metric
+        self._index = IdMapIndex(dim=num_dimensions, bit_width=bit_width)
+        self._lock = AsyncRWLock()
+
+    @override
+    async def add(self, vectors: Mapping[int, Sequence[float]]) -> None:
+        if not vectors:
+            return
+        async with self._lock.write_lock():
+            await asyncio.to_thread(self._sync_add, vectors)
+
+    def _sync_add(self, vectors: Mapping[int, Sequence[float]]) -> None:
+        keys = np.array(list(vectors.keys()), dtype=np.uint64)
+        array = self._prepare_vectors(list(vectors.values()))
+        self._index.add_with_ids(array, keys)
+        self._index.prepare()
+
+    @override
+    async def search(
+        self,
+        vectors: Iterable[Sequence[float]],
+        *,
+        limit: int,
+        allowed_keys: Container[int] | None = None,
+    ) -> list[SearchResult]:
+        vectors = list(vectors)
+        if not vectors or limit <= 0:
+            return [SearchResult(matches=[]) for _ in vectors]
+        async with self._lock.read_lock():
+            return await asyncio.to_thread(
+                self._sync_search, vectors, limit, allowed_keys
+            )
+
+    def _sync_search(
+        self,
+        vectors: Sequence[Sequence[float]],
+        limit: int,
+        allowed_keys: Container[int] | None,
+    ) -> list[SearchResult]:
+        query = self._prepare_vectors(vectors)
+
+        if allowed_keys is None:
+            scores, ids = self._index.search(query, limit)
+            return [
+                SearchResult(matches=self._to_matches(scores[i], ids[i], limit, None))
+                for i in range(query.shape[0])
+            ]
+
+        return [
+            self._search_one_filtered(query[i : i + 1], limit, allowed_keys)
+            for i in range(query.shape[0])
+        ]
+
+    def _search_one_filtered(
+        self,
+        query: np.ndarray,
+        limit: int,
+        allowed_keys: Container[int],
+    ) -> SearchResult:
+        fetch_limit = limit * self._OVERFETCH_BASE
+        while True:
+            scores, ids = self._index.search(query, fetch_limit)
+            matches = self._to_matches(scores[0], ids[0], limit, allowed_keys)
+            exhausted = ids.shape[1] < fetch_limit
+            if len(matches) >= limit or exhausted:
+                return SearchResult(matches=matches)
+            fetch_limit *= self._OVERFETCH_BASE
+
+    def _to_matches(
+        self,
+        scores: Iterable[float],
+        keys: Iterable[int],
+        limit: int,
+        allowed_keys: Container[int] | None,
+    ) -> list[SearchMatch]:
+        matches: list[SearchMatch] = []
+        for score, key in zip(scores, keys, strict=True):
+            int_key = int(key)
+            if allowed_keys is not None and int_key not in allowed_keys:
+                continue
+            matches.append(SearchMatch(key=int_key, score=float(score)))
+            if len(matches) >= limit:
+                break
+        return matches
+
+    def _prepare_vectors(self, vectors: Sequence[Sequence[float]]) -> np.ndarray:
+        array = np.array(vectors, dtype=np.float32)
+        if self._similarity_metric is SimilarityMetric.COSINE:
+            norms = np.linalg.norm(array, axis=1, keepdims=True)
+            norms[norms == 0.0] = 1.0
+            array = array / norms
+        return array
+
+    @override
+    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
+        raise NotImplementedError(
+            "turbovec stores only TurboQuant-compressed vectors; "
+            "the original vectors cannot be retrieved"
+        )
+
+    @override
+    async def remove(self, keys: Iterable[int]) -> None:
+        async with self._lock.write_lock():
+            await asyncio.to_thread(self._sync_remove, keys)
+
+    def _sync_remove(self, keys: Iterable[int]) -> None:
+        for key in keys:
+            self._index.remove(key)
+
+    @override
+    async def save(self, path: str) -> None:
+        async with self._lock.write_lock():
+            await asyncio.to_thread(self._sync_save, path)
+
+    def _sync_save(self, path: str) -> None:
+        with atomic_index_write(path) as temp_path:
+            self._index.write(temp_path)
+
+    @override
+    async def load(self, path: str) -> None:
+        async with self._lock.write_lock():
+            self._index = await asyncio.to_thread(self._sync_load, path)
+
+    def _sync_load(self, path: str) -> IdMapIndex:
+        clear_stale_index_temp(path)
+        return IdMapIndex.load(path)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -126,10 +126,16 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             int_key = int(key)
             if allowed_keys is not None and int_key not in allowed_keys:
                 continue
-            matches.append(SearchMatch(key=int_key, score=float(score)))
+            matches.append(SearchMatch(key=int_key, score=self._to_score(score)))
             if len(matches) >= limit:
                 break
         return matches
+
+    def _to_score(self, score: float) -> float:
+        value = float(score)
+        if self._similarity_metric is SimilarityMetric.COSINE:
+            return min(1.0, max(-1.0, value))
+        return value
 
     def _prepare_vectors(self, vectors: Sequence[Sequence[float]]) -> np.ndarray:
         array = np.array(vectors, dtype=np.float32)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -1,6 +1,7 @@
 """turbovec (TurboQuant) implementation of VectorSearchEngine."""
 
 import asyncio
+import math
 from collections.abc import Container, Iterable, Mapping, Sequence
 from typing import ClassVar, override
 
@@ -14,7 +15,15 @@ from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
 class TurboVecVectorSearchEngine(VectorSearchEngine):
-    """Vector search engine backed by turbovec."""
+    """
+    Vector search engine backed by turbovec.
+
+    turbovec indexes a dimensionality that is a multiple of 8, so a vector of
+    any other width is zero-padded up to one. Padding is exact for both metrics
+    this engine serves -- a zero coordinate adds nothing to an inner product
+    and nothing to an L2 norm -- so the padded index answers as the unpadded
+    one would, and any embedding width the other engines accept works here too.
+    """
 
     _SUPPORTED_METRICS: ClassVar[frozenset[SimilarityMetric]] = frozenset(
         {SimilarityMetric.COSINE, SimilarityMetric.DOT}
@@ -47,7 +56,9 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             )
 
         self._similarity_metric = similarity_metric
-        self._index = IdMapIndex(dim=num_dimensions, bit_width=bit_width)
+        self._num_dimensions = num_dimensions
+        self._padded_dimensions = math.ceil(num_dimensions / 8) * 8
+        self._index = IdMapIndex(dim=self._padded_dimensions, bit_width=bit_width)
         self._lock = AsyncRWLock()
 
     @override
@@ -138,7 +149,13 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
         return value
 
     def _prepare_vectors(self, vectors: Sequence[Sequence[float]]) -> np.ndarray:
-        array = np.array(vectors, dtype=np.float32)
+        array = np.zeros((len(vectors), self._padded_dimensions), dtype=np.float32)
+        try:
+            array[:, : self._num_dimensions] = vectors
+        except ValueError as error:
+            raise ValueError(
+                f"vectors must have {self._num_dimensions} dimensions"
+            ) from error
         if self._similarity_metric is SimilarityMetric.COSINE:
             norms = np.linalg.norm(array, axis=1, keepdims=True)
             norms[norms == 0.0] = 1.0

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
@@ -11,6 +11,7 @@ from usearch.index import Index, MetricKind
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
+from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -186,9 +187,17 @@ class USearchVectorSearchEngine(VectorSearchEngine):
     @override
     async def save(self, path: str) -> None:
         async with self._lock.write_lock():
-            await asyncio.to_thread(self._index.save, path)
+            await asyncio.to_thread(self._sync_save, path)
+
+    def _sync_save(self, path: str) -> None:
+        with atomic_index_write(path) as temp_path:
+            self._index.save(temp_path)
 
     @override
     async def load(self, path: str) -> None:
         async with self._lock.write_lock():
-            await asyncio.to_thread(self._index.load, path)
+            await asyncio.to_thread(self._sync_load, path)
+
+    def _sync_load(self, path: str) -> None:
+        clear_stale_index_temp(path)
+        self._index.load(path)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
@@ -11,7 +11,7 @@ from usearch.index import Index, MetricKind
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
-from .index_persistence import publish_index, published_index_path
+from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -190,8 +190,8 @@ class USearchVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        with publish_index(path) as slot_path:
-            self._index.save(slot_path)
+        with atomic_index_write(path) as temp_path:
+            self._index.save(temp_path)
 
     @override
     async def load(self, path: str) -> None:
@@ -199,7 +199,5 @@ class USearchVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> None:
-        published = published_index_path(path)
-        if published is None:
-            raise FileNotFoundError(f"No published index for {path}")
-        self._index.load(published)
+        clear_stale_index_temp(path)
+        self._index.load(path)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
@@ -11,7 +11,7 @@ from usearch.index import Index, MetricKind
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
-from .index_persistence import atomic_index_write, clear_stale_index_temp
+from .index_persistence import publish_index, published_index_path
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -190,8 +190,8 @@ class USearchVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        with atomic_index_write(path) as temp_path:
-            self._index.save(temp_path)
+        with publish_index(path) as slot_path:
+            self._index.save(slot_path)
 
     @override
     async def load(self, path: str) -> None:
@@ -199,5 +199,7 @@ class USearchVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> None:
-        clear_stale_index_temp(path)
-        self._index.load(path)
+        published = published_index_path(path)
+        if published is None:
+            raise FileNotFoundError(f"No published index for {path}")
+        self._index.load(published)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
@@ -122,42 +122,30 @@ class VectorSearchEngine(ABC):
     @abstractmethod
     async def save(self, path: str) -> None:
         """
-        Persist the index under `path`, durably.
+        Publish the index at `path`, replacing whatever index is there.
 
-        Returning must mean that a later `load` produces this index even if the
-        machine loses power on the next instruction. Not "written", not "handed
-        to the OS", not "renamed on a filesystem that has yet to flush the
-        directory". The caller trims its pending-operation log — the only other
-        copy of these vectors — as soon as this returns, so anything weaker
-        loses data.
+        Returning must mean a later `load` reads this index or the one it
+        replaced, never a half-written mixture of the two. It does *not* mean
+        the publication survives a power failure: implementations may publish
+        with an atomic rename, which a power failure can roll back after this
+        returns.
 
-        Durability is entirely the implementation's, including which artifact is
-        live: nothing about the layout may leak out, and the caller keeps no
-        pointer, manifest, or generation of its own. `path` is therefore a base
-        name rather than a promise about the files on disk — an engine may keep
-        one file, two slots, or a set of segments under it.
-
-        `index_persistence.publish_index` provides this for a backend that can
-        only write an index to a path; an engine whose backend publishes durably
-        on its own may delegate to that instead.
+        Callers must therefore treat a published index as possibly stale, but
+        never as corrupt. `SQLiteVectorStore` trims its pending-operation log
+        once this returns, so a rolled-back publication leaves records whose
+        vectors are missing from the index until they are re-upserted.
 
         Args:
             path (str):
-                Base path for the index files.
+                File path to write the index to.
         """
 
     @abstractmethod
     async def load(self, path: str) -> None:
         """
-        Load the index most recently published under `path`.
-
-        Raising is correct when nothing is published or the published index does
-        not parse. Implementations must **not** substitute an older copy they
-        may still hold: the caller trimmed its log against the published one, so
-        an older copy is stale by exactly the operations that can no longer be
-        replayed, and serving it would be data loss dressed as success.
+        Load the index from disk.
 
         Args:
             path (str):
-                Base path for the index files.
+                File path to read the index from.
         """

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
@@ -122,7 +122,26 @@ class VectorSearchEngine(ABC):
     @abstractmethod
     async def save(self, path: str) -> None:
         """
-        Persist the index to disk.
+        Persist the index to `path`, atomically and durably.
+
+        Write elsewhere, flush, and replace `path` in one step, so a crash
+        leaves either the previous index or the new one and never a partial
+        file — then make that replacement durable by whatever means the
+        platform provides.
+
+        The caller trims its pending-operation log — its only other copy of
+        these vectors — once this returns, so an implementation that merely
+        writes and flushes, leaving a half-written file reachable at `path`,
+        does not satisfy this. An engine whose backend implements the whole
+        protocol natively may delegate to it; the rest should use
+        `index_persistence.atomic_index_write`, which implements it against a
+        backend that can only write to a path.
+
+        "As durably as the platform allows" is deliberate rather than a hedge.
+        On POSIX the replacement is made durable by fsyncing the parent
+        directory. Windows has no equivalent operation, so the replacement is
+        atomic through NTFS metadata journaling but is not necessarily flushed
+        when the call returns.
 
         Args:
             path (str):
@@ -133,6 +152,10 @@ class VectorSearchEngine(ABC):
     async def load(self, path: str) -> None:
         """
         Load the index from disk.
+
+        Implementations should clear any temp file a previously interrupted
+        save left beside `path` (`index_persistence.clear_stale_index_temp`),
+        so a crash does not leak one across restarts.
 
         Args:
             path (str):

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
@@ -122,42 +122,42 @@ class VectorSearchEngine(ABC):
     @abstractmethod
     async def save(self, path: str) -> None:
         """
-        Persist the index to `path`, atomically and durably.
+        Persist the index under `path`, durably.
 
-        Write elsewhere, flush, and replace `path` in one step, so a crash
-        leaves either the previous index or the new one and never a partial
-        file — then make that replacement durable by whatever means the
-        platform provides.
+        Returning must mean that a later `load` produces this index even if the
+        machine loses power on the next instruction. Not "written", not "handed
+        to the OS", not "renamed on a filesystem that has yet to flush the
+        directory". The caller trims its pending-operation log — the only other
+        copy of these vectors — as soon as this returns, so anything weaker
+        loses data.
 
-        The caller trims its pending-operation log — its only other copy of
-        these vectors — once this returns, so an implementation that merely
-        writes and flushes, leaving a half-written file reachable at `path`,
-        does not satisfy this. An engine whose backend implements the whole
-        protocol natively may delegate to it; the rest should use
-        `index_persistence.atomic_index_write`, which implements it against a
-        backend that can only write to a path.
+        Durability is entirely the implementation's, including which artifact is
+        live: nothing about the layout may leak out, and the caller keeps no
+        pointer, manifest, or generation of its own. `path` is therefore a base
+        name rather than a promise about the files on disk — an engine may keep
+        one file, two slots, or a set of segments under it.
 
-        "As durably as the platform allows" is deliberate rather than a hedge.
-        On POSIX the replacement is made durable by fsyncing the parent
-        directory. Windows has no equivalent operation, so the replacement is
-        atomic through NTFS metadata journaling but is not necessarily flushed
-        when the call returns.
+        `index_persistence.publish_index` provides this for a backend that can
+        only write an index to a path; an engine whose backend publishes durably
+        on its own may delegate to that instead.
 
         Args:
             path (str):
-                File path to write the index to.
+                Base path for the index files.
         """
 
     @abstractmethod
     async def load(self, path: str) -> None:
         """
-        Load the index from disk.
+        Load the index most recently published under `path`.
 
-        Implementations should clear any temp file a previously interrupted
-        save left beside `path` (`index_persistence.clear_stale_index_temp`),
-        so a crash does not leak one across restarts.
+        Raising is correct when nothing is published or the published index does
+        not parse. Implementations must **not** substitute an older copy they
+        may still hold: the caller trimmed its log against the published one, so
+        an older copy is stale by exactly the operations that can no longer be
+        replayed, and serving it would be data loss dressed as success.
 
         Args:
             path (str):
-                File path to read the index from.
+                Base path for the index files.
         """

--- a/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
@@ -616,13 +616,28 @@ class VectorStoreSemanticStorage(SemanticStorage):
         )
 
     async def _get_existing_vector_record(self, feature_id: FeatureIdT) -> Record:
+        """Read back a feature's stored embedding.
+
+        A vector store publishes its index atomically but not durably (see
+        `common.vector_store.sqlite_vector_store`), so a power failure can
+        leave a record the store still knows about but whose vector the index
+        no longer holds. The two cases are reported apart because the caller
+        can act on them differently: a missing embedding is repaired by
+        passing a fresh one to `update_feature`, while a missing record is
+        not.
+        """
         records = await self._vector_collection.get(
             record_uuids=[feature_vector_uuid(feature_id)],
             return_vector=True,
             return_properties=False,
         )
-        if not records or records[0].vector is None:
+        if not records:
             raise ResourceNotFoundError(f"Vector record not found: {feature_id}")
+        if records[0].vector is None:
+            raise ResourceNotFoundError(
+                f"Vector record {feature_id} has no stored embedding; "
+                "pass an embedding to update this feature"
+            )
         return records[0]
 
     async def _delete_vector_records(self, feature_ids: Sequence[FeatureIdT]) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,7 @@ name = "blis"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/d0/d8cc8c9a4488a787e7fa430f6055e5bd1ddb22c340a751d9e901b82e2efe/blis-1.3.3.tar.gz", hash = "sha256:034d4560ff3cc43e8aa37e188451b0440e3261d989bb8a42ceee865607715ecd", size = 2644873, upload-time = "2025-11-17T12:28:30.511Z" }
 wheels = [
@@ -839,7 +839,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -870,43 +870,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -973,46 +973,12 @@ wheels = [
 ]
 
 [[package]]
-name = "datasets"
-version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dill" },
-    { name = "filelock" },
-    { name = "fsspec", extra = ["http"] },
-    { name = "httpx" },
-    { name = "huggingface-hub" },
-    { name = "multiprocess" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "xxhash" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/85/ce4f780c32f7e36d71257f1c27e8ba898ebe379cb54f211f5f2013f2c219/datasets-5.0.0.tar.gz", hash = "sha256:83dbbbdb07a33b82192b8c419deb18739b138ee2ce1a322d55ce6b100954ec1a", size = 631708, upload-time = "2026-06-05T13:18:26.124Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/66/73034ad30b59f13439b75e620989dacba4c047256e358ba7c2e9ec98ea22/datasets-5.0.0-py3-none-any.whl", hash = "sha256:7dd34927a0fd7046e98aad5cb9430e699c373238a15befa7b9bf22b991a7fee6", size = 555084, upload-time = "2026-06-05T13:18:24.435Z" },
-]
-
-[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
-]
-
-[[package]]
-name = "dill"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
 ]
 
 [[package]]
@@ -1393,11 +1359,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
-]
-
-[package.optional-dependencies]
-http = [
-    { name = "aiohttp" },
 ]
 
 [[package]]
@@ -2246,7 +2207,6 @@ dependencies = [
     { name = "boto3" },
     { name = "boto3-stubs" },
     { name = "cohere" },
-    { name = "datasets" },
     { name = "dotenv" },
     { name = "fastapi" },
     { name = "fastmcp" },
@@ -2293,6 +2253,9 @@ nebula = [
 qdrant = [
     { name = "qdrant-client" },
 ]
+turbovec = [
+    { name = "turbovec" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2303,7 +2266,6 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.40.40" },
     { name = "boto3-stubs", specifier = "==1.43.13" },
     { name = "cohere", specifier = ">=5.20.0" },
-    { name = "datasets", specifier = ">=5.0.0" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "fastmcp", specifier = ">=3.2.0" },
@@ -2332,11 +2294,12 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'gpu'", specifier = ">=5.1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.43" },
     { name = "sqlite-vec", specifier = ">=0.1.9" },
+    { name = "turbovec", marker = "extra == 'turbovec'", specifier = ">=0.7.0" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.1" },
     { name = "usearch", specifier = ">=2.25.1" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
-provides-extras = ["gpu", "hnswlib", "nebula", "qdrant", "milvus", "litellm"]
+provides-extras = ["gpu", "hnswlib", "nebula", "qdrant", "milvus", "litellm", "turbovec"]
 
 [[package]]
 name = "milvus-lite"
@@ -2487,23 +2450,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
-]
-
-[[package]]
-name = "multiprocess"
-version = "0.70.19"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dill" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/45/8004d1e6b9185c1a444d6b55ac5682acf9d98035e54386d967366035a03a/multiprocess-0.70.19-py310-none-any.whl", hash = "sha256:97404393419dcb2a8385910864eedf47a3cadf82c66345b44f036420eb0b5d87", size = 134948, upload-time = "2026-01-19T06:47:32.325Z" },
-    { url = "https://files.pythonhosted.org/packages/86/c2/dec9722dc3474c164a0b6bcd9a7ed7da542c98af8cabce05374abab35edd/multiprocess-0.70.19-py311-none-any.whl", hash = "sha256:928851ae7973aea4ce0eaf330bbdafb2e01398a91518d5c8818802845564f45c", size = 144457, upload-time = "2026-01-19T06:47:33.711Z" },
-    { url = "https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl", hash = "sha256:3a56c0e85dd5025161bac5ce138dcac1e49174c7d8e74596537e729fd5c53c28", size = 150281, upload-time = "2026-01-19T06:47:35.037Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/74/d2c27e03cb84251dfe7249b8e82923643c6d48fa4883b9476b025e7dc7eb/multiprocess-0.70.19-py313-none-any.whl", hash = "sha256:8d5eb4ec5017ba2fab4e34a747c6d2c2b6fecfe9e7236e77988db91580ada952", size = 156414, upload-time = "2026-01-19T06:47:35.915Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl", hash = "sha256:e8cc7fbdff15c0613f0a1f1f8744bef961b0a164c0ca29bdff53e9d2d93c5e5f", size = 160318, upload-time = "2026-01-19T06:47:37.497Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
 ]
 
 [[package]]
@@ -2752,7 +2698,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2791,7 +2737,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2803,7 +2749,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2833,9 +2779,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2847,7 +2793,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3115,8 +3061,8 @@ name = "preshed"
 version = "3.0.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cymem" },
-    { name = "murmurhash" },
+    { name = "cymem", marker = "python_full_version < '3.14'" },
+    { name = "murmurhash", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/75/fe6b7bbd0dea530a001b0e24c331b21a0be2786e402abf3c57f5dce43d4b/preshed-3.0.13.tar.gz", hash = "sha256:d75f718bbfd97e992f7827e0fa7faf6a91bdd9c922d5baa4b50d62731396cb89", size = 18338, upload-time = "2026-03-23T08:57:31.378Z" }
 wheels = [
@@ -4135,8 +4081,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -4194,7 +4140,7 @@ name = "smart-open"
 version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt" },
+    { name = "wrapt", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/3e/79fd5fd2375a8a500b9ec2f6a0762fc1ac33e35582d4a87483a78d19408f/smart_open-8.0.0.tar.gz", hash = "sha256:5a2008d60688bd3b33c52e2ef666d3c60cf956e73e215de8c7b242cf56fdd1b2", size = 61520, upload-time = "2026-06-27T16:28:11.894Z" }
 wheels = [
@@ -4215,25 +4161,25 @@ name = "spacy"
 version = "3.8.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "catalogue" },
-    { name = "confection" },
-    { name = "cymem" },
-    { name = "jinja2" },
-    { name = "murmurhash" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "preshed" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "setuptools" },
-    { name = "spacy-legacy" },
-    { name = "spacy-loggers" },
-    { name = "srsly" },
-    { name = "thinc" },
-    { name = "tqdm" },
-    { name = "typer" },
-    { name = "wasabi" },
-    { name = "weasel" },
+    { name = "catalogue", marker = "python_full_version < '3.14'" },
+    { name = "confection", marker = "python_full_version < '3.14'" },
+    { name = "cymem", marker = "python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version < '3.14'" },
+    { name = "murmurhash", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "preshed", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "setuptools", marker = "python_full_version < '3.14'" },
+    { name = "spacy-legacy", marker = "python_full_version < '3.14'" },
+    { name = "spacy-loggers", marker = "python_full_version < '3.14'" },
+    { name = "srsly", marker = "python_full_version < '3.14'" },
+    { name = "thinc", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "typer", marker = "python_full_version < '3.14'" },
+    { name = "wasabi", marker = "python_full_version < '3.14'" },
+    { name = "weasel", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/78/e4f2ae19a791cae756cd0e801204953eaec4e9ab75a60ad39f671dbb8d5a/spacy-3.8.14-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:726f02c60a2c6b0029167370d22d51731172a053d29c7e2ea6190db6de3ab483", size = 6218335, upload-time = "2026-03-29T10:40:46.298Z" },
@@ -4329,7 +4275,7 @@ name = "srsly"
 version = "2.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "catalogue" },
+    { name = "catalogue", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/db/f794f219a6c788b881252d2536a8c4a97d2bdaadc690391e1cb53d123d71/srsly-2.5.3.tar.gz", hash = "sha256:08f98dbecbff3a31466c4ae7c833131f59d3655a0ad8ac749e6e2c149e2b0680", size = 490881, upload-time = "2026-03-23T11:56:59.865Z" }
 wheels = [
@@ -4443,18 +4389,18 @@ name = "thinc"
 version = "8.3.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "blis" },
-    { name = "catalogue" },
-    { name = "confection" },
-    { name = "cymem" },
-    { name = "murmurhash" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "preshed" },
-    { name = "pydantic" },
-    { name = "setuptools" },
-    { name = "srsly" },
-    { name = "wasabi" },
+    { name = "blis", marker = "python_full_version < '3.14'" },
+    { name = "catalogue", marker = "python_full_version < '3.14'" },
+    { name = "confection", marker = "python_full_version < '3.14'" },
+    { name = "cymem", marker = "python_full_version < '3.14'" },
+    { name = "murmurhash", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "preshed", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "setuptools", marker = "python_full_version < '3.14'" },
+    { name = "srsly", marker = "python_full_version < '3.14'" },
+    { name = "wasabi", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/46/76df95f2c327f9a9cef30c1523bf285627897097163584dcf5f77b2ebce2/thinc-8.3.13.tar.gz", hash = "sha256:68e658549fc1eb3ff92aed5147fcbb9c15d6e9cc0e623b4d0998d16522ffb4f9", size = 194640, upload-time = "2026-03-23T07:22:36.41Z" }
 wheels = [
@@ -4695,6 +4641,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
     { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
     { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
+]
+
+[[package]]
+name = "turbovec"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/d2/00c981bd1a6be5b6a875435bf678e627f191e3daf47ea70e1b5ee3109c36/turbovec-1.0.0.tar.gz", hash = "sha256:4ceb3c4ad08e48c6b3483b88aca63d81a06449f90d5fbc1b162dd11df10b8fb2", size = 702952, upload-time = "2026-08-18T20:43:31.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/e0/d759918244236356199b0f4d868ee331d0440a9824f147780aaefa8fe1af/turbovec-1.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:a69e8e2e26ba943f31fba546ab595b60e9b4c25087ed905c3e6ceb0d297ee234", size = 668359, upload-time = "2026-08-18T20:43:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e9/8de1e7d2636a8f5c73d39c64ec6fb4bd20180d8c966962d919356d06e175/turbovec-1.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:09aa495e802701f139820e21700dc947ea21734446112afefb4e480a8f65fa90", size = 700020, upload-time = "2026-08-18T20:43:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/6d/c1acf31a1ef381b588de86ebebb32c3ca7d310cbb84279ac1f65c3a3e854/turbovec-1.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c810f50b967c2163b78d1e27d29e153ab5e8820de23921ad959227acca8bb06a", size = 719275, upload-time = "2026-08-18T20:43:28.402Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/7d/e0c14b09f6dfb7ff156d1f884119daebc5c8bf9f5b8fc72ada26c2674256/turbovec-1.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:cd855e0b318a57dc57c733f9a62ae98de5192f4f6c2c760e305523e8ceb1b090", size = 611788, upload-time = "2026-08-18T20:43:29.854Z" },
 ]
 
 [[package]]
@@ -4947,7 +4908,7 @@ name = "wasabi"
 version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/054e6e2f1071e963b5e746b48d1e3727470b2a490834d18ad92364929db3/wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878", size = 30391, upload-time = "2024-05-31T16:56:18.99Z" }
 wheels = [
@@ -5045,15 +5006,15 @@ name = "weasel"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cloudpathlib" },
-    { name = "confection" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "smart-open" },
-    { name = "srsly" },
-    { name = "typer" },
-    { name = "wasabi" },
+    { name = "cloudpathlib", marker = "python_full_version < '3.14'" },
+    { name = "confection", marker = "python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "smart-open", marker = "python_full_version < '3.14'" },
+    { name = "srsly", marker = "python_full_version < '3.14'" },
+    { name = "typer", marker = "python_full_version < '3.14'" },
+    { name = "wasabi", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/e5/e272bb9a045105a1fdf4b798d8086f5932a178f4d738f17a74f5c9e0ae9a/weasel-1.0.0.tar.gz", hash = "sha256:7b129b44c90cc543b760532974ca1e4eb30dad2aa2026f57bdce66354ae610fc", size = 38682, upload-time = "2026-03-20T08:10:25.266Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'gpu'", specifier = ">=5.1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.43" },
     { name = "sqlite-vec", specifier = ">=0.1.9" },
-    { name = "turbovec", marker = "extra == 'turbovec'", specifier = ">=0.7.0" },
+    { name = "turbovec", marker = "extra == 'turbovec'", specifier = ">=1.0.0" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.1" },
     { name = "usearch", specifier = ">=2.25.1" },
     { name = "uvicorn", specifier = ">=0.35.0" },


### PR DESCRIPTION
> **Depends on #1460** and is branched from it, so everything here except
> `Add VectorSearchEngine backed by turbovec` and `Update turbovec to 1.0.0 and
> let it publish the index` is either that PR's or a merge of `main` (taken to
> resolve `uv.lock` against the Milvus backend that landed since). Supersedes
> #1448.

### Purpose of the change

`SQLiteVectorStore` backed by turbovec is smaller and faster than
`SQLiteVecVectorStore` backed by sqlite-vec. Both are linear full scans, but
turbovec keeps TurboQuant-compressed vectors in RAM, so its scaling constant is
much smaller and an index is a fraction of the size of the f32 engines'.

### Description

Adds `TurboVecVectorSearchEngine`, a `VectorSearchEngine` backed by turbovec,
behind a new `turbovec` optional extra floored at 1.0.0. turbovec indexes a
dimensionality that is a multiple of 8, so any other width is zero-padded up to
one -- exact for both metrics here, since a zero coordinate adds nothing to an
inner product or to an L2 norm -- and every width the other engines accept
works.

Publication is turbovec's own. 1.0.0 is upstream's first stable release, and
what it commits to is the on-disk format: v7 is the only container turbovec
reads or writes, and a file written by 1.0.0 stays readable by later releases.
v7 is also what makes `sync` possible, and `save` calls it -- a checkpoint
appends what changed since the last one rather than restating the whole index,
and commits it durably, so a crash at any byte leaves the previous commit
intact and the publication survives a power failure. The engine therefore does
not route through the shared `atomic_index_write` helper that the hnswlib and
usearch engines use on #1460: wrapping `sync` would restate the index on every
checkpoint and publish it through the weaker of the two protocols, a rename the
helper's own docstring declines to make durable.

That is what supersedes #1448, which added the same engine against turbovec
0.x, whose `write` had no publication protocol of its own and wrote straight to
the final path -- an interrupted save left a truncated file where the store
expects a loadable index, and because `index_saved` makes a published index a
durable contract, that is a hard `IndexLoadError` rather than a silent rebuild.

Known limitations, both consequences of storing only compressed vectors:

- `get_vectors` raises `NotImplementedError`, since the original vectors are not
  recoverable. That makes the engine usable by EventMemory but not by semantic
  memory, whose feature updates read stored embeddings back.
- Search is approximate. A self-match lands near the exact score rather than on
  it, so the tests assert ranking and membership rather than magnitudes. The
  quantized inner product also overshoots the cosine range -- 40 of 50
  self-matches at 8 dimensions, and every dimension measured at bit width 2 --
  so `SearchMatch` scores are clamped to `[-1, 1]` under a cosine metric, which
  is what its docstring promises and what `score_threshold` compares against.
  A dot product is unbounded by contract and is not clamped.

Removal is a strong point by comparison: turbovec drops the id from its map
rather than tombstoning it, so deletions stay cheap and a removed key cannot
resurface in results.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- [x] Unit Test

`test_turbovec_engine.py` covers construction, add, remove, cosine and dot
search, filtered search, `get_vectors` raising, score range (clamped under
cosine, untouched under dot), unaligned widths (search, save/load, and a
wrong-width vector refused), and persistence -- a save/load
round-trip, a load replacing a live index, a save leaving nothing but the index
behind, and what a later checkpoint carries, reading a bulk removal and an
append back through a fresh engine. The module is `importorskip`-guarded, so the
suite still runs without the extra installed.

**Test Results:** `uv run pytest packages/server/server_tests/memmachine_server/common/vector_store`
-> 346 passed. `ruff check` and `ruff format --check` clean. The `ty` jobs are
red on `main` itself (`nebulagraph_python.client` lost the members the graph
store imports), fixed by #1519 rather than here; nothing `ty` reports is in
this diff.

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (#1460 is still open)
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected
