### PR TITLE
Feat: Declare concurrency scope and data-plane contracts on storage ABCs (collection registry stack 4/5)

### DIFF
--- a/design/concurrency_scopes.md
+++ b/design/concurrency_scopes.md
@@ -1,0 +1,104 @@
+# Concurrency scopes and data-plane contracts
+
+Contributor-facing design notes for `ConcurrencyScope` and the visibility and
+authority contracts on `VectorStoreCollection`.
+
+## The problem
+
+The `VectorStore` contract said a logical collection "must be managed by at
+most one process at a time". That is true of some implementations and not
+others, and it is about to stop being true of more of them: the moment one
+backend genuinely supports multi-process management, a blanket sentence is
+either false for it or forbids what it supports -- capability the contract
+cannot express is capability no consumer may use.
+
+## Declared scope
+
+`ConcurrencyScope` (`common/data_types.py`) is an `IntEnum`,
+`PROCESS < MACHINE < CLUSTER`: the widest deployment boundary within which
+concurrent instances of a component may safely manage the same resources.
+Ordered by breadth, so the effective scope of a composed system is the `min`
+of its parts' scopes.
+
+`VectorStore` and `SegmentStore` declare an abstract
+`concurrency_scope` property, and the blanket sentences defer to it:
+concurrent management of the same collection/partition is safe within the
+declared scope; beyond it, at most one instance manages a resource and the
+consumer shards names, as before.
+
+Declarations:
+
+| Component | Scope | Why |
+|---|---|---|
+| `SQLAlchemySegmentStore` | `CLUSTER` on PostgreSQL, `MACHINE` on SQLite | cross-process safe via unique-constraint create and row locks |
+| `QdrantVectorStore` | `PROCESS` | bookkeeping guarded only by in-process locks |
+| `MilvusVectorStore` | `PROCESS` | bookkeeping guarded only by in-process locks |
+| `SQLiteVectorStore` | `PROCESS` | search-engine state lives in process memory |
+| `SQLiteVecVectorStore` | `PROCESS` | check-then-write bookkeeping within one process |
+
+A deployment can therefore introspect what it is allowed to do, instead of
+relying on out-of-band knowledge, and a component that composes several
+reports the `min` of them. `PROCESS` declarations are honest labels for
+current implementations, not permanent judgments: a store whose metadata
+moves to a cross-process authority widens to whatever that authority
+reaches, and the property is the place that change becomes visible.
+
+## Data-plane contracts
+
+Two properties stated on `VectorStoreCollection`. Both are pre-existing
+behavior; multi-process deployment is what makes them worth stating, because
+single-process consumers could survive assuming their negations.
+
+- Visibility: a returned write is durably accepted but is not guaranteed
+  visible to a subsequent query, from this instance or any other. Consumers
+  must not build on read-your-writes. (True even single-process today;
+  uniform staleness, not a per-client asymmetry.)
+- Authority: stored properties and property filters operate on the
+  collection's own copy of a record, with no freshness guarantee relative to
+  any external source of truth. A vector store can promise internal
+  consistency of its own copy, never authority over data governed elsewhere;
+  consumers whose records are governed by an external authority (e.g. SQL
+  holding access-determining attributes) must re-validate results against it.
+  Post-validation at the source of truth can only remove candidates -- an
+  attribute may be pre-filtered inside the vector store only if it is
+  immutable after ingest or if staleness can only produce false positives.
+
+## Handle lifetime is not scope-conditional
+
+The data-plane contracts include one invariant deliberately stated
+without reference to scope: a write through a handle whose collection
+has been deleted must never surface in a collection later created under
+the same name.
+
+Scope is what makes the uniformity necessary rather than tidy. PROCESS
+is the only scope at which the *application* could be the guarantor,
+since inside one process it sees every handle it holds and every delete
+it issues. Above PROCESS that is impossible -- one process holds a
+handle while another deletes and recreates, and the first cannot learn
+of it -- so any store declaring MACHINE or CLUSTER has to provide the
+invariant outright. Making it conditional would then leave consumers
+writing against the lenient reading and breaking when a backend's scope
+widens under them, which is what any move to a cross-process metadata
+authority would do to Qdrant and Milvus. The discipline it would delegate is also expensive and
+silently violable: handle-lifetime tracking across tasks, in every
+consumer, to avoid a failure whose symptom is corrupted data rather than
+an error.
+
+Known non-conformance: both SQLite-backed vector stores derive their
+native resources from (namespace, name) alone and do resurrect such
+writes -- immediately in `SQLiteVecVectorStore`, and on the next index
+save in `SQLiteVectorStore`, whose stale handle also rewrites the live
+index file of the replacement collection. Tracked in
+MemMachine/MemMachine#1536 and, for Qdrant, MemMachine/MemMachine#1563.
+Incarnation-scoped partition keys are the fix in both cases.
+
+## Rejected alternatives
+
+- Deleting the one-process sentence outright: Milvus and the SQLite stores
+  still need it; per-instance declaration is the only shape that tells the
+  truth for all implementations at once.
+- Boolean "multi-process safe" flag: loses the machine/cluster distinction,
+  which is exactly the distinction a shared-SQLite deployment needs.
+- Runtime enforcement (detecting out-of-scope concurrent managers): requires
+  cross-process membership machinery; the scope is a contract, like the
+  identifier constraints, not a guard.

--- a/design/storage_lifecycle_strictness.md
+++ b/design/storage_lifecycle_strictness.md
@@ -1,0 +1,71 @@
+# Strict create/open storage lifecycles
+
+Contributor-facing design notes for the removal of `open_or_create_*` from
+`VectorStore` and `SegmentStore`.
+
+## The rule
+
+`create` fails on an existing resource; `open` returns nothing for a missing
+one. Adopt-on-exists (ensure) is not a lifecycle primitive on a store. Where
+a call site needs it, it composes it: open, create suppressing
+`AlreadyExistsError` (a concurrent creator winning is fine), open again.
+
+## Why: a store has no provenance
+
+Not because strictness is a virtue. Because a store, handed a name, cannot
+tell a retry of its own caller's create from a create by someone else who
+chose the same name. Only a caller knows why an existing resource is
+acceptable -- it is resuming work it started. Idempotency is a property of a
+step that has provenance, and the store is precisely the layer without it.
+An `open_or_create` on the store answers a question the store cannot
+actually answer, and answers it silently.
+
+What the removed methods bundled, beyond idempotency, was a config and a
+returned handle: does this exist, what shape is it, and give me access, in
+one call. The config half is what `ConfigMismatchError` existed to
+compensate for -- adopting someone else's differently-configured resource --
+and it is the half that is genuinely wrong, since no call site derives its
+config from input. With strict create/open, a caller that loses a creation
+race adopts the winner's resource via `open`, and the handle carries the
+stored config for any consumer wanting its own equality policy.
+
+An audit found exactly two consumers of the removed methods
+(`semantic_manager.get_semantic_storage` and the episodic event backend's
+`service_locator`), neither needing adoption as a primitive; both now use the
+composed form, and both are callers that do know they are resuming their own
+work. `EventMemory` itself never had ensure semantics -- it receives
+already-opened handles.
+
+## Removed
+
+- `VectorStore.open_or_create_collection` (all four implementations) and
+  `VectorStoreCollectionConfigMismatchError` (the method was its only
+  raiser).
+- `SegmentStore.open_or_create_partition` and
+  `SegmentStorePartitionConfigMismatchError`, with the implementation's
+  mismatch-check helper.
+
+Untouched, and out of scope: `EpisodicMemoryManager
+.open_or_create_episodic_memory` is an in-process instance-cache accessor
+(get-or-construct a session's memory object), not a durable-storage ensure.
+
+## Relation to the server redesign
+
+`design/server_redesign.md` reaches the same store interface by the same
+argument, and places idempotency in a tenant layer's `ensure`, which has the
+provenance a store lacks: it inserted the tenant row before any job ran, so
+a live row is its own earlier attempt.
+
+It also asks strict create to do something this change does not, and the
+difference is worth not eliding. There, a key is a UUID minted once and
+never reused, so a row existing under a key is evidence of a violated
+invariant, and a create that raises on a row *in any state, including a
+tombstone*, is the detector for it -- which is why tombstones are retained
+rather than dropped after reclamation.
+
+Here, names are reused by design: a collection can be deleted and another
+created under the same name later. `create` raising means "this exists", not
+"an invariant was violated", and separation between successive lives of a
+name comes from incarnation-scoped resources (#1537, #1563) rather than from
+the name being unique in time. The two read alike at the signature and prove
+different things; do not carry the stronger reading across.

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_semantic_manager_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_semantic_manager_vector_store.py
@@ -21,7 +21,9 @@ from memmachine_server.semantic_memory.storage.vector_store_semantic_storage imp
 async def test_semantic_manager_builds_vector_store_backend(sqlalchemy_sqlite_engine):
     vector_store = MagicMock()
     vector_collection = MagicMock()
-    vector_store.open_or_create_collection = AsyncMock(return_value=vector_collection)
+    # First open misses; the manager then creates and re-opens.
+    vector_store.open_collection = AsyncMock(side_effect=[None, vector_collection])
+    vector_store.create_collection = AsyncMock()
 
     resource_manager = MagicMock()
     resource_manager.get_sql_engine = AsyncMock(return_value=sqlalchemy_sqlite_engine)
@@ -49,6 +51,7 @@ async def test_semantic_manager_builds_vector_store_backend(sqlalchemy_sqlite_en
         "semantic_db", validate=True
     )
     resource_manager.get_vector_store.assert_awaited_once_with("semantic_vectors")
-    vector_store.open_or_create_collection.assert_awaited_once()
+    vector_store.create_collection.assert_awaited_once()
+    assert vector_store.open_collection.await_count == 2
 
     await storage.cleanup()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -14,7 +14,11 @@ pymilvus = pytest.importorskip("pymilvus")
 DataType = pymilvus.DataType
 MilvusClient = pymilvus.MilvusClient
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import (
+    ConcurrencyScope,
+    PropertyValue,
+    SimilarityMetric,
+)
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -539,3 +543,7 @@ class TestPartitionIsolation:
 
         await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
         await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
+
+
+def test_concurrency_scope_is_process(store):
+    assert store.concurrency_scope == ConcurrencyScope.PROCESS

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -27,7 +27,6 @@ from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from memmachine_server.common.vector_store.milvus_vector_store import (
     MilvusVectorStore,
@@ -142,21 +141,6 @@ class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_delete_nonexistent_is_idempotent(self, store):
         await store.delete_collection(namespace=NAMESPACE, name="nonexistent")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_raises_on_config_mismatch(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="mismatch",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        with pytest.raises(VectorStoreCollectionConfigMismatchError):
-            await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name="mismatch",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1),
-            )
-        await store.delete_collection(namespace=NAMESPACE, name="mismatch")
 
     @pytest.mark.asyncio
     async def test_same_config_shares_native_collection(self, store):

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -23,7 +23,6 @@ from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from memmachine_server.common.vector_store.qdrant_vector_store import (
     QdrantVectorStore,
@@ -143,42 +142,6 @@ class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_delete_nonexistent_is_idempotent(self, store):
         await store.delete_collection(namespace=NAMESPACE, name="nonexistent")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_creates_when_missing(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="new", config=config
-        )
-        assert isinstance(coll, QdrantVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="new")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_opens_when_exists(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        assert isinstance(coll, QdrantVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="existing")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_raises_on_config_mismatch(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="mismatch",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        with pytest.raises(VectorStoreCollectionConfigMismatchError):
-            await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name="mismatch",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1),
-            )
-        await store.delete_collection(namespace=NAMESPACE, name="mismatch")
 
     @pytest.mark.asyncio
     async def test_same_config_shares_native_collection(self, store):

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -9,7 +9,11 @@ import pytest
 import pytest_asyncio
 from qdrant_client import AsyncQdrantClient
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import (
+    ConcurrencyScope,
+    PropertyValue,
+    SimilarityMetric,
+)
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -1117,6 +1121,15 @@ class TestMetrics:
         assert call_labels[1]["labels"]["status"] == "ok"
 
         await store.delete_collection(namespace=NAMESPACE, name="metrics_test")
+
+
+# ── Concurrency scope ──
+
+
+@pytest.mark.asyncio
+async def test_concurrency_scope_is_process(store):
+    """Collection bookkeeping is guarded only by in-process locks."""
+    assert store.concurrency_scope == ConcurrencyScope.PROCESS
 
 
 # ── Distributed sharding ──

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -21,7 +21,6 @@ from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from memmachine_server.common.vector_store.sqlite_vec_vector_store import (
     SQLiteVecVectorStore,
@@ -37,6 +36,14 @@ pytestmark = pytest.mark.skipif(
 NAMESPACE = "test_namespace"
 NAME = "test_name"
 VECTOR_DIM = 3
+
+
+async def _create_and_open(store, *, namespace, name, config):
+    """Create a collection and open a handle to it."""
+    await store.create_collection(namespace=namespace, name=name, config=config)
+    coll = await store.open_collection(namespace=namespace, name=name)
+    assert coll is not None
+    return coll
 
 
 def _normalize(vector: list[float]) -> list[float]:
@@ -134,42 +141,6 @@ class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_delete_nonexistent_is_idempotent(self, store):
         await store.delete_collection(namespace=NAMESPACE, name="nonexistent")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_creates_when_missing(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="new", config=config
-        )
-        assert isinstance(coll, SQLiteVecVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="new")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_opens_when_exists(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        assert isinstance(coll, SQLiteVecVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="existing")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_raises_on_config_mismatch(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="mismatch",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        with pytest.raises(VectorStoreCollectionConfigMismatchError):
-            await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name="mismatch",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1),
-            )
-        await store.delete_collection(namespace=NAMESPACE, name="mismatch")
 
     @pytest.mark.asyncio
     async def test_open_nonexistent_returns_none(self, store):
@@ -830,11 +801,11 @@ class TestPartitionIsolation:
     async def test_delete_collection_does_not_affect_sibling(self, store):
         """Deleting one collection doesn't break a sibling sharing tables."""
         config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll_a = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="sibling_a", config=config
+        coll_a = await _create_and_open(
+            store, namespace=NAMESPACE, name="sibling_a", config=config
         )
-        coll_b = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="sibling_b", config=config
+        coll_b = await _create_and_open(
+            store, namespace=NAMESPACE, name="sibling_b", config=config
         )
 
         v1 = _normalize([1.0, 0.0, 0.0])
@@ -862,8 +833,8 @@ class TestEuclideanMetric:
             vector_dimensions=2,
             similarity_metric=SimilarityMetric.EUCLIDEAN,
         )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="euclidean", config=config
         )
         r1 = _make_record(vector=[0.0, 0.0])
         r2 = _make_record(vector=[3.0, 4.0])
@@ -882,8 +853,8 @@ class TestNoProperties:
     @pytest.mark.asyncio
     async def test_collection_without_properties(self, store):
         config = VectorStoreCollectionConfig(vector_dimensions=2)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="no_props", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="no_props", config=config
         )
         r1 = _make_record(vector=[1.0, 0.0])
         await coll.upsert(records=[r1])
@@ -938,8 +909,8 @@ class TestScoreSemantics:
             vector_dimensions=2,
             similarity_metric=SimilarityMetric.EUCLIDEAN,
         )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean_score", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="euclidean_score", config=config
         )
         r1 = _make_record(vector=[0.0, 0.0])
         r2 = _make_record(vector=[3.0, 4.0])

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -9,7 +9,7 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.data_types import ConcurrencyScope, SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -982,3 +982,7 @@ class TestFilterEdgeCases:
         assert r1.uuid in uuids
         assert r3.uuid in uuids
         assert r2.uuid not in uuids
+
+
+def test_concurrency_scope_is_process(store):
+    assert store.concurrency_scope == ConcurrencyScope.PROCESS

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -9,7 +9,7 @@ import pytest_asyncio
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.data_types import ConcurrencyScope, SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -1452,3 +1452,7 @@ class TestIndexFileDurability:
 
         await store2.shutdown()
         await engine2.dispose()
+
+
+def test_concurrency_scope_is_process(store):
+    assert store.concurrency_scope == ConcurrencyScope.PROCESS

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -21,7 +21,6 @@ from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from memmachine_server.common.vector_store.sqlite_vector_store import (
     IndexLoadError,
@@ -38,6 +37,14 @@ from memmachine_server.common.vector_store.vector_search_engine.usearch_engine i
 NAMESPACE = "test_namespace"
 NAME = "test_name"
 VECTOR_DIM = 3
+
+
+async def _create_and_open(store, *, namespace, name, config):
+    """Create a collection and open a handle to it."""
+    await store.create_collection(namespace=namespace, name=name, config=config)
+    coll = await store.open_collection(namespace=namespace, name=name)
+    assert coll is not None
+    return coll
 
 
 def _normalize(vector: list[float]) -> list[float]:
@@ -140,42 +147,6 @@ class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_delete_nonexistent_is_idempotent(self, store):
         await store.delete_collection(namespace=NAMESPACE, name="nonexistent")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_creates_when_missing(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="new", config=config
-        )
-        assert isinstance(coll, SQLiteVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="new")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_opens_when_exists(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        assert isinstance(coll, SQLiteVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="existing")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_raises_on_config_mismatch(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="mismatch",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        with pytest.raises(VectorStoreCollectionConfigMismatchError):
-            await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name="mismatch",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1),
-            )
-        await store.delete_collection(namespace=NAMESPACE, name="mismatch")
 
     @pytest.mark.asyncio
     async def test_open_nonexistent_returns_none(self, store):
@@ -836,11 +807,11 @@ class TestPartitionIsolation:
     async def test_delete_collection_does_not_affect_sibling(self, store):
         """Deleting one collection doesn't break a sibling sharing tables."""
         config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll_a = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="sibling_a", config=config
+        coll_a = await _create_and_open(
+            store, namespace=NAMESPACE, name="sibling_a", config=config
         )
-        coll_b = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="sibling_b", config=config
+        coll_b = await _create_and_open(
+            store, namespace=NAMESPACE, name="sibling_b", config=config
         )
 
         v1 = _normalize([1.0, 0.0, 0.0])
@@ -868,8 +839,8 @@ class TestEuclideanMetric:
             vector_dimensions=2,
             similarity_metric=SimilarityMetric.EUCLIDEAN,
         )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="euclidean", config=config
         )
         r1 = _make_record(vector=[0.0, 0.0])
         r2 = _make_record(vector=[3.0, 4.0])
@@ -889,8 +860,8 @@ class TestNoProperties:
     @pytest.mark.asyncio
     async def test_collection_without_properties(self, store):
         config = VectorStoreCollectionConfig(vector_dimensions=2)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="no_props", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="no_props", config=config
         )
         r1 = _make_record(vector=[1.0, 0.0])
         await coll.upsert(records=[r1])
@@ -912,8 +883,8 @@ class TestDotProductMetric:
             vector_dimensions=VECTOR_DIM,
             similarity_metric=SimilarityMetric.DOT,
         )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="dot", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="dot", config=config
         )
         v1 = _normalize([1.0, 0.0, 0.0])
         v2 = _normalize([0.0, 1.0, 0.0])
@@ -971,8 +942,8 @@ class TestScoreSemantics:
             vector_dimensions=2,
             similarity_metric=SimilarityMetric.EUCLIDEAN,
         )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean_score", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="euclidean_score", config=config
         )
         r1 = _make_record(vector=[0.0, 0.0])
         r2 = _make_record(vector=[3.0, 4.0])
@@ -1128,8 +1099,8 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         records = [
             _make_record(vector=_normalize([1.0, 0.0, 0.0])),
@@ -1159,8 +1130,8 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         records = [
             _make_record(vector=_normalize([1.0, 0.0, 0.0])),
@@ -1192,8 +1163,8 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         r1 = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
         r2 = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
@@ -1224,8 +1195,8 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         r1 = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
         r2 = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
@@ -1260,8 +1231,8 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=2)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
 
         # Upsert 1 record: below threshold, pending op should remain.
@@ -1283,8 +1254,8 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         records = [
             _make_record(vector=_normalize([1.0, 0.0, 0.0])),
@@ -1347,9 +1318,7 @@ class TestIndexFileDurability:
         """A freshly created collection has index_saved=False."""
         db_path = tmp_path / "test.db"
         store, engine = await _fresh_store(db_path, tmp_path)
-        await store.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        await _create_and_open(store, namespace=NAMESPACE, name=NAME, config=CONFIG)
 
         assert await _get_index_saved(engine, NAMESPACE, NAME) is False
 
@@ -1362,8 +1331,8 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store, engine = await _fresh_store(db_path, tmp_path, save_threshold=1)
 
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
 
@@ -1378,8 +1347,8 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store, engine = await _fresh_store(db_path, tmp_path, save_threshold=1000)
 
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
 
@@ -1397,8 +1366,8 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
         await store1.shutdown()
@@ -1428,8 +1397,8 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
         await store1.shutdown()
@@ -1456,8 +1425,8 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=1000)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         await coll.upsert(
             records=[

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
@@ -11,6 +11,7 @@ import pytest_asyncio
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from memmachine_server.common.data_types import ConcurrencyScope
 from memmachine_server.common.filter.filter_parser import Comparison
 from memmachine_server.common.payload_codec.payload_codec_config import (
     PlaintextPayloadCodecConfig,
@@ -991,3 +992,11 @@ async def test_pg_mixed_context_types(
 
     result = await partition.get_segment_contexts([s_none.uuid])
     assert result[s_none.uuid][0].context == NullContext()
+
+
+@pytest.mark.asyncio
+async def test_concurrency_scope_matches_dialect(store: SQLAlchemySegmentStore) -> None:
+    if store._engine.dialect.name == "postgresql":
+        assert store.concurrency_scope == ConcurrencyScope.CLUSTER
+    else:
+        assert store.concurrency_scope == ConcurrencyScope.MACHINE

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
@@ -116,11 +116,20 @@ def store(request) -> SQLAlchemySegmentStore:
     return request.getfixturevalue(request.param)
 
 
+async def _create_and_open_partition(store, partition_key, config):
+    """Create a partition and open a handle to it."""
+    await store.create_partition(partition_key, config)
+    partition = await store.open_partition(partition_key)
+    assert partition is not None
+    return partition
+
+
 @pytest_asyncio.fixture
 async def partition(
     store: SQLAlchemySegmentStore,
 ) -> SQLAlchemySegmentStorePartition:
-    return await store.open_or_create_partition(
+    return await _create_and_open_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -481,13 +490,15 @@ async def test_contexts_session_isolation(store: SQLAlchemySegmentStore) -> None
     s_seed = _seg(event_uuid=ep, offset=1, ts_offset_seconds=1)
     s_after = _seg(event_uuid=ep, offset=2, ts_offset_seconds=2)
 
-    other_partition = await store.open_or_create_partition(
+    other_partition = await _create_and_open_partition(
+        store,
         "other_session",
         _plaintext_partition_config(),
     )
     await other_partition.add_segments(_links(s_other))
 
-    partition = await store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -672,12 +683,11 @@ async def test_delete_segments_partial(
 
 
 async def _get_partition(engine: AsyncEngine) -> SQLAlchemySegmentStorePartition:
-    """Create a partition handle that shares the engine."""
+    """Open a second handle to the existing partition over a shared engine."""
     store = SQLAlchemySegmentStore(SQLAlchemySegmentStoreParams(engine=engine))
-    return await store.open_or_create_partition(
-        PARTITION_KEY,
-        _plaintext_partition_config(),
-    )
+    partition = await store.open_partition(PARTITION_KEY)
+    assert partition is not None
+    return partition
 
 
 @pytest.mark.asyncio
@@ -686,6 +696,7 @@ async def test_concurrent_add_disjoint(
 ) -> None:
     """Concurrent additions with disjoint segments should not interfere."""
     engine = store._engine
+    await store.create_partition(PARTITION_KEY, _plaintext_partition_config())
 
     async def add_batch(batch_id: int) -> None:
         part = await _get_partition(engine)
@@ -712,7 +723,8 @@ async def test_concurrent_reads_during_writes(
 ) -> None:
     """Reads should not fail or block indefinitely while writes are happening."""
     engine = store._engine
-    partition = await store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -752,7 +764,8 @@ async def test_concurrent_context_reads_during_deletes(
 ) -> None:
     """get_segment_contexts should not crash if segments are deleted concurrently."""
     engine = store._engine
-    partition = await store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -797,10 +810,11 @@ async def test_concurrent_context_reads_during_deletes(
 
 
 @pytest.mark.asyncio
-async def test_open_or_create_partition_defaults_to_plaintext_config(
+async def test_create_partition_defaults_to_plaintext_config(
     store: SQLAlchemySegmentStore,
 ) -> None:
-    partition = await store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        store,
         "plaintext_default",
         _plaintext_partition_config(),
     )
@@ -835,32 +849,9 @@ async def test_open_partition_existing(store: SQLAlchemySegmentStore) -> None:
 
 
 @pytest.mark.asyncio
-async def test_open_or_create_partition_creates(store: SQLAlchemySegmentStore) -> None:
-    partition = await store.open_or_create_partition(
-        "fresh",
-        _plaintext_partition_config(),
-    )
-    assert partition is not None
-    # Verify it was actually created.
-    opened = await store.open_partition("fresh")
-    assert opened is not None
-
-
-@pytest.mark.asyncio
-async def test_open_or_create_partition_idempotent(
-    store: SQLAlchemySegmentStore,
-) -> None:
-    await store.create_partition("idem", _plaintext_partition_config())
-    partition = await store.open_or_create_partition(
-        "idem",
-        _plaintext_partition_config(),
-    )
-    assert partition is not None
-
-
-@pytest.mark.asyncio
 async def test_delete_partition_removes_data(store: SQLAlchemySegmentStore) -> None:
-    partition = await store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        store,
         "to_delete",
         _plaintext_partition_config(),
     )
@@ -877,7 +868,8 @@ async def test_delete_partition_removes_data(store: SQLAlchemySegmentStore) -> N
 async def test_delete_partition_cascades_segments(
     store: SQLAlchemySegmentStore,
 ) -> None:
-    partition = await store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        store,
         "cascade_test",
         _plaintext_partition_config(),
     )
@@ -888,7 +880,8 @@ async def test_delete_partition_cascades_segments(
     await store.delete_partition("cascade_test")
 
     # Re-create the partition and verify data is gone.
-    new_partition = await store.open_or_create_partition(
+    new_partition = await _create_and_open_partition(
+        store,
         "cascade_test",
         _plaintext_partition_config(),
     )
@@ -932,7 +925,8 @@ async def test_pg_context_preserved_via_lateral_join(
     pg_store: SQLAlchemySegmentStore,
 ) -> None:
     """Context is preserved when retrieved via the LATERAL join path (multiple seeds)."""
-    partition = await pg_store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        pg_store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -971,7 +965,8 @@ async def test_pg_mixed_context_types(
     pg_store: SQLAlchemySegmentStore,
 ) -> None:
     """Different context types (producer, None) round-trip correctly on PG."""
-    partition = await pg_store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        pg_store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )

--- a/packages/server/src/memmachine_server/common/data_types.py
+++ b/packages/server/src/memmachine_server/common/data_types.py
@@ -1,7 +1,7 @@
 """Common data types for MemMachine."""
 
 from datetime import datetime
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Final
 
 PropertyValue = bool | int | float | str | datetime
@@ -24,6 +24,25 @@ FilterValue = bool | int | float | str | datetime | list[int] | list[str]
 
 OrderedValue = int | float | datetime
 """Type for values that can be ordered/sorted."""
+
+
+class ConcurrencyScope(IntEnum):
+    """
+    Widest safe deployment boundary for concurrent resource management.
+
+    The scope within which concurrent instances of a component may safely
+    manage the same resources. Ordered by breadth, so the effective scope
+    of a composed system is the minimum of its parts' scopes.
+    """
+
+    PROCESS = 1
+    """Concurrent management is safe only within a single process."""
+
+    MACHINE = 2
+    """Concurrent management is safe across processes on one machine."""
+
+    CLUSTER = 3
+    """Concurrent management is safe across machines."""
 
 
 class SimilarityMetric(Enum):

--- a/packages/server/src/memmachine_server/common/resource_manager/semantic_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/semantic_manager.py
@@ -1,6 +1,7 @@
 """Manager for semantic memory resources and services."""
 
 import asyncio
+import contextlib
 from typing import cast
 
 from pydantic import InstanceOf
@@ -15,7 +16,10 @@ from memmachine_server.common.episode_store import EpisodeStorage
 from memmachine_server.common.errors import ResourceNotReadyError
 from memmachine_server.common.language_model import LanguageModel
 from memmachine_server.common.resource_manager import CommonResourceManager
-from memmachine_server.common.vector_store import VectorStoreCollectionConfig
+from memmachine_server.common.vector_store import (
+    VectorStoreCollectionAlreadyExistsError,
+    VectorStoreCollectionConfig,
+)
 from memmachine_server.semantic_memory.config_store.caching_semantic_config_storage import (
     CachingSemanticConfigStorage,
 )
@@ -147,27 +151,44 @@ class SemanticResourceManager:
         if vector_dimensions is None:
             vector_dimensions = (await self._get_default_embedder()).dimensions
 
-        collection = await vector_store.open_or_create_collection(
+        collection_config = VectorStoreCollectionConfig(
+            vector_dimensions=vector_dimensions,
+            similarity_metric=self._conf.vector_similarity_metric,
+            indexed_properties_schema={
+                "feature_id": str,
+                "set_id": str,
+                "set": str,
+                "semantic_category_id": str,
+                "category_name": str,
+                "category": str,
+                "tag_id": str,
+                "tag": str,
+                "feature": str,
+                "feature_name": str,
+                "value": str,
+            },
+        )
+        collection = await vector_store.open_collection(
             namespace=_VECTOR_STORE_NAMESPACE,
             name=_VECTOR_STORE_COLLECTION_NAME,
-            config=VectorStoreCollectionConfig(
-                vector_dimensions=vector_dimensions,
-                similarity_metric=self._conf.vector_similarity_metric,
-                indexed_properties_schema={
-                    "feature_id": str,
-                    "set_id": str,
-                    "set": str,
-                    "semantic_category_id": str,
-                    "category_name": str,
-                    "category": str,
-                    "tag_id": str,
-                    "tag": str,
-                    "feature": str,
-                    "feature_name": str,
-                    "value": str,
-                },
-            ),
         )
+        if collection is None:
+            # Tolerate concurrent creation: the collection then exists.
+            with contextlib.suppress(VectorStoreCollectionAlreadyExistsError):
+                await vector_store.create_collection(
+                    namespace=_VECTOR_STORE_NAMESPACE,
+                    name=_VECTOR_STORE_COLLECTION_NAME,
+                    config=collection_config,
+                )
+            collection = await vector_store.open_collection(
+                namespace=_VECTOR_STORE_NAMESPACE,
+                name=_VECTOR_STORE_COLLECTION_NAME,
+            )
+            if collection is None:
+                raise ResourceNotReadyError(
+                    "Vector store collection could not be opened after creation.",
+                    "semantic_memory",
+                )
         storage = VectorStoreSemanticStorage(sql_engine, collection)
         await storage.startup()
         return storage

--- a/packages/server/src/memmachine_server/common/vector_store/__init__.py
+++ b/packages/server/src/memmachine_server/common/vector_store/__init__.py
@@ -5,7 +5,6 @@ from .data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from .vector_store import VectorStore, VectorStoreCollection
 
@@ -16,5 +15,4 @@ __all__ = [
     "VectorStoreCollection",
     "VectorStoreCollectionAlreadyExistsError",
     "VectorStoreCollectionConfig",
-    "VectorStoreCollectionConfigMismatchError",
 ]

--- a/packages/server/src/memmachine_server/common/vector_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_store/data_types.py
@@ -85,28 +85,6 @@ class VectorStoreCollectionAlreadyExistsError(Exception):
         super().__init__(f"Collection ({namespace!r}, {name!r}) already exists.")
 
 
-class VectorStoreCollectionConfigMismatchError(Exception):
-    """Raised when opening a collection with a different configuration than it was created with."""
-
-    def __init__(
-        self,
-        namespace: str,
-        name: str,
-        existing_config: VectorStoreCollectionConfig,
-        requested_config: VectorStoreCollectionConfig,
-    ) -> None:
-        """Initialize with the namespace, name, and configurations."""
-        self.namespace = namespace
-        self.name = name
-        self.existing_config = existing_config
-        self.requested_config = requested_config
-        super().__init__(
-            f"Collection ({namespace!r}, {name!r}) already exists with a different configuration. "
-            f"Existing config: {existing_config.model_dump_json()}, "
-            f"requested config: {requested_config.model_dump_json()}."
-        )
-
-
 class Record(BaseModel):
     """
     A record in the vector store.

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -49,7 +49,6 @@ from .data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from .utils import validate_filter, validate_identifier
 from .vector_store import VectorStore, VectorStoreCollection
@@ -760,42 +759,6 @@ class MilvusVectorStore(VectorStore):
                 raise VectorStoreCollectionAlreadyExistsError(namespace, name)
             await self._create_native_collection(namespace, config)
             await self._register_collection(namespace, name, config)
-
-    @override
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> MilvusVectorStoreCollection:
-        """Open the collection if it exists, or create and return it."""
-        if not validate_identifier(namespace):
-            raise ValueError(
-                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        if not validate_identifier(name):
-            raise ValueError(
-                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        self._validate_metric(config.similarity_metric)
-        async with (
-            self._client_name_locks[(namespace, name)],
-            self._tracker("open_or_create_collection"),
-        ):
-            entry = await self._get_registry_entry(namespace, name)
-            if entry is not None:
-                existing_config = MilvusVectorStore._parse_entry(entry)
-                if existing_config != config:
-                    raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
-                    )
-                return self._build_collection_handle(namespace, name, existing_config)
-
-            await self._ensure_namespace_registry_collection(namespace)
-            await self._create_native_collection(namespace, config)
-            await self._register_collection(namespace, name, config)
-            return self._build_collection_handle(namespace, name, config)
 
     @override
     async def open_collection(

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -14,7 +14,11 @@ from pydantic import BaseModel, Field, InstanceOf
 from pymilvus import DataType, MilvusClient
 from pymilvus.exceptions import MilvusException
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import (
+    ConcurrencyScope,
+    PropertyValue,
+    SimilarityMetric,
+)
 from memmachine_server.common.filter.filter_parser import (
     And as FilterAnd,
 )
@@ -512,6 +516,12 @@ class MilvusVectorStore(VectorStore):
         self._client_name_locks = MilvusVectorStore._name_locks.setdefault(
             self._client, defaultdict(asyncio.Lock)
         )
+
+    @property
+    @override
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """Collection bookkeeping is guarded only by in-process locks."""
+        return ConcurrencyScope.PROCESS
 
     @override
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -50,7 +50,6 @@ from .data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from .utils import validate_filter, validate_identifier
 from .vector_store import VectorStore, VectorStoreCollection
@@ -846,46 +845,6 @@ class QdrantVectorStore(VectorStore):
                 )
                 await self._ensure_shard_key(native_collection_name, name)
             await self._register_collection(namespace, name, config)
-
-    @override
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> QdrantVectorStoreCollection:
-        """Open the collection if it exists, or create and return it."""
-        if not validate_identifier(namespace):
-            raise ValueError(
-                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        if not validate_identifier(name):
-            raise ValueError(
-                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        async with (
-            self._client_name_locks[(namespace, name)],
-            self._tracker("open_or_create_collection"),
-        ):
-            entry = await self._get_registry_entry(namespace, name)
-            if entry is not None:
-                existing_config = QdrantVectorStore._parse_entry(entry)
-                if existing_config != config:
-                    raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
-                    )
-                return self._build_collection_handle(namespace, name, existing_config)
-
-            await self._ensure_namespace_registry_collection(namespace)
-            await self._create_native_collection(namespace, config)
-            if self._is_distributed:
-                native_collection_name = (
-                    QdrantVectorStore._build_native_collection_name(namespace, config)
-                )
-                await self._ensure_shard_key(native_collection_name, name)
-            await self._register_collection(namespace, name, config)
-            return self._build_collection_handle(namespace, name, config)
 
     @override
     async def open_collection(

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -16,6 +16,7 @@ from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.http.exceptions import ResponseHandlingException, UnexpectedResponse
 
 from memmachine_server.common.data_types import (
+    ConcurrencyScope,
     OrderedValue,
     PropertyValue,
     SimilarityMetric,
@@ -641,6 +642,12 @@ class QdrantVectorStore(VectorStore):
         self._client_name_locks = QdrantVectorStore._name_locks.setdefault(
             self._client, defaultdict(asyncio.Lock)
         )
+
+    @property
+    @override
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """Collection bookkeeping is guarded only by in-process locks."""
+        return ConcurrencyScope.PROCESS
 
     @override
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -33,7 +33,11 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase, MappedColumn, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import (
+    ConcurrencyScope,
+    PropertyValue,
+    SimilarityMetric,
+)
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
 from memmachine_server.common.properties_json import (
@@ -483,6 +487,12 @@ class SQLiteVecVectorStore(VectorStore):
                 await aio_connection.enable_load_extension(False)
 
             dbapi_connection.run_async(_load_extension)
+
+    @property
+    @override
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """Collection bookkeeping is check-then-write within one process."""
+        return ConcurrencyScope.PROCESS
 
     @override
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -47,7 +47,6 @@ from .data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from .utils import validate_filter, validate_identifier
 from .vector_store import VectorStore, VectorStoreCollection
@@ -519,54 +518,6 @@ class SQLiteVecVectorStore(VectorStore):
                     config_json=config.model_dump(mode="json"),
                 )
             )
-
-    @override
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> VectorStoreCollection:
-        if not validate_identifier(namespace) or not validate_identifier(name):
-            raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
-        self._validate_metric(config.similarity_metric)
-
-        async with self._create_session() as session, session.begin():
-            existing_config = await self._get_stored_config(session, namespace, name)
-            if existing_config is not None:
-                if existing_config != config:
-                    raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
-                    )
-
-                records_table, vector_table_name = await self._ensure_collection_tables(
-                    session, namespace, name, existing_config
-                )
-                return SQLiteVecVectorStoreCollection(
-                    create_session=self._create_session,
-                    config=existing_config,
-                    records_table=records_table,
-                    vector_table_name=vector_table_name,
-                )
-
-            records_table, vector_table_name = await self._ensure_collection_tables(
-                session, namespace, name, config
-            )
-            session.add(
-                _CollectionRow(
-                    namespace=namespace,
-                    name=name,
-                    config_json=config.model_dump(mode="json"),
-                )
-            )
-
-        return SQLiteVecVectorStoreCollection(
-            create_session=self._create_session,
-            config=config,
-            records_table=records_table,
-            vector_table_name=vector_table_name,
-        )
 
     @override
     async def open_collection(

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -41,7 +41,11 @@ from sqlalchemy.orm import DeclarativeBase, MappedColumn, Session, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 from sqlalchemy.sql.elements import ColumnElement
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import (
+    ConcurrencyScope,
+    PropertyValue,
+    SimilarityMetric,
+)
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
 from memmachine_server.common.properties_json import (
@@ -704,6 +708,12 @@ class SQLiteVectorStore(VectorStore):
             raise RuntimeError(
                 "VectorStore has not been started. Call startup() first."
             )
+
+    @property
+    @override
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """Search engine state lives in process memory."""
+        return ConcurrencyScope.PROCESS
 
     @override
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -55,7 +55,6 @@ from .data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from .utils import validate_filter, validate_identifier
 from .vector_search_engine import VectorSearchEngine
@@ -825,66 +824,6 @@ class SQLiteVectorStore(VectorStore):
                     config_json=config.model_dump(mode="json"),
                 )
             )
-
-    @override
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> VectorStoreCollection:
-        self._require_started()
-        if not validate_identifier(namespace) or not validate_identifier(name):
-            raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
-
-        index_path = self._index_path(namespace, name)
-
-        async with self._create_session() as session, session.begin():
-            existing_config = await self._get_stored_config(session, namespace, name)
-            if existing_config is not None:
-                if existing_config != config:
-                    raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
-                    )
-                records_table, search_engine = await self._ensure_collection_resources(
-                    session, namespace, name, existing_config
-                )
-                return SQLiteVectorStoreCollection(
-                    create_session=self._create_session,
-                    sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
-                    records_table=records_table,
-                    search_engine=search_engine,
-                    namespace=namespace,
-                    name=name,
-                    config=existing_config,
-                    index_path=str(index_path) if index_path is not None else None,
-                    save_threshold=self._save_threshold,
-                )
-
-            self._clear_search_engine_state(namespace, name)
-            records_table, search_engine = await self._ensure_collection_resources(
-                session, namespace, name, config
-            )
-            session.add(
-                _CollectionRow(
-                    namespace=namespace,
-                    name=name,
-                    config_json=config.model_dump(mode="json"),
-                )
-            )
-
-        return SQLiteVectorStoreCollection(
-            create_session=self._create_session,
-            sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
-            records_table=records_table,
-            search_engine=search_engine,
-            namespace=namespace,
-            name=name,
-            config=config,
-            index_path=str(index_path) if index_path is not None else None,
-            save_threshold=self._save_threshold,
-        )
 
     @override
     async def open_collection(

--- a/packages/server/src/memmachine_server/common/vector_store/vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_store.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from uuid import UUID
 
+from memmachine_server.common.data_types import ConcurrencyScope
 from memmachine_server.common.filter.filter_parser import (
     FilterExpr,
 )
@@ -31,6 +32,24 @@ class VectorStoreCollection(ABC):
 
     The schema exists to support indexing on fixed-type record properties.
     Record properties not declared in the schema may have mixed-type values.
+
+    Visibility: a returned write is durably accepted,
+    but is not guaranteed to be visible to a subsequent query,
+    from this instance or any other.
+    Consumers must not build on read-your-writes.
+
+    Authority: stored properties and property filters operate on
+    the collection's own copy of a record,
+    with no freshness guarantee relative to any external source of truth.
+    Consumers whose records are governed by an external authority
+    must re-validate results against it.
+
+    Lifetime: a handle is valid only while its collection exists.
+    Once the collection is deleted the handle is invalid,
+    and a write through it
+    must never become visible in a collection
+    subsequently created with the same namespace and name.
+    This holds at every concurrency scope.
     """
 
     @property
@@ -149,8 +168,10 @@ class VectorStore(ABC):
     Abstract base class for a vector store.
 
     A given logical collection identified by a (namespace, name) pair
-    must be managed by at most one process at a time.
-    The consumer is responsible for sharding names across processes.
+    may be managed concurrently by multiple VectorStore instances
+    only within this store's declared concurrency_scope.
+    Beyond that scope, at most one instance may manage a collection,
+    and the consumer is responsible for sharding names accordingly.
 
     Different namespaces are fully independent (separate native collections).
     Multiple logical collections with the same (namespace, vector dimensions, similarity metric, indexed properties schema)
@@ -161,6 +182,18 @@ class VectorStore(ABC):
           (lowercase alphanumeric and underscores only).
         - Each identifier must be at most 32 bytes.
     """
+
+    @property
+    @abstractmethod
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """
+        Widest boundary for concurrently managing the same collection.
+
+        Instances of this store deployed within the declared scope
+        (and configured against the same backing services)
+        may concurrently manage the same logical collections.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_store.py
@@ -203,36 +203,6 @@ class VectorStore(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> VectorStoreCollection:
-        """
-        Open the collection if it exists, or create it if it does not.
-
-        Args:
-            namespace (str):
-                Groups related collections and guarantees storage
-                isolation at the native collection level.
-            name (str):
-                Name to identify the collection within a namespace.
-            config (VectorStoreCollectionConfig):
-                Configuration for the collection.
-
-        Returns:
-            VectorStoreCollection:
-                A handle to the opened or created collection.
-
-        Raises:
-            VectorStoreCollectionConfigMismatchError: If a collection with the same
-                (namespace, name) already exists with a different configuration.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     async def open_collection(
         self, *, namespace: str, name: str
     ) -> VectorStoreCollection | None:

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/__init__.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/__init__.py
@@ -3,7 +3,6 @@
 from .data_types import (
     SegmentStorePartitionAlreadyExistsError,
     SegmentStorePartitionConfig,
-    SegmentStorePartitionConfigMismatchError,
 )
 from .segment_store import (
     SegmentStore,
@@ -15,5 +14,4 @@ __all__ = [
     "SegmentStorePartition",
     "SegmentStorePartitionAlreadyExistsError",
     "SegmentStorePartitionConfig",
-    "SegmentStorePartitionConfigMismatchError",
 ]

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/data_types.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/data_types.py
@@ -46,26 +46,6 @@ class SegmentStorePartitionConfig(BaseModel):
         return value
 
 
-class SegmentStorePartitionConfigMismatchError(Exception):
-    """Raised when opening a partition with a different configuration than it was created with."""
-
-    def __init__(
-        self,
-        partition_key: str,
-        existing_config: SegmentStorePartitionConfig,
-        requested_config: SegmentStorePartitionConfig,
-    ) -> None:
-        """Initialize with the partition key and configurations."""
-        self.partition_key = partition_key
-        self.existing_config = existing_config
-        self.requested_config = requested_config
-        super().__init__(
-            f"Partition {partition_key!r} already exists with a different configuration. "
-            f"Existing config: {existing_config.model_dump_json()}, "
-            f"requested config: {requested_config.model_dump_json()}."
-        )
-
-
 class SegmentStorePartitionAlreadyExistsError(Exception):
     """Raised when creating a partition that already exists."""
 

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
@@ -176,31 +176,6 @@ class SegmentStore(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def open_or_create_partition(
-        self,
-        partition_key: str,
-        config: SegmentStorePartitionConfig,
-    ) -> SegmentStorePartition:
-        """
-        Open the partition if it exists, or create it if it does not.
-
-        Args:
-            partition_key (str):
-                The key of the partition.
-            config (SegmentStorePartitionConfig):
-                Configuration for the partition.
-
-        Returns:
-            SegmentStorePartition:
-                A partition-scoped handle.
-
-        Raises:
-            SegmentStorePartitionConfigMismatchError:
-                If the partition already exists with a different configuration.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     async def close_partition(
         self, segment_store_partition: SegmentStorePartition
     ) -> None:

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
 from uuid import UUID
 
+from memmachine_server.common.data_types import ConcurrencyScope
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.episodic_memory.event_memory.data_types import (
     Segment,
@@ -125,10 +126,28 @@ class SegmentStore(ABC):
 
     Manages partition-scoped handles.
 
+    A given partition may be managed concurrently
+    by multiple SegmentStore instances
+    only within this store's declared concurrency_scope.
+    Beyond that scope, at most one instance may manage a partition,
+    and the consumer is responsible for sharding keys accordingly.
+
     Partition keys must match `[a-z0-9_]+`
     (lowercase alphanumeric and underscores only)
     and be at most 32 bytes.
     """
+
+    @property
+    @abstractmethod
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """
+        Widest boundary for concurrently managing the same partition.
+
+        Instances of this store deployed within the declared scope
+        (and configured against the same backing services)
+        may concurrently manage the same partitions.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
@@ -52,6 +52,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 from sqlalchemy.sql.elements import ColumnElement
 
+from memmachine_server.common.data_types import ConcurrencyScope
 from memmachine_server.common.filter.filter_parser import (
     FilterExpr,
     demangle_user_metadata_key,
@@ -785,6 +786,14 @@ class SQLAlchemySegmentStore(SegmentStore):
                 cursor.close()
 
     # Lifecycle
+
+    @property
+    @override
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """CLUSTER on PostgreSQL; MACHINE on file-backed SQLite."""
+        if self._is_postgresql:
+            return ConcurrencyScope.CLUSTER
+        return ConcurrencyScope.MACHINE
 
     @override
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
@@ -90,7 +90,6 @@ from memmachine_server.episodic_memory.event_memory.data_types import (
 from memmachine_server.episodic_memory.event_memory.segment_store.data_types import (
     SegmentStorePartitionAlreadyExistsError,
     SegmentStorePartitionConfig,
-    SegmentStorePartitionConfigMismatchError,
 )
 from memmachine_server.episodic_memory.event_memory.segment_store.segment_store import (
     SegmentStore,
@@ -850,73 +849,6 @@ class SQLAlchemySegmentStore(SegmentStore):
             return await self._partition_from_partition_row(partition_row)
 
     @override
-    async def open_or_create_partition(
-        self,
-        partition_key: str,
-        config: SegmentStorePartitionConfig,
-    ) -> SQLAlchemySegmentStorePartition:
-        SQLAlchemySegmentStore._validate_partition_key(partition_key)
-        async with self._tracker("open_or_create_partition"):
-            return await self._open_or_create_partition(partition_key, config)
-
-    async def _open_or_create_partition(
-        self,
-        partition_key: str,
-        config: SegmentStorePartitionConfig,
-    ) -> SQLAlchemySegmentStorePartition:
-        try:
-            async with self._create_session() as session, session.begin():
-                if self._is_postgresql:
-                    await session.execute(
-                        SQLAlchemySegmentStore._PG_LOCK_PARTITIONS_TABLE
-                    )
-
-                partition_row = await SQLAlchemySegmentStore._get_partition_row(
-                    session, partition_key
-                )
-                if partition_row is None:
-                    payload_codec = await self._load_payload_codec(config)
-                    await session.execute(
-                        insert(PartitionRow).values(
-                            partition_key=partition_key,
-                            payload_codec_config=encode_payload_codec_config(
-                                config.payload_codec_config
-                            ),
-                        )
-                    )
-                    if self._is_postgresql:
-                        connection = await session.connection()
-                        await SQLAlchemySegmentStore._create_pg_child_tables(
-                            connection, partition_key
-                        )
-
-                    return SQLAlchemySegmentStorePartition(
-                        partition_key=partition_key,
-                        engine=self._engine,
-                        config=config,
-                        payload_codec=payload_codec,
-                        tracker=self._tracker,
-                    )
-
-                SQLAlchemySegmentStore._raise_if_partition_config_mismatch(
-                    partition_row, config
-                )
-                return await self._partition_from_partition_row(partition_row)
-
-        except IntegrityError:
-            pass  # Concurrent creation: partition now exists.
-
-        async with self._create_session() as session:
-            partition_row = await SQLAlchemySegmentStore._get_partition_row(
-                session, partition_key
-            )
-        if partition_row is None:
-            raise RuntimeError(f"Partition {partition_key!r} could not be opened")
-
-        self._raise_if_partition_config_mismatch(partition_row, config)
-        return await self._partition_from_partition_row(partition_row)
-
-    @override
     async def close_partition(
         self, segment_store_partition: SegmentStorePartition
     ) -> None:
@@ -1022,24 +954,6 @@ class SQLAlchemySegmentStore(SegmentStore):
                 select(PartitionRow).where(PartitionRow.partition_key == partition_key)
             )
         ).scalar_one_or_none()
-
-    @staticmethod
-    def _raise_if_partition_config_mismatch(
-        partition_row: PartitionRow,
-        config: SegmentStorePartitionConfig,
-    ) -> None:
-        """Raise if an existing partition row does not match the requested config."""
-        existing_config = SegmentStorePartitionConfig(
-            payload_codec_config=decode_payload_codec_config(
-                partition_row.payload_codec_config
-            )
-        )
-        if existing_config != config:
-            raise SegmentStorePartitionConfigMismatchError(
-                partition_row.partition_key,
-                existing_config,
-                config,
-            )
 
     @staticmethod
     async def _create_pg_child_tables(

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
@@ -1,5 +1,6 @@
 """Helpers for building long-term memory from configuration."""
 
+import contextlib
 import hashlib
 import logging
 import re
@@ -22,7 +23,10 @@ from memmachine_server.common.data_types import (
     PropertyValue,
 )
 from memmachine_server.common.resource_manager import CommonResourceManager
-from memmachine_server.common.vector_store import VectorStoreCollectionConfig
+from memmachine_server.common.vector_store import (
+    VectorStoreCollectionAlreadyExistsError,
+    VectorStoreCollectionConfig,
+)
 from memmachine_server.episodic_memory.event_memory.deriver import Deriver
 from memmachine_server.episodic_memory.event_memory.deriver.text_deriver import (
     SentenceTextDeriver,
@@ -30,6 +34,7 @@ from memmachine_server.episodic_memory.event_memory.deriver.text_deriver import 
 )
 from memmachine_server.episodic_memory.event_memory.event_memory import EventMemory
 from memmachine_server.episodic_memory.event_memory.segment_store import (
+    SegmentStorePartitionAlreadyExistsError,
     SegmentStorePartitionConfig,
 )
 from memmachine_server.episodic_memory.event_memory.segmenter import Segmenter
@@ -122,11 +127,13 @@ async def _event_params(
                 **user_schema,
             },
         )
-        await vector_store.create_collection(
-            namespace=_EVENT_BACKEND_NAMESPACE,
-            name=partition_key,
-            config=collection_config,
-        )
+        # Tolerate concurrent creation: the collection then exists.
+        with contextlib.suppress(VectorStoreCollectionAlreadyExistsError):
+            await vector_store.create_collection(
+                namespace=_EVENT_BACKEND_NAMESPACE,
+                name=partition_key,
+                config=collection_config,
+            )
         collection = await vector_store.open_collection(
             namespace=_EVENT_BACKEND_NAMESPACE,
             name=partition_key,
@@ -137,10 +144,20 @@ async def _event_params(
                 f"partition {partition_key!r}"
             )
 
-    partition = await segment_store.open_or_create_partition(
-        partition_key,
-        SegmentStorePartitionConfig(),
-    )
+    partition = await segment_store.open_partition(partition_key)
+    if partition is None:
+        # Tolerate concurrent creation: the partition then exists.
+        with contextlib.suppress(SegmentStorePartitionAlreadyExistsError):
+            await segment_store.create_partition(
+                partition_key,
+                SegmentStorePartitionConfig(),
+            )
+        partition = await segment_store.open_partition(partition_key)
+        if partition is None:
+            raise RuntimeError(
+                f"Failed to open segment store partition after creation for "
+                f"partition {partition_key!r}"
+            )
 
     segmenter = _build_segmenter(config.segmenter)
     deriver = _build_deriver(config.deriver)


### PR DESCRIPTION
### Purpose of the change

Make the multi-process capability from #1526/#1527 reachable through the API contract. After those PRs, QdrantVectorStore supports multiple processes managing the same collections — but the `VectorStore` ABC still said a collection "must be managed by at most one process at a time", so no consumer was *permitted* to rely on it. This PR replaces that blanket sentence with a declared, per-instance concurrency scope, and states the data-plane contracts that multi-process consumers need to know (#1525).

**Stacked on the open-or-create removal PR**; only the last commit is new to this PR.

### Description

**`ConcurrencyScope`** (`common/data_types.py`): `PROCESS < MACHINE < CLUSTER` — the widest deployment boundary within which concurrent instances of a component may safely manage the same resources. An `IntEnum`, ordered by breadth, so the effective scope of a composed system is the `min` of its parts' scopes.

**Declared on the ABCs** — `VectorStore`, `SegmentStore`, and `CollectionRegistry` gain an abstract `concurrency_scope` property, and the one-process-per-collection/partition sentences are rewritten to defer to it: concurrent management of the same collection/partition is safe within the declared scope; beyond it, consumers shard names, as before.

**Declared by the implementations:**

| Component | Scope | Why |
|---|---|---|
| `QdrantVectorStore` | `min(CLUSTER, registry.concurrency_scope)` | Qdrant is shareable across machines; the collection registry governs |
| `SQLAlchemyCollectionRegistry` | `CLUSTER` on PostgreSQL, `MACHINE` on file-backed SQLite | the CAS is as wide as the database's reach |
| `SQLAlchemySegmentStore` | `CLUSTER` on PostgreSQL, `MACHINE` on SQLite | already safe cross-process via unique-constraint create and row locks |
| `MilvusVectorStore` | `PROCESS` | collection bookkeeping guarded only by in-process locks (widened by the Milvus registry PR later in this stack) |
| `SQLiteVectorStore` | `PROCESS` | search-engine state lives in process memory |
| `SQLiteVecVectorStore` | `PROCESS` | check-then-write bookkeeping within one process |

So a Qdrant store backed by a PostgreSQL registry declares `CLUSTER`, and one backed by a shared SQLite file declares `MACHINE` — the deployment can introspect what it is allowed to do instead of relying on out-of-band knowledge.

**Data-plane contracts** stated on `VectorStoreCollection` (documentation only; both are pre-existing properties that multi-process deployment makes worth stating):

- *Visibility*: a returned write is durably accepted but not guaranteed visible to a subsequent query, from this instance or any other — consumers must not build on read-your-writes.
- *Authority*: stored properties and property filters operate on the collection's own copy of a record, with no freshness guarantee relative to any external source of truth; consumers governed by an external authority (e.g. SQL as the record of access-determining attributes) must re-validate results against it.

**Design doc**: `design/concurrency_scopes.md`.

### Fixes/Closes

Related to #1525 (contract half of the redesign).

### Type of change

- [x] New feature (non-breaking change which adds functionality)

(Adding an abstract property is breaking for out-of-tree `VectorStore`/`SegmentStore`/`CollectionRegistry` implementations, which must now declare a scope.)

### How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test

Scope assertions per implementation: qdrant with a SQLite registry declares `MACHINE` and with a PostgreSQL registry (integration) declares `CLUSTER`; the SQLAlchemy segment store and config registry assert dialect-based scopes across the sqlite/PG fixture matrix; Milvus and both SQLite stores assert `PROCESS`.

**Test Results:** 1897 passed (default run); 585 passed (targeted integration run); `ruff check`, `ruff format --check`, `ty check packages` clean (no new diagnostics).

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [ ] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Further comments

Milvus's `PROCESS` declaration is honest at this point in the stack; the final PR moves Milvus onto the collection registry and widens it to `min(CLUSTER, registry scope)`.

