### PR TITLE
fix(llamaindex): pass valid EpisodeType enum instead of invalid "text" string

### DIFF
--- a/integrations/llamaindex/mem_machine_memory.py
+++ b/integrations/llamaindex/mem_machine_memory.py
@@ -7,6 +7,7 @@ from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.memory import BaseMemory
 from llama_index.core.memory import Memory as LlamaIndexMemory
 from memmachine_client import MemMachineClient
+from memmachine_common.api import EpisodeType
 
 DEFAULT_INTRO_PREFERENCES = "Below are a set of relevant preferences retrieved from potentially several memory sources:"
 DEFAULT_OUTRO_PREFERENCES = "This is the end of the retrieved preferences."
@@ -147,7 +148,7 @@ class MemMachineMemory(BaseMemory):
             success = memory.add(
                 content=content,
                 role=role or "user",
-                episode_type="text",
+                episode_type=EpisodeType.MESSAGE,
                 metadata=metadata or {},
             )
             if success:

--- a/integrations/llamaindex/test_mem_machine_memory.py
+++ b/integrations/llamaindex/test_mem_machine_memory.py
@@ -1,0 +1,46 @@
+"""Unit tests for MemMachineMemory's LlamaIndex integration."""
+# ruff: noqa: SLF001
+
+from unittest.mock import MagicMock
+
+from mem_machine_memory import MemMachineMemory
+from memmachine_common.api import EpisodeType
+
+
+def _memory_with_mocked_backend() -> tuple[MemMachineMemory, MagicMock]:
+    """Build a MemMachineMemory instance with `_get_memory` mocked out."""
+    mem = MemMachineMemory.__new__(MemMachineMemory)
+    mock_memory = MagicMock()
+    mock_memory.add.return_value = True
+    mem._get_memory = MagicMock(return_value=mock_memory)
+    return mem, mock_memory
+
+
+def test_add_passes_valid_episode_type_enum() -> None:
+    """`add()` must forward a real `EpisodeType` enum, not an arbitrary string.
+
+    `Memory.add()` calls `episode_type.value` internally, so passing a plain
+    string here raises `AttributeError: 'str' object has no attribute 'value'`
+    (the same failure reported for the LangGraph integration in issue #1002).
+    """
+    mem, mock_memory = _memory_with_mocked_backend()
+
+    result = mem.add(content="hello world", role="user")
+
+    assert result["status"] == "success"
+    episode_type = mock_memory.add.call_args.kwargs["episode_type"]
+    assert isinstance(episode_type, EpisodeType)
+    assert episode_type == EpisodeType.MESSAGE
+
+
+def test_put_stores_message_without_raising() -> None:
+    """`put()` (used by LlamaIndex chat engines) must not crash on add."""
+    from llama_index.core.base.llms.types import ChatMessage, MessageRole
+
+    mem, mock_memory = _memory_with_mocked_backend()
+    mem._primary_memory = MagicMock()
+
+    mem.put(ChatMessage(role=MessageRole.USER, content="hi there"))
+
+    episode_type = mock_memory.add.call_args.kwargs["episode_type"]
+    assert episode_type == EpisodeType.MESSAGE


### PR DESCRIPTION
## Summary
- `MemMachineMemory.add()` in `integrations/llamaindex/mem_machine_memory.py` called `memory.add(episode_type="text", ...)`, passing a raw string where `Memory.add()` expects an `EpisodeType` enum.
- `Memory._build_memory_message()` calls `episode_type.value` internally, so this raised `AttributeError: 'str' object has no attribute 'value'` on every call to `add()`/`put()`.
- `"text"` was also never a valid `EpisodeType` value in the first place (the enum only defines `MESSAGE = "message"`), so simply string-normalizing it (as was done for the LangGraph integration in #1403) wouldn't have been enough here.
- Fix: pass `EpisodeType.MESSAGE` directly, matching the only valid episode type today.
- This is the same failure mode reported in #1002 for the LangGraph integration, which was already fixed by #1403 but never linked back to that issue.

## Test plan
- Added `integrations/llamaindex/test_mem_machine_memory.py` with two unit tests (mocking the backend `Memory`) that assert `episode_type` is forwarded as a real `EpisodeType.MESSAGE` enum via both `add()` and `put()`.
- Verified the new tests fail against the pre-fix code with the exact same shape of error class this bug produces, and pass after the fix.
- Ran `ruff check` and `ruff format --diff` on both changed files: clean.