### PR TITLE
Feat: Back QdrantVectorStore collection metadata with SQL collection registry (collection registry stack 2/5)

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,13 @@
+# Design notes
+
+Contributor-facing notes on the reasoning behind a design: the problem it
+solves, the alternatives weighed, and the constraints that decided it.
+They record why the code is shaped the way it is, which the code itself
+and its docstrings cannot say.
+
+These documents are written for people working on the server. They are
+not part of the deployed documentation site (`docs/`) and are not
+packaged into distributions; user-facing documentation belongs in
+`docs/`.
+
+One document per design, named after what it covers.

--- a/design/collection_registry.md
+++ b/design/collection_registry.md
@@ -1,0 +1,372 @@
+# Vector store collection registry
+
+Contributor-facing design notes for
+`memmachine_server.common.vector_store.collection_registry`.
+
+## Problem
+
+Horizontal scalability: multiple server processes should be able to work with
+the same collections on one backend. Strict sharding (each collection managed
+by exactly one process) has always worked; the blocker to lifting it is
+collection *metadata* management. Backends without conditional writes,
+transactions, or unique constraints (Qdrant, Milvus) cannot make
+create / open / delete atomic, so their ad-hoc catalogs are read-check-write
+sequences guarded by per-process locks.
+
+The collection registry is the enabling primitive: a durable catalog mapping
+(namespace, name) to an immutable `CollectionRegistryEntry`, with
+registration atomic across processes via a real compare-and-set. A vector
+store holds a registry dedicated to it and cannot reach any other registry
+through it.
+
+## Scope: collections, not a generic registry
+
+The registry is deliberately specific to vector store collections. An
+earlier draft generalized it to a key -> config registry with pluggable
+types; that was narrowed because it had exactly one consumer kind, and the
+realistic reuse axis (other vector store backends) is *within* the
+collection domain -- Milvus's needs are the same shape. The compatibility
+asymmetry decides the default: widening a specific API later (extracting a
+generic ABC when a non-collection consumer actually materializes) is an
+additive refactor; narrowing a shipped generic ABC is a breaking change.
+Being collection-specific also lets the API speak the domain --
+`register(namespace, name, entry)` rather than key/adapter plumbing -- and
+turns the key encoding into an implementation detail.
+
+## The entry
+
+`CollectionRegistryEntry` = `{config, native_collection_name,
+partition_key}`. One entry format is shared by all vector store backends:
+`config` is the ABC-level `VectorStoreCollectionConfig` every backend already
+takes, and the two identity fields are the shared mechanism (config-hashed
+shared native collections, per-collection partition keys) that Qdrant and
+Milvus both use.
+
+- `native_collection_name` is pinned at registration instead of being
+  re-derived from `sha256(config)` on every open: any change to config
+  serialization -- even an added optional field -- would otherwise re-hash
+  every stored config and silently repoint existing collections at new,
+  empty native collections.
+- `partition_key` is generation-scoped (minted per registration): records
+  written through handles held across a deregistration land under the dead
+  generation -- invisible, never resurrected by a re-registration, no locks
+  and no per-write round trips.
+
+Evolution policy -- covering the whole stored document: the entry envelope
+and every model nested in it, `VectorStoreCollectionConfig` included, since
+the config is serialized inside the entry's JSON and read back through the
+same validation. Extend by adding optional fields with defaults -- no
+version bump, no migration, old rows validate under the new model. The rule
+has a semantic half: a new field's default must reproduce the behavior that
+existed before the field, because stored rows predating it are read through
+that default. A change whose default cannot mean the old behavior is not
+additive -- it is a breaking change and takes the version bump path.
+Backend-specific needs are expressed the same way, not with per-backend
+entry types.
+
+Terminology: "generation" is reserved for collection incarnations (the
+partition-key uuid); evolution of the entry or config models is a format
+"version". Content-hash native naming has the side effect of never sharing
+native collections across config-model versions (any model change drifts
+the hash) -- conservative quarantine at the cost of gradual fragmentation.
+
+## Portability across vector store providers
+
+Two identity fields locate a collection, and that arity is structural
+rather than a Qdrant/Milvus accident. The pair is the *container* -- the
+unit a provider creates, deletes, caps, and pins fixed physical
+attributes to (dimensionality, metric, index structures) -- and a
+*discriminator*, the unit of isolation within a container. Every
+surveyed provider decomposes this way, under its own vocabulary:
+
+| Provider   | Container           | Discriminator          |
+| ---------- | ------------------- | ---------------------- |
+| Qdrant     | collection          | payload key, shard key |
+| Milvus     | collection          | partition-key field    |
+| Pinecone   | index               | namespace              |
+| Weaviate   | collection          | tenant                 |
+| S3 Vectors | index within bucket | metadata field         |
+| Chroma     | collection          | (none needed)          |
+
+The entry calls the second field `partition_key`, after the two shipped
+backends and the house term for the same subdivision in the segment
+store. Note that Pinecone's "namespace" is a discriminator, not this
+registry's `namespace`, which is a component of the logical key.
+
+The discriminator level is essentially free: it asks nothing of a
+provider beyond storing a value per record and filtering it by equality,
+which is below the bar for being usable as a vector store at all. Chroma
+is the degenerate end -- collections are cheap enough there to give each
+logical collection its own, leaving nothing for a discriminator to do.
+One container with many discriminators and many containers with none are
+the same entry shape, which is the portability claim in one line.
+
+So the only open question is whether one container per logical
+collection suffices. Three cases where it would not, none of which argues
+for adding a field now:
+
+- A level above the container becomes variable: S3 buckets, Milvus
+  databases, Pinecone projects, or simply a second cluster once a
+  per-parent cap is reached. Today the parent is fixed by store
+  configuration. Lifting that needs a locator, not a second container.
+- One logical collection needs several containers -- multiple vectors
+  per record with differing dimensions or metrics on a provider that
+  indexes one vector per container, or a collection outgrowing a
+  per-container capacity cap. The first is excluded a level up:
+  `VectorStoreCollectionConfig` declares a single `vector_dimensions`
+  and `similarity_metric`. The second is remote at surveyed caps, and
+  when a *shared* container fills rather than a single collection it is
+  resolved by minting a new container for subsequent collections, which
+  needs no entry change since each entry names its own.
+- A collection transiently spans containers during an online re-index.
+  Handled a level up, by creating a new logical collection and swapping.
+
+The guarantee is not that two fields are provably sufficient forever; it
+is that the arity sits on the cheapest axis of change. The registry
+stores the entry and never parses it, so a third field is
+add-optional-only (`backend_id: str | None = None`, defaulting to the
+configured backend) and reproduces prior behavior by construction. What
+would be expensive is changing the key shape or the atomicity contract,
+and no surveyed provider pressures either.
+
+Both identity fields are opaque strings minted by the store and never
+derived by the registry, which keeps per-provider naming budgets out of
+this layer -- and those budgets are strict. The current
+`{namespace}__{sha256hex}` native name runs to 98 bytes, over Pinecone's
+and S3 Vectors' index-name limits; the `{name}#{uuid4hex}` partition key
+is 65 bytes and contains "#", over Weaviate's 64-byte tenant limit and
+outside its charset. A backend for those providers shortens the digest
+and picks a charset-safe generation format without touching the
+registry: the ABC requires only that the partition key be unique and
+carry a per-registration generation, never a format. That is why the key
+format is duplicated between the Qdrant and Milvus stores rather than
+shared.
+
+One budget does reach the addressing scheme. The index set stays inside
+the native name's config hash deliberately -- collections sharing a
+container then have identical index sets by construction, instead of the
+container accumulating the union of its tenants' indexes with each
+tenant paying memory and build time for another's fields. The cost is
+that containers accumulate one per config revision and are never
+reclaimed. At Qdrant's ~1000 collections per cluster that is cosmetic
+fragmentation; at Pinecone's 20-200 indexes per project it is a hard
+operational cap, which would make reclaiming orphaned containers a
+prerequisite for such a backend rather than a cleanup nicety.
+
+## Which backends need a registry
+
+Not every backend needs one. The registry does four jobs -- atomic
+create, durable storage of the entry, the logical-to-native name
+mapping, and the generation that stops a deleted collection's records
+from being resurrected -- and a backend that provides all four itself
+should use its own and take none. Where those four jobs land is what
+decides it:
+
+- **Qdrant and Milvus take one.** Both fail the first job (no
+  conditional writes and no unique constraints, so create is a
+  read-check-write) and the fourth (native collections are
+  name-addressed and shared by config hash). Those two failures are the
+  entire reason this primitive exists.
+- **`SQLiteVectorStore` cannot be helped by one.** Its authoritative
+  index state is a `dict[(namespace, name), VectorSearchEngine]` held in
+  process memory and flushed to disk on a threshold, so a second process
+  would search a divergent index. The limit is the data plane; repairing
+  metadata would not move it, and a registry would only add a
+  cross-process authority to a store that cannot be used across
+  processes.
+- **`SQLiteVecVectorStore` does not need one, but does need the
+  compare-and-set it already has the machinery for.** Its vectors live in
+  SQLite tables rather than in process memory, and it owns a
+  `_CollectionRow` table whose primary key is (namespace, name) -- the
+  same kind of arbiter this registry's implementation relies on. Its
+  create is nonetheless a check-then-write inside one transaction, which
+  is what confines concurrent collection management to a single process.
+  Turning that pre-check into an insert that maps `IntegrityError` onto
+  the domain error is the change `SQLAlchemyCollectionRegistry.register`
+  already makes, done in place rather than delegated. Two caveats: the
+  generation gap would remain, since its table names derive from
+  (namespace, name), so a handle held across a deletion addresses
+  whatever is later recreated under those names; and widening its reach
+  past one process needs the usual multi-process SQLite conditions
+  besides -- WAL, busy timeouts, a local filesystem.
+- **A container-per-collection provider covers all four.** A uniqueness
+  constraint on container names for atomic create, container metadata for
+  the entry, a direct name lookup for the mapping, and -- the
+  load-bearing one -- a container identity that is not its name, so that
+  a recreated container is a different object and handles held across the
+  deletion fault instead of writing into it. That last check matters
+  because the obvious alternative, putting the generation into the name,
+  destroys the first: two processes racing a create would mint different
+  generations, produce different names, and both succeed, leaving two
+  live containers for one logical collection.
+
+Chroma is the worked example of that last case, checked against 1.5.9
+rather than assumed. Collections carry a uuid that changes across
+delete-and-recreate, and operations route by it, so a handle held across
+a recreation raises rather than writing into the new collection -- a
+stronger generation than the synthetic one here, because the backend
+enforces it instead of merely hiding the records. Creates are genuinely
+atomic rather than only rejected: eight concurrent clients racing
+`create_collection` against a Chroma server produced exactly one winner
+in 25 of 25 rounds and never two collections of one name, and the
+`get_or_create` race converged all eight callers on a single id -- the
+same contract `get_or_register` provides here. A Chroma backend would
+therefore take no registry.
+
+What Chroma does not provide is a classifiable failure. The
+already-exists condition surfaces as `ChromaError` code 400 over HTTP and
+`InternalError` code 500 through the local binding -- two types, two
+codes, neither of them the `UniqueConstraintError` the same module
+defines and exports -- leaving the message as the only portable
+discriminator. That is a worse version of the error-classification
+problem this stack cleaned up for Qdrant and Milvus, and it is a
+backend-side concern rather than a reason to reach for a registry.
+
+Adding a registry to a backend that already satisfies all four would be
+a regression rather than caution: it introduces a second authority that
+can disagree with the first, which is precisely the divergence the
+create and delete orderings in this design exist to bound.
+
+## API shape
+
+Docstrings say what each operation does; this section says why the
+surface has the shape it has. It is five operations plus a lifecycle
+pair, and each shape is a decision rather than a default.
+
+**The key is two parameters, not one.** An earlier draft took a single
+opaque `key: str` and let each consumer compose it from its own parts.
+Namespacing is enforced by the contract instead: the registry guarantees
+that distinct (namespace, name) pairs never collide, so a store cannot
+get the encoding wrong and two stores cannot disagree about it. The "/"
+join in the SQLAlchemy implementation is consequently an implementation
+detail, and the test that ("a__b", "c") and ("a", "b__c") remain
+distinct tests the contract rather than the encoding.
+
+**Every parameter is keyword-only.** `namespace` and `name` are both
+`str` over the same charset, so a positional swap type-checks cleanly
+and then silently addresses the wrong collection. Keyword-only makes the
+swap unrepresentable rather than merely discouraged.
+
+**`register` raises and `get` returns `None`.** The asymmetry is
+deliberate. Absence on read is an ordinary expected outcome -- it is how
+a store learns a collection does not exist, and `open_collection`
+returning `None` is that same answer one layer up -- so raising would
+put try/except on the common path. A lost registration race is rare,
+contended, and has to interrupt a multi-step lifecycle sequence, so it
+raises, and the store translates it into its own already-exists error.
+A boolean return would invite callers to drop it on the floor.
+
+**`register` raises whether or not the stored entry matches the one
+offered.** The registry never compares entries, here or in
+`get_or_register`. Equality policy belongs to the store: what counts as
+"the same collection" is backend-specific, and two entries can carry
+equal configs while naming different native collections. Keeping
+comparison out also keeps registry behavior independent of how config
+models evolve, which is what lets the evolution policy below be stated
+in terms of validation alone.
+
+**`get_or_register` returns `(stored_entry, registered)`.** It returns
+the *stored* entry rather than the caller's, which is what makes it the
+atomic commit point: both sides of a race leave holding identical
+identity and therefore cannot write to different native collections
+under one logical name. The boolean is separate because the two outcomes
+demand different work from the store -- minting a native collection
+versus adopting one that already exists -- and that distinction is not
+recoverable from the returned entry.
+
+It exists because the create path genuinely needs "register if absent,
+else tell me what is already there" as a single atomic step; this is the
+commit point of an otherwise non-atomic sequence, which is the one place
+ensure-style semantics earn their keep. It is implemented natively -- a
+`SELECT` fast path, then `INSERT .. ON CONFLICT DO NOTHING`, then a
+re-read only when that insert lost -- rather than as try/except around
+`register`, so ordinary paths cost one statement and no control flow
+runs through exceptions.
+
+**`deregister` is idempotent and returns nothing.** It is the tail of a
+sequence that begins by destroying data, so a crash partway has to leave
+it re-runnable; reporting "already absent" as an error would force every
+retry to branch on a distinction with no consequence. It does not hand
+back the removed entry, because the caller necessarily read that entry
+first in order to find the data to delete, and returning it would invite
+a read-modify-write shape the registry deliberately cannot support.
+
+**There is no `update`.** Entries are immutable by contract, and this is
+the decision the generation scheme rests on: if `partition_key` could be
+rewritten in place, a handle held across the rewrite would silently
+begin writing into a different partition, and the guarantee that a
+deregistered collection's records are never resurrected would be gone.
+Changing a collection's identity is deregister followed by register,
+which mints a fresh generation by construction.
+
+**There is no way to enumerate entries.** This is a dated omission
+rather than a principle, and it is distinct from the registry-management
+surface rejected below -- that one is about listing and deleting whole
+registries. Reclaiming orphaned native containers needs enumeration, and
+the portability section above shows it stops being optional on providers
+with low container caps. A read-only enumeration operation is purely
+additive, so it waits for the reclamation design that would consume it.
+
+**`startup` and `shutdown` rather than a constructor that performs
+I/O.** Every store in the codebase separates construction from starting,
+so wiring code can build the object graph and then start it. `startup`
+is idempotent because every process runs it at boot and none is
+privileged. `shutdown` is a no-op in the SQLAlchemy implementation
+because the engine is shared and externally owned: the registry does not
+close what it did not open.
+
+## Storage (SQLAlchemy implementation)
+
+- Table per registry (`collection_registry_<name>`: `key` VARCHAR(255) PK,
+  `entry` JSON, JSONB on PostgreSQL). Registry names become SQL identifier
+  components, hence the `[a-z0-9_]+`, 32-byte constraint (prefix + name
+  stays inside PostgreSQL's 63-byte identifier limit). Storage keys are
+  `f"{namespace}/{name}"` -- "/" is outside the identifier charset, so
+  distinct pairs can never collide ("__" would be ambiguous).
+- The primary key is the concurrency arbiter: `register` is a plain INSERT
+  with `IntegrityError` mapped to `CollectionAlreadyRegisteredError` (the
+  `SQLAlchemySegmentStore.create_partition` pattern); `get_or_register` is a
+  SELECT fast path, then a native `INSERT .. ON CONFLICT DO NOTHING`, then a
+  re-SELECT of the winner on conflict. `get_or_register` never compares
+  entries -- config equality policy belongs to the store.
+- Flat JSON rather than typed columns: every access is get-by-key, pydantic
+  validates at the boundary, and typed columns would turn entry evolution
+  into DDL migrations in a codebase whose schema management is
+  `create_all`-on-startup.
+- Dialects: PostgreSQL and SQLite, the two relational providers the server
+  offers.
+
+## Format evolution without standing version machinery
+
+There is deliberately no stored format version and no version check. The
+evolution policy above is what makes that safe: because every change is
+add-optional-only and old rows classify exactly through defaults, a future
+breaking change can introduce an entry format version field (default 1)
+*at the moment it is first needed* -- the policy guarantees every
+pre-existing row is correctly version 1 -- and ship its migration
+(migrate-then-deploy with a window; low-downtime migrations are explicitly
+not a goal). The accepted residual: an old binary started against migrated
+data fails with validation errors at first read rather than being refused
+at startup.
+
+## Rejected alternatives
+
+- Distributed locks or leases: operationally heavier, and crash-recovery
+  semantics are worse than an insert that is atomic by construction.
+- A generic `ConfigRegistry[ConfigT]` (the earlier draft): speculative with
+  one consumer kind; see "Scope" above.
+- Registry management surface (list/delete registries): registries are
+  constructed by wiring code from configuration; the database catalog
+  already lists `collection_registry_*` tables, and management operations
+  are exactly the power stores must not have.
+- Schema-compatibility rules (Confluent-style): the right machinery when
+  many independently deployed writers and readers evolve on their own
+  schedules; wrong scale for an embedded component with one codebase owning
+  both sides.
+- A standing registry-of-registries version stamp (an earlier draft:
+  declarations table, startup version check, redeclare): under the
+  add-optional-only policy the version field is retrofittable with exact
+  classification at first need, so the standing machinery insured against a
+  scenario the policy already insures, at the cost of real API and doc
+  surface. Its one unique protection -- boot-time refusal of old binaries
+  against migrated data -- is the residual noted above.

--- a/design/qdrant_collection_registry.md
+++ b/design/qdrant_collection_registry.md
@@ -1,0 +1,85 @@
+# Qdrant on the collection registry
+
+Contributor-facing design notes for QdrantVectorStore's collection metadata,
+which lives in the SQL-backed collection registry (see
+`collection_registry.md`) rather than in Qdrant itself.
+
+## Why the registry moved out of Qdrant
+
+Qdrant offers no conditional writes, transactions, or unique constraints. The
+previous design kept collection metadata in per-namespace `<ns>__registry`
+Qdrant collections (dummy-vector points keyed `uuid5(name)`), which made
+`create_collection` / `open_collection` / `delete_collection` non-atomic
+read-check-write sequences guarded only by a per-process asyncio lock. The
+moment two processes manage the same name:
+
+1. `VectorStoreCollectionAlreadyExistsError` stops firing -- both creates
+   pass the absence check and last-writer-wins the registry point.
+2. Two creations with different configs each create a different native
+   collection (native names hash the config) while contending for one
+   registry point; records written through the losing handle become
+   permanently unreachable.
+
+With the registry's unique-constraint insert as the commit point, both
+guarantees hold across processes sharing the registry database. The
+per-process `_name_locks` remain only as in-process serialization; they are
+no longer correctness-bearing.
+
+## Registry entries store resolved identity
+
+Collections register a `CollectionRegistryEntry` =
+`{config, native_collection_name, partition_key}` (see
+`collection_registry.md` for the entry design and evolution policy).
+
+Qdrant-specific use of the shared fields: the native naming scheme for new
+collections is `f"{namespace}__{sha256(config)}"` (unchanged -- collections
+with the same config share a native collection, separated by partition key),
+generations are minted as `f"{name}#{uuid4().hex}"`, and `partition_key`
+doubles as the shard key in distributed mode.
+
+## Generations make deletion safe against held handles
+
+`delete_collection` deletes that generation's data (partition filter delete,
+or shard-key drop in distributed mode), then removes the registry entry. A
+handle held in another process across the deletion keeps writing into the
+dead generation: invisible to every reader, never resurrected, because a
+re-creation of the same name mints a fresh generation -- even with an
+identical config and therefore the identical shared native collection. No
+locks, no per-write round trips; the residual cost is bounded garbage under
+dead generations, sweepable by a future GC that deletes points whose
+partition keys are absent from the registry.
+
+## Ordering and crash windows
+
+- Create: native collection first, registry entry last. The registry insert
+  is the atomic commit point. A crash -- or a lost creation race -- before it
+  leaves only an empty native collection (shared by config, adopted by the
+  next same-config creation) and, in distributed mode, an unused shard key.
+  Cleanup of the loser's native collection is deliberately not attempted:
+  native collections are shared by config, and the registry intentionally has
+  no list operation, so nothing can safely prove no other logical collection
+  references one. The residue is bounded by the number of distinct configs
+  attempted. Registry-first ordering would be worse: `open_collection` builds
+  handles straight from the entry, so a crash between claim and native
+  creation would hand out handles to a nonexistent native collection. The
+  invariant is: registry entry implies native collection exists.
+- Delete: data first, deregistration last. A crash in between leaves a
+  registered-but-empty collection (documented on `delete_collection`);
+  retrying the deletion completes it.
+
+## Configuration and migration
+
+`QdrantConf.registry_database` (required) names a configured relational
+database entry; all processes sharing a Qdrant instance must use the same
+registry database. There is deliberately no per-host SQLite fallback --
+divergent per-host registries would look consistent while reproducing exactly
+the races this design removes. One registry per Qdrant conf entry
+(`qdrant_<conf name>`), so instances sharing a registry database get separate
+tables.
+
+Deployed `<ns>__registry` data is not migrated. Native collection names are
+unchanged, so re-creation with an unchanged config re-registers the same
+native collection and data is reachable again; the caveat is paths that
+re-create with a currently-derived schema (the episodic event backend) orphan
+old partitions if that schema drifted since original creation. Stale
+`__registry` collections can be deleted manually.

--- a/design/schema_creation.md
+++ b/design/schema_creation.md
@@ -1,0 +1,176 @@
+# Schema creation and DDL
+
+Contributor-facing design notes on where the server runs DDL and why.
+
+## Problem
+
+Horizontal scalability: several server processes should be able to run against
+one database. Every SQLAlchemy-backed store creates its own schema during
+`startup()` with `metadata.create_all`, which is check-then-create -- SQLAlchemy
+reflects, then emits `CREATE TABLE` without `IF NOT EXISTS`. Two processes
+booting against a database that does not yet have the tables can both pass the
+check; the loser's `CREATE TABLE` fails and takes its boot down with it.
+
+This note records the decision to keep that shape for now, the argument that
+makes it survivable, and the conditions under which the argument stops holding.
+
+## What the server does today
+
+Schema creation in `startup()`, via `create_all`:
+
+- `common/episode_store/episode_sqlalchemy_store.py:170`
+- `common/session_manager/session_data_manager_sql_impl.py:144`
+- `common/vector_store/sqlite_vector_store.py:718`
+- `common/vector_store/sqlite_vec_vector_store.py:491`
+- `episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py:793`
+- `semantic_memory/cluster_store/cluster_store_sqlalchemy.py:101`
+- `semantic_memory/config_store/config_store_sqlalchemy.py:238`
+- `semantic_memory/storage/vector_store_semantic_storage.py:196`
+
+Schema creation at runtime, driven by traffic rather than by configuration.
+This is worth stating plainly, because it is easy to assume the server only
+creates schema when an operator changes something. It does not. The event
+backend derives a partition key per session --
+`partition_key_for_session(session_id)`, a truncated SHA-256 of the session id
+(`long_term_memory/service_locator.py:106` and `:165-183`) -- and uses it as
+both the segment store partition key and the vector store collection name. So
+the first use of a new session runs DDL:
+
+- On PostgreSQL, two `CREATE TABLE ... PARTITION OF` statements for the segment
+  store child tables (`sqlalchemy_segment_store.py:1045-1061`, reached through
+  `open_or_create_partition` at `service_locator.py:140`).
+- On the SQLite vector stores, `create_all(tables=[records_table])` for the
+  collection's records table (`sqlite_vector_store.py:1061`,
+  `sqlite_vec_vector_store.py:692`). The sqlite-vec store follows it with
+  `CREATE VIRTUAL TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS` for the
+  vec0 table and property indexes, which are re-emitted on every open.
+
+Runtime DDL is therefore an ordinary, per-session occurrence, not a rare
+administrative one, and the crash-and-restart argument below does not cover it.
+
+Of those two, only the segment store's matters for running several processes
+against one database. The SQLite stores are single-process by construction --
+one file, one writer -- so concurrent creation of the same collection is
+outside what they promise, and the DDL they run per session is not a
+multi-process hazard. The segment store's partitions are shared, which is why
+that path had to be made race-free rather than left to a restart.
+
+The registry is what keeps this list from growing. Qdrant and Milvus also mint
+a collection per session, but registering one is an `INSERT` into a table that
+already exists, so adding a session adds a row rather than a table. Turning
+runtime metadata management into a transactional row write is the point of the
+primitive, and it means the only schema those backends need is created once, at
+boot, from configuration.
+
+Alembic exists (`semantic_memory/storage/alembic_pg`) but is also driven from
+the boot path: `apply_alembic_migrations` runs `command.upgrade(config, "head")`
+in-process, called from `SqlAlchemyPgVectorSemanticStorage.startup()`
+(`sqlalchemy_pgvector_semantic.py:172-211`). Having Alembic in the repo is
+therefore not the same as having schema creation out of the boot path.
+
+## Decision
+
+New SQLAlchemy-backed stores keep `create_all` in `startup()` and match the
+existing shape. They do not add per-store race handling of their own.
+
+The reasoning is uniformity, not that the race is imaginary. A one-off guard on
+a single new store would leave seven other boot paths with the same behavior
+while making the repo harder to reason about as a whole -- the reader could no
+longer assume that "SQLAlchemy store, `startup()`, `create_all`" means one
+thing. Moving schema creation out of the boot path is a change to the
+deployment model, not to one file, and it should be made once, deliberately,
+for every store at the same time.
+
+## Why crash-and-restart is acceptable for boot-path DDL
+
+The loser of a boot race raises, the process exits, the supervisor restarts it,
+`create_all` reflects, finds the tables present, emits nothing, and boot
+proceeds. The database converges on the correct schema and no writes are lost
+or misdirected in the meantime, because the failure is entirely before the
+store serves traffic.
+
+Three properties are what make that true, and they are properties of the
+current code rather than of `create_all` in general:
+
+1. **The schema each `create_all` emits is a single statement, or a set of
+   statements with no ordering dependency between them.** This is the load-
+   bearing one. `create_all`'s `checkfirst` tests for *table* existence and
+   skips the whole `CREATE TABLE` when the table is present, indexes included.
+   A partially applied multi-statement schema -- table created, a following
+   index not -- is therefore *not* repaired by a restart; the restart skips the
+   table and the index stays missing forever. Where a store emits indexes as
+   separate `CREATE INDEX IF NOT EXISTS` statements after `create_all`, as the
+   sqlite-vec store does, they are re-emitted on every open and the gap closes.
+2. **On PostgreSQL, DDL is transactional.** Stores that wrap `create_all` in
+   `engine.begin()` get all-or-nothing application, so a failed boot leaves no
+   half-built schema behind at all.
+3. **The set of tables is fixed by configuration, not by traffic.** Boot-path
+   `create_all` covers a static metadata. The race window is a cold database,
+   or the first boot after an operator adds a configuration entry that names a
+   new table. It is not re-entered per request.
+
+## Where the argument stops holding
+
+Any of these invalidates the reasoning above, and a store that has one needs to
+be handled explicitly rather than inheriting this decision:
+
+- **A table whose schema needs more than one statement**, i.e. a `Table` that
+  carries `Index()` objects, or DDL emitted after `create_all` that is not
+  itself `IF NOT EXISTS`. Then a partial application is permanent, per (1).
+- **Table names derived at runtime rather than from configuration.** The
+  failure moves from a boot crash, which a supervisor absorbs, to a 500 in a
+  process that is already serving traffic, and it recurs for each new name
+  rather than once per deployment.
+- **Deployments with no supervisor restart**, where a crashed boot is a
+  permanent outage rather than a retry.
+
+The collection registry satisfies all three properties: its table
+(`sqlalchemy_collection_registry.py:143-148`) is one `Table` with a primary key
+and a JSON column and no `Index()` objects, so `create_all` emits exactly one
+`CREATE TABLE`; `startup()` wraps it in `engine.begin()`; and registry names
+come from the vector store configuration (`qdrant_{name}` per configured Qdrant
+instance, built during `DatabaseManager.build_all`), so the table set is fixed
+before the server accepts a request.
+
+## The DDL path that is already race-free
+
+Segment store partition creation is the exception worth pointing at. It runs in
+steady state, on the first use of every new session, so restarting is not an
+available answer -- the failure would be a 500 in a process that is already
+serving, recurring per session rather than once per deployment.
+`create_partition` and `_open_or_create_partition`
+(`sqlalchemy_segment_store.py:805-895`) take an explicit lock on the partitions
+table, insert the partition row, and emit
+`CREATE TABLE ... PARTITION OF` -- all inside one transaction. PostgreSQL's
+transactional DDL means the loser's insert conflicts and the child-table
+creation rolls back with it. Runtime DDL that cannot be answered with a restart
+has to look like this.
+
+## Deferred: moving schema creation out of the boot path
+
+The standard answer is to make schema creation a distinct deployment step --
+`alembic upgrade head` as an init job, an initContainer, or a deploy stage --
+and reduce `startup()` to verifying that the expected schema is present and
+failing fast when it is not. Exactly one process runs DDL, so there is no race
+to handle, and a binary can refuse to serve against a schema it does not
+understand instead of silently adapting to it.
+
+This is deferred rather than rejected. It is a change to how the server is
+deployed, it touches all eight boot paths plus the in-process Alembic call, and
+it needs the operator-facing story (what runs the migration, what happens on
+rollback) decided alongside the code. Nothing in the current stack depends on
+it: the failure it prevents is a cold-start crash loop that resolves itself,
+not data loss or divergence between processes.
+
+## Follow-ups
+
+- Decide the repo-wide model, and apply it to every store in one pass rather
+  than store by store.
+- The four copies of the engine validator
+  (`sqlite_vector_store.py:655`, `sqlite_vec_vector_store.py:447`,
+  `sqlalchemy_segment_store.py:749`, `sqlalchemy_collection_registry.py:93`)
+  should be deduplicated. They share a gap: the ephemeral-SQLite check tests
+  `db is None or db == ":memory:"`, but `sqlite+aiosqlite:///` parses to
+  `database == ""` and passes, giving every connection its own private
+  temporary database. That one is a plain bug, not a race, and no restart
+  converges out of it.

--- a/docs/open_source/configuration.mdx
+++ b/docs/open_source/configuration.mdx
@@ -392,6 +392,7 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
       | `config.uri`  | The URI for the given database.                                      | Depends on provider |
       | `config.token` | Milvus auth token for Zilliz Cloud or auth-enabled Milvus server.   | `""` |
       | `config.consistency_level` | Milvus collection consistency level: `Strong`, `Session`, `Bounded`, or `Eventually`. | `Session` |
+      | `config.registry_database` | Qdrant: name of a configured relational database (a `postgres` or `sqlite` entry) that stores the collection registry. All processes sharing the Qdrant instance must use the same registry database. | *Required for `qdrant`* |
       | `config.path`  | The path for the given database.                                    | Depends on provider |
       | `config.username` | Username for internal graph store authentication.                | Depends on provider |
       | `my_storage_id` | The specific configuration for the system's internal graph store.  | *Required*  |

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_database_conf.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_database_conf.py
@@ -1,6 +1,6 @@
 import pytest
 import yaml
-from pydantic import SecretStr
+from pydantic import SecretStr, ValidationError
 
 from memmachine_server.common.configuration.database_conf import (
     DatabasesConf,
@@ -121,7 +121,7 @@ def db_conf_dict() -> dict:
                     "prefer_grpc": True,
                     "api_key": "test-key",
                     "is_distributed": True,
-                    "registry_replication_factor": 3,
+                    "registry_database": "local_sqlite",
                 },
             },
             "my_milvus": {
@@ -205,7 +205,7 @@ def test_parse_valid_storage_dict(db_conf_dict):
     assert qdrant_conf.prefer_grpc is True
     assert qdrant_conf.api_key == SecretStr("test-key")
     assert qdrant_conf.is_distributed is True
-    assert qdrant_conf.registry_replication_factor == 3
+    assert qdrant_conf.registry_database == "local_sqlite"
 
     # Milvus check
     milvus_conf = storage_conf.milvus_confs["my_milvus"]
@@ -358,26 +358,38 @@ def test_neo4j_uri_with_special_host():
 
 
 def test_qdrant_conf_defaults():
-    conf = QdrantConf()
+    conf = QdrantConf(registry_database="registry_db")
     assert conf.host == "localhost"
     assert conf.port == 6333
     assert conf.grpc_port == 6334
     assert conf.prefer_grpc is False
     assert conf.https is False
     assert conf.is_distributed is False
-    assert conf.registry_replication_factor == 1
+    assert conf.registry_database == "registry_db"
     assert conf.api_key.get_secret_value() == ""
+
+
+def test_qdrant_conf_requires_registry_database():
+    with pytest.raises(ValidationError):
+        QdrantConf.model_validate({})
 
 
 def test_qdrant_conf_api_key_from_env(monkeypatch):
     monkeypatch.setenv("QDRANT_API_KEY", "env-qdrant-key")
-    conf = QdrantConf(api_key=SecretStr("$QDRANT_API_KEY"))
+    conf = QdrantConf(
+        api_key=SecretStr("$QDRANT_API_KEY"), registry_database="registry_db"
+    )
     assert conf.api_key == SecretStr("env-qdrant-key")
 
 
 def test_qdrant_build_config():
     config = SupportedDB.QDRANT.build_config(
-        {"host": "qdrant.local", "port": 9333, "is_distributed": True}
+        {
+            "host": "qdrant.local",
+            "port": 9333,
+            "is_distributed": True,
+            "registry_database": "registry_db",
+        }
     )
     assert isinstance(config, QdrantConf)
     assert config.host == "qdrant.local"

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import SecretStr
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from memmachine_server.common.configuration.database_conf import (
     DatabasesConf,
@@ -23,6 +23,10 @@ from memmachine_server.common.errors import (
 )
 from memmachine_server.common.resource_manager.database_manager import DatabaseManager
 from memmachine_server.common.vector_graph_store import VectorGraphStore
+from memmachine_server.common.vector_store import VectorStoreCollectionConfig
+from memmachine_server.common.vector_store.collection_registry import (
+    CollectionRegistryEntry,
+)
 
 requires_pymilvus = pytest.mark.skipif(
     importlib.util.find_spec("pymilvus") is None,
@@ -296,7 +300,9 @@ def _qdrant_only_conf() -> MagicMock:
     conf.relational_db_confs = {}
     conf.nebula_graph_confs = {}
     conf.qdrant_confs = {
-        "qdrant1": QdrantConf(host="localhost", port=6333),
+        "qdrant1": QdrantConf(
+            host="localhost", port=6333, registry_database="registry_db"
+        ),
     }
     conf.sqlite_vector_store_confs = {}
     conf.sqlite_vec_vector_store_confs = {}
@@ -314,6 +320,7 @@ async def test_qdrant_client_kwargs_forwarded():
         prefer_grpc=True,
         https=True,
         api_key=SecretStr("secret-key"),
+        registry_database="registry_db",
     )
 
     mock_client = AsyncMock()
@@ -331,6 +338,11 @@ async def test_qdrant_client_kwargs_forwarded():
             "qdrant_client.AsyncQdrantClient",
             return_value=mock_client,
         ) as mock_cls,
+        patch.object(
+            DatabaseManager,
+            "_build_qdrant_collection_registry",
+            new=AsyncMock(),
+        ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
@@ -365,6 +377,11 @@ async def test_qdrant_api_key_omitted_when_empty():
             "qdrant_client.AsyncQdrantClient",
             return_value=mock_client,
         ) as mock_cls,
+        patch.object(
+            DatabaseManager,
+            "_build_qdrant_collection_registry",
+            new=AsyncMock(),
+        ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
@@ -379,11 +396,12 @@ async def test_qdrant_creates_vector_store():
     conf = _qdrant_only_conf()
     conf.qdrant_confs["qdrant1"] = QdrantConf(
         is_distributed=True,
-        registry_replication_factor=3,
+        registry_database="registry_db",
     )
 
     mock_client = AsyncMock()
     mock_client.close = AsyncMock()
+    mock_registry = MagicMock()
 
     with (
         patch(
@@ -396,6 +414,11 @@ async def test_qdrant_creates_vector_store():
             "qdrant_client.AsyncQdrantClient",
             return_value=mock_client,
         ),
+        patch.object(
+            DatabaseManager,
+            "_build_qdrant_collection_registry",
+            new=AsyncMock(return_value=mock_registry),
+        ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
@@ -404,11 +427,88 @@ async def test_qdrant_creates_vector_store():
     mock_params_cls.assert_called_once_with(
         client=mock_client,
         is_distributed=True,
-        registry_replication_factor=3,
+        registry=mock_registry,
     )
     mock_store_cls.assert_called_once_with(mock_params_cls.return_value)
     mock_store_cls.return_value.startup.assert_awaited_once()
     assert "qdrant1" in builder.vector_stores
+
+
+@pytest.mark.asyncio
+async def test_qdrant_registry_database_not_configured():
+    """A registry_database naming no relational database fails with a clear error."""
+    conf = _qdrant_only_conf()
+    conf.relational_db_confs = {}
+
+    mock_client = AsyncMock()
+    mock_client.close = AsyncMock()
+
+    with patch(
+        "qdrant_client.AsyncQdrantClient",
+        return_value=mock_client,
+    ):
+        builder = DatabaseManager(conf)
+        with pytest.raises(QdrantConfigurationError, match="registry_database"):
+            await builder.async_get_qdrant_client("qdrant1")
+
+    mock_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_qdrant_conf_name_unusable_as_registry_name(tmp_path):
+    """A qdrant conf entry name that cannot name a registry table fails clearly."""
+    conf = _qdrant_only_conf()
+    conf.qdrant_confs = {
+        "qdrant-1": QdrantConf(registry_database="registry_db"),
+    }
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/registry.db")
+    mock_client = AsyncMock()
+    mock_client.close = AsyncMock()
+
+    with (
+        patch(
+            "qdrant_client.AsyncQdrantClient",
+            return_value=mock_client,
+        ),
+        patch.object(
+            DatabaseManager,
+            "async_get_sql_engine",
+            new=AsyncMock(return_value=engine),
+        ),
+    ):
+        builder = DatabaseManager(conf)
+        with pytest.raises(QdrantConfigurationError, match="Rename"):
+            await builder.async_get_qdrant_client("qdrant-1")
+
+    mock_client.close.assert_awaited_once()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_qdrant_builds_registry_on_named_database(tmp_path):
+    """The collection registry is built and started on the named engine."""
+    conf = _qdrant_only_conf()
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/registry.db")
+
+    with patch.object(
+        DatabaseManager,
+        "async_get_sql_engine",
+        new=AsyncMock(return_value=engine),
+    ):
+        builder = DatabaseManager(conf)
+        registry = await builder._build_qdrant_collection_registry(
+            "qdrant1", conf.qdrant_confs["qdrant1"]
+        )
+
+    entry = CollectionRegistryEntry(
+        config=VectorStoreCollectionConfig(vector_dimensions=3),
+        native_collection_name="ns__digest",
+        partition_key="name#generation",
+    )
+    await registry.register(namespace="ns", name="name", entry=entry)
+    assert await registry.get(namespace="ns", name="name") == entry
+    await engine.dispose()
 
 
 @pytest.mark.asyncio
@@ -430,6 +530,11 @@ async def test_get_vector_store_qdrant():
         patch(
             "qdrant_client.AsyncQdrantClient",
             return_value=mock_client,
+        ),
+        patch.object(
+            DatabaseManager,
+            "_build_qdrant_collection_registry",
+            new=AsyncMock(),
         ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
@@ -480,6 +585,11 @@ async def test_qdrant_close():
         patch(
             "qdrant_client.AsyncQdrantClient",
             return_value=mock_client,
+        ),
+        patch.object(
+            DatabaseManager,
+            "_build_qdrant_collection_registry",
+            new=AsyncMock(),
         ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -1,5 +1,6 @@
 """Tests for QdrantVectorStore."""
 
+import asyncio
 import math
 from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import MagicMock
@@ -19,6 +20,10 @@ from memmachine_server.common.filter.filter_parser import (
     Or,
 )
 from memmachine_server.common.metrics_factory import MetricsFactory
+from memmachine_server.common.vector_store.collection_registry.sqlalchemy_collection_registry import (
+    SQLAlchemyCollectionRegistry,
+    SQLAlchemyCollectionRegistryParams,
+)
 from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
@@ -53,8 +58,21 @@ def any_qdrant_client(request):
 
 
 @pytest_asyncio.fixture
-async def store(any_qdrant_client):
-    params = QdrantVectorStoreParams(client=any_qdrant_client)
+async def collection_registry(sqlalchemy_sqlite_engine):
+    registry = SQLAlchemyCollectionRegistry(
+        SQLAlchemyCollectionRegistryParams(
+            engine=sqlalchemy_sqlite_engine, name="qdrant_test"
+        )
+    )
+    await registry.startup()
+    return registry
+
+
+@pytest_asyncio.fixture
+async def store(any_qdrant_client, collection_registry):
+    params = QdrantVectorStoreParams(
+        client=any_qdrant_client, registry=collection_registry
+    )
     s = QdrantVectorStore(params)
     await s.startup()
     yield s
@@ -1117,13 +1135,14 @@ class TestPartitionIsolation:
 @pytest.mark.integration
 class TestMetrics:
     @pytest.mark.asyncio
-    async def test_metrics_collection(self, qdrant_client):
+    async def test_metrics_collection(self, qdrant_client, collection_registry):
         mock_factory = MagicMock(spec=MetricsFactory)
         mock_histogram = MagicMock(spec=MetricsFactory.Histogram)
         mock_factory.get_histogram.return_value = mock_histogram
 
         params = QdrantVectorStoreParams(
             client=qdrant_client,
+            registry=collection_registry,
             metrics_factory=mock_factory,
         )
         store = QdrantVectorStore(params)
@@ -1156,13 +1175,169 @@ class TestMetrics:
         await store.delete_collection(namespace=NAMESPACE, name="metrics_test")
 
 
+# ── Collection registry integration ──
+
+
+class TestRegistryIntegration:
+    """The config registry, not Qdrant, is the collection metadata authority."""
+
+    CONFIG = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
+    OTHER_CONFIG = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1)
+
+    def _second_store(self, client, registry) -> QdrantVectorStore:
+        return QdrantVectorStore(
+            QdrantVectorStoreParams(client=client, registry=registry)
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_registry_collections_in_qdrant(self, any_qdrant_client, store):
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=self.CONFIG
+        )
+
+        collections = await any_qdrant_client.get_collections()
+        assert all(
+            not collection.name.endswith("__registry")
+            for collection in collections.collections
+        )
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+
+    @pytest.mark.asyncio
+    async def test_stores_sharing_a_registry_share_collections(
+        self, any_qdrant_client, collection_registry, store
+    ):
+        other_store = self._second_store(any_qdrant_client, collection_registry)
+
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=self.CONFIG
+        )
+
+        with pytest.raises(VectorStoreCollectionAlreadyExistsError):
+            await other_store.create_collection(
+                namespace=NAMESPACE, name=NAME, config=self.CONFIG
+            )
+
+        coll = await other_store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert coll is not None
+        assert coll.config == self.CONFIG
+
+        await other_store.delete_collection(namespace=NAMESPACE, name=NAME)
+        assert await store.open_collection(namespace=NAMESPACE, name=NAME) is None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_open_or_create_mismatched_configs(
+        self, any_qdrant_client, collection_registry, store
+    ):
+        other_store = self._second_store(any_qdrant_client, collection_registry)
+
+        results = await asyncio.gather(
+            store.open_or_create_collection(
+                namespace=NAMESPACE, name=NAME, config=self.CONFIG
+            ),
+            other_store.open_or_create_collection(
+                namespace=NAMESPACE, name=NAME, config=self.OTHER_CONFIG
+            ),
+            return_exceptions=True,
+        )
+
+        errors = [result for result in results if isinstance(result, Exception)]
+        assert len(errors) == 1
+        assert isinstance(errors[0], VectorStoreCollectionConfigMismatchError)
+
+        winners = [result for result in results if not isinstance(result, Exception)]
+        assert len(winners) == 1
+        stored = await store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert stored is not None
+        assert stored.config == winners[0].config
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+
+    @pytest.mark.asyncio
+    async def test_registry_keys_are_unambiguous(self, store):
+        # ("a__b", "c") and ("a", "b__c") must be distinct collections,
+        # so the registry key separator cannot be an identifier character.
+        await store.create_collection(namespace="a__b", name="c", config=self.CONFIG)
+        await store.create_collection(
+            namespace="a", name="b__c", config=self.OTHER_CONFIG
+        )
+
+        coll_a = await store.open_collection(namespace="a__b", name="c")
+        coll_b = await store.open_collection(namespace="a", name="b__c")
+        assert coll_a is not None
+        assert coll_b is not None
+        assert coll_a.config == self.CONFIG
+        assert coll_b.config == self.OTHER_CONFIG
+
+        await store.delete_collection(namespace="a__b", name="c")
+        assert await store.open_collection(namespace="a", name="b__c") is not None
+        await store.delete_collection(namespace="a", name="b__c")
+
+    @pytest.mark.asyncio
+    async def test_recreation_mints_a_fresh_generation(
+        self, collection_registry, store
+    ):
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=self.CONFIG
+        )
+        first_entry = await collection_registry.get(namespace=NAMESPACE, name=NAME)
+        assert first_entry is not None
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=self.CONFIG
+        )
+        second_entry = await collection_registry.get(namespace=NAMESPACE, name=NAME)
+        assert second_entry is not None
+
+        assert second_entry.native_collection_name == first_entry.native_collection_name
+        assert second_entry.partition_key != first_entry.partition_key
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+
+    @pytest.mark.asyncio
+    async def test_held_handle_after_delete_cannot_resurrect_records(self, store):
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=self.CONFIG
+        )
+        held = await store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert held is not None
+
+        live_record = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
+        await held.upsert(records=[live_record])
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+
+        # A handle held across the deletion writes into the dead generation.
+        stale_record = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+        await held.upsert(records=[stale_record])
+
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=self.CONFIG
+        )
+        reopened = await store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert reopened is not None
+
+        assert (
+            await reopened.get(record_uuids=[live_record.uuid, stale_record.uuid]) == []
+        )
+        query_results = list(
+            await reopened.query(query_vectors=[_normalize([0.0, 1.0, 0.0])], limit=10)
+        )
+        assert query_results[0].matches == []
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+
+
 # ── Distributed sharding ──
 
 
 @pytest_asyncio.fixture
-async def distributed_store(distributed_qdrant_client):
+async def distributed_store(distributed_qdrant_client, collection_registry):
     params = QdrantVectorStoreParams(
-        client=distributed_qdrant_client, is_distributed=True
+        client=distributed_qdrant_client,
+        is_distributed=True,
+        registry=collection_registry,
     )
     s = QdrantVectorStore(params)
     await s.startup()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlalchemy_collection_registry.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlalchemy_collection_registry.py
@@ -1,0 +1,289 @@
+"""Tests for SQLAlchemyCollectionRegistry — SQLite (unit) and PostgreSQL (integration)."""
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import inspect
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool, StaticPool
+
+from memmachine_server.common.vector_store import VectorStoreCollectionConfig
+from memmachine_server.common.vector_store.collection_registry import (
+    CollectionAlreadyRegisteredError,
+    CollectionRegistryEntry,
+)
+from memmachine_server.common.vector_store.collection_registry.sqlalchemy_collection_registry import (
+    SQLAlchemyCollectionRegistry,
+    SQLAlchemyCollectionRegistryParams,
+)
+
+REGISTRY_NAME = "test_registry"
+NAMESPACE = "test_namespace"
+NAME = "test_name"
+
+ENTRY = CollectionRegistryEntry(
+    config=VectorStoreCollectionConfig(vector_dimensions=3),
+    native_collection_name="test_namespace__digest",
+    partition_key="test_name#generation",
+)
+OTHER_ENTRY = CollectionRegistryEntry(
+    config=VectorStoreCollectionConfig(vector_dimensions=4),
+    native_collection_name="test_namespace__otherdigest",
+    partition_key="test_name#othergeneration",
+)
+
+
+def _build_registry(engine, name=REGISTRY_NAME):
+    return SQLAlchemyCollectionRegistry(
+        SQLAlchemyCollectionRegistryParams(engine=engine, name=name)
+    )
+
+
+@pytest_asyncio.fixture
+async def registry(sqlalchemy_engine):
+    registry = _build_registry(sqlalchemy_engine)
+    await registry.startup()
+    yield registry
+    async with sqlalchemy_engine.begin() as connection:
+        await connection.run_sync(registry._table.metadata.drop_all)
+
+
+@pytest.mark.asyncio
+async def test_startup_is_idempotent(sqlalchemy_engine, registry):
+    await registry.startup()
+
+    other_instance = _build_registry(sqlalchemy_engine)
+    await other_instance.startup()
+
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+    assert await other_instance.get(namespace=NAMESPACE, name=NAME) == ENTRY
+
+
+@pytest.mark.asyncio
+async def test_register_and_get_round_trip(registry):
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+
+    stored_entry = await registry.get(namespace=NAMESPACE, name=NAME)
+    assert stored_entry == ENTRY
+    assert isinstance(stored_entry, CollectionRegistryEntry)
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_none(registry):
+    assert await registry.get(namespace=NAMESPACE, name="missing") is None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_register_raises(registry):
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+
+    with pytest.raises(CollectionAlreadyRegisteredError) as exc_info:
+        await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+    assert exc_info.value.namespace == NAMESPACE
+    assert exc_info.value.name == NAME
+
+
+@pytest.mark.asyncio
+async def test_duplicate_register_with_different_entry_raises(registry):
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+
+    with pytest.raises(CollectionAlreadyRegisteredError):
+        await registry.register(namespace=NAMESPACE, name=NAME, entry=OTHER_ENTRY)
+
+    assert await registry.get(namespace=NAMESPACE, name=NAME) == ENTRY
+
+
+@pytest.mark.asyncio
+async def test_get_or_register_registers_when_missing(registry):
+    stored_entry, registered = await registry.get_or_register(
+        namespace=NAMESPACE, name=NAME, entry=ENTRY
+    )
+
+    assert registered
+    assert stored_entry == ENTRY
+    assert await registry.get(namespace=NAMESPACE, name=NAME) == ENTRY
+
+
+@pytest.mark.asyncio
+async def test_get_or_register_returns_stored_entry_unchanged(registry):
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+
+    stored_entry, registered = await registry.get_or_register(
+        namespace=NAMESPACE, name=NAME, entry=OTHER_ENTRY
+    )
+
+    assert not registered
+    assert stored_entry == ENTRY
+    assert await registry.get(namespace=NAMESPACE, name=NAME) == ENTRY
+
+
+@pytest.mark.asyncio
+async def test_deregister_is_idempotent(registry):
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+
+    await registry.deregister(namespace=NAMESPACE, name=NAME)
+    assert await registry.get(namespace=NAMESPACE, name=NAME) is None
+
+    await registry.deregister(namespace=NAMESPACE, name=NAME)
+
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+    assert await registry.get(namespace=NAMESPACE, name=NAME) == ENTRY
+
+
+@pytest.mark.asyncio
+async def test_registries_are_isolated(sqlalchemy_engine, registry):
+    other_registry = _build_registry(sqlalchemy_engine, name="test_other")
+    await other_registry.startup()
+
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+    await other_registry.register(namespace=NAMESPACE, name=NAME, entry=OTHER_ENTRY)
+
+    assert await registry.get(namespace=NAMESPACE, name=NAME) == ENTRY
+    assert await other_registry.get(namespace=NAMESPACE, name=NAME) == OTHER_ENTRY
+
+    await other_registry.deregister(namespace=NAMESPACE, name=NAME)
+    assert await registry.get(namespace=NAMESPACE, name=NAME) == ENTRY
+    assert await other_registry.get(namespace=NAMESPACE, name=NAME) is None
+
+    async with sqlalchemy_engine.begin() as connection:
+        await connection.run_sync(other_registry._table.metadata.drop_all)
+
+
+@pytest.mark.asyncio
+async def test_registry_table_name_is_derived_from_name(sqlalchemy_engine, registry):
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+
+    async with sqlalchemy_engine.connect() as connection:
+        table_names = await connection.run_sync(
+            lambda sync_connection: inspect(sync_connection).get_table_names()
+        )
+    assert f"collection_registry_{REGISTRY_NAME}" in table_names
+
+
+@pytest.mark.asyncio
+async def test_collection_keys_are_unambiguous(registry):
+    # ("a__b", "c") and ("a", "b__c") must be distinct collections,
+    # so the storage key separator cannot be an identifier character.
+    await registry.register(namespace="a__b", name="c", entry=ENTRY)
+    await registry.register(namespace="a", name="b__c", entry=OTHER_ENTRY)
+
+    assert await registry.get(namespace="a__b", name="c") == ENTRY
+    assert await registry.get(namespace="a", name="b__c") == OTHER_ENTRY
+
+    await registry.deregister(namespace="a__b", name="c")
+    assert await registry.get(namespace="a", name="b__c") == OTHER_ENTRY
+
+
+class TestValidation:
+    @pytest.mark.asyncio
+    async def test_invalid_namespace_raises(self, registry):
+        with pytest.raises(ValueError, match="Namespace"):
+            await registry.get(namespace="Bad-Namespace", name=NAME)
+
+    @pytest.mark.asyncio
+    async def test_invalid_name_raises(self, registry):
+        with pytest.raises(ValueError, match="Name"):
+            await registry.register(namespace=NAMESPACE, name="", entry=ENTRY)
+
+    @pytest.mark.parametrize(
+        "name",
+        ["", "Uppercase", "hyphen-ated", "dotted.name", "x" * 33],
+    )
+    def test_invalid_registry_name_raises(self, sqlalchemy_engine, name):
+        with pytest.raises(ValueError, match="Registry name"):
+            _build_registry(sqlalchemy_engine, name=name)
+
+    def test_static_pool_engine_raises(self):
+        engine = create_async_engine(
+            "sqlite+aiosqlite://",
+            poolclass=StaticPool,
+        )
+        with pytest.raises(Exception, match="StaticPool"):
+            _build_registry(engine)
+
+    def test_ephemeral_sqlite_engine_raises(self):
+        # NullPool to sidestep the StaticPool default for async SQLite memory DBs,
+        # exercising the ephemeral check itself.
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", poolclass=NullPool)
+        with pytest.raises(ValueError, match="ephemeral"):
+            _build_registry(engine)
+
+
+class TestConcurrency:
+    """Concurrency tests using a second registry instance over the same engine."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_register_same_collection(
+        self, sqlalchemy_engine, registry
+    ):
+        other_instance = _build_registry(sqlalchemy_engine)
+
+        results = await asyncio.gather(
+            registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY),
+            other_instance.register(namespace=NAMESPACE, name=NAME, entry=OTHER_ENTRY),
+            return_exceptions=True,
+        )
+
+        errors = [result for result in results if isinstance(result, Exception)]
+        assert len(errors) == 1
+        assert isinstance(errors[0], CollectionAlreadyRegisteredError)
+        assert await registry.get(namespace=NAMESPACE, name=NAME) is not None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_get_or_register_mismatched_entries(
+        self, sqlalchemy_engine, registry
+    ):
+        other_instance = _build_registry(sqlalchemy_engine)
+
+        results = await asyncio.gather(
+            registry.get_or_register(namespace=NAMESPACE, name=NAME, entry=ENTRY),
+            other_instance.get_or_register(
+                namespace=NAMESPACE, name=NAME, entry=OTHER_ENTRY
+            ),
+        )
+
+        stored_entries = [stored_entry for stored_entry, _ in results]
+        assert stored_entries[0] == stored_entries[1]
+        assert stored_entries[0] in (ENTRY, OTHER_ENTRY)
+
+        registered_flags = [registered for _, registered in results]
+        assert sorted(registered_flags) == [False, True]
+
+        assert await registry.get(namespace=NAMESPACE, name=NAME) == stored_entries[0]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_register_distinct_collections(
+        self, sqlalchemy_engine, registry
+    ):
+        other_instance = _build_registry(sqlalchemy_engine)
+
+        await asyncio.gather(
+            registry.register(namespace=NAMESPACE, name="test_name_a", entry=ENTRY),
+            other_instance.register(
+                namespace=NAMESPACE, name="test_name_b", entry=ENTRY
+            ),
+        )
+
+        assert await registry.get(namespace=NAMESPACE, name="test_name_a") == ENTRY
+        assert await registry.get(namespace=NAMESPACE, name="test_name_b") == ENTRY
+
+
+def test_version_1_rows_stay_readable():
+    """
+    Guards the add-optional-only evolution rule: an entry row exactly as
+    version 1 code wrote it must always validate under the current model.
+    """
+    version_1_row = {
+        "config": {
+            "vector_dimensions": 3,
+            "similarity_metric": "cosine",
+            "indexed_properties_schema": {"name": "str"},
+        },
+        "native_collection_name": "test_namespace__digest",
+        "partition_key": "test_name#generation",
+    }
+    entry = CollectionRegistryEntry.model_validate(version_1_row)
+    assert entry.config.vector_dimensions == 3
+    assert entry.native_collection_name == "test_namespace__digest"
+    assert entry.partition_key == "test_name#generation"

--- a/packages/server/src/memmachine_server/common/configuration/database_conf.py
+++ b/packages/server/src/memmachine_server/common/configuration/database_conf.py
@@ -258,11 +258,13 @@ class QdrantConf(YamlSerializableMixin, ApiKeyMixin):
             "If True, native collections use custom sharding."
         ),
     )
-    registry_replication_factor: int = Field(
-        default=1,
+    registry_database: str = Field(
+        ...,
         description=(
-            "Replication factor for registry collections. Write consistency factor "
-            "is set to match so all replicas confirm writes."
+            "Name of a configured relational database (a `databases` entry with "
+            "provider `postgres` or `sqlite`) that stores the collection registry. "
+            "All processes sharing this Qdrant instance must use the same "
+            "registry database."
         ),
     )
 

--- a/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from memmachine_server.common.configuration.database_conf import (
     DatabasesConf,
     Neo4jConf,
+    QdrantConf,
     SQLiteVectorStoreConf,
     SQLiteVectorStoreEngine,
 )
@@ -30,6 +31,13 @@ from memmachine_server.common.vector_graph_store.neo4j_vector_graph_store import
     Neo4jVectorGraphStoreParams,
 )
 from memmachine_server.common.vector_store import VectorStore
+from memmachine_server.common.vector_store.collection_registry import (
+    CollectionRegistry,
+)
+from memmachine_server.common.vector_store.collection_registry.sqlalchemy_collection_registry import (
+    SQLAlchemyCollectionRegistry,
+    SQLAlchemyCollectionRegistryParams,
+)
 from memmachine_server.common.vector_store.vector_search_engine import (
     VectorSearchEngine,
 )
@@ -537,6 +545,35 @@ class DatabaseManager:
 
     # --- Qdrant ---
 
+    async def _build_qdrant_collection_registry(
+        self, name: str, conf: QdrantConf
+    ) -> CollectionRegistry:
+        """Build and start the collection registry for a Qdrant instance."""
+        try:
+            engine = await self.async_get_sql_engine(conf.registry_database)
+        except ValueError as e:
+            raise QdrantConfigurationError(
+                f"Qdrant config '{name}': registry_database "
+                f"'{conf.registry_database}' is not a configured relational database.",
+            ) from e
+
+        # One registry per Qdrant instance, so instances sharing a registry
+        # database get separate tables.
+        registry_name = f"qdrant_{name}"
+        try:
+            registry = SQLAlchemyCollectionRegistry(
+                SQLAlchemyCollectionRegistryParams(engine=engine, name=registry_name)
+            )
+        except ValueError as e:
+            raise QdrantConfigurationError(
+                f"Qdrant config name '{name}' cannot name a collection registry "
+                f"({registry_name!r} is not a valid registry name). "
+                "Rename the qdrant databases entry to match [a-z0-9_]+ "
+                "and be at most 25 bytes.",
+            ) from e
+        await registry.startup()
+        return registry
+
     @staticmethod
     async def _close_qdrant_client(name: str, client: "AsyncQdrantClient") -> None:
         try:
@@ -584,12 +621,13 @@ class DatabaseManager:
                 QdrantVectorStoreParams,
             )
 
-            params = QdrantVectorStoreParams(
-                client=client,
-                is_distributed=conf.is_distributed,
-                registry_replication_factor=conf.registry_replication_factor,
-            )
             try:
+                registry = await self._build_qdrant_collection_registry(name, conf)
+                params = QdrantVectorStoreParams(
+                    client=client,
+                    is_distributed=conf.is_distributed,
+                    registry=registry,
+                )
                 store = QdrantVectorStore(params)
                 await store.startup()
             except Exception:

--- a/packages/server/src/memmachine_server/common/vector_store/collection_registry/__init__.py
+++ b/packages/server/src/memmachine_server/common/vector_store/collection_registry/__init__.py
@@ -1,0 +1,13 @@
+"""Collection registry interface and implementations."""
+
+from .collection_registry import (
+    CollectionAlreadyRegisteredError,
+    CollectionRegistry,
+    CollectionRegistryEntry,
+)
+
+__all__ = [
+    "CollectionAlreadyRegisteredError",
+    "CollectionRegistry",
+    "CollectionRegistryEntry",
+]

--- a/packages/server/src/memmachine_server/common/vector_store/collection_registry/collection_registry.py
+++ b/packages/server/src/memmachine_server/common/vector_store/collection_registry/collection_registry.py
@@ -1,0 +1,182 @@
+"""
+Abstract base class for a vector store collection registry.
+
+Defines the interface for registering, retrieving,
+and deregistering logical collections.
+"""
+
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel, Field
+
+from memmachine_server.common.vector_store.data_types import (
+    VectorStoreCollectionConfig,
+)
+
+
+class CollectionRegistryEntry(BaseModel):
+    """
+    Registered identity of a logical vector store collection.
+
+    Stores the collection's resolved identity alongside its config:
+    the native collection name is fixed at registration,
+    so later changes to config serialization
+    cannot silently repoint the collection at a new native collection,
+    and the partition key carries a per-registration generation,
+    so records written through handles held across a deregistration
+    stay invisible and are never resurrected by a re-registration.
+
+    One entry format is shared by all vector store backends;
+    extend it by adding optional fields with defaults
+    rather than with backend-specific entry types.
+    A new field's default must reproduce the behavior
+    that existed before the field:
+    stored entries predating it are read through that default.
+    A change that cannot be expressed that way is breaking:
+    introduce an entry format version field (default 1) at that point --
+    the rule above guarantees pre-existing entries classify correctly --
+    and migrate deliberately.
+    """
+
+    config: VectorStoreCollectionConfig = Field(
+        ...,
+        description="Configuration for the collection",
+    )
+    native_collection_name: str = Field(
+        ...,
+        description="Native collection storing the records",
+    )
+    partition_key: str = Field(
+        ...,
+        description=("Generation-scoped partition key for the collection's records"),
+    )
+
+
+class CollectionAlreadyRegisteredError(Exception):
+    """Raised when registering a collection that is already registered."""
+
+    def __init__(self, namespace: str, name: str) -> None:
+        """Initialize with the namespace and name of the existing collection."""
+        self.namespace = namespace
+        self.name = name
+        super().__init__(f"Collection ({namespace!r}, {name!r}) is already registered.")
+
+
+class CollectionRegistry(ABC):
+    """
+    Abstract base class for a vector store collection registry.
+
+    A collection registry is a durable catalog of a vector store's
+    logical collections: a mapping from (namespace, name)
+    to an immutable CollectionRegistryEntry.
+    It is the metadata authority that makes collection lifecycle
+    operations atomic across processes sharing the same backing store;
+    the vector store holds a registry dedicated to it
+    and cannot reach any other registry through it.
+
+    Entries are immutable:
+    a collection holds the entry it was registered with
+    until it is deregistered.
+    Implementations must make registration atomic
+    across processes sharing the same backing store.
+
+    Stored entries are canonicalized by serialization,
+    so a returned entry may differ from the object it was registered from
+    (e.g. defaults filled in), but is identical for every reader.
+
+    Namespaces and names follow the VectorStore naming constraints.
+    """
+
+    @abstractmethod
+    async def startup(self) -> None:
+        """Prepare the registry's backing storage. Idempotent."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def shutdown(self) -> None:
+        """Shutdown."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def register(
+        self, *, namespace: str, name: str, entry: CollectionRegistryEntry
+    ) -> None:
+        """
+        Atomically register a collection.
+
+        Args:
+            namespace (str):
+                Namespace of the collection.
+            name (str):
+                Name of the collection within the namespace.
+            entry (CollectionRegistryEntry):
+                Registered identity of the collection.
+
+        Raises:
+            CollectionAlreadyRegisteredError:
+                If the collection is already registered,
+                regardless of whether its stored entry
+                matches the provided entry.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get(self, *, namespace: str, name: str) -> CollectionRegistryEntry | None:
+        """
+        Get the stored entry for a collection.
+
+        Args:
+            namespace (str):
+                Namespace of the collection.
+            name (str):
+                Name of the collection within the namespace.
+
+        Returns:
+            CollectionRegistryEntry | None:
+                The stored entry, or None if the collection is not registered.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_or_register(
+        self, *, namespace: str, name: str, entry: CollectionRegistryEntry
+    ) -> tuple[CollectionRegistryEntry, bool]:
+        """
+        Atomically register a collection if it is not registered.
+
+        Never compares entries:
+        if the collection is already registered,
+        its stored entry is returned unchanged
+        regardless of the provided entry.
+        Callers enforce their own config equality policy.
+
+        Args:
+            namespace (str):
+                Namespace of the collection.
+            name (str):
+                Name of the collection within the namespace.
+            entry (CollectionRegistryEntry):
+                Registered identity to store if the collection
+                is not registered.
+
+        Returns:
+            tuple[CollectionRegistryEntry, bool]:
+                The stored entry,
+                and whether this call registered the collection.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def deregister(self, *, namespace: str, name: str) -> None:
+        """
+        Deregister a collection.
+
+        It is idempotent.
+
+        Args:
+            namespace (str):
+                Namespace of the collection.
+            name (str):
+                Name of the collection within the namespace.
+        """
+        raise NotImplementedError

--- a/packages/server/src/memmachine_server/common/vector_store/collection_registry/sqlalchemy_collection_registry.py
+++ b/packages/server/src/memmachine_server/common/vector_store/collection_registry/sqlalchemy_collection_registry.py
@@ -1,0 +1,273 @@
+"""SQLAlchemy-backed collection registry implementation."""
+
+import re
+from typing import override
+
+from pydantic import (
+    BaseModel,
+    Field,
+    InstanceOf,
+    JsonValue,
+    TypeAdapter,
+    field_validator,
+)
+from sqlalchemy import (
+    JSON,
+    Column,
+    Insert,
+    MetaData,
+    String,
+    Table,
+    delete,
+    insert,
+    select,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.pool import StaticPool
+
+from memmachine_server.common.vector_store.utils import validate_identifier
+
+from .collection_registry import (
+    CollectionAlreadyRegisteredError,
+    CollectionRegistry,
+    CollectionRegistryEntry,
+)
+
+_JSON_AUTO = JSON().with_variant(JSONB, "postgresql")
+
+_TABLE_NAME_PREFIX = "collection_registry_"
+
+# Registry names become SQL identifier components:
+# prefix (20 bytes) + name (32 bytes) stays within
+# PostgreSQL's 63-byte identifier limit.
+_REGISTRY_NAME_RE = re.compile(r"^[a-z0-9_]+$")
+_MAX_REGISTRY_NAME_BYTES = 32
+
+_MAX_KEY_LENGTH = 255
+
+_SUPPORTED_DIALECTS = ("postgresql", "sqlite")
+
+_ENTRY_ADAPTER: TypeAdapter[CollectionRegistryEntry] = TypeAdapter(
+    CollectionRegistryEntry
+)
+
+
+class SQLAlchemyCollectionRegistryParams(BaseModel):
+    """
+    Parameters for SQLAlchemyCollectionRegistry.
+
+    Attributes:
+        engine (AsyncEngine):
+            Async SQLAlchemy engine.
+            Must use a PostgreSQL or SQLite dialect.
+        name (str):
+            Name identifying which vector store this is the registry for.
+            Determines the registry's table name,
+            so it must match `[a-z0-9_]+`
+            and be at most 32 bytes.
+    """
+
+    engine: InstanceOf[AsyncEngine] = Field(
+        ...,
+        description="Async SQLAlchemy engine with a PostgreSQL or SQLite dialect",
+    )
+    name: str = Field(
+        ...,
+        description=(
+            "Name identifying which vector store this is the registry for; "
+            "determines the registry's table name, "
+            "so it must match [a-z0-9_]+ and be at most 32 bytes"
+        ),
+    )
+
+    @field_validator("engine")
+    @classmethod
+    def _validate_engine(cls, engine: AsyncEngine) -> AsyncEngine:
+        assert not isinstance(engine.pool, StaticPool), (
+            "Engine uses StaticPool, which shares one connection across sessions. "
+            "Use a multi-connection pool instead."
+        )
+        db = engine.url.database
+        if engine.dialect.name == "sqlite" and (db is None or db == ":memory:"):
+            raise ValueError(
+                "Engine uses ephemeral SQLite, where each connection gets a separate database. "
+                "Use a file path instead."
+            )
+        if engine.dialect.name not in _SUPPORTED_DIALECTS:
+            raise ValueError(
+                f"Engine dialect {engine.dialect.name!r} is not supported. "
+                f"Supported dialects: {', '.join(_SUPPORTED_DIALECTS)}."
+            )
+        return engine
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, name: str) -> str:
+        if not _REGISTRY_NAME_RE.match(name):
+            raise ValueError(
+                f"Registry name {name!r} must match [a-z0-9_]+ "
+                "(lowercase alphanumeric and underscores only)"
+            )
+        if len(name.encode()) > _MAX_REGISTRY_NAME_BYTES:
+            raise ValueError(
+                f"Registry name {name!r} must be at most "
+                f"{_MAX_REGISTRY_NAME_BYTES} bytes"
+            )
+        return name
+
+
+class SQLAlchemyCollectionRegistry(CollectionRegistry):
+    """
+    Asynchronous SQLAlchemy-backed implementation of CollectionRegistry.
+
+    Each registry owns a dedicated table named after the registry
+    (`collection_registry_<name>`),
+    so registries sharing a database never collide
+    and an instance can only reach its own registry.
+
+    Registration is atomic across processes:
+    the table's primary key is the arbiter,
+    via plain INSERT for register
+    and native INSERT .. ON CONFLICT DO NOTHING for get_or_register.
+    """
+
+    def __init__(self, params: SQLAlchemyCollectionRegistryParams) -> None:
+        """Initialize the collection registry with the provided parameters."""
+        super().__init__()
+        self._engine = params.engine
+        self._name = params.name
+
+        self._table = Table(
+            _TABLE_NAME_PREFIX + params.name,
+            MetaData(),
+            Column("key", String(_MAX_KEY_LENGTH), primary_key=True),
+            Column("entry", _JSON_AUTO, nullable=False),
+        )
+
+    @staticmethod
+    def _key(namespace: str, name: str) -> str:
+        """
+        Build the storage key for a collection.
+
+        The separator is outside the identifier charset ([a-z0-9_]+),
+        so distinct (namespace, name) pairs can never produce the same key.
+        """
+        return f"{namespace}/{name}"
+
+    @staticmethod
+    def _validate_collection_identifiers(namespace: str, name: str) -> None:
+        """Validate a collection's namespace and name."""
+        if not validate_identifier(namespace):
+            raise ValueError(
+                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
+            )
+        if not validate_identifier(name):
+            raise ValueError(
+                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
+            )
+
+    def _insert_ignoring_conflicts(self, key: str, dumped_entry: JsonValue) -> Insert:
+        """Build a dialect-native INSERT that ignores primary key conflicts."""
+        if self._engine.dialect.name == "postgresql":
+            return (
+                postgresql_insert(self._table)
+                .values(key=key, entry=dumped_entry)
+                .on_conflict_do_nothing()
+            )
+        return (
+            sqlite_insert(self._table)
+            .values(key=key, entry=dumped_entry)
+            .on_conflict_do_nothing()
+        )
+
+    @override
+    async def startup(self) -> None:
+        """Idempotently create the registry's table."""
+        async with self._engine.begin() as connection:
+            await connection.run_sync(self._table.metadata.create_all)
+
+    @override
+    async def shutdown(self) -> None:
+        """No-op; engine lifecycle is managed externally."""
+
+    @override
+    async def register(
+        self, *, namespace: str, name: str, entry: CollectionRegistryEntry
+    ) -> None:
+        """Atomically register a collection in the registry table."""
+        SQLAlchemyCollectionRegistry._validate_collection_identifiers(namespace, name)
+        dumped_entry = _ENTRY_ADAPTER.dump_python(entry, mode="json")
+        try:
+            async with self._engine.begin() as connection:
+                await connection.execute(
+                    insert(self._table).values(
+                        key=SQLAlchemyCollectionRegistry._key(namespace, name),
+                        entry=dumped_entry,
+                    )
+                )
+        except IntegrityError as err:
+            raise CollectionAlreadyRegisteredError(namespace, name) from err
+
+    @override
+    async def get(self, *, namespace: str, name: str) -> CollectionRegistryEntry | None:
+        """Get the stored entry for a collection."""
+        SQLAlchemyCollectionRegistry._validate_collection_identifiers(namespace, name)
+        async with self._engine.connect() as connection:
+            result = await connection.execute(
+                select(self._table.c.entry).where(
+                    self._table.c.key
+                    == SQLAlchemyCollectionRegistry._key(namespace, name)
+                )
+            )
+            row = result.one_or_none()
+        if row is None:
+            return None
+        return _ENTRY_ADAPTER.validate_python(row.entry)
+
+    @override
+    async def get_or_register(
+        self, *, namespace: str, name: str, entry: CollectionRegistryEntry
+    ) -> tuple[CollectionRegistryEntry, bool]:
+        """Atomically register a collection if it is not registered."""
+        SQLAlchemyCollectionRegistry._validate_collection_identifiers(namespace, name)
+
+        stored_entry = await self.get(namespace=namespace, name=name)
+        if stored_entry is not None:
+            return stored_entry, False
+
+        dumped_entry = _ENTRY_ADAPTER.dump_python(entry, mode="json")
+        async with self._engine.begin() as connection:
+            result = await connection.execute(
+                self._insert_ignoring_conflicts(
+                    SQLAlchemyCollectionRegistry._key(namespace, name),
+                    dumped_entry,
+                )
+            )
+            registered = result.rowcount == 1
+        if registered:
+            return _ENTRY_ADAPTER.validate_python(dumped_entry), True
+
+        # Lost a concurrent registration race; the winner's entry is stored.
+        stored_entry = await self.get(namespace=namespace, name=name)
+        if stored_entry is None:
+            raise RuntimeError(
+                f"Collection ({namespace!r}, {name!r}) in registry {self._name!r} "
+                "was deregistered during concurrent registration"
+            )
+        return stored_entry, False
+
+    @override
+    async def deregister(self, *, namespace: str, name: str) -> None:
+        """Idempotently deregister a collection."""
+        SQLAlchemyCollectionRegistry._validate_collection_identifiers(namespace, name)
+        async with self._engine.begin() as connection:
+            await connection.execute(
+                delete(self._table).where(
+                    self._table.c.key
+                    == SQLAlchemyCollectionRegistry._key(namespace, name)
+                )
+            )

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -3,10 +3,10 @@
 import asyncio
 import hashlib
 from collections import defaultdict
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
 from datetime import datetime
 from typing import Any, ClassVar, cast, override
-from uuid import UUID, uuid5
+from uuid import UUID, uuid4
 from weakref import WeakKeyDictionary
 
 import grpc
@@ -44,6 +44,11 @@ from memmachine_server.common.filter.filter_parser import (
 from memmachine_server.common.metrics_factory import MetricsFactory, OperationTracker
 from memmachine_server.common.utils import ensure_tz_aware
 
+from .collection_registry import (
+    CollectionAlreadyRegisteredError,
+    CollectionRegistry,
+    CollectionRegistryEntry,
+)
 from .data_types import (
     QueryMatch,
     QueryResult,
@@ -504,10 +509,10 @@ class QdrantVectorStoreParams(BaseModel):
             so each logical collection maps to a dedicated shard key.
             This enables logical collection deletion via shard drop
             instead of filter-based deletion.
-        registry_replication_factor (int):
-            Replication factor for registry collections. Write consistency factor is
-            set to match so all replicas confirm writes before returning, guaranteeing
-            read-your-writes from any available replica.
+        registry (CollectionRegistry):
+            Registry cataloging this store's logical collections.
+            Must be dedicated to this Qdrant vector store
+            and shared by every process using it.
         metrics_factory (MetricsFactory | None):
             An instance of MetricsFactory for collecting usage metrics
             (default: None).
@@ -528,12 +533,12 @@ class QdrantVectorStoreParams(BaseModel):
             "instead of filter-based deletion"
         ),
     )
-    registry_replication_factor: int = Field(
-        1,
+    registry: InstanceOf[CollectionRegistry] = Field(
+        ...,
         description=(
-            "Replication factor for registry collections. Write consistency factor is "
-            "set to match so all replicas confirm writes before returning, guaranteeing "
-            "read-your-writes from any available replica"
+            "Registry cataloging this store's logical collections. "
+            "Must be dedicated to this Qdrant vector store "
+            "and shared by every process using it"
         ),
     )
     metrics_factory: InstanceOf[MetricsFactory] | None = Field(
@@ -564,19 +569,9 @@ class QdrantVectorStore(VectorStore):
         datetime: models.PayloadSchemaType.DATETIME,
     }
 
-    # Registry collection keys (stored on registry points, one per logical collection)
-    _REGISTRY_SUFFIX: ClassVar[str] = "__registry"
-    _REGISTRY_NAME: ClassVar[str] = "name"
-    _REGISTRY_VECTOR_DIMENSIONS: ClassVar[str] = "vector_dimensions"
-    _REGISTRY_SIMILARITY_METRIC: ClassVar[str] = "similarity_metric"
-    _REGISTRY_INDEXED_PROPERTIES_SCHEMA: ClassVar[str] = "indexed_properties_schema"
-
-    # Fixed UUID namespace for deterministic registry point IDs.
-    _REGISTRY_UUID_NAMESPACE: ClassVar[UUID] = UUID(
-        "a3c1f6d2-4b8e-4f2a-9c7d-1e5f8a0b3d6c"
-    )
-
     # Keyed by client so locks are garbage-collected when the client is.
+    # Serializes lifecycle operations on a logical collection within this
+    # process only; cross-process exclusion comes from the config registry.
     _name_locks: ClassVar[
         WeakKeyDictionary[
             AsyncQdrantClient,
@@ -586,35 +581,40 @@ class QdrantVectorStore(VectorStore):
 
     @staticmethod
     def _is_already_exists_error(error: Exception) -> bool:
-        """Check if an exception indicates a resource already exists."""
-        if isinstance(error, UnexpectedResponse):
-            return error.status_code == 409
-        if isinstance(error, grpc.aio.AioRpcError):
-            return error.code() == grpc.StatusCode.ALREADY_EXISTS
-        if isinstance(error, ValueError):
-            return "already exists" in str(error).lower()
-        return False
+        """
+        Check if an exception indicates a resource already exists.
+
+        Typed status codes are the authority; the message check is a last
+        resort for responses without a distinctive code (the local
+        :memory: client raises bare ValueError, and some server errors
+        carry only a message).
+        """
+        if isinstance(error, UnexpectedResponse) and error.status_code == 409:
+            return True
+        if (
+            isinstance(error, grpc.aio.AioRpcError)
+            and error.code() == grpc.StatusCode.ALREADY_EXISTS
+        ):
+            return True
+        return "already exists" in str(error).lower()
 
     @staticmethod
     def _is_not_found_error(error: Exception) -> bool:
-        """Check if an exception indicates a resource was not found."""
-        if isinstance(error, UnexpectedResponse):
-            return error.status_code == 404
-        if isinstance(error, grpc.aio.AioRpcError):
-            return error.code() == grpc.StatusCode.NOT_FOUND
-        if isinstance(error, ValueError):
-            return "not found" in str(error).lower()
-        return False
+        """
+        Check if an exception indicates a resource was not found.
 
-    @staticmethod
-    def _registry_collection_name(namespace: str) -> str:
-        """Return the registry collection name for a namespace."""
-        return f"{namespace}{QdrantVectorStore._REGISTRY_SUFFIX}"
-
-    @staticmethod
-    def _registry_point_uuid(name: str) -> UUID:
-        """Return a deterministic UUID for a logical collection name."""
-        return uuid5(QdrantVectorStore._REGISTRY_UUID_NAMESPACE, name)
+        Typed status codes are the authority; the message check is a last
+        resort for responses without a distinctive code.
+        """
+        if isinstance(error, UnexpectedResponse) and error.status_code == 404:
+            return True
+        if (
+            isinstance(error, grpc.aio.AioRpcError)
+            and error.code() == grpc.StatusCode.NOT_FOUND
+        ):
+            return True
+        message = str(error).lower()
+        return "not found" in message or "does not exist" in message
 
     @staticmethod
     def _build_native_collection_name(
@@ -630,7 +630,7 @@ class QdrantVectorStore(VectorStore):
         self._client: AsyncQdrantClient = params.client
         self._is_distributed = params.is_distributed
 
-        self._registry_replication_factor = params.registry_replication_factor
+        self._registry: CollectionRegistry = params.registry
 
         self._hnsw_m = 16
 
@@ -651,85 +651,33 @@ class QdrantVectorStore(VectorStore):
     async def shutdown(self) -> None:
         """No-op; client lifecycle is managed externally."""
 
-    async def _ensure_namespace_registry_collection(self, namespace: str) -> None:
-        """Idempotently create the registry collection for a namespace."""
-        registry_collection_name = QdrantVectorStore._registry_collection_name(
-            namespace
-        )
-        try:
-            await self._client.create_collection(
-                collection_name=registry_collection_name,
-                vectors_config=models.VectorParams(
-                    size=1,
-                    distance=models.Distance.COSINE,
-                ),
-                hnsw_config=models.HnswConfigDiff(
-                    m=0,
-                ),
-                replication_factor=self._registry_replication_factor,
-                write_consistency_factor=self._registry_replication_factor,
-            )
-        except (UnexpectedResponse, grpc.aio.AioRpcError, ValueError) as e:
-            if not QdrantVectorStore._is_already_exists_error(e):
-                raise
-
-    async def _get_registry_entry(
-        self, namespace: str, name: str
-    ) -> dict[str, Any] | None:
-        """
-        Retrieve the registry entry for a logical collection name.
-
-        Verifies the stored name matches
-        to guard against SHA-1 collisions in the uuid5 point ID.
-        """
-        registry_collection_name = QdrantVectorStore._registry_collection_name(
-            namespace
-        )
-        point_uuid = QdrantVectorStore._registry_point_uuid(name)
-        try:
-            points = await self._client.retrieve(
-                collection_name=registry_collection_name,
-                ids=[point_uuid],
-                with_payload=True,
-            )
-        except (UnexpectedResponse, grpc.aio.AioRpcError, ValueError) as e:
-            if QdrantVectorStore._is_not_found_error(e):
-                return None
-            raise
-
-        if not points:
-            return None
-
-        payload = cast(dict[str, Any], points[0].payload)
-        if payload.get(QdrantVectorStore._REGISTRY_NAME) != name:
-            return None
-
-        return payload
-
     @staticmethod
-    def _parse_entry(entry: Mapping[str, Any]) -> VectorStoreCollectionConfig:
-        """Parse a VectorStoreCollectionConfig from a registry entry."""
-        return VectorStoreCollectionConfig(
-            vector_dimensions=entry[QdrantVectorStore._REGISTRY_VECTOR_DIMENSIONS],
-            similarity_metric=entry[QdrantVectorStore._REGISTRY_SIMILARITY_METRIC],
-            indexed_properties_schema=entry[
-                QdrantVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA
-            ],
+    def _build_collection_entry(
+        namespace: str, name: str, config: VectorStoreCollectionConfig
+    ) -> CollectionRegistryEntry:
+        """Build a registry entry with a fresh generation for a new collection."""
+        return CollectionRegistryEntry(
+            config=config,
+            native_collection_name=QdrantVectorStore._build_native_collection_name(
+                namespace, config
+            ),
+            # "#" is outside the identifier charset ([a-z0-9_]+),
+            # so generationed partition keys can never collide
+            # with each other or with plain names.
+            partition_key=f"{name}#{uuid4().hex}",
         )
 
     def _build_collection_handle(
-        self, namespace: str, name: str, config: VectorStoreCollectionConfig
+        self, entry: CollectionRegistryEntry
     ) -> QdrantVectorStoreCollection:
-        """Build a QdrantVectorStoreCollection handle."""
+        """Build a QdrantVectorStoreCollection handle from a registry entry."""
         return QdrantVectorStoreCollection(
             client=self._client,
-            collection_name=QdrantVectorStore._build_native_collection_name(
-                namespace, config
-            ),
-            partition_key=name,
-            config=config,
+            collection_name=entry.native_collection_name,
+            partition_key=entry.partition_key,
+            config=entry.config,
             tracker=self._tracker,
-            shard_key=name if self._is_distributed else None,
+            shard_key=entry.partition_key if self._is_distributed else None,
         )
 
     async def _create_native_collection(
@@ -787,33 +735,8 @@ class QdrantVectorStore(VectorStore):
                 native_collection_name, shard_key=shard_key
             )
         except (UnexpectedResponse, grpc.aio.AioRpcError) as e:
-            if "already exists" not in str(e).lower():
+            if not QdrantVectorStore._is_already_exists_error(e):
                 raise
-
-    async def _register_collection(
-        self, namespace: str, name: str, config: VectorStoreCollectionConfig
-    ) -> None:
-        """Write the logical collection entry to the registry."""
-        registry_name = QdrantVectorStore._registry_collection_name(namespace)
-        point_uuid = QdrantVectorStore._registry_point_uuid(name)
-        await self._client.upsert(
-            collection_name=registry_name,
-            points=[
-                models.PointStruct(
-                    id=point_uuid,
-                    vector=[0.0],
-                    payload={
-                        QdrantVectorStore._REGISTRY_NAME: name,
-                        QdrantVectorStore._REGISTRY_VECTOR_DIMENSIONS: config.vector_dimensions,
-                        QdrantVectorStore._REGISTRY_SIMILARITY_METRIC: config.similarity_metric.value,
-                        QdrantVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA: config.model_dump(
-                            mode="json"
-                        )["indexed_properties_schema"],
-                    },
-                ),
-            ],
-            wait=True,
-        )
 
     @override
     async def create_collection(
@@ -836,16 +759,23 @@ class QdrantVectorStore(VectorStore):
             self._client_name_locks[(namespace, name)],
             self._tracker("create_collection"),
         ):
-            await self._ensure_namespace_registry_collection(namespace)
-            if await self._get_registry_entry(namespace, name) is not None:
-                raise VectorStoreCollectionAlreadyExistsError(namespace, name)
+            entry = QdrantVectorStore._build_collection_entry(namespace, name, config)
             await self._create_native_collection(namespace, config)
             if self._is_distributed:
-                native_collection_name = (
-                    QdrantVectorStore._build_native_collection_name(namespace, config)
+                await self._ensure_shard_key(
+                    entry.native_collection_name, entry.partition_key
                 )
-                await self._ensure_shard_key(native_collection_name, name)
-            await self._register_collection(namespace, name, config)
+            # The registry entry is the atomic commit point.
+            # A crash or a lost creation race before it leaves only an empty
+            # native collection (shared by config and adopted by the next
+            # creation with the same config) and, in distributed mode, an
+            # unused shard key.
+            try:
+                await self._registry.register(
+                    namespace=namespace, name=name, entry=entry
+                )
+            except CollectionAlreadyRegisteredError as e:
+                raise VectorStoreCollectionAlreadyExistsError(namespace, name) from e
 
     @override
     async def open_or_create_collection(
@@ -868,24 +798,28 @@ class QdrantVectorStore(VectorStore):
             self._client_name_locks[(namespace, name)],
             self._tracker("open_or_create_collection"),
         ):
-            entry = await self._get_registry_entry(namespace, name)
-            if entry is not None:
-                existing_config = QdrantVectorStore._parse_entry(entry)
-                if existing_config != config:
+            existing_entry = await self._registry.get(namespace=namespace, name=name)
+            if existing_entry is not None:
+                if existing_entry.config != config:
                     raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
+                        namespace, name, existing_entry.config, config
                     )
-                return self._build_collection_handle(namespace, name, existing_config)
+                return self._build_collection_handle(existing_entry)
 
-            await self._ensure_namespace_registry_collection(namespace)
+            entry = QdrantVectorStore._build_collection_entry(namespace, name, config)
             await self._create_native_collection(namespace, config)
             if self._is_distributed:
-                native_collection_name = (
-                    QdrantVectorStore._build_native_collection_name(namespace, config)
+                await self._ensure_shard_key(
+                    entry.native_collection_name, entry.partition_key
                 )
-                await self._ensure_shard_key(native_collection_name, name)
-            await self._register_collection(namespace, name, config)
-            return self._build_collection_handle(namespace, name, config)
+            stored_entry, registered = await self._registry.get_or_register(
+                namespace=namespace, name=name, entry=entry
+            )
+            if not registered and stored_entry.config != config:
+                raise VectorStoreCollectionConfigMismatchError(
+                    namespace, name, stored_entry.config, config
+                )
+            return self._build_collection_handle(stored_entry)
 
     @override
     async def open_collection(
@@ -900,12 +834,10 @@ class QdrantVectorStore(VectorStore):
             raise ValueError(
                 f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
             )
-        entry = await self._get_registry_entry(namespace, name)
+        entry = await self._registry.get(namespace=namespace, name=name)
         if entry is None:
             return None
-        return self._build_collection_handle(
-            namespace, name, QdrantVectorStore._parse_entry(entry)
-        )
+        return self._build_collection_handle(entry)
 
     @override
     async def close_collection(self, *, collection: VectorStoreCollection) -> None:
@@ -913,7 +845,12 @@ class QdrantVectorStore(VectorStore):
 
     @override
     async def delete_collection(self, *, namespace: str, name: str) -> None:
-        """Delete a logical collection from the Qdrant vector store."""
+        """
+        Delete a logical collection from the Qdrant vector store.
+
+        A crash between data deletion and deregistration leaves the
+        collection registered but empty; retrying the deletion completes it.
+        """
         if not validate_identifier(namespace):
             raise ValueError(
                 f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
@@ -926,38 +863,31 @@ class QdrantVectorStore(VectorStore):
             self._client_name_locks[(namespace, name)],
             self._tracker("delete_collection"),
         ):
-            entry = await self._get_registry_entry(namespace, name)
+            entry = await self._registry.get(namespace=namespace, name=name)
             if entry is None:
                 return
 
-            config = QdrantVectorStore._parse_entry(entry)
-            native_collection_name = QdrantVectorStore._build_native_collection_name(
-                namespace, config
-            )
-
-            # Delete partition data, then registry entry.
+            # Delete partition data, then the registry entry:
+            # a crash in between leaves a registered-but-empty collection,
+            # and retrying the delete is idempotent.
+            # Records written through handles held across this deletion land
+            # under the dead generation's partition key: invisible to every
+            # reader, and never resurrected by a re-creation, which mints a
+            # fresh generation.
             if self._is_distributed:
                 try:
                     await self._client.delete_shard_key(
-                        native_collection_name, shard_key=name
+                        entry.native_collection_name, shard_key=entry.partition_key
                     )
                 except (UnexpectedResponse, grpc.aio.AioRpcError) as e:
-                    if "does not exist" not in str(e).lower():
+                    if not QdrantVectorStore._is_not_found_error(e):
                         raise
             else:
                 await self._client.delete(
-                    collection_name=native_collection_name,
+                    collection_name=entry.native_collection_name,
                     points_selector=models.FilterSelector(
-                        filter=_partition_filter(name),
+                        filter=_partition_filter(entry.partition_key),
                     ),
                 )
 
-            registry_name = QdrantVectorStore._registry_collection_name(namespace)
-            point_uuid = QdrantVectorStore._registry_point_uuid(name)
-            await self._client.delete(
-                collection_name=registry_name,
-                points_selector=models.PointIdsList(
-                    points=[point_uuid],
-                ),
-                wait=True,
-            )
+            await self._registry.deregister(namespace=namespace, name=name)

--- a/packages/server/src/memmachine_server/installation/configuration_wizard.py
+++ b/packages/server/src/memmachine_server/installation/configuration_wizard.py
@@ -494,7 +494,11 @@ class ConfigurationWizard:
             case self.QDRANT_VECTOR_STORE_ID:
                 # Localhost defaults assume `docker run -p 6333:6333 qdrant/qdrant`
                 # or similar; user can edit cfg.yml to point at a remote Qdrant.
-                databases.qdrant_confs = {self.QDRANT_VECTOR_STORE_ID: QdrantConf()}
+                databases.qdrant_confs = {
+                    self.QDRANT_VECTOR_STORE_ID: QdrantConf(
+                        registry_database=self.SQLITE_DB_ID,
+                    )
+                }
             case self.MILVUS_VECTOR_STORE_ID:
                 # Local file defaults use Milvus Lite. Users can edit cfg.yml
                 # to point at a Milvus server or Zilliz Cloud URI/token.

--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -102,6 +102,7 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        registry_database: sqlite_test  # relational database (databases entry) storing collection metadata; must be the same for every process sharing this Qdrant
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
     # VectorStore for vector-backed semantic memory.
     # Wire it via `semantic_memory.vector_collection`.
@@ -113,6 +114,7 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        registry_database: sqlite_test  # relational database (databases entry) storing collection metadata; must be the same for every process sharing this Qdrant
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
     #
     # Alternative: Milvus. The local .db URI uses Milvus Lite; replace it with

--- a/sample_configs/episodic_memory_config.gpu.sample
+++ b/sample_configs/episodic_memory_config.gpu.sample
@@ -101,6 +101,7 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        registry_database: sqlite_test  # relational database (databases entry) storing collection metadata; must be the same for every process sharing this Qdrant
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
     # VectorStore for vector-backed semantic memory.
     # Wire it via `semantic_memory.vector_collection`.
@@ -112,6 +113,7 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        registry_database: sqlite_test  # relational database (databases entry) storing collection metadata; must be the same for every process sharing this Qdrant
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
     #
     # Alternative: Milvus. The local .db URI uses Milvus Lite; replace it with

--- a/sample_configs/episodic_memory_config.nebula.sample
+++ b/sample_configs/episodic_memory_config.nebula.sample
@@ -118,6 +118,7 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        registry_database: sqlite_test  # relational database (databases entry) storing collection metadata; must be the same for every process sharing this Qdrant
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
     #
     # Alternative: Milvus. The local .db URI uses Milvus Lite; replace it with


### PR DESCRIPTION
### Purpose of the change

Horizontal scalability: let multiple MemMachine server processes work with the *same* logical collections on one Qdrant cluster (#1525). Strict sharding of collection names across processes — what the `VectorStore` contract requires today — has always worked; this PR is the redesign that lifts the restriction for collection lifecycle management, by moving QdrantVectorStore's collection metadata out of Qdrant onto the SQL-backed config registry from #1526.

**Stacked on #1526**; only the last commit is new to this PR.

Qdrant offers no conditional writes, transactions, or unique constraints, so the current `<ns>__registry` bookkeeping (dummy-vector points keyed `uuid5(name)`) makes `create_collection` / `open_or_create_collection` / `delete_collection` non-atomic read-check-write sequences, guarded only by a per-process asyncio lock. The moment two processes manage the same name:

- `VectorStoreCollectionAlreadyExistsError` stops firing — two concurrent creates both pass the absence check and last-writer-wins the registry point.
- Worse, two `open_or_create_collection` calls with **different** configs each create a *different* native collection (native names are `sha256(config)` while registry points are keyed by name), one silently wins the registry, and records written through the loser's handle become permanently unreachable. `VectorStoreCollectionConfigMismatchError` never fires.

With the registry's unique-constraint CAS as the commit point, both guarantees hold across processes sharing the same registry database, and generationed partition keys make `delete_collection` safe against handles held in other processes. Scope: lifecycle/metadata management — data-path read-after-write visibility tuning remains a separate concern.

### Description

**`qdrant_vector_store.py`**: all `__registry` machinery is deleted (`_REGISTRY_*` constants, uuid5 point ids, `_ensure_namespace_registry_collection`, `_get_registry_entry`, `_parse_entry`, `_register_collection`, `_is_not_found_error`, `registry_replication_factor`). `QdrantVectorStoreParams` gains a required `registry: CollectionRegistry`.

**Registry entries store resolved identity, not just config** (`CollectionRegistryEntry` from #1526): `config`, `native_collection_name`, and a generation-scoped `partition_key` (minted at creation; also the shard key in distributed mode).

- *Native name pinned at creation*: handles are built from the stored name rather than re-deriving `sha256(config)` on every open, so a later change to the config model's serialization (any added field re-hashes every config) cannot silently repoint existing collections at new empty native collections. The naming scheme for new collections is untouched.
- *Generationed partition keys make deletion safe against held handles*: `delete_collection` removes that generation's data and the entry; a handle held across the deletion keeps writing into the dead generation — invisible to every reader, storage-only garbage — and a re-creation mints a fresh generation, so stale records are never resurrected. No locks and no per-write round trips; the residual cost is bounded garbage under dead generations (a future GC can sweep partition keys absent from the registry).

Lifecycle ordering, chosen for crash windows:

- **Create: native-first, register-last.** The registry insert is the atomic commit point. A crash after native creation leaves only an empty native collection, which is shared by config and adopted by the next creation with the same config. (Claim-registry-first would be worse: `open_collection` builds handles straight from the entry, so a crash between claim and native create would hand out handles to a nonexistent native collection.) Invariant: registry entry implies native collection exists.
- **Delete: data-first, unregister-last** (unchanged ordering). A crash in between leaves a registered-but-empty collection (documented on `delete_collection`); retrying the delete completes it.
- **Create-race losers leave an empty native collection** (created before the CAS) and, in distributed mode, an unused shard key. Cleanup is deliberately not attempted — native collections are config-shared, so nothing can safely decide no other logical collection references one — and the residue is bounded by the number of distinct configs attempted.

`_name_locks` stays, with its comment updated: it now only serializes lifecycle operations within a process (preserving today's single-process open-vs-delete interleaving semantics and avoiding redundant idempotent round trips); cross-process correctness comes from the registry CAS.

**Wiring** (`database_manager.py`): `async_get_qdrant_client` builds and starts a `SQLAlchemyCollectionRegistry` named `qdrant_<conf name>` on the engine named by the new `QdrantConf.registry_database`, passing it into the store — QdrantVectorStore holds a registry dedicated to it and cannot reach any other. One registry per Qdrant conf entry, so two Qdrant instances sharing one registry database get separate tables. Misconfiguration (unknown database name, or a conf entry name that cannot form a registry table name) raises `QdrantConfigurationError` with the fix spelled out.

**Configuration** (`database_conf.py`, samples, docs): `QdrantConf.registry_database` (required) names a configured relational database (`postgres` or `sqlite` entry); `registry_replication_factor` is removed — it existed to give the Qdrant-hosted registry read-your-writes, which is moot now. Sample configs and the configuration docs gained the new field; the installation wizard points Qdrant at its existing SQLite entry.

**Design doc**: `design/collection_registry_backends.md`.

### Breaking changes

- `QdrantConf.registry_database` is required: existing Qdrant users add one line of YAML (single-node setups can point at a `sqlite` relational entry). There is deliberately no per-host auto-SQLite fallback — divergent per-host registries would look consistent while reproducing exactly the races this PR removes. Stale `registry_replication_factor` YAML keys are silently ignored (`extra="ignore"`).
- Existing `<ns>__registry` Qdrant collections are no longer read, and there is no data migration. This is mostly self-healing: native collection names are unchanged, so the first `open_or_create_collection` with an unchanged config re-registers it and all data is reachable again. Caveat: paths that re-create with a *currently derived* schema (e.g. the episodic event backend) will orphan old partitions if that schema drifted since original creation — the old registry would have preserved the original config. Stale `__registry` collections can be deleted manually.

### Fixes/Closes

Fixes #1525

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test

- Existing QdrantVectorStore suite unchanged in behavior, now parametrized with a registry over the full client matrix: in-memory (unit) plus HTTP, gRPC, and distributed-cluster containers (`integration`).
- New `TestRegistryIntegration`: no `__registry`-suffixed collections exist in Qdrant after creation; two stores sharing one registry+client see each other's collections (create raises `AlreadyExists` cross-store, delete in one is observed by the other); concurrent `open_or_create_collection` with mismatched configs yields exactly one winner and one `VectorStoreCollectionConfigMismatchError`; `("a__b", "c")` and `("a", "b__c")` are distinct collections (key-ambiguity regression); re-creation mints a fresh generation over the same native collection; records upserted through a handle held across a deletion are unreachable from the re-created collection (resurrection regression).
- `test_database_manager.py`: registry built on the named engine and passed into the store; unknown `registry_database` and un-usable conf entry names raise `QdrantConfigurationError` and close the client.
- `test_database_conf.py`: field swap, required-field validation.

**Test Results:** full server suite 1901 passed locally; targeted integration run (qdrant containers + PostgreSQL registry) 452 passed; `ruff check`, `ruff format --check`, `ty check packages` clean (no new diagnostics).

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [ ] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Further comments

The same swap for `MilvusVectorStore` lands later in this stack.

