### PR TITLE
fix: substitute the retrieval agent model in memmachine-compose.sh

### DIFF
--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -262,6 +262,7 @@ generate_config_for_provider() {
         current_section = ""
         in_episodic = 0
         in_semantic = 0
+        in_retrieval = 0
         in_long_term = 0
         in_short_term = 0
     }
@@ -290,7 +291,7 @@ generate_config_for_provider() {
     }
     
     # Exit embedders/language_models when hitting another 2-space section
-    /^  [a-zA-Z_][a-zA-Z0-9_]*:$/ && !/^  (embedders|language_models):$/ && !in_episodic && !in_semantic {
+    /^  [a-zA-Z_][a-zA-Z0-9_]*:$/ && !/^  (embedders|language_models):$/ && !in_episodic && !in_semantic && !in_retrieval {
         if (in_model_section || in_embedder_section) {
             print ""
             in_model_section = 0
@@ -328,6 +329,12 @@ generate_config_for_provider() {
             in_semantic = 0
         }
         
+        if (current_section == "retrieval_agent") {
+            in_retrieval = 1
+        } else {
+            in_retrieval = 0
+        }
+
         print
         next
     }
@@ -426,6 +433,16 @@ generate_config_for_provider() {
         next
     }
     
+    # Handle retrieval_agent section - update model reference
+    in_retrieval {
+        if (/^  llm_model:/) {
+            print "  llm_model: " model_name
+            next
+        }
+        print
+        next
+    }
+
     # Default: print all other lines
     { print }
 AWK_SCRIPT


### PR DESCRIPTION
### Purpose of the change

memmachine-compose.sh generates configuration.yml from the sample
templates and rewrites every provider-specific model reference so that it
matches the provider the user selected. The awk program that performs the
rewrite tracked only the episodic_memory and semantic_memory sections, so
the top-level retrieval_agent section was copied through verbatim. Both
templates hardcode openai_model there:
```yaml
    retrieval_agent:
      llm_model: openai_model
      reranker: my_reranker_id
```
As a result, every provider other than OPENAI produced a configuration in
which the retrieval agent still pointed at the OpenAI language model even
though the rest of the file had been switched over. Selecting the OLLAMA
provider, for example, yielded:
```yaml
    episodic_memory:
      short_term_memory:
        llm_model: ollama_model      # rewritten
    semantic_memory:
      llm_model: ollama_model        # rewritten
    retrieval_agent:
      llm_model: openai_model        # left behind
```
With this change, the llm_model in retrieval_agent is correctly fixed as
follows.
```yaml
    episodic_memory:
      short_term_memory:
        llm_model: ollama_model
    semantic_memory:
      llm_model: ollama_model
    retrieval_agent:
      llm_model: ollama_model        # correctly fixed
```
The reranker in retrieval_agent needs no substitution, because
my_reranker_id fuses the vector-search order with a local bm25 ranking
and calls neither a language model nor an embedder.

### Fixes/Closes

N/A

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Manual verification (list step-by-step instructions)

```sh
$ ./memmachine-compose.sh                      # select OLLAMA
$ grep -A2 '^retrieval_agent:' configuration.yml
```

**Test Results:**
- `llm_model: openai_model` before the change
- `llm_model: ollama_model` after.

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected

### Screenshots/Gifs

N/A

### Further comments

None