### PR TITLE
Default the episodic long-term memory backend to event memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,9 @@ ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SCM_VERSION}
 # Install dependencies into a virtual environment, but NOT the project itself
 RUN --mount=type=cache,target=/root/.cache/uv \
     if [ "$GPU" = "true" ]; then \
-        uv sync --frozen --package memmachine-server --no-install-workspace --no-editable --no-dev --extra gpu; \
+        uv sync --frozen --package memmachine-server --no-install-workspace --no-editable --no-dev --extra gpu --extra qdrant; \
     else \
-        uv sync --frozen --package memmachine-server --no-install-workspace --no-editable --no-dev; \
+        uv sync --frozen --package memmachine-server --no-install-workspace --no-editable --no-dev --extra qdrant; \
     fi
 
 # Copy the application source code
@@ -40,9 +40,9 @@ COPY . /app
 # Install the project itself from the local source
 RUN --mount=type=cache,target=/root/.cache/uv \
     if [ "$GPU" = "true" ]; then \
-        uv sync --frozen --package memmachine-server --no-editable --no-dev --extra gpu; \
+        uv sync --frozen --package memmachine-server --no-editable --no-dev --extra gpu --extra qdrant; \
     else \
-        uv sync --frozen --package memmachine-server --no-editable --no-dev; \
+        uv sync --frozen --package memmachine-server --no-editable --no-dev --extra qdrant; \
     fi
 
 #

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ See the [MCP documentation](https://docs.memmachine.ai/integrations/mcp) for set
 
 - **Multiple Memory Types**: Working (short-term), Episodic (long-term conversational), and Profile (user facts) memory
 - **Developer-Friendly APIs**: Python SDK, RESTful API, TypeScript SDK, and MCP server interfaces
-- **Flexible Storage**: Graph database (Neo4j) for episodic memory, SQL for profiles
+- **Flexible Storage**: Vector store (Qdrant, Milvus, or SQLite) plus SQL for episodic memory, SQL for profiles; a graph database (Neo4j or NebulaGraph) backend is also available
 - **LLM Agnostic**: Works with OpenAI, Anthropic, Bedrock, Ollama, and any LLM provider
 - **Self-Hosted or Cloud**: Run locally, in Docker, or use our managed service
 

--- a/deployments/helm/README.md
+++ b/deployments/helm/README.md
@@ -1,6 +1,15 @@
 # MemMachine Helm Chart
 
-Deploys MemMachine with optional in-cluster PostgreSQL (pgvector) and Neo4j. Both databases can be replaced with external instances via `postgres.enabled=false` / `neo4j.enabled=false`.
+Deploys MemMachine with optional in-cluster PostgreSQL (pgvector), Qdrant, and Neo4j. Each database can be replaced with an external instance via `postgres.enabled=false` / `qdrant.enabled=false` / `neo4j.enabled=false`.
+
+The long-term memory backend is selected by `memmachine.longTermMemory.backend`:
+
+| Backend                | Stores used            | Enable with |
+|------------------------|------------------------|-------------|
+| `event` (**default**)  | Qdrant + PostgreSQL    | *(nothing; this is the default)* |
+| `declarative`          | Neo4j                  | `--set memmachine.longTermMemory.backend=declarative --set neo4j.enabled=true` |
+
+Only the resources the selected backend needs are written into `configuration.yml`, because MemMachine connects to and validates **every** configured resource at startup. Neo4j is therefore not deployed by default (`neo4j.enabled=false`).
 
 ## Chart Info
 
@@ -26,7 +35,8 @@ Deploys MemMachine with optional in-cluster PostgreSQL (pgvector) and Neo4j. Bot
   │   (port 8080)       │
   │                     │
   │  init: wait-for-postgres ──► postgres.host:postgres.port
-  │  init: wait-for-neo4j    ──► neo4j.host:neo4j.port
+  │  init: wait-for-qdrant   ──► qdrant.host:qdrant.port   (event backend)
+  │  init: wait-for-neo4j    ──► neo4j.host:neo4j.port     (declarative backend)
   └──────────┬──────────┘
              │ reads configuration.yml + .env from ConfigMaps
              │ reads OPENAI_API_KEY, POSTGRES_PASSWORD,
@@ -36,17 +46,18 @@ Deploys MemMachine with optional in-cluster PostgreSQL (pgvector) and Neo4j. Bot
      ┌───────┴────────┐
      │                │
      ▼                ▼
-memmachine-postgres  memmachine-neo4j       ← only if enabled: true
-(ClusterIP :5432)    (ClusterIP :7687 Bolt, :7474 HTTP, :7473 HTTPS)
-     │                │
-postgres-pvc         neo4j-pvc              ← only if enabled: true
-(/var/lib/           (/data)
+memmachine-postgres  memmachine-qdrant     memmachine-neo4j    ← only if enabled: true
+(ClusterIP :5432)    (ClusterIP :6333 REST, (ClusterIP :7687 Bolt,
+     │                :6334 gRPC)            :7474 HTTP, :7473 HTTPS)
+     │                │                      │
+postgres-pvc         qdrant-pvc             neo4j-pvc           ← only if enabled: true
+(/var/lib/           (/qdrant/storage)      (/data)
  postgresql/data)
 ```
 
-**Startup order**: Two `initContainers` (`wait-for-postgres`, `wait-for-neo4j`) use `busybox` + `nc` to poll TCP connectivity before the main container starts. The host/port probed are taken from `postgres.host`/`postgres.port` and `neo4j.host`/`neo4j.port`, so they work for both in-cluster and external endpoints.
+**Startup order**: Two `initContainers` use `busybox` + `nc` to poll TCP connectivity before the main container starts: `wait-for-postgres` always, plus `wait-for-qdrant` (event backend) or `wait-for-neo4j` (declarative backend). The host/port probed are taken from the matching `*.host`/`*.port` values, so they work for both in-cluster and external endpoints.
 
-**Network model**: When deployed in-cluster, PostgreSQL and Neo4j are only reachable inside the cluster (ClusterIP). When `enabled: false`, MemMachine connects directly to the externally configured host. Only the MemMachine API is exposed externally via a NodePort.
+**Network model**: When deployed in-cluster, PostgreSQL, Qdrant, and Neo4j are only reachable inside the cluster (ClusterIP). When `enabled: false`, MemMachine connects directly to the externally configured host. Only the MemMachine API is exposed externally via a NodePort.
 
 ---
 
@@ -58,14 +69,16 @@ postgres-pvc         neo4j-pvc              ← only if enabled: true
 |----------------------|------------|--------------------------------|---------------------------------|------------------------|
 | MemMachine           | Deployment | `memmachine-service`           | NodePort 31001 → :80 → pod:8080 | Always                 |
 | PostgreSQL (pgvector)| Deployment | `memmachine-postgres`          | ClusterIP :5432                 | `postgres.enabled=true`|
-| Neo4j                | Deployment | `memmachine-neo4j`             | ClusterIP :7687, :7474, :7473   | `neo4j.enabled=true`   |
+| Qdrant               | Deployment | `memmachine-qdrant`            | ClusterIP :6333, :6334          | `qdrant.enabled=true` (default) |
+| Neo4j                | Deployment | `memmachine-neo4j`             | ClusterIP :7687, :7474, :7473   | `neo4j.enabled=true` (off by default) |
 
 ### Persistent Storage
 
-Up to three PVCs are created, all using the same `storageClass` and `pvcSize`:
+Up to four PVCs are created, all using the same `storageClass` and `pvcSize`:
 
 | PVC name         | Mounted in     | Mount path                    | Purpose                         | Conditional?           |
 |------------------|----------------|-------------------------------|---------------------------------|------------------------|
+| `qdrant-pvc`     | Qdrant pod     | `/qdrant/storage`             | Derivative vectors and indexes  | `qdrant.enabled=true`  |
 | `neo4j-pvc`      | Neo4j pod      | `/data`                       | Graph data, indexes, plugins    | `neo4j.enabled=true`   |
 | `postgres-pvc`   | PostgreSQL pod | `/var/lib/postgresql/data`    | Relational/vector data          | `postgres.enabled=true`|
 | `memmachine-pvc` | MemMachine pod | `/app/data`                   | Application logs and data files | Always                 |
@@ -74,7 +87,7 @@ All PVCs request `ReadWriteMany` (RWX) access mode. This requires a StorageClass
 
 ### Secrets
 
-All three secrets are always created regardless of `postgres.enabled` / `neo4j.enabled`.
+All three secrets are always created regardless of `postgres.enabled` / `qdrant.enabled` / `neo4j.enabled`.
 
 | Secret name          | Keys                                          | Consumed by                                                                   |
 |----------------------|-----------------------------------------------|-------------------------------------------------------------------------------|
@@ -100,9 +113,11 @@ All three secrets are always created regardless of `postgres.enabled` / `neo4j.e
 | `templates/memmachine-configmaps.yaml` | ConfigMap × 2            | `memmachine-config` (configuration.yml) and `memmachine-env-config` (.env) |
 | `templates/neo4j-deployment.yaml`      | Deployment (neo4j)       | Neo4j with APOC + GDS plugins, PVC for data                     |
 | `templates/neo4j-service.yaml`         | Service (ClusterIP)      | Internal Neo4j access (Bolt 7687, HTTP 7474, HTTPS 7473)        |
+| `templates/qdrant-deployment.yaml`     | Deployment (qdrant)      | Qdrant vector store, PVC for storage                            |
+| `templates/qdrant-service.yaml`        | Service (ClusterIP)      | Internal Qdrant access (REST 6333, gRPC 6334)                   |
 | `templates/postgres-deployment.yaml`   | Deployment (memmachine-postgres) | PostgreSQL with pgvector, credentials from Secret           |
 | `templates/postgres-service.yaml`      | Service (ClusterIP)      | Internal PostgreSQL access on port 5432                         |
-| `templates/pvc.yaml`                   | PersistentVolumeClaim × 1–3 | `memmachine-pvc` always; `neo4j-pvc` if `neo4j.enabled`; `postgres-pvc` if `postgres.enabled` |
+| `templates/pvc.yaml`                   | PersistentVolumeClaim × 1–4 | `memmachine-pvc` always; `postgres-pvc` if `postgres.enabled`; `qdrant-pvc` if `qdrant.enabled`; `neo4j-pvc` if `neo4j.enabled` |
 | `templates/secrets.yaml`               | Secret × 3               | `postgres-secret`, `memmachine-secrets`, `neo4j-secret` — all always created |
 
 ---
@@ -121,10 +136,14 @@ episode_store:
   database: db_postgres            # references resources.databases.db_postgres
 
 episodic_memory:
-  long_term_memory:
+  long_term_memory:                # shape depends on memmachine.longTermMemory.backend
+    backend: event                 # default; "declarative" swaps the two lines below
     embedder: default_embedder     # references resources.embedders.default_embedder
     reranker: my_reranker_id       # references resources.rerankers.my_reranker_id
-    vector_graph_store: db_neo4j   # references resources.databases.db_neo4j
+    vector_store: db_qdrant        # event backend: references resources.databases.db_qdrant
+    segment_store: db_postgres     # event backend: references resources.databases.db_postgres
+  # backend: declarative
+  #   vector_graph_store: db_neo4j # declarative backend: references resources.databases.db_neo4j
   short_term_memory:
     llm_model: default_model       # references resources.language_models.default_model
     message_capacity: 500
@@ -145,7 +164,8 @@ prompt:
 resources:
   databases:
     db_postgres: { provider: postgres, config: { host, port, user, password: $POSTGRES_PASSWORD, ... } }
-    db_neo4j:    { provider: neo4j,    config: { uri, username: $NEO4J_USER, password: $NEO4J_PASSWORD, pool, ... } }
+    db_qdrant:   { provider: qdrant,   config: { host, port, grpc_port, prefer_grpc, https } }   # event backend only
+    db_neo4j:    { provider: neo4j,    config: { uri, username: $NEO4J_USER, password: $NEO4J_PASSWORD, pool, ... } }  # declarative backend only
   embedders:
     default_embedder: { provider, config: { model, api_key: $OPENAI_API_KEY, base_url, dimensions } }
   language_models:
@@ -156,7 +176,7 @@ resources:
     bm_ranker_id:     { provider: bm25 }
 ```
 
-Resource IDs used in top-level sections (`default_model`, `default_embedder`, `db_postgres`, `db_neo4j`, `my_reranker_id`) are resolved under `resources.*`.
+Resource IDs used in top-level sections (`default_model`, `default_embedder`, `db_postgres`, `db_qdrant`, `db_neo4j`, `my_reranker_id`) are resolved under `resources.*`. Only the database resource the selected backend needs is emitted -- MemMachine connects to and validates every configured resource at startup, so an unused entry would make its server a hard dependency.
 
 ---
 
@@ -166,7 +186,7 @@ Resource IDs used in top-level sections (`default_model`, `default_embedder`, `d
 
 | Value          | Default        | Description                                                                 |
 |----------------|----------------|-----------------------------------------------------------------------------|
-| `storageClass` | `nfs-client`   | StorageClass for all three PVCs (e.g., `standard` on kind/minikube)        |
+| `storageClass` | `nfs-client`   | StorageClass for all PVCs (e.g., `standard` on kind/minikube)              |
 | `accessMode`   | `ReadWriteMany`| PVC access mode. Use `ReadWriteMany` for NFS-style RWX classes, or `ReadWriteOnce` for local/standard classes that do not support RWX. |
 | `pvcSize`      | `5Gi`          | Storage request size for each PVC                                           |
 
@@ -174,7 +194,7 @@ Resource IDs used in top-level sections (`default_model`, `default_embedder`, `d
 
 | Value                                 | Default               | Description                              |
 |---------------------------------------|-----------------------|------------------------------------------|
-| `neo4j.enabled`                       | `true`                | Deploy in-cluster Neo4j. Set to `false` to skip and use an external host |
+| `neo4j.enabled`                       | `false`               | Deploy in-cluster Neo4j. Only the `declarative` backend uses it; set to `true` together with `memmachine.longTermMemory.backend=declarative`, or point `neo4j.host` at an external instance |
 | `neo4j.host`                          | `memmachine-neo4j`    | Bolt hostname; override with external host when `enabled: false` |
 | `neo4j.port`                          | `7687`                | Bolt port; override if external uses a different port |
 | `neo4j.image`                         | `neo4j:5.23-community`| Container image                          |
@@ -191,6 +211,23 @@ Resource IDs used in top-level sections (`default_model`, `default_embedder`, `d
 | `neo4j.resources.requests.cpu`        | `500m`                | CPU request (JVM startup is CPU-intensive) |
 | `neo4j.resources.requests.memory`     | `1Gi`                 | Memory request (covers JVM heap initial 512m + overhead) |
 | `neo4j.resources.limits.memory`       | `2Gi`                 | Memory limit (covers heap.max 1G + page cache + OS overhead) |
+
+### Qdrant (`qdrant.*`)
+
+Backing vector store for the default `event` long-term memory backend.
+
+| Value                                 | Default               | Description                              |
+|---------------------------------------|-----------------------|------------------------------------------|
+| `qdrant.enabled`                      | `true`                | Deploy in-cluster Qdrant. Set to `false` to skip and use an external host |
+| `qdrant.host`                         | `memmachine-qdrant`   | Hostname; override with external host when `enabled: false` |
+| `qdrant.port`                         | `6333`                | REST port                                |
+| `qdrant.grpcPort`                     | `6334`                | gRPC port                                |
+| `qdrant.image`                        | `qdrant/qdrant:v1.19.0` | Container image                        |
+| `qdrant.preferGrpc`                   | `false`               | Use gRPC instead of REST for client calls |
+| `qdrant.https`                        | `false`               | Use HTTPS/TLS for client calls           |
+| `qdrant.resources.requests.cpu`       | `250m`                | CPU request                              |
+| `qdrant.resources.requests.memory`    | `512Mi`               | Memory request                           |
+| `qdrant.resources.limits.memory`      | `2Gi`                 | Memory limit                             |
 
 ### PostgreSQL (`postgres.*`)
 
@@ -217,6 +254,7 @@ Resource IDs used in top-level sections (`default_model`, `default_embedder`, `d
 | `memmachine.tag`                   | `v0.2.6-cpu`                                     | Image tag                                     |
 | `memmachine.pullPolicy`            | `IfNotPresent`                                   | Image pull policy                             |
 | `memmachine.openaiApiKey`          | `<OPENAI_API_KEY>`                               | Stored in `memmachine-secrets`; injected as `OPENAI_API_KEY` env var and used as `api_key` for LLM and embedder |
+| `memmachine.longTermMemory.backend` | `event`                                         | Long-term memory backend: `event` (Qdrant + PostgreSQL) or `declarative` (Neo4j; also set `neo4j.enabled=true`) |
 | `memmachine.config.loggingLevel`   | `INFO`                                           | Controls `FAST_MCP_LOG_LEVEL` env var         |
 | `memmachine.config.memoryConfigPath` | `/app/configuration.yml`                       | Path to configuration.yml inside the container |
 | `memmachine.config.baseUrl`        | `http://127.0.0.1:8080`                          | `MCP_BASE_URL` env var                        |

--- a/deployments/helm/templates/memmachine-configmaps.yaml
+++ b/deployments/helm/templates/memmachine-configmaps.yaml
@@ -6,6 +6,12 @@
 #      application configuration: database connections, LLM/embedder resource
 #      definitions, reranker pipeline, episodic/semantic memory settings, and
 #      session manager. Values are templated from values.yaml.
+#      The long-term memory backend is selected by
+#      memmachine.longTermMemory.backend: "event" (default) wires the
+#      VectorStore + SegmentStore pair (db_qdrant + db_postgres), while
+#      "declarative" wires the VectorGraphStore (db_neo4j). Only the resource
+#      the selected backend needs is emitted, because every configured
+#      resource is connected and validated at startup.
 #
 #   2. memmachine-env-config
 #      Generates /app/.env with non-secret env vars (POSTGRES_HOST, POSTGRES_PORT,
@@ -29,9 +35,18 @@ data:
 
     episodic_memory:
       long_term_memory:
+        {{- if eq .Values.memmachine.longTermMemory.backend "event" }}
+        backend: event
+        embedder: default_embedder
+        reranker: my_reranker_id
+        vector_store: db_qdrant
+        segment_store: db_postgres
+        {{- else }}
+        backend: declarative
         embedder: default_embedder
         reranker: my_reranker_id
         vector_graph_store: db_neo4j
+        {{- end }}
       short_term_memory:
         llm_model: default_model
         message_capacity: 500
@@ -64,6 +79,16 @@ data:
             pool_timeout: {{ .Values.postgres.pool_timeout }}
             pool_recycle: {{ .Values.postgres.pool_recycle }}
             pool_pre_ping: {{ .Values.postgres.pool_pre_ping }}
+        {{- if eq .Values.memmachine.longTermMemory.backend "event" }}
+        db_qdrant:
+          provider: qdrant
+          config:
+            host: {{ .Values.qdrant.host }}
+            port: {{ .Values.qdrant.port }}
+            grpc_port: {{ .Values.qdrant.grpcPort }}
+            prefer_grpc: {{ .Values.qdrant.preferGrpc }}
+            https: {{ .Values.qdrant.https }}
+        {{- else }}
         db_neo4j:
           provider: neo4j
           config:
@@ -78,6 +103,7 @@ data:
             {{- if ne .Values.neo4j.pool.liveness_check_timeout nil }}
             liveness_check_timeout: {{ .Values.neo4j.pool.liveness_check_timeout }}
             {{- end }}
+        {{- end }}
       embedders:
         default_embedder:
           provider: "{{ .Values.memmachine.embedder.provider }}"

--- a/deployments/helm/templates/memmachine-deployment.yaml
+++ b/deployments/helm/templates/memmachine-deployment.yaml
@@ -25,10 +25,17 @@ spec:
         - name: wait-for-postgres
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -zv {{ .Values.postgres.host }} {{ .Values.postgres.port }}; do echo waiting for postgres; sleep 2; done']
+{{- if eq .Values.memmachine.longTermMemory.backend "event" }}
+
+        - name: wait-for-qdrant
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -zv {{ .Values.qdrant.host }} {{ .Values.qdrant.port }}; do echo waiting for qdrant; sleep 2; done']
+{{- else }}
 
         - name: wait-for-neo4j
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -zv {{ .Values.neo4j.host }} {{ .Values.neo4j.port }}; do echo waiting for neo4j; sleep 2; done']
+{{- end }}
 
       containers:
         - name: memmachine

--- a/deployments/helm/templates/pvc.yaml
+++ b/deployments/helm/templates/pvc.yaml
@@ -1,7 +1,8 @@
 # pvc.yaml
-# Defines three PersistentVolumeClaims (all ReadWriteMany), one per stateful component:
+# Defines one PersistentVolumeClaim (all ReadWriteMany) per enabled stateful component:
 #   - neo4j-pvc      → mounted at /data in the Neo4j pod
 #   - postgres-pvc   → mounted at /var/lib/postgresql/data in the PostgreSQL pod
+#   - qdrant-pvc     → mounted at /qdrant/storage in the Qdrant pod
 #   - memmachine-pvc → mounted at /app/data in the MemMachine pod (logs/data)
 # All PVCs use the same storageClass and pvcSize from values.yaml.
 # ReadWriteMany (RWX) requires an NFS-backed or similarly capable StorageClass.
@@ -27,6 +28,21 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: postgres-pvc
+  namespace: {{ $namespace }}
+spec:
+  accessModes:
+    - {{ .Values.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.pvcSize }}
+  storageClassName: {{ .Values.storageClass }}
+{{- end }}
+{{- if .Values.qdrant.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qdrant-pvc
   namespace: {{ $namespace }}
 spec:
   accessModes:

--- a/deployments/helm/templates/qdrant-deployment.yaml
+++ b/deployments/helm/templates/qdrant-deployment.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.qdrant.enabled }}
+# qdrant-deployment.yaml
+# Deploys Qdrant (1 replica), the VectorStore backing the event long-term
+# memory backend (memmachine.longTermMemory.backend: event, the default).
+# Data is persisted to the qdrant-pvc PVC at /qdrant/storage.
+# Exposes: REST (6333), gRPC (6334).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qdrant
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: qdrant
+  template:
+    metadata:
+      labels:
+        app: qdrant
+    spec:
+      containers:
+        - name: qdrant
+          image: {{ .Values.qdrant.image }}
+          ports:
+            - containerPort: 6333
+            - containerPort: 6334
+          resources:
+            {{- toYaml .Values.qdrant.resources | nindent 12 }}
+          startupProbe:
+            tcpSocket:
+              port: 6333
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            tcpSocket:
+              port: 6333
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            tcpSocket:
+              port: 6333
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          volumeMounts:
+            - name: qdrant-data
+              mountPath: /qdrant/storage
+      volumes:
+        - name: qdrant-data
+          persistentVolumeClaim:
+            claimName: qdrant-pvc
+{{- end }}

--- a/deployments/helm/templates/qdrant-service.yaml
+++ b/deployments/helm/templates/qdrant-service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.qdrant.enabled }}
+# qdrant-service.yaml
+# ClusterIP Service for internal access to Qdrant.
+# Exposes two ports:
+#   - 6333 (REST — used by MemMachine unless prefer_grpc is set)
+#   - 6334 (gRPC)
+# DNS inside the cluster: memmachine-qdrant.<namespace>.svc.cluster.local
+# The MemMachine configuration.yml connects to memmachine-qdrant:6333
+apiVersion: v1
+kind: Service
+metadata:
+  name: memmachine-qdrant
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: qdrant
+  ports:
+    - name: http
+      port: 6333
+      targetPort: 6333
+    - name: grpc
+      port: 6334
+      targetPort: 6334
+{{- end }}

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -6,18 +6,27 @@
 # secrets out-of-band (e.g., Vault, sealed-secrets); see README.
 #
 # Sections:
-#   storageClass / accessMode / pvcSize     - shared PVC settings for all three volumes
+#   storageClass / accessMode / pvcSize     - shared PVC settings for all volumes
 #   neo4j.*                    - Neo4j image, auth, JVM heap, and connection pool
 #   postgres.*                 - PostgreSQL image, credentials, and pool settings
+#   qdrant.*                   - Qdrant image and connection settings
 #   memmachine.*               - App image, LLM/embedder backend, and app config
 #   nodePorts.*                - NodePort assignments for external access
+#
+# Long-term memory backend: memmachine.longTermMemory.backend selects between
+# the event backend (default; Qdrant + PostgreSQL) and the declarative backend
+# (Neo4j). Switching to "declarative" also requires neo4j.enabled: true (or an
+# external Neo4j via neo4j.host).
 
 storageClass: nfs-client
 accessMode: ReadWriteMany
 pvcSize: 5Gi
 
 neo4j:
-  enabled: true              # false = skip in-cluster Deployment/Service/PVC, use external host
+  # Only needed by the declarative long-term memory backend, which is no longer
+  # the default -- set memmachine.longTermMemory.backend: declarative and flip
+  # this to true (or point neo4j.host at an external instance) to use it.
+  enabled: false             # false = skip in-cluster Deployment/Service/PVC, use external host
   host: memmachine-neo4j     # internal service name (default); override when enabled: false
   port: 7687                 # default Bolt port; override if external uses different port
   image: neo4j:5.23-community
@@ -61,6 +70,21 @@ postgres:
     limits:
       memory: 2Gi
 
+qdrant:
+  enabled: true              # false = skip in-cluster Deployment/Service/PVC, use external host
+  host: memmachine-qdrant    # internal service name (default); override when enabled: false
+  port: 6333                 # REST port
+  grpcPort: 6334             # gRPC port
+  image: qdrant/qdrant:v1.19.0
+  preferGrpc: false
+  https: false
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      memory: 2Gi
+
 memmachine:
   image: docker.io/memmachine/memmachine
   tag: latest-cpu
@@ -72,6 +96,10 @@ memmachine:
     limits:
       memory: 2Gi
   openaiApiKey: <OPENAI_API_KEY>
+  longTermMemory:
+    # "event" (default): VectorStore + SegmentStore, i.e. Qdrant + PostgreSQL.
+    # "declarative": VectorGraphStore, i.e. Neo4j (also set neo4j.enabled: true).
+    backend: event
   config:
     loggingLevel: INFO
     memoryConfigPath: /app/configuration.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,13 @@ services:
     networks:
       - memmachine-network
 
-  # Neo4j database for graph storage
+  # Neo4j database for graph storage.
+  # Only the declarative long-term memory backend uses it, and that is no longer
+  # the default, so it sits behind a compose profile. To run it, switch
+  # configuration.yml back to `backend: declarative` and start with:
+  #   docker compose --profile declarative up
   neo4j:
+    profiles: ["declarative"]
     image: neo4j:5.23-community
     container_name: memmachine-neo4j
     restart: unless-stopped
@@ -53,6 +58,27 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
+    networks:
+      - memmachine-network
+
+  # Qdrant vector store for the event-backed episodic memory
+  qdrant:
+    image: ${QDRANT_IMAGE:-qdrant/qdrant:v1.19.0}
+    container_name: memmachine-qdrant
+    restart: unless-stopped
+    ports:
+      - "${QDRANT_PORT:-6333}:6333"  # HTTP / REST
+      - "${QDRANT_GRPC_PORT:-6334}:6334"  # gRPC
+    volumes:
+      - qdrant_data:/qdrant/storage
+    healthcheck:
+      # The Qdrant image ships neither curl nor wget, so probe the HTTP port
+      # with bash's /dev/tcp instead.
+      test: ["CMD-SHELL", "bash -c ':> /dev/tcp/127.0.0.1/6333' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     networks:
       - memmachine-network
 
@@ -94,7 +120,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      neo4j:
+      qdrant:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "--fail", "--silent", "http://localhost:8080/api/v2/health"]
@@ -126,6 +152,8 @@ volumes:
   neo4j_import:
     driver: local
   neo4j_plugins:
+    driver: local
+  qdrant_data:
     driver: local
   memmachine_logs:
     driver: local

--- a/docs/install_guide/install_guide.mdx
+++ b/docs/install_guide/install_guide.mdx
@@ -17,7 +17,8 @@ Before you install the MemMachine software itself, you'll need to set up a few t
 
 - **Python 3.12+**: MemMachine requires Python version 3.12 or newer.
 - **PostgreSQL**: You will need a local PostgreSQL instance with the `pgvector` extension. You can find installation instructions on the official [PostgreSQL Downloads page](https://www.postgresql.org/download/). Once installed, create a new database and a user with full privileges for that database.
-- **Graph Database** (choose one):
+- **Vector Store**: The default long-term memory backend (`backend: event`) stores derivative embeddings in a vector store. [Qdrant](https://qdrant.tech/documentation/guides/installation/) is the default and can be started with `docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant`. Milvus and a file-backed SQLite vector store are also supported -- see the commented alternatives in the sample configuration.
+- **Graph Database** (only for the declarative backend, i.e. `backend: declarative`; choose one):
   - **Neo4j**: You can find installation instructions on the official [Neo4j Documentation page](https://neo4j.com/docs/). After installation, start the Neo4j server and set a password for the default `neo4j` user.
   - **NebulaGraph Enterprise**: An alternative to Neo4j with native vector support. See the [NebulaGraph Integration Guide](./integrate/nebula_graph_integration_guide) for setup instructions.
 
@@ -107,9 +108,11 @@ episode_store:
 
 episodic_memory:
   long_term_memory:
+    backend: event
     embedder: openai_embedder
     reranker: my_reranker_id
-    vector_graph_store: my_storage_id
+    vector_store: event_vector_store
+    segment_store: profile_storage
   short_term_memory:
     llm_model: openai_model
     message_capacity: 500
@@ -136,12 +139,12 @@ resources:
         user: postgres
         password: <YOUR_PASSWORD_HERE>
         db_name: postgres
-    my_storage_id:
-      provider: neo4j
+    event_vector_store:
+      provider: qdrant
       config:
-        uri: 'bolt://localhost:7687'
-        username: neo4j
-        password: <YOUR_PASSWORD_HERE>
+        host: localhost
+        port: 6333
+        grpc_port: 6334
     sqlite_test:
       provider: sqlite
       config:
@@ -224,9 +227,11 @@ episode_store:
 
 episodic_memory:
   long_term_memory:
+    backend: event
     embedder: openai_embedder
     reranker: my_reranker_id
-    vector_graph_store: my_storage_id
+    vector_store: event_vector_store
+    segment_store: profile_storage
   short_term_memory:
     llm_model: openai_model
     message_capacity: 500
@@ -253,12 +258,12 @@ resources:
         user: postgres
         db_name: postgres
         password: <YOUR_PASSWORD_HERE>
-    my_storage_id:
-      provider: neo4j
+    event_vector_store:
+      provider: qdrant
       config:
-        uri: 'bolt://localhost:7687'
-        username: neo4j
-        password: <YOUR_PASSWORD_HERE>
+        host: localhost
+        port: 6333
+        grpc_port: 6334
     sqlite_test:
       provider: sqlite
       config:

--- a/docs/open_source/configuration.mdx
+++ b/docs/open_source/configuration.mdx
@@ -130,7 +130,7 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
     | `long_term_memory_enabled`      | Whether long-term episodic memory is enabled.                              | `true`       |
     | `short_term_memory_enabled`     | Whether short-term episodic memory is enabled.                             | `true`       |
     | `enabled`                       | Whether episodic memory as a whole is enabled.                             | `true`       |
-    | `long_term_memory.backend`      | Long-term memory backend. Use `event` for VectorStore + SegmentStore, or `declarative` for VectorGraphStore. | `declarative` when omitted |
+    | `long_term_memory.backend`      | Long-term memory backend. Use `event` for VectorStore + SegmentStore, or `declarative` for VectorGraphStore. The shipped sample configurations and the configuration wizard set `event` explicitly; omitting the field still falls back to `declarative` for backwards compatibility with pre-discriminator configs. | `declarative` when omitted |
     | `long_term_memory.vector_store` | Event backend only: ID of a VectorStore defined in `resources.databases`. | *Required for event backend* |
     | `long_term_memory.segment_store` | Event backend only: ID of a SQL database defined in `resources.databases`. | *Required for event backend* |
     | `long_term_memory.vector_graph_store` | Declarative backend only: ID of a VectorGraphStore defined in `resources.databases`. | *Required for declarative backend* |

--- a/memmachine-compose.sh
+++ b/memmachine-compose.sh
@@ -459,6 +459,9 @@ set_config_defaults() {
 /provider:/ && /postgres/ {
   vendor = "postgres"
 }
+/provider:/ && /qdrant/ {
+  vendor = "qdrant"
+}
 
 vendor == "neo4j" && /host:/ { sub(/localhost/, "neo4j") }
 vendor == "neo4j" && /uri:/ { sub(/localhost/, "neo4j") }
@@ -469,6 +472,9 @@ vendor == "postgres" && /host:/ { sub(/localhost/, "postgres") }
 vendor == "postgres" && /user:/ { sub(/postgres/, pg_user) }
 vendor == "postgres" && /db_name:/ { sub(/postgres/, pg_db) }
 vendor == "postgres" && /password:/ { sub(/<YOUR_PASSWORD_HERE>/, pg_pass) }
+
+# Handle qdrant configurations (event long-term memory vector store)
+vendor == "qdrant" && /host:/ { sub(/localhost/, "qdrant") }
 
 { print }
 ' configuration.yml > configuration.yml.tmp && mv configuration.yml.tmp configuration.yml
@@ -830,13 +836,24 @@ wait_for_health() {
         exit 1
     fi
     
-    # Wait for Neo4j
-    print_info "Waiting for Neo4j to be ready..."
-    if timeout 120 bash -c "until docker exec memmachine-neo4j cypher-shell -u ${NEO4J_USER:-neo4j} -p ${NEO4J_PASSWORD:-neo4j_password} 'RETURN 1' > /dev/null 2>&1; do sleep 2; done"; then
-        print_success "Neo4j is ready"
+    # Wait for Qdrant (vector store for the event long-term memory backend)
+    print_info "Waiting for Qdrant to be ready..."
+    if timeout 120 bash -c "until curl -f http://localhost:${QDRANT_PORT:-6333}/healthz > /dev/null 2>&1; do sleep 2; done"; then
+        print_success "Qdrant is ready"
     else
-        print_error "Neo4j failed to become ready in 120 seconds. Check container logs and configuration."
+        print_error "Qdrant failed to become ready in 120 seconds. Check container logs and configuration."
         exit 1
+    fi
+
+    # Wait for Neo4j, but only when it was started (declarative backend profile)
+    if docker ps --format '{{.Names}}' | grep -q '^memmachine-neo4j$'; then
+        print_info "Waiting for Neo4j to be ready..."
+        if timeout 120 bash -c "until docker exec memmachine-neo4j cypher-shell -u ${NEO4J_USER:-neo4j} -p ${NEO4J_PASSWORD:-neo4j_password} 'RETURN 1' > /dev/null 2>&1; do sleep 2; done"; then
+            print_success "Neo4j is ready"
+        else
+            print_error "Neo4j failed to become ready in 120 seconds. Check container logs and configuration."
+            exit 1
+        fi
     fi
     
     # Wait for MemMachine
@@ -855,13 +872,18 @@ show_service_info() {
     echo ""
     echo "Service URLs:"
     echo "  📊 MemMachine API Docs: http://localhost:${MEMORY_SERVER_PORT:-8080}/docs"
-    echo "  🗄️  Neo4j Browser: http://localhost:${NEO4J_HTTP_PORT:-7474}"
+    if docker ps --format '{{.Names}}' | grep -q '^memmachine-neo4j$'; then
+        echo "  🗄️  Neo4j Browser: http://localhost:${NEO4J_HTTP_PORT:-7474}"
+    fi
     echo "  📈 Health Check: http://localhost:${MEMORY_SERVER_PORT:-8080}/api/v2/health"
     echo "  📊 Metrics: http://localhost:${MEMORY_SERVER_PORT:-8080}/api/v2/metrics"
     echo ""
     echo "Database Access:"
     echo "  🐘 PostgreSQL: localhost:${POSTGRES_PORT:-5432} (user: ${POSTGRES_USER:-memmachine}, db: ${POSTGRES_DB:-memmachine})"
-    echo "  🔗 Neo4j Bolt: localhost:${NEO4J_PORT:-7687} (user: ${NEO4J_USER:-neo4j})"
+    echo "  🧭 Qdrant: localhost:${QDRANT_PORT:-6333} (dashboard: http://localhost:${QDRANT_PORT:-6333}/dashboard)"
+    if docker ps --format '{{.Names}}' | grep -q '^memmachine-neo4j$'; then
+        echo "  🔗 Neo4j Bolt: localhost:${NEO4J_PORT:-7687} (user: ${NEO4J_USER:-neo4j})"
+    fi
     echo ""
     echo "Useful Commands:"
     echo "  📋 View logs: ${COMPOSE_CMD} logs -f"

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_configuration.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_configuration.py
@@ -376,10 +376,35 @@ def test_partial_merge_primary_backend_wins_over_fallback():
     assert isinstance(merged, EventLongTermMemoryConf)
 
 
-def test_existing_sample_yaml_loads_as_declarative_via_full_configuration():
-    """Existing sample YAMLs (no `backend` field) load through Configuration."""
+def test_sample_yaml_loads_as_event_via_full_configuration():
+    """The shipped sample YAMLs declare the event backend explicitly."""
     config_path = find_config_file("episodic_memory_config.cpu.sample")
     conf = Configuration.load_yml_file(str(config_path))
+    assert conf.episodic_memory.long_term_memory is not None
+    assert conf.episodic_memory.long_term_memory.backend == "event"
+    ltm_merged = LongTermMemoryConfPartial(session_id="test_session").merge(
+        conf.episodic_memory.long_term_memory
+    )
+    assert isinstance(ltm_merged, EventLongTermMemoryConf)
+    assert ltm_merged.embedder == "openai_embedder"
+    assert ltm_merged.vector_store == "event_vector_store"
+    assert ltm_merged.segment_store == "profile_storage"
+
+
+def test_backendless_yaml_loads_as_declarative_via_full_configuration(tmp_path: Path):
+    """A config written before the discriminator still resolves to declarative."""
+    config_path = find_config_file("episodic_memory_config.cpu.sample")
+    raw = yaml.safe_load(config_path.read_text())
+    # Rewrite the episodic block into its pre-discriminator shape.
+    raw["episodic_memory"]["long_term_memory"] = {
+        "embedder": "openai_embedder",
+        "reranker": "my_reranker_id",
+        "vector_graph_store": "my_storage_id",
+    }
+    legacy_path = tmp_path / "legacy_config.yml"
+    legacy_path.write_text(yaml.safe_dump(raw))
+
+    conf = Configuration.load_yml_file(str(legacy_path))
     assert conf.episodic_memory.long_term_memory is not None
     # Configuration.episodic_memory is the partial; backend stays None on load.
     assert conf.episodic_memory.long_term_memory.backend is None

--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -7,19 +7,13 @@ episode_store:
 
 episodic_memory:
   long_term_memory:
-    # Default backend: a VectorGraphStore-backed declarative memory.
-    # backend: declarative                  # explicit; same as omitting the field
-    embedder: openai_embedder
-    reranker: my_reranker_id
-    vector_graph_store: my_storage_id
-    #
-    # Alternative backend: event memory (VectorStore + SegmentStore).
+    # Default backend: event memory (VectorStore + SegmentStore).
     # See `event_vector_store` and `profile_storage` under resources.databases below.
-    # backend: event
-    # embedder: openai_embedder
-    # reranker: my_reranker_id              # optional; omit to use embedding scores
-    # vector_store: event_vector_store      # references resources.databases (a sqlite_vector_store, qdrant, etc.)
-    # segment_store: profile_storage        # references a relational DB; segment store is created from it
+    backend: event
+    embedder: openai_embedder
+    reranker: my_reranker_id                # optional; omit to use embedding scores
+    vector_store: event_vector_store        # references resources.databases (qdrant, milvus, sqlite_vector_store, ...)
+    segment_store: profile_storage          # references a relational DB; segment store is created from it
     # properties_schema:                    # optional — user-defined filterable properties
     #   source_role: str
     #   target_id: str
@@ -27,6 +21,13 @@ episodic_memory:
     #   type: passthrough                   # or: text (with max_chunk_length)
     # deriver:                              # optional — defaults to whole-text deriver
     #   type: whole_text                    # or: sentence_text
+    #
+    # Alternative backend: a VectorGraphStore-backed declarative memory.
+    # Uncomment `my_storage_id` under resources.databases below as well.
+    # backend: declarative
+    # embedder: openai_embedder
+    # reranker: my_reranker_id
+    # vector_graph_store: my_storage_id
   short_term_memory:
     llm_model: openai_model
     message_capacity: 500
@@ -73,26 +74,30 @@ resources:
         pool_timeout: 30      # max seconds to wait for a pool connection (default: 30)
         pool_recycle: -1      # max connection age in seconds; -1 = disabled (default: -1)
         pool_pre_ping: false  # test connections for liveness before use (default: false)
-    my_storage_id:
-      provider: neo4j
-      config:
-        uri: 'bolt://localhost:7687'
-        user: neo4j
-        password: <YOUR_PASSWORD_HERE>
-        max_connection_pool_size: 100
-        connection_acquisition_timeout: 60.0
-        range_index_creation_threshold: 10000
-        vector_index_creation_threshold: 10000
-        max_connection_lifetime: 3600  # max connection age in seconds; lower for AuraDB (e.g. 3000) (default: 3600)
-        # liveness_check_timeout: ~    # test idle connections after N seconds; 0 = always (default: disabled)
+    # VectorGraphStore for the declarative long-term memory backend.
+    # Every configured resource is connected and validated at startup, so this
+    # stays commented out while `long_term_memory` uses the event backend --
+    # otherwise a Neo4j server would be required even though nothing uses it.
+    # my_storage_id:
+    #   provider: neo4j
+    #   config:
+    #     uri: 'bolt://localhost:7687'
+    #     user: neo4j
+    #     password: <YOUR_PASSWORD_HERE>
+    #     max_connection_pool_size: 100
+    #     connection_acquisition_timeout: 60.0
+    #     range_index_creation_threshold: 10000
+    #     vector_index_creation_threshold: 10000
+    #     max_connection_lifetime: 3600  # max connection age in seconds; lower for AuraDB (e.g. 3000) (default: 3600)
+    #     # liveness_check_timeout: ~    # test idle connections after N seconds; 0 = always (default: disabled)
     sqlite_test:
       provider: sqlite
       config:
         path: sqlite_test.db
-    # VectorStore for the event-backed long-term memory.
-    # Wire it via `episodic_memory.long_term_memory.vector_store`.
-    # Qdrant is the recommended default for server deployments (concurrent
-    # access, scaling). Run a local instance with:
+    # VectorStore backing the event long-term memory (the default backend).
+    # Wired via `episodic_memory.long_term_memory.vector_store` above.
+    # Qdrant is the default for server deployments (concurrent access, scaling)
+    # and is started for you by docker-compose. To run one by hand:
     #   docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant
     event_vector_store:
       provider: qdrant

--- a/sample_configs/episodic_memory_config.gpu.sample
+++ b/sample_configs/episodic_memory_config.gpu.sample
@@ -7,18 +7,13 @@ episode_store:
 
 episodic_memory:
   long_term_memory:
-    # Default backend: a VectorGraphStore-backed declarative memory.
-    # backend: declarative                  # explicit; same as omitting the field
+    # Default backend: event memory (VectorStore + SegmentStore).
+    # See `event_vector_store` and `profile_storage` under resources.databases below.
+    backend: event
     embedder: openai_embedder
-    reranker: my_reranker_id
-    vector_graph_store: my_storage_id
-    #
-    # Alternative backend: event memory (VectorStore + SegmentStore).
-    # backend: event
-    # embedder: openai_embedder
-    # reranker: my_reranker_id              # optional; omit to use embedding scores
-    # vector_store: event_vector_store      # references resources.databases
-    # segment_store: profile_storage        # references a relational DB; segment store is created from it
+    reranker: my_reranker_id                # optional; omit to use embedding scores
+    vector_store: event_vector_store        # references resources.databases (qdrant, milvus, sqlite_vector_store, ...)
+    segment_store: profile_storage          # references a relational DB; segment store is created from it
     # properties_schema:                    # optional — user-defined filterable properties
     #   source_role: str
     #   target_id: str
@@ -26,6 +21,13 @@ episodic_memory:
     #   type: passthrough                   # or: text (with max_chunk_length)
     # deriver:                              # optional — defaults to whole-text deriver
     #   type: whole_text                    # or: sentence_text
+    #
+    # Alternative backend: a VectorGraphStore-backed declarative memory.
+    # Uncomment `my_storage_id` under resources.databases below as well.
+    # backend: declarative
+    # embedder: openai_embedder
+    # reranker: my_reranker_id
+    # vector_graph_store: my_storage_id
   short_term_memory:
     llm_model: openai_model
     message_capacity: 500
@@ -72,26 +74,30 @@ resources:
         pool_timeout: 30      # max seconds to wait for a pool connection (default: 30)
         pool_recycle: -1      # max connection age in seconds; -1 = disabled (default: -1)
         pool_pre_ping: false  # test connections for liveness before use (default: false)
-    my_storage_id:
-      provider: neo4j
-      config:
-        uri: 'bolt://localhost:7687'
-        user: neo4j
-        password: <YOUR_PASSWORD_HERE>
-        max_connection_pool_size: 100
-        connection_acquisition_timeout: 60.0
-        range_index_creation_threshold: 10000
-        vector_index_creation_threshold: 10000
-        max_connection_lifetime: 3600  # max connection age in seconds; lower for AuraDB (e.g. 3000) (default: 3600)
-        # liveness_check_timeout: ~    # test idle connections after N seconds; 0 = always (default: disabled)
+    # VectorGraphStore for the declarative long-term memory backend.
+    # Every configured resource is connected and validated at startup, so this
+    # stays commented out while `long_term_memory` uses the event backend --
+    # otherwise a Neo4j server would be required even though nothing uses it.
+    # my_storage_id:
+    #   provider: neo4j
+    #   config:
+    #     uri: 'bolt://localhost:7687'
+    #     user: neo4j
+    #     password: <YOUR_PASSWORD_HERE>
+    #     max_connection_pool_size: 100
+    #     connection_acquisition_timeout: 60.0
+    #     range_index_creation_threshold: 10000
+    #     vector_index_creation_threshold: 10000
+    #     max_connection_lifetime: 3600  # max connection age in seconds; lower for AuraDB (e.g. 3000) (default: 3600)
+    #     # liveness_check_timeout: ~    # test idle connections after N seconds; 0 = always (default: disabled)
     sqlite_test:
       provider: sqlite
       config:
         path: sqlite_test.db
-    # VectorStore for the event-backed long-term memory.
-    # Wire it via `episodic_memory.long_term_memory.vector_store`.
-    # Qdrant is the recommended default for server deployments (concurrent
-    # access, scaling). Run a local instance with:
+    # VectorStore backing the event long-term memory (the default backend).
+    # Wired via `episodic_memory.long_term_memory.vector_store` above.
+    # Qdrant is the default for server deployments (concurrent access, scaling)
+    # and is started for you by docker-compose. To run one by hand:
     #   docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant
     event_vector_store:
       provider: qdrant

--- a/sample_configs/episodic_memory_config.nebula.sample
+++ b/sample_configs/episodic_memory_config.nebula.sample
@@ -7,8 +7,10 @@ episode_store:
 
 episodic_memory:
   long_term_memory:
-    # Default backend: a VectorGraphStore-backed declarative memory.
-    # backend: declarative                  # explicit; same as omitting the field
+    # This sample demonstrates the declarative backend on NebulaGraph, so it
+    # deliberately keeps `backend: declarative`. The default backend for new
+    # deployments is event memory -- see the cpu/gpu samples.
+    backend: declarative
     embedder: openai_embedder
     reranker: my_reranker_id
     vector_graph_store: nebula_storage  # Using NebulaGraph


### PR DESCRIPTION
### Purpose of the change

The configuration wizard has defaulted to `backend: event` for a while (`configuration_wizard.py`), but the *static* shipped configs still wired the declarative VectorGraphStore backend. So every install that does not go through the wizard -- `memmachine-compose.sh`, the Helm chart, anyone copying a sample -- landed on declarative. This makes the event backend (VectorStore + SegmentStore) the default in the configuration files too, and makes the shipped stacks actually able to run it.

### Description

**Configuration files**

- `sample_configs/episodic_memory_config.{cpu,gpu}.sample`: `backend: event` with `vector_store: event_vector_store` and `segment_store: profile_storage`. The declarative block is preserved as the commented alternative.
- `sample_configs/episodic_memory_config.nebula.sample` stays declarative on purpose -- it exists to demonstrate NebulaGraph as the `vector_graph_store` -- and now states `backend: declarative` explicitly with a pointer to the cpu/gpu samples.
- The Neo4j resource is commented out in the cpu/gpu samples. Resources are **not** lazy: `ResourceManager.build()` calls `DatabaseManager.build_all(validate=True)`, which connects to and validates every configured database. A configured-but-unused Neo4j entry would keep a reachable Neo4j server as a hard startup requirement, so leaving it defined would defeat the switch.
- Helm ConfigMap: the episodic block and the database resources are now selected by a new `memmachine.longTermMemory.backend` value (default `event`). Only the resource the selected backend needs is emitted, for the same eager-validation reason.

**Making the default runnable**

Qdrant is the shipped vector store, matching what the samples already recommended and what the wizard picks when the extra is available.

- `Dockerfile`: installs the `qdrant` extra. Without it, `qdrant-client` is missing inside the published image and a qdrant resource fails to build. (No `pyproject.toml`/`uv.lock` change -- `qdrant-client>=1.17.0` is already a declared optional dependency and is in the lock.)
- `docker-compose.yml`: adds a `qdrant` service (pinned `v1.19.0`), a `qdrant_data` volume, and a healthcheck. The healthcheck probes the port with bash's `/dev/tcp` because the Qdrant image ships neither curl nor wget.
- `docker-compose.yml`: Neo4j moves behind a `declarative` compose profile, and MemMachine's `depends_on` switches from Neo4j to Qdrant. A default `docker compose up` no longer starts or blocks on a database nothing uses; `docker compose --profile declarative up` brings it back.
- `memmachine-compose.sh`: waits on Qdrant, keeps the Neo4j wait for when that profile is running, prints the Qdrant endpoint, and rewrites `localhost` to the `qdrant` service name for qdrant resources -- the same treatment postgres and neo4j already get.
- Helm: new `qdrant-deployment.yaml` / `qdrant-service.yaml` / `qdrant-pvc`, a `qdrant.*` values block, and the app's init container waits on Qdrant or Neo4j to match the selected backend.

**One deliberate asymmetry to flag for review.** In docker-compose the Neo4j service is kept (behind a profile) so switching back is easy. In Helm, `neo4j.enabled` now defaults to `false`, so the chart does not provision an in-cluster Neo4j Deployment plus a 5Gi RWX PVC that nothing reads. Switching back is `--set memmachine.longTermMemory.backend=declarative --set neo4j.enabled=true`. Happy to flip that to `true` if you would rather the chart keep deploying Neo4j by default.

**Not changed:** the parse-time default. A config with no `backend` field still loads as declarative (`_long_term_memory_backend_discriminator`), so pre-discriminator configs keep working.

### Fixes/Closes

N/A

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)

### How Has This Been Tested?

- [x] Unit Test
- [x] Test Script (please provide)

`test_existing_sample_yaml_loads_as_declarative_via_full_configuration` pinned both "the cpu sample has no `backend` field" and "a backend-less config resolves to declarative". Those are now separate tests: one asserts the sample declares the event backend and resolves to `EventLongTermMemoryConf`, the other synthesizes a pre-discriminator config and asserts it still resolves to `DeclarativeLongTermMemoryConf`.

**Test Results:**

```
$ uv run --package memmachine-server pytest \
    packages/server/server_tests/memmachine_server/common/configuration \
    packages/server/server_tests/memmachine_server/installation \
    packages/server/server_tests/memmachine_server/server/api_v2/test_config_service.py \
    packages/server/server_tests/memmachine_server/server/api_v2/test_config_router.py -q
240 passed, 3 warnings in 2.78s
```

Every changed config was also validated against the real `Configuration` pydantic model, not just parsed as YAML:

| Config | Result |
|---|---|
| cpu sample | OK -- `backend='event' vector_store='event_vector_store' segment_store='profile_storage'` |
| gpu sample | OK -- same |
| cpu sample after `memmachine-compose.sh`'s awk rewrite | OK -- hosts rewritten to `postgres` / `qdrant` |
| `helm template` default | OK -- `backend='event' vector_store='db_qdrant' segment_store='db_postgres'` |
| `helm template --set memmachine.longTermMemory.backend=declarative --set neo4j.enabled=true` | OK -- `backend='declarative' vector_graph_store='db_neo4j'` |

Also checked:

- `docker compose config` passes; `config --services` lists `qdrant, docs, postgres, memmachine` by default and adds `neo4j` under `--profile declarative`.
- `helm template` renders cleanly in both backend modes; the default render contains no Neo4j Deployment/Service/PVC.
- `bash -n memmachine-compose.sh`, and the awk rewrite was extracted and run against the new sample.
- `uv lock --check` passes (no dependency change).

Not tested: an actual `docker compose up` end to end, since no Docker daemon was available in this environment. The Qdrant healthcheck's reliance on bash in the Qdrant image is worth one live confirmation before merge (the image is `debian:13-slim`-based, which includes bash but not curl).

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Screenshots/Gifs

N/A

### Further comments

**Migration.** This does not migrate data. Memories written through the declarative backend live in Neo4j and are not visible to the event backend. Existing deployments are unaffected until they adopt the new samples, because `configuration.yml` is gitignored and generated only when absent -- but a fresh install after this change will not see an old install's memories.

**Docs left alone deliberately.** The provider-specific guides (`docs/install_guide/{ollama,aws_bedrock}.mdx` and their `config/` copies, the NebulaGraph integration guide, and the CloudFormation template in `cloud_deploy/aws_cloudformation.mdx`) still show the declarative backend. Each is tied to a specific stack, and the CloudFormation one would need Qdrant added to the template. Happy to do those in a follow-up if you want them converted.

**Unrelated pre-existing issue noticed.** `sample_configs/episodic_memory_config.nebula.sample` fails `Configuration.model_validate` on `semantic_memory.config_database` being required but absent. This reproduces identically on `main`, so it is untouched here -- flagging it rather than mixing the fix into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
