### PR TITLE
fix(semantic-memory): stop unbounded LLM retry storm on persistent extraction failures

### DIFF
--- a/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py
@@ -277,6 +277,130 @@ async def test_process_single_set_marks_context_length_errors_as_ingested(
 
 
 @pytest.mark.asyncio
+async def test_process_single_set_gives_up_on_persistent_generic_errors(
+    ingestion_service: IngestionService,
+    semantic_storage: SemanticStorage,
+    episode_storage: EpisodeStorage,
+    monkeypatch,
+):
+    """A message whose feature update fails deterministically (e.g. a
+    malformed LLM response for that specific content) must not be re-fetched
+    and re-sent to the LLM forever. Regression test for the runaway
+    background-ingestion cost reported in #1453: previously a generic
+    (non-context-length) failure left the message permanently un-ingested,
+    so every subsequent background poll cycle re-sent it to the LLM with no
+    backoff and no way to ever stop."""
+    message_id = await add_history(
+        episode_storage,
+        content="message that always fails feature extraction",
+    )
+    await semantic_storage.add_history_to_set(
+        set_id="user-poison-message",
+        history_id=message_id,
+    )
+
+    llm_feature_update_mock = AsyncMock(
+        side_effect=ValueError("structured-output validation failed")
+    )
+    monkeypatch.setattr(
+        "memmachine_server.semantic_memory.semantic_ingestion.llm_feature_update",
+        llm_feature_update_mock,
+    )
+
+    await ingestion_service._process_single_set("user-poison-message")
+
+    # Retried a bounded number of times, not once and not forever.
+    from memmachine_server.semantic_memory.semantic_ingestion import (
+        _MAX_FEATURE_UPDATE_ATTEMPTS,
+    )
+
+    assert llm_feature_update_mock.await_count == _MAX_FEATURE_UPDATE_ATTEMPTS
+
+    # Given up and marked ingested so it stops showing up as pending work.
+    assert (
+        await _collect(
+            semantic_storage.get_history_messages(
+                set_ids=["user-poison-message"],
+                is_ingested=False,
+            )
+        )
+        == []
+    )
+    assert await _collect(
+        semantic_storage.get_history_messages(
+            set_ids=["user-poison-message"],
+            is_ingested=True,
+        )
+    ) == [message_id]
+
+    # Simulate the next background poll cycle: with nothing left pending,
+    # it must not call the LLM again.
+    await ingestion_service._process_single_set("user-poison-message")
+    assert llm_feature_update_mock.await_count == _MAX_FEATURE_UPDATE_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_process_single_set_retries_and_recovers_from_transient_error(
+    ingestion_service: IngestionService,
+    semantic_storage: SemanticStorage,
+    episode_storage: EpisodeStorage,
+    semantic_category: SemanticCategory,
+    embedder_double: MockEmbedder,
+    monkeypatch,
+):
+    """A transient failure on the first attempt should not give up early —
+    the retry should recover and the message should be fully ingested."""
+    message_id = await add_history(
+        episode_storage,
+        content="I love blue cars",
+    )
+    await semantic_storage.add_history_to_set(
+        set_id="user-transient-error",
+        history_id=message_id,
+    )
+
+    commands = [
+        SemanticCommand(
+            command=SemanticCommandType.ADD,
+            feature="favorite_car",
+            tag="car",
+            value="blue",
+        ),
+    ]
+
+    async def flaky(*args, **kwargs):
+        if llm_feature_update_mock.await_count == 1:
+            raise ValueError("transient parse failure")
+        return commands
+
+    llm_feature_update_mock = AsyncMock(side_effect=flaky)
+    monkeypatch.setattr(
+        "memmachine_server.semantic_memory.semantic_ingestion.llm_feature_update",
+        llm_feature_update_mock,
+    )
+
+    await ingestion_service._process_single_set("user-transient-error")
+
+    assert llm_feature_update_mock.await_count == 2
+    assert await _collect(
+        semantic_storage.get_history_messages(
+            set_ids=["user-transient-error"],
+            is_ingested=True,
+        )
+    ) == [message_id]
+
+    filter_str = (
+        f"set_id IN ('user-transient-error') "
+        f"AND category_name IN ('{semantic_category.name}')"
+    )
+    features = await _collect(
+        semantic_storage.get_feature_set(filter_expr=parse_filter(filter_str))
+    )
+    assert len(features) == 1
+    assert features[0].feature_name == "favorite_car"
+
+
+@pytest.mark.asyncio
 async def test_consolidation_groups_by_tag(
     ingestion_service: IngestionService,
     semantic_storage: SemanticStorage,

--- a/packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py
+++ b/packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py
@@ -33,6 +33,7 @@ from memmachine_server.semantic_memory.storage.storage_base import SemanticStora
 logger = logging.getLogger(__name__)
 
 _MAX_CONSOLIDATION_ATTEMPTS = 2
+_MAX_FEATURE_UPDATE_ATTEMPTS = 2
 
 
 class _ConsolidationContextLengthError(Exception):
@@ -211,32 +212,14 @@ class IngestionService:
                     )
                 ]
 
-                try:
-                    commands = await llm_feature_update(
-                        features=features,
-                        message_content=message.content,
-                        model=resources.language_model,
-                        update_prompt=semantic_category.prompt.update_prompt,
-                    )
-                except Exception as err:
-                    if _is_context_length_exceeded_error(err):
-                        logger.warning(
-                            "Skipping message %s for semantic type %s due to non-retryable context length error",
-                            message.uid,
-                            semantic_category.name,
-                        )
-                        if message.uid not in mark_messages:
-                            mark_messages.append(message.uid)
-                        continue
-
-                    logger.exception(
-                        "Failed to process message %s for semantic type %s",
-                        message.uid,
-                        semantic_category.name,
-                    )
-                    if self._debug_fail_loudly:
-                        raise
-
+                commands = await self._try_feature_update(
+                    features=features,
+                    message=message,
+                    semantic_category=semantic_category,
+                    resources=resources,
+                    mark_messages=mark_messages,
+                )
+                if commands is None:
                     continue
 
                 await self._apply_commands(
@@ -276,6 +259,74 @@ class IngestionService:
             set_id=set_id,
             resources=resources,
         )
+
+    async def _try_feature_update(
+        self,
+        *,
+        features: list[SemanticFeature],
+        message: Episode,
+        semantic_category: InstanceOf[SemanticCategory],
+        resources: InstanceOf[Resources],
+        mark_messages: list[EpisodeIdT],
+    ) -> list[SemanticCommand] | None:
+        """Call llm_feature_update with bounded retry on transient failures.
+
+        Mirrors ``_try_consolidate``: a context-length error is non-retryable
+        and gives up immediately. A generic exception is retried up to
+        ``_MAX_FEATURE_UPDATE_ATTEMPTS`` times. In both give-up cases the
+        message is still appended to ``mark_messages`` so a persistently
+        failing ("poison") message is not re-fetched and re-sent to the LLM
+        on every background poll cycle forever — without this, a message
+        that fails deterministically would retry unbounded at the fast
+        idle-polling interval instead of the outer loop's error backoff.
+        Raises instead of giving up when ``debug_fail_loudly`` is set and
+        the final failure was not a context-length error.
+        """
+        for attempt in range(1, _MAX_FEATURE_UPDATE_ATTEMPTS + 1):
+            try:
+                return await llm_feature_update(
+                    features=features,
+                    message_content=message.content,
+                    model=resources.language_model,
+                    update_prompt=semantic_category.prompt.update_prompt,
+                )
+            except Exception as err:
+                if _is_context_length_exceeded_error(err):
+                    logger.warning(
+                        "Skipping message %s for semantic type %s due to non-retryable context length error",
+                        message.uid,
+                        semantic_category.name,
+                    )
+                    if message.uid not in mark_messages:
+                        mark_messages.append(message.uid)
+                    return None
+
+                if attempt < _MAX_FEATURE_UPDATE_ATTEMPTS:
+                    logger.warning(
+                        "Feature update raised %s on attempt %d/%d for message %s, semantic type %s, retrying",
+                        type(err).__name__,
+                        attempt,
+                        _MAX_FEATURE_UPDATE_ATTEMPTS,
+                        message.uid,
+                        semantic_category.name,
+                    )
+                    continue
+
+                logger.exception(
+                    "Failed to process message %s for semantic type %s after %d attempts; "
+                    "marking as ingested to stop repeated background retries",
+                    message.uid,
+                    semantic_category.name,
+                    _MAX_FEATURE_UPDATE_ATTEMPTS,
+                )
+                if self._debug_fail_loudly:
+                    raise
+
+                if message.uid not in mark_messages:
+                    mark_messages.append(message.uid)
+                return None
+
+        return None  # pragma: no cover - loop always returns or raises above
 
     async def _apply_commands(
         self,


### PR DESCRIPTION
## Summary
Fixes #1453 (reported ~$200 in unexpected LLM cost from background semantic/profile ingestion running for many hours with no user activity).

Root cause, traced in `packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py`:
- The background ingestion loop (`semantic_memory.py::_background_ingestion_task`) polls every `feature_update_interval_sec` (default **2 seconds**) for any set with un-ingested messages.
- Per-message idempotency already exists via an `is_ingested` flag — once a message is successfully processed (or hits a non-retryable context-length error), it's marked ingested and won't be re-fetched.
- But when `llm_feature_update` failed with any *other* exception (a transient API error, a malformed/unparseable LLM response for that specific content, etc.), the code logged it and `continue`d **without marking the message ingested**.
- That message stays `is_ingested=False` forever, so the very next poll cycle (2 seconds later) fetches it again and calls the LLM again — forever, with no backoff, since the exception is swallowed locally and never reaches the outer loop's error-backoff handling.
- A single message that fails deterministically for the same input (which is plausible — malformed JSON output, a specific content pattern the LLM mishandles, etc.) therefore becomes an unbounded retry storm: thousands of LLM calls over hours from a single stuck message, matching the reporter's symptom exactly.

## Fix
- Added `_try_feature_update`, mirroring the existing `_try_consolidate` bounded-retry pattern already used for the consolidation path in the same file.
- A generic failure is now retried up to `_MAX_FEATURE_UPDATE_ATTEMPTS` (2, matching `_MAX_CONSOLIDATION_ATTEMPTS`) times.
- Once retries are exhausted, the message is marked ingested — same treatment already given to non-retryable context-length errors — so a persistently failing message stops being re-fetched instead of retrying every 2 seconds forever.
- `debug_fail_loudly` still raises instead of silently giving up, unchanged behavior for that flag.
- This does not address the other (larger, separately-scoped) asks in the issue — cost/concurrency budgets, a queue/status API, content-hash dedup for resubmitted history. Those are legitimate follow-ups but a bigger feature than this bug fix.

## Test plan
- Added `test_process_single_set_gives_up_on_persistent_generic_errors`: simulates a message whose feature update fails every time, asserts the LLM is called only `_MAX_FEATURE_UPDATE_ATTEMPTS` times (not once, not forever), that the message ends up marked ingested, and that a second `_process_single_set` call (simulating the next poll cycle) makes zero further LLM calls.
- Added `test_process_single_set_retries_and_recovers_from_transient_error`: fails once then succeeds, asserts the retry recovers and the feature is correctly applied.
- Verified both new tests **fail against the pre-fix code** (confirming they catch the real bug: 1 call instead of the expected bounded retries, no backoff before infinite reprocessing) and pass after the fix.
- Ran the full `semantic_memory` test suite (`uv run pytest packages/server/server_tests/memmachine_server/semantic_memory/`): 349 passed, 2 skipped (pre-existing, unrelated), integration tests requiring Postgres/Neo4j deselected as usual.
- `ruff check` and `ruff format --diff` on both changed files: clean.