### PR TITLE
fix(metrics): wire the Qdrant vector store, and let a build include it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,18 @@ COPY pyproject.toml uv.lock ./
 # Determine whether to include GPU dependencies
 ARG GPU="false"
 ARG SCM_VERSION="0.0.0"
+# Optional dependency groups, e.g. EXTRAS="--extra qdrant". The vector-store
+# backends are optional extras, so an image built without the one its config
+# selects starts cleanly and then fails every request on ImportError.
+ARG EXTRAS=""
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SCM_VERSION}
 
 # Install dependencies into a virtual environment, but NOT the project itself
 RUN --mount=type=cache,target=/root/.cache/uv \
     if [ "$GPU" = "true" ]; then \
-        uv sync --frozen --package memmachine-server --no-install-workspace --no-editable --no-dev --extra gpu; \
+        uv sync --frozen --package memmachine-server --no-install-workspace --no-editable --no-dev --extra gpu ${EXTRAS}; \
     else \
-        uv sync --frozen --package memmachine-server --no-install-workspace --no-editable --no-dev; \
+        uv sync --frozen --package memmachine-server --no-install-workspace --no-editable --no-dev ${EXTRAS}; \
     fi
 
 # Copy the application source code
@@ -40,9 +44,9 @@ COPY . /app
 # Install the project itself from the local source
 RUN --mount=type=cache,target=/root/.cache/uv \
     if [ "$GPU" = "true" ]; then \
-        uv sync --frozen --package memmachine-server --no-editable --no-dev --extra gpu; \
+        uv sync --frozen --package memmachine-server --no-editable --no-dev --extra gpu ${EXTRAS}; \
     else \
-        uv sync --frozen --package memmachine-server --no-editable --no-dev; \
+        uv sync --frozen --package memmachine-server --no-editable --no-dev ${EXTRAS}; \
     fi
 
 #

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
@@ -401,11 +401,15 @@ async def test_qdrant_creates_vector_store():
         builder = DatabaseManager(conf)
         await builder.async_get_qdrant_client("qdrant1")
 
-    mock_params_cls.assert_called_once_with(
-        client=mock_client,
-        is_distributed=True,
-        registry_replication_factor=3,
-    )
+    mock_params_cls.assert_called_once()
+    kwargs = mock_params_cls.call_args.kwargs
+    assert kwargs["client"] is mock_client
+    assert kwargs["is_distributed"] is True
+    assert kwargs["registry_replication_factor"] == 3
+    # Asserted as "not None" rather than pinned to a value: OperationTracker
+    # accepts None and then discards every timing without error, so passing the
+    # keyword is not the property that matters - passing a factory is.
+    assert kwargs["metrics_factory"] is not None
     mock_store_cls.assert_called_once_with(mock_params_cls.return_value)
     mock_store_cls.return_value.startup.assert_awaited_once()
     assert "qdrant1" in builder.vector_stores

--- a/packages/server/src/memmachine_server/common/configuration/database_conf.py
+++ b/packages/server/src/memmachine_server/common/configuration/database_conf.py
@@ -229,7 +229,7 @@ class NebulaGraphConf(YamlSerializableMixin, PasswordMixin):
         return self.hosts
 
 
-class QdrantConf(YamlSerializableMixin, ApiKeyMixin):
+class QdrantConf(MetricsFactoryIdMixin, YamlSerializableMixin, ApiKeyMixin):
     """Configuration options for a Qdrant instance."""
 
     host: str = Field(

--- a/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
@@ -592,6 +592,7 @@ class DatabaseManager:
                 client=client,
                 is_distributed=conf.is_distributed,
                 registry_replication_factor=conf.registry_replication_factor,
+                metrics_factory=conf.get_metrics_factory(),
             )
             try:
                 store = QdrantVectorStore(params)


### PR DESCRIPTION
Follow-on to #1523, which wired three `OperationTracker`s that had shipped instrumented but never given a metrics factory. `QdrantVectorStore` is the fourth.

## The defect

`OperationTracker` accepts `metrics_factory=None` and then discards every timing without an error, a warning, or a series. A component that is fully instrumented but never handed a factory looks identical to one that was never instrumented — the only way to notice is to go looking for a metric that should exist and find nothing.

That is what `QdrantVectorStore` was doing. `QdrantConf` gains `MetricsFactoryIdMixin` so it can resolve one, and `database_manager` passes it through.

## The build arg

The `Dockerfile` gains `ARG EXTRAS=""` on all four `uv sync` lines. Without `--extra qdrant` the `qdrant-client` package is never installed and the provider raises `ModuleNotFoundError` on every request — so an image intended to exercise this path could not run at all. That is not hypothetical; it is how the first Qdrant testbed deploy failed.

## The test change

`test_qdrant_creates_vector_store` pinned the exact `QdrantVectorStoreParams` kwargs and had to change. It now asserts `metrics_factory is not None` rather than pinning a value: passing the keyword is not the property worth guarding, since `None` is accepted and silently discards everything. Removing the wiring fails it.

## Verified

1,228 common/server tests pass; `ruff check` and `ruff format --check` clean; `ty` reports no diagnostics in these files.

Measured on a live deployment rather than only in tests: with this in place the Qdrant vector store reports **26 ms mean** per search against a real corpus, alongside the segment store at 53 ms and the OpenAI embedder at 231 ms. Before it, that layer produced no series at all — so the question "is Qdrant the bottleneck?" was unanswerable, and the answer turns out to be an emphatic no.

Companion chart change (the deployment side of the same work): MemVerge/MemMachine-Platform#1005.