### PR TITLE
Feat: Back MilvusVectorStore collection metadata with SQL collection registry (collection registry stack 5/5)

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,13 @@
+# Design notes
+
+Contributor-facing notes on the reasoning behind a design: the problem it
+solves, the alternatives weighed, and the constraints that decided it.
+They record why the code is shaped the way it is, which the code itself
+and its docstrings cannot say.
+
+These documents are written for people working on the server. They are
+not part of the deployed documentation site (`docs/`) and are not
+packaged into distributions; user-facing documentation belongs in
+`docs/`.
+
+One document per design, named after what it covers.

--- a/design/collection_registry.md
+++ b/design/collection_registry.md
@@ -315,6 +315,13 @@ privileged. `shutdown` is a no-op in the SQLAlchemy implementation
 because the engine is shared and externally owned: the registry does not
 close what it did not open.
 
+**`concurrency_scope` is declared by the registry** rather than derived
+by each store, because the registry is what actually bounds atomicity: a
+store reports `min(its own ceiling, its registry's scope)`, so a
+cluster-capable backend sitting behind a file-backed SQLite registry
+correctly declares itself machine-scoped. One answer per backing store,
+not one per consumer. See `concurrency_scopes.md`.
+
 ## Storage (SQLAlchemy implementation)
 
 - Table per registry (`collection_registry_<name>`: `key` VARCHAR(255) PK,

--- a/design/collection_registry.md
+++ b/design/collection_registry.md
@@ -1,0 +1,372 @@
+# Vector store collection registry
+
+Contributor-facing design notes for
+`memmachine_server.common.vector_store.collection_registry`.
+
+## Problem
+
+Horizontal scalability: multiple server processes should be able to work with
+the same collections on one backend. Strict sharding (each collection managed
+by exactly one process) has always worked; the blocker to lifting it is
+collection *metadata* management. Backends without conditional writes,
+transactions, or unique constraints (Qdrant, Milvus) cannot make
+create / open / delete atomic, so their ad-hoc catalogs are read-check-write
+sequences guarded by per-process locks.
+
+The collection registry is the enabling primitive: a durable catalog mapping
+(namespace, name) to an immutable `CollectionRegistryEntry`, with
+registration atomic across processes via a real compare-and-set. A vector
+store holds a registry dedicated to it and cannot reach any other registry
+through it.
+
+## Scope: collections, not a generic registry
+
+The registry is deliberately specific to vector store collections. An
+earlier draft generalized it to a key -> config registry with pluggable
+types; that was narrowed because it had exactly one consumer kind, and the
+realistic reuse axis (other vector store backends) is *within* the
+collection domain -- Milvus's needs are the same shape. The compatibility
+asymmetry decides the default: widening a specific API later (extracting a
+generic ABC when a non-collection consumer actually materializes) is an
+additive refactor; narrowing a shipped generic ABC is a breaking change.
+Being collection-specific also lets the API speak the domain --
+`register(namespace, name, entry)` rather than key/adapter plumbing -- and
+turns the key encoding into an implementation detail.
+
+## The entry
+
+`CollectionRegistryEntry` = `{config, native_collection_name,
+partition_key}`. One entry format is shared by all vector store backends:
+`config` is the ABC-level `VectorStoreCollectionConfig` every backend already
+takes, and the two identity fields are the shared mechanism (config-hashed
+shared native collections, per-collection partition keys) that Qdrant and
+Milvus both use.
+
+- `native_collection_name` is pinned at registration instead of being
+  re-derived from `sha256(config)` on every open: any change to config
+  serialization -- even an added optional field -- would otherwise re-hash
+  every stored config and silently repoint existing collections at new,
+  empty native collections.
+- `partition_key` is generation-scoped (minted per registration): records
+  written through handles held across a deregistration land under the dead
+  generation -- invisible, never resurrected by a re-registration, no locks
+  and no per-write round trips.
+
+Evolution policy -- covering the whole stored document: the entry envelope
+and every model nested in it, `VectorStoreCollectionConfig` included, since
+the config is serialized inside the entry's JSON and read back through the
+same validation. Extend by adding optional fields with defaults -- no
+version bump, no migration, old rows validate under the new model. The rule
+has a semantic half: a new field's default must reproduce the behavior that
+existed before the field, because stored rows predating it are read through
+that default. A change whose default cannot mean the old behavior is not
+additive -- it is a breaking change and takes the version bump path.
+Backend-specific needs are expressed the same way, not with per-backend
+entry types.
+
+Terminology: "generation" is reserved for collection incarnations (the
+partition-key uuid); evolution of the entry or config models is a format
+"version". Content-hash native naming has the side effect of never sharing
+native collections across config-model versions (any model change drifts
+the hash) -- conservative quarantine at the cost of gradual fragmentation.
+
+## Portability across vector store providers
+
+Two identity fields locate a collection, and that arity is structural
+rather than a Qdrant/Milvus accident. The pair is the *container* -- the
+unit a provider creates, deletes, caps, and pins fixed physical
+attributes to (dimensionality, metric, index structures) -- and a
+*discriminator*, the unit of isolation within a container. Every
+surveyed provider decomposes this way, under its own vocabulary:
+
+| Provider   | Container           | Discriminator          |
+| ---------- | ------------------- | ---------------------- |
+| Qdrant     | collection          | payload key, shard key |
+| Milvus     | collection          | partition-key field    |
+| Pinecone   | index               | namespace              |
+| Weaviate   | collection          | tenant                 |
+| S3 Vectors | index within bucket | metadata field         |
+| Chroma     | collection          | (none needed)          |
+
+The entry calls the second field `partition_key`, after the two shipped
+backends and the house term for the same subdivision in the segment
+store. Note that Pinecone's "namespace" is a discriminator, not this
+registry's `namespace`, which is a component of the logical key.
+
+The discriminator level is essentially free: it asks nothing of a
+provider beyond storing a value per record and filtering it by equality,
+which is below the bar for being usable as a vector store at all. Chroma
+is the degenerate end -- collections are cheap enough there to give each
+logical collection its own, leaving nothing for a discriminator to do.
+One container with many discriminators and many containers with none are
+the same entry shape, which is the portability claim in one line.
+
+So the only open question is whether one container per logical
+collection suffices. Three cases where it would not, none of which argues
+for adding a field now:
+
+- A level above the container becomes variable: S3 buckets, Milvus
+  databases, Pinecone projects, or simply a second cluster once a
+  per-parent cap is reached. Today the parent is fixed by store
+  configuration. Lifting that needs a locator, not a second container.
+- One logical collection needs several containers -- multiple vectors
+  per record with differing dimensions or metrics on a provider that
+  indexes one vector per container, or a collection outgrowing a
+  per-container capacity cap. The first is excluded a level up:
+  `VectorStoreCollectionConfig` declares a single `vector_dimensions`
+  and `similarity_metric`. The second is remote at surveyed caps, and
+  when a *shared* container fills rather than a single collection it is
+  resolved by minting a new container for subsequent collections, which
+  needs no entry change since each entry names its own.
+- A collection transiently spans containers during an online re-index.
+  Handled a level up, by creating a new logical collection and swapping.
+
+The guarantee is not that two fields are provably sufficient forever; it
+is that the arity sits on the cheapest axis of change. The registry
+stores the entry and never parses it, so a third field is
+add-optional-only (`backend_id: str | None = None`, defaulting to the
+configured backend) and reproduces prior behavior by construction. What
+would be expensive is changing the key shape or the atomicity contract,
+and no surveyed provider pressures either.
+
+Both identity fields are opaque strings minted by the store and never
+derived by the registry, which keeps per-provider naming budgets out of
+this layer -- and those budgets are strict. The current
+`{namespace}__{sha256hex}` native name runs to 98 bytes, over Pinecone's
+and S3 Vectors' index-name limits; the `{name}#{uuid4hex}` partition key
+is 65 bytes and contains "#", over Weaviate's 64-byte tenant limit and
+outside its charset. A backend for those providers shortens the digest
+and picks a charset-safe generation format without touching the
+registry: the ABC requires only that the partition key be unique and
+carry a per-registration generation, never a format. That is why the key
+format is duplicated between the Qdrant and Milvus stores rather than
+shared.
+
+One budget does reach the addressing scheme. The index set stays inside
+the native name's config hash deliberately -- collections sharing a
+container then have identical index sets by construction, instead of the
+container accumulating the union of its tenants' indexes with each
+tenant paying memory and build time for another's fields. The cost is
+that containers accumulate one per config revision and are never
+reclaimed. At Qdrant's ~1000 collections per cluster that is cosmetic
+fragmentation; at Pinecone's 20-200 indexes per project it is a hard
+operational cap, which would make reclaiming orphaned containers a
+prerequisite for such a backend rather than a cleanup nicety.
+
+## Which backends need a registry
+
+Not every backend needs one. The registry does four jobs -- atomic
+create, durable storage of the entry, the logical-to-native name
+mapping, and the generation that stops a deleted collection's records
+from being resurrected -- and a backend that provides all four itself
+should use its own and take none. Where those four jobs land is what
+decides it:
+
+- **Qdrant and Milvus take one.** Both fail the first job (no
+  conditional writes and no unique constraints, so create is a
+  read-check-write) and the fourth (native collections are
+  name-addressed and shared by config hash). Those two failures are the
+  entire reason this primitive exists.
+- **`SQLiteVectorStore` cannot be helped by one.** Its authoritative
+  index state is a `dict[(namespace, name), VectorSearchEngine]` held in
+  process memory and flushed to disk on a threshold, so a second process
+  would search a divergent index. The limit is the data plane; repairing
+  metadata would not move it, and a registry would only add a
+  cross-process authority to a store that cannot be used across
+  processes.
+- **`SQLiteVecVectorStore` does not need one, but does need the
+  compare-and-set it already has the machinery for.** Its vectors live in
+  SQLite tables rather than in process memory, and it owns a
+  `_CollectionRow` table whose primary key is (namespace, name) -- the
+  same kind of arbiter this registry's implementation relies on. Its
+  create is nonetheless a check-then-write inside one transaction, which
+  is what confines concurrent collection management to a single process.
+  Turning that pre-check into an insert that maps `IntegrityError` onto
+  the domain error is the change `SQLAlchemyCollectionRegistry.register`
+  already makes, done in place rather than delegated. Two caveats: the
+  generation gap would remain, since its table names derive from
+  (namespace, name), so a handle held across a deletion addresses
+  whatever is later recreated under those names; and widening its reach
+  past one process needs the usual multi-process SQLite conditions
+  besides -- WAL, busy timeouts, a local filesystem.
+- **A container-per-collection provider covers all four.** A uniqueness
+  constraint on container names for atomic create, container metadata for
+  the entry, a direct name lookup for the mapping, and -- the
+  load-bearing one -- a container identity that is not its name, so that
+  a recreated container is a different object and handles held across the
+  deletion fault instead of writing into it. That last check matters
+  because the obvious alternative, putting the generation into the name,
+  destroys the first: two processes racing a create would mint different
+  generations, produce different names, and both succeed, leaving two
+  live containers for one logical collection.
+
+Chroma is the worked example of that last case, checked against 1.5.9
+rather than assumed. Collections carry a uuid that changes across
+delete-and-recreate, and operations route by it, so a handle held across
+a recreation raises rather than writing into the new collection -- a
+stronger generation than the synthetic one here, because the backend
+enforces it instead of merely hiding the records. Creates are genuinely
+atomic rather than only rejected: eight concurrent clients racing
+`create_collection` against a Chroma server produced exactly one winner
+in 25 of 25 rounds and never two collections of one name, and the
+`get_or_create` race converged all eight callers on a single id -- the
+same contract `get_or_register` provides here. A Chroma backend would
+therefore take no registry.
+
+What Chroma does not provide is a classifiable failure. The
+already-exists condition surfaces as `ChromaError` code 400 over HTTP and
+`InternalError` code 500 through the local binding -- two types, two
+codes, neither of them the `UniqueConstraintError` the same module
+defines and exports -- leaving the message as the only portable
+discriminator. That is a worse version of the error-classification
+problem this stack cleaned up for Qdrant and Milvus, and it is a
+backend-side concern rather than a reason to reach for a registry.
+
+Adding a registry to a backend that already satisfies all four would be
+a regression rather than caution: it introduces a second authority that
+can disagree with the first, which is precisely the divergence the
+create and delete orderings in this design exist to bound.
+
+## API shape
+
+Docstrings say what each operation does; this section says why the
+surface has the shape it has. It is five operations plus a lifecycle
+pair, and each shape is a decision rather than a default.
+
+**The key is two parameters, not one.** An earlier draft took a single
+opaque `key: str` and let each consumer compose it from its own parts.
+Namespacing is enforced by the contract instead: the registry guarantees
+that distinct (namespace, name) pairs never collide, so a store cannot
+get the encoding wrong and two stores cannot disagree about it. The "/"
+join in the SQLAlchemy implementation is consequently an implementation
+detail, and the test that ("a__b", "c") and ("a", "b__c") remain
+distinct tests the contract rather than the encoding.
+
+**Every parameter is keyword-only.** `namespace` and `name` are both
+`str` over the same charset, so a positional swap type-checks cleanly
+and then silently addresses the wrong collection. Keyword-only makes the
+swap unrepresentable rather than merely discouraged.
+
+**`register` raises and `get` returns `None`.** The asymmetry is
+deliberate. Absence on read is an ordinary expected outcome -- it is how
+a store learns a collection does not exist, and `open_collection`
+returning `None` is that same answer one layer up -- so raising would
+put try/except on the common path. A lost registration race is rare,
+contended, and has to interrupt a multi-step lifecycle sequence, so it
+raises, and the store translates it into its own already-exists error.
+A boolean return would invite callers to drop it on the floor.
+
+**`register` raises whether or not the stored entry matches the one
+offered.** The registry never compares entries, here or in
+`get_or_register`. Equality policy belongs to the store: what counts as
+"the same collection" is backend-specific, and two entries can carry
+equal configs while naming different native collections. Keeping
+comparison out also keeps registry behavior independent of how config
+models evolve, which is what lets the evolution policy below be stated
+in terms of validation alone.
+
+**`get_or_register` returns `(stored_entry, registered)`.** It returns
+the *stored* entry rather than the caller's, which is what makes it the
+atomic commit point: both sides of a race leave holding identical
+identity and therefore cannot write to different native collections
+under one logical name. The boolean is separate because the two outcomes
+demand different work from the store -- minting a native collection
+versus adopting one that already exists -- and that distinction is not
+recoverable from the returned entry.
+
+It exists because the create path genuinely needs "register if absent,
+else tell me what is already there" as a single atomic step; this is the
+commit point of an otherwise non-atomic sequence, which is the one place
+ensure-style semantics earn their keep. It is implemented natively -- a
+`SELECT` fast path, then `INSERT .. ON CONFLICT DO NOTHING`, then a
+re-read only when that insert lost -- rather than as try/except around
+`register`, so ordinary paths cost one statement and no control flow
+runs through exceptions.
+
+**`deregister` is idempotent and returns nothing.** It is the tail of a
+sequence that begins by destroying data, so a crash partway has to leave
+it re-runnable; reporting "already absent" as an error would force every
+retry to branch on a distinction with no consequence. It does not hand
+back the removed entry, because the caller necessarily read that entry
+first in order to find the data to delete, and returning it would invite
+a read-modify-write shape the registry deliberately cannot support.
+
+**There is no `update`.** Entries are immutable by contract, and this is
+the decision the generation scheme rests on: if `partition_key` could be
+rewritten in place, a handle held across the rewrite would silently
+begin writing into a different partition, and the guarantee that a
+deregistered collection's records are never resurrected would be gone.
+Changing a collection's identity is deregister followed by register,
+which mints a fresh generation by construction.
+
+**There is no way to enumerate entries.** This is a dated omission
+rather than a principle, and it is distinct from the registry-management
+surface rejected below -- that one is about listing and deleting whole
+registries. Reclaiming orphaned native containers needs enumeration, and
+the portability section above shows it stops being optional on providers
+with low container caps. A read-only enumeration operation is purely
+additive, so it waits for the reclamation design that would consume it.
+
+**`startup` and `shutdown` rather than a constructor that performs
+I/O.** Every store in the codebase separates construction from starting,
+so wiring code can build the object graph and then start it. `startup`
+is idempotent because every process runs it at boot and none is
+privileged. `shutdown` is a no-op in the SQLAlchemy implementation
+because the engine is shared and externally owned: the registry does not
+close what it did not open.
+
+## Storage (SQLAlchemy implementation)
+
+- Table per registry (`collection_registry_<name>`: `key` VARCHAR(255) PK,
+  `entry` JSON, JSONB on PostgreSQL). Registry names become SQL identifier
+  components, hence the `[a-z0-9_]+`, 32-byte constraint (prefix + name
+  stays inside PostgreSQL's 63-byte identifier limit). Storage keys are
+  `f"{namespace}/{name}"` -- "/" is outside the identifier charset, so
+  distinct pairs can never collide ("__" would be ambiguous).
+- The primary key is the concurrency arbiter: `register` is a plain INSERT
+  with `IntegrityError` mapped to `CollectionAlreadyRegisteredError` (the
+  `SQLAlchemySegmentStore.create_partition` pattern); `get_or_register` is a
+  SELECT fast path, then a native `INSERT .. ON CONFLICT DO NOTHING`, then a
+  re-SELECT of the winner on conflict. `get_or_register` never compares
+  entries -- config equality policy belongs to the store.
+- Flat JSON rather than typed columns: every access is get-by-key, pydantic
+  validates at the boundary, and typed columns would turn entry evolution
+  into DDL migrations in a codebase whose schema management is
+  `create_all`-on-startup.
+- Dialects: PostgreSQL and SQLite, the two relational providers the server
+  offers.
+
+## Format evolution without standing version machinery
+
+There is deliberately no stored format version and no version check. The
+evolution policy above is what makes that safe: because every change is
+add-optional-only and old rows classify exactly through defaults, a future
+breaking change can introduce an entry format version field (default 1)
+*at the moment it is first needed* -- the policy guarantees every
+pre-existing row is correctly version 1 -- and ship its migration
+(migrate-then-deploy with a window; low-downtime migrations are explicitly
+not a goal). The accepted residual: an old binary started against migrated
+data fails with validation errors at first read rather than being refused
+at startup.
+
+## Rejected alternatives
+
+- Distributed locks or leases: operationally heavier, and crash-recovery
+  semantics are worse than an insert that is atomic by construction.
+- A generic `ConfigRegistry[ConfigT]` (the earlier draft): speculative with
+  one consumer kind; see "Scope" above.
+- Registry management surface (list/delete registries): registries are
+  constructed by wiring code from configuration; the database catalog
+  already lists `collection_registry_*` tables, and management operations
+  are exactly the power stores must not have.
+- Schema-compatibility rules (Confluent-style): the right machinery when
+  many independently deployed writers and readers evolve on their own
+  schedules; wrong scale for an embedded component with one codebase owning
+  both sides.
+- A standing registry-of-registries version stamp (an earlier draft:
+  declarations table, startup version check, redeclare): under the
+  add-optional-only policy the version field is retrofittable with exact
+  classification at first need, so the standing machinery insured against a
+  scenario the policy already insures, at the cost of real API and doc
+  surface. Its one unique protection -- boot-time refusal of old binaries
+  against migrated data -- is the residual noted above.

--- a/design/collection_registry_backends.md
+++ b/design/collection_registry_backends.md
@@ -1,8 +1,9 @@
-# Qdrant on the collection registry
+# Vector store backends on the collection registry
 
-Contributor-facing design notes for QdrantVectorStore's collection metadata,
-which lives in the SQL-backed collection registry (see
-`collection_registry.md`) rather than in Qdrant itself.
+Contributor-facing design notes for QdrantVectorStore's and
+MilvusVectorStore's collection metadata, which lives in the SQL-backed
+collection registry (see `collection_registry.md`) rather than in the vector
+databases themselves.
 
 ## Why the registry moved out of Qdrant
 
@@ -83,3 +84,31 @@ native collection and data is reachable again; the caveat is paths that
 re-create with a currently-derived schema (the episodic event backend) orphan
 old partitions if that schema drifted since original creation. Stale
 `__registry` collections can be deleted manually.
+
+## Milvus
+
+Milvus previously kept the same bookkeeping in per-namespace
+`memmachine_<ns>__registry` Milvus collections (dummy-vector rows keyed by
+collection name), with the same non-atomic read-check-write lifecycle and the
+same races. It now follows the Qdrant design exactly: entries registered in
+the collection registry, native-first/register-last creation with the
+registry insert as the commit point, generationed partition keys making
+deletion safe against held handles, data-first/deregister-last deletion.
+
+Milvus-specific notes:
+
+- Native naming for new collections is unchanged:
+  `memmachine_{namespace}__{sha256(config)}`, shared by config and separated
+  by the partition key field.
+- There is no shard-key machinery; the generationed partition key is used
+  only as the partition key field value. The native schema's partition key
+  VARCHAR length is sized for generationed keys (name + "#" + 32 hex
+  characters), and native primary ids embed them
+  (`{partition_key}:{record_uuid}`), which also keeps ids unique across
+  generations.
+- The store's concurrency scope widens from PROCESS to
+  `min(CLUSTER, registry scope)`. Milvus's default `Session` consistency
+  means process B may read stale data relative to process A's writes; that
+  sits within the `VectorStoreCollection` visibility contract (no
+  read-your-writes is promised), but deployments wanting stronger data-plane
+  visibility should configure `consistency_level` accordingly.

--- a/design/concurrency_scopes.md
+++ b/design/concurrency_scopes.md
@@ -1,0 +1,104 @@
+# Concurrency scopes and data-plane contracts
+
+Contributor-facing design notes for `ConcurrencyScope` and the visibility and
+authority contracts on `VectorStoreCollection`.
+
+## The problem
+
+The `VectorStore` contract said a logical collection "must be managed by at
+most one process at a time". Once one implementation (Qdrant over a SQL
+config registry) genuinely supports multi-process management, a blanket
+sentence is either false for it or forbids what it supports -- capability the
+contract cannot express is capability no consumer may use.
+
+## Declared scope
+
+`ConcurrencyScope` (`common/data_types.py`) is an `IntEnum`,
+`PROCESS < MACHINE < CLUSTER`: the widest deployment boundary within which
+concurrent instances of a component may safely manage the same resources.
+Ordered by breadth, so the effective scope of a composed system is the `min`
+of its parts' scopes.
+
+`VectorStore`, `SegmentStore`, and `CollectionRegistry` declare an abstract
+`concurrency_scope` property, and the blanket sentences defer to it:
+concurrent management of the same collection/partition is safe within the
+declared scope; beyond it, at most one instance manages a resource and the
+consumer shards names, as before.
+
+Declarations:
+
+| Component | Scope | Why |
+|---|---|---|
+| `QdrantVectorStore` | `min(CLUSTER, registry scope)` | Qdrant is shareable across machines; the collection registry governs |
+| `SQLAlchemyCollectionRegistry` | `CLUSTER` on PostgreSQL, `MACHINE` on file-backed SQLite | the CAS reaches as far as the database does |
+| `SQLAlchemySegmentStore` | `CLUSTER` on PostgreSQL, `MACHINE` on SQLite | cross-process safe via unique-constraint create and row locks |
+| `MilvusVectorStore` | `PROCESS` | bookkeeping guarded only by in-process locks |
+| `SQLiteVectorStore` | `PROCESS` | search-engine state lives in process memory |
+| `SQLiteVecVectorStore` | `PROCESS` | check-then-write bookkeeping within one process |
+
+A deployment can therefore introspect what it is allowed to do -- a Qdrant
+store wired to a PostgreSQL registry reports `CLUSTER`; the same store over a
+shared SQLite file reports `MACHINE` -- instead of relying on out-of-band
+knowledge. `PROCESS` declarations are honest labels for current
+implementations, not permanent judgments; moving Milvus onto the config
+registry the way Qdrant was is the natural widening path.
+
+## Data-plane contracts
+
+Two properties stated on `VectorStoreCollection`. Both are pre-existing
+behavior; multi-process deployment is what makes them worth stating, because
+single-process consumers could survive assuming their negations.
+
+- Visibility: a returned write is durably accepted but is not guaranteed
+  visible to a subsequent query, from this instance or any other. Consumers
+  must not build on read-your-writes. (True even single-process today;
+  uniform staleness, not a per-client asymmetry.)
+- Authority: stored properties and property filters operate on the
+  collection's own copy of a record, with no freshness guarantee relative to
+  any external source of truth. A vector store can promise internal
+  consistency of its own copy, never authority over data governed elsewhere;
+  consumers whose records are governed by an external authority (e.g. SQL
+  holding access-determining attributes) must re-validate results against it.
+  Post-validation at the source of truth can only remove candidates -- an
+  attribute may be pre-filtered inside the vector store only if it is
+  immutable after ingest or if staleness can only produce false positives.
+
+## Handle lifetime is not scope-conditional
+
+The data-plane contracts include one invariant deliberately stated
+without reference to scope: a write through a handle whose collection
+has been deleted must never surface in a collection later created under
+the same name.
+
+Scope is what makes the uniformity necessary rather than tidy. PROCESS
+is the only scope at which the *application* could be the guarantor,
+since inside one process it sees every handle it holds and every delete
+it issues. Above PROCESS that is impossible -- one process holds a
+handle while another deletes and recreates, and the first cannot learn
+of it -- so any store declaring MACHINE or CLUSTER has to provide the
+invariant outright. Making it conditional would then leave consumers
+writing against the lenient reading and breaking when a backend's scope
+widens under them, which is exactly what the registry PRs do to Qdrant
+and Milvus. The discipline it would delegate is also expensive and
+silently violable: handle-lifetime tracking across tasks, in every
+consumer, to avoid a failure whose symptom is corrupted data rather than
+an error.
+
+Known non-conformance: both SQLite-backed vector stores derive their
+native resources from (namespace, name) alone and do resurrect such
+writes -- immediately in `SQLiteVecVectorStore`, and on the next index
+save in `SQLiteVectorStore`, whose stale handle also rewrites the live
+index file of the replacement collection. Tracked in
+MemMachine/MemMachine#1536; the registry-backed stores satisfy the
+invariant through generation-scoped partition keys.
+
+## Rejected alternatives
+
+- Deleting the one-process sentence outright: Milvus and the SQLite stores
+  still need it; per-instance declaration is the only shape that tells the
+  truth for all implementations at once.
+- Boolean "multi-process safe" flag: loses the machine/cluster distinction,
+  which is exactly the distinction a shared-SQLite deployment needs.
+- Runtime enforcement (detecting out-of-scope concurrent managers): requires
+  cross-process membership machinery; the scope is a contract, like the
+  identifier constraints, not a guard.

--- a/design/qdrant_collection_registry.md
+++ b/design/qdrant_collection_registry.md
@@ -1,0 +1,85 @@
+# Qdrant on the collection registry
+
+Contributor-facing design notes for QdrantVectorStore's collection metadata,
+which lives in the SQL-backed collection registry (see
+`collection_registry.md`) rather than in Qdrant itself.
+
+## Why the registry moved out of Qdrant
+
+Qdrant offers no conditional writes, transactions, or unique constraints. The
+previous design kept collection metadata in per-namespace `<ns>__registry`
+Qdrant collections (dummy-vector points keyed `uuid5(name)`), which made
+`create_collection` / `open_collection` / `delete_collection` non-atomic
+read-check-write sequences guarded only by a per-process asyncio lock. The
+moment two processes manage the same name:
+
+1. `VectorStoreCollectionAlreadyExistsError` stops firing -- both creates
+   pass the absence check and last-writer-wins the registry point.
+2. Two creations with different configs each create a different native
+   collection (native names hash the config) while contending for one
+   registry point; records written through the losing handle become
+   permanently unreachable.
+
+With the registry's unique-constraint insert as the commit point, both
+guarantees hold across processes sharing the registry database. The
+per-process `_name_locks` remain only as in-process serialization; they are
+no longer correctness-bearing.
+
+## Registry entries store resolved identity
+
+Collections register a `CollectionRegistryEntry` =
+`{config, native_collection_name, partition_key}` (see
+`collection_registry.md` for the entry design and evolution policy).
+
+Qdrant-specific use of the shared fields: the native naming scheme for new
+collections is `f"{namespace}__{sha256(config)}"` (unchanged -- collections
+with the same config share a native collection, separated by partition key),
+generations are minted as `f"{name}#{uuid4().hex}"`, and `partition_key`
+doubles as the shard key in distributed mode.
+
+## Generations make deletion safe against held handles
+
+`delete_collection` deletes that generation's data (partition filter delete,
+or shard-key drop in distributed mode), then removes the registry entry. A
+handle held in another process across the deletion keeps writing into the
+dead generation: invisible to every reader, never resurrected, because a
+re-creation of the same name mints a fresh generation -- even with an
+identical config and therefore the identical shared native collection. No
+locks, no per-write round trips; the residual cost is bounded garbage under
+dead generations, sweepable by a future GC that deletes points whose
+partition keys are absent from the registry.
+
+## Ordering and crash windows
+
+- Create: native collection first, registry entry last. The registry insert
+  is the atomic commit point. A crash -- or a lost creation race -- before it
+  leaves only an empty native collection (shared by config, adopted by the
+  next same-config creation) and, in distributed mode, an unused shard key.
+  Cleanup of the loser's native collection is deliberately not attempted:
+  native collections are shared by config, and the registry intentionally has
+  no list operation, so nothing can safely prove no other logical collection
+  references one. The residue is bounded by the number of distinct configs
+  attempted. Registry-first ordering would be worse: `open_collection` builds
+  handles straight from the entry, so a crash between claim and native
+  creation would hand out handles to a nonexistent native collection. The
+  invariant is: registry entry implies native collection exists.
+- Delete: data first, deregistration last. A crash in between leaves a
+  registered-but-empty collection (documented on `delete_collection`);
+  retrying the deletion completes it.
+
+## Configuration and migration
+
+`QdrantConf.registry_database` (required) names a configured relational
+database entry; all processes sharing a Qdrant instance must use the same
+registry database. There is deliberately no per-host SQLite fallback --
+divergent per-host registries would look consistent while reproducing exactly
+the races this design removes. One registry per Qdrant conf entry
+(`qdrant_<conf name>`), so instances sharing a registry database get separate
+tables.
+
+Deployed `<ns>__registry` data is not migrated. Native collection names are
+unchanged, so re-creation with an unchanged config re-registers the same
+native collection and data is reachable again; the caveat is paths that
+re-create with a currently-derived schema (the episodic event backend) orphan
+old partitions if that schema drifted since original creation. Stale
+`__registry` collections can be deleted manually.

--- a/design/schema_creation.md
+++ b/design/schema_creation.md
@@ -1,0 +1,176 @@
+# Schema creation and DDL
+
+Contributor-facing design notes on where the server runs DDL and why.
+
+## Problem
+
+Horizontal scalability: several server processes should be able to run against
+one database. Every SQLAlchemy-backed store creates its own schema during
+`startup()` with `metadata.create_all`, which is check-then-create -- SQLAlchemy
+reflects, then emits `CREATE TABLE` without `IF NOT EXISTS`. Two processes
+booting against a database that does not yet have the tables can both pass the
+check; the loser's `CREATE TABLE` fails and takes its boot down with it.
+
+This note records the decision to keep that shape for now, the argument that
+makes it survivable, and the conditions under which the argument stops holding.
+
+## What the server does today
+
+Schema creation in `startup()`, via `create_all`:
+
+- `common/episode_store/episode_sqlalchemy_store.py:170`
+- `common/session_manager/session_data_manager_sql_impl.py:144`
+- `common/vector_store/sqlite_vector_store.py:718`
+- `common/vector_store/sqlite_vec_vector_store.py:491`
+- `episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py:793`
+- `semantic_memory/cluster_store/cluster_store_sqlalchemy.py:101`
+- `semantic_memory/config_store/config_store_sqlalchemy.py:238`
+- `semantic_memory/storage/vector_store_semantic_storage.py:196`
+
+Schema creation at runtime, driven by traffic rather than by configuration.
+This is worth stating plainly, because it is easy to assume the server only
+creates schema when an operator changes something. It does not. The event
+backend derives a partition key per session --
+`partition_key_for_session(session_id)`, a truncated SHA-256 of the session id
+(`long_term_memory/service_locator.py:106` and `:165-183`) -- and uses it as
+both the segment store partition key and the vector store collection name. So
+the first use of a new session runs DDL:
+
+- On PostgreSQL, two `CREATE TABLE ... PARTITION OF` statements for the segment
+  store child tables (`sqlalchemy_segment_store.py:1045-1061`, reached through
+  `open_or_create_partition` at `service_locator.py:140`).
+- On the SQLite vector stores, `create_all(tables=[records_table])` for the
+  collection's records table (`sqlite_vector_store.py:1061`,
+  `sqlite_vec_vector_store.py:692`). The sqlite-vec store follows it with
+  `CREATE VIRTUAL TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS` for the
+  vec0 table and property indexes, which are re-emitted on every open.
+
+Runtime DDL is therefore an ordinary, per-session occurrence, not a rare
+administrative one, and the crash-and-restart argument below does not cover it.
+
+Of those two, only the segment store's matters for running several processes
+against one database. The SQLite stores are single-process by construction --
+one file, one writer -- so concurrent creation of the same collection is
+outside what they promise, and the DDL they run per session is not a
+multi-process hazard. The segment store's partitions are shared, which is why
+that path had to be made race-free rather than left to a restart.
+
+The registry is what keeps this list from growing. Qdrant and Milvus also mint
+a collection per session, but registering one is an `INSERT` into a table that
+already exists, so adding a session adds a row rather than a table. Turning
+runtime metadata management into a transactional row write is the point of the
+primitive, and it means the only schema those backends need is created once, at
+boot, from configuration.
+
+Alembic exists (`semantic_memory/storage/alembic_pg`) but is also driven from
+the boot path: `apply_alembic_migrations` runs `command.upgrade(config, "head")`
+in-process, called from `SqlAlchemyPgVectorSemanticStorage.startup()`
+(`sqlalchemy_pgvector_semantic.py:172-211`). Having Alembic in the repo is
+therefore not the same as having schema creation out of the boot path.
+
+## Decision
+
+New SQLAlchemy-backed stores keep `create_all` in `startup()` and match the
+existing shape. They do not add per-store race handling of their own.
+
+The reasoning is uniformity, not that the race is imaginary. A one-off guard on
+a single new store would leave seven other boot paths with the same behavior
+while making the repo harder to reason about as a whole -- the reader could no
+longer assume that "SQLAlchemy store, `startup()`, `create_all`" means one
+thing. Moving schema creation out of the boot path is a change to the
+deployment model, not to one file, and it should be made once, deliberately,
+for every store at the same time.
+
+## Why crash-and-restart is acceptable for boot-path DDL
+
+The loser of a boot race raises, the process exits, the supervisor restarts it,
+`create_all` reflects, finds the tables present, emits nothing, and boot
+proceeds. The database converges on the correct schema and no writes are lost
+or misdirected in the meantime, because the failure is entirely before the
+store serves traffic.
+
+Three properties are what make that true, and they are properties of the
+current code rather than of `create_all` in general:
+
+1. **The schema each `create_all` emits is a single statement, or a set of
+   statements with no ordering dependency between them.** This is the load-
+   bearing one. `create_all`'s `checkfirst` tests for *table* existence and
+   skips the whole `CREATE TABLE` when the table is present, indexes included.
+   A partially applied multi-statement schema -- table created, a following
+   index not -- is therefore *not* repaired by a restart; the restart skips the
+   table and the index stays missing forever. Where a store emits indexes as
+   separate `CREATE INDEX IF NOT EXISTS` statements after `create_all`, as the
+   sqlite-vec store does, they are re-emitted on every open and the gap closes.
+2. **On PostgreSQL, DDL is transactional.** Stores that wrap `create_all` in
+   `engine.begin()` get all-or-nothing application, so a failed boot leaves no
+   half-built schema behind at all.
+3. **The set of tables is fixed by configuration, not by traffic.** Boot-path
+   `create_all` covers a static metadata. The race window is a cold database,
+   or the first boot after an operator adds a configuration entry that names a
+   new table. It is not re-entered per request.
+
+## Where the argument stops holding
+
+Any of these invalidates the reasoning above, and a store that has one needs to
+be handled explicitly rather than inheriting this decision:
+
+- **A table whose schema needs more than one statement**, i.e. a `Table` that
+  carries `Index()` objects, or DDL emitted after `create_all` that is not
+  itself `IF NOT EXISTS`. Then a partial application is permanent, per (1).
+- **Table names derived at runtime rather than from configuration.** The
+  failure moves from a boot crash, which a supervisor absorbs, to a 500 in a
+  process that is already serving traffic, and it recurs for each new name
+  rather than once per deployment.
+- **Deployments with no supervisor restart**, where a crashed boot is a
+  permanent outage rather than a retry.
+
+The collection registry satisfies all three properties: its table
+(`sqlalchemy_collection_registry.py:143-148`) is one `Table` with a primary key
+and a JSON column and no `Index()` objects, so `create_all` emits exactly one
+`CREATE TABLE`; `startup()` wraps it in `engine.begin()`; and registry names
+come from the vector store configuration (`qdrant_{name}` per configured Qdrant
+instance, built during `DatabaseManager.build_all`), so the table set is fixed
+before the server accepts a request.
+
+## The DDL path that is already race-free
+
+Segment store partition creation is the exception worth pointing at. It runs in
+steady state, on the first use of every new session, so restarting is not an
+available answer -- the failure would be a 500 in a process that is already
+serving, recurring per session rather than once per deployment.
+`create_partition` and `_open_or_create_partition`
+(`sqlalchemy_segment_store.py:805-895`) take an explicit lock on the partitions
+table, insert the partition row, and emit
+`CREATE TABLE ... PARTITION OF` -- all inside one transaction. PostgreSQL's
+transactional DDL means the loser's insert conflicts and the child-table
+creation rolls back with it. Runtime DDL that cannot be answered with a restart
+has to look like this.
+
+## Deferred: moving schema creation out of the boot path
+
+The standard answer is to make schema creation a distinct deployment step --
+`alembic upgrade head` as an init job, an initContainer, or a deploy stage --
+and reduce `startup()` to verifying that the expected schema is present and
+failing fast when it is not. Exactly one process runs DDL, so there is no race
+to handle, and a binary can refuse to serve against a schema it does not
+understand instead of silently adapting to it.
+
+This is deferred rather than rejected. It is a change to how the server is
+deployed, it touches all eight boot paths plus the in-process Alembic call, and
+it needs the operator-facing story (what runs the migration, what happens on
+rollback) decided alongside the code. Nothing in the current stack depends on
+it: the failure it prevents is a cold-start crash loop that resolves itself,
+not data loss or divergence between processes.
+
+## Follow-ups
+
+- Decide the repo-wide model, and apply it to every store in one pass rather
+  than store by store.
+- The four copies of the engine validator
+  (`sqlite_vector_store.py:655`, `sqlite_vec_vector_store.py:447`,
+  `sqlalchemy_segment_store.py:749`, `sqlalchemy_collection_registry.py:93`)
+  should be deduplicated. They share a gap: the ephemeral-SQLite check tests
+  `db is None or db == ":memory:"`, but `sqlite+aiosqlite:///` parses to
+  `database == ""` and passes, giving every connection its own private
+  temporary database. That one is a plain bug, not a race, and no restart
+  converges out of it.

--- a/design/storage_lifecycle_strictness.md
+++ b/design/storage_lifecycle_strictness.md
@@ -1,0 +1,50 @@
+# Strict create/open storage lifecycles
+
+Contributor-facing design notes for the removal of `open_or_create_*` from
+`VectorStore` and `SegmentStore`.
+
+## The rule
+
+Storage lifecycle APIs are strict: `create` fails on an existing resource,
+`open` returns nothing for a missing one. Adopt-on-exists (ensure) semantics
+are not a lifecycle primitive; where a call site genuinely needs them, it
+composes them -- open, create suppressing `AlreadyExistsError` (a concurrent
+creator winning is fine), open again.
+
+## Why
+
+Adopt-on-exists is the right primitive only where creation is a lazy side
+effect of use by symmetric actors and there is nothing for adoption to get
+wrong. Collections and partitions are not that: creation carries a config,
+and adopting someone else's differently-configured resource is a hazard the
+API was compensating for with `ConfigMismatchError` machinery. With strict
+create/open, a caller that loses a creation race adopts the winner's resource
+via `open`, and the handle carries the stored config for any consumer that
+wants to enforce its own equality policy -- no current consumer does, because
+every call site derives its config from code, not input.
+
+An audit found exactly two consumers of the removed methods
+(`semantic_manager.get_semantic_storage` and the episodic event backend's
+`service_locator`), neither needing adoption as a primitive; both now use the
+composed form. `EventMemory` itself never had ensure semantics -- it receives
+already-opened handles.
+
+The one place ensure remains is collection registry `startup()`,
+deliberately: registry storage is materialized lazily at bootstrap by
+symmetric processes, from names derived in code, and carries nothing for
+adoption to mismatch (the entry format version is validated separately, by
+the registry of registries). Bootstrap is where ensure semantics belongs;
+everything above it is strict.
+
+## Removed
+
+- `VectorStore.open_or_create_collection` (all four implementations) and
+  `VectorStoreCollectionConfigMismatchError` (the method was its only
+  raiser).
+- `SegmentStore.open_or_create_partition` and
+  `SegmentStorePartitionConfigMismatchError`, with the implementation's
+  mismatch-check helper.
+
+Untouched, and out of scope: `EpisodicMemoryManager
+.open_or_create_episodic_memory` is an in-process instance-cache accessor
+(get-or-construct a session's memory object), not a durable-storage ensure.

--- a/docs/open_source/configuration.mdx
+++ b/docs/open_source/configuration.mdx
@@ -392,7 +392,7 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
       | `config.uri`  | The URI for the given database.                                      | Depends on provider |
       | `config.token` | Milvus auth token for Zilliz Cloud or auth-enabled Milvus server.   | `""` |
       | `config.consistency_level` | Milvus collection consistency level: `Strong`, `Session`, `Bounded`, or `Eventually`. | `Session` |
-      | `config.registry_database` | Qdrant: name of a configured relational database (a `postgres` or `sqlite` entry) that stores the collection registry. All processes sharing the Qdrant instance must use the same registry database. | *Required for `qdrant`* |
+      | `config.registry_database` | Qdrant/Milvus: name of a configured relational database (a `postgres` or `sqlite` entry) that stores the collection registry. All processes sharing the vector store instance must use the same registry database. | *Required for `qdrant` and `milvus`* |
       | `config.path`  | The path for the given database.                                    | Depends on provider |
       | `config.username` | Username for internal graph store authentication.                | Depends on provider |
       | `my_storage_id` | The specific configuration for the system's internal graph store.  | *Required*  |

--- a/docs/open_source/configuration.mdx
+++ b/docs/open_source/configuration.mdx
@@ -392,6 +392,7 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
       | `config.uri`  | The URI for the given database.                                      | Depends on provider |
       | `config.token` | Milvus auth token for Zilliz Cloud or auth-enabled Milvus server.   | `""` |
       | `config.consistency_level` | Milvus collection consistency level: `Strong`, `Session`, `Bounded`, or `Eventually`. | `Session` |
+      | `config.registry_database` | Qdrant: name of a configured relational database (a `postgres` or `sqlite` entry) that stores the collection registry. All processes sharing the Qdrant instance must use the same registry database. | *Required for `qdrant`* |
       | `config.path`  | The path for the given database.                                    | Depends on provider |
       | `config.username` | Username for internal graph store authentication.                | Depends on provider |
       | `my_storage_id` | The specific configuration for the system's internal graph store.  | *Required*  |

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_database_conf.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_database_conf.py
@@ -130,6 +130,7 @@ def db_conf_dict() -> dict:
                     "uri": "https://example.zillizcloud.com",
                     "token": "test-token",
                     "db_name": "memory",
+                    "registry_database": "local_sqlite",
                     "consistency_level": "Strong",
                 },
             },
@@ -213,6 +214,7 @@ def test_parse_valid_storage_dict(db_conf_dict):
     assert milvus_conf.uri == "https://example.zillizcloud.com"
     assert milvus_conf.token == SecretStr("test-token")
     assert milvus_conf.db_name == "memory"
+    assert milvus_conf.registry_database == "local_sqlite"
     assert milvus_conf.consistency_level == "Strong"
 
     # SQLiteVectorStore (hnswlib engine)
@@ -281,11 +283,17 @@ def test_serialize_deserialize_database_conf(db_conf_dict):
 
 
 def test_milvus_conf_defaults():
-    conf = MilvusConf()
+    conf = MilvusConf(registry_database="registry_db")
     assert conf.uri == "./milvus.db"
     assert conf.token == SecretStr("")
     assert conf.db_name == ""
     assert conf.consistency_level == "Session"
+    assert conf.registry_database == "registry_db"
+
+
+def test_milvus_conf_requires_registry_database():
+    with pytest.raises(ValidationError):
+        MilvusConf.model_validate({})
 
 
 def test_milvus_conf_reads_env(monkeypatch):
@@ -296,6 +304,7 @@ def test_milvus_conf_reads_env(monkeypatch):
         uri="$MILVUS_URI",
         token=SecretStr("${MILVUS_TOKEN}"),
         db_name="$MILVUS_DB_NAME",
+        registry_database="registry_db",
     )
     assert conf.uri == "https://example.zillizcloud.com"
     assert conf.token == SecretStr("env-token")
@@ -304,9 +313,9 @@ def test_milvus_conf_reads_env(monkeypatch):
 
 def test_milvus_conf_rejects_invalid_values():
     with pytest.raises(ValueError, match="non-empty 'uri'"):
-        MilvusConf(uri="")
+        MilvusConf(uri="", registry_database="registry_db")
     with pytest.raises(ValueError, match="consistency_level"):
-        MilvusConf(consistency_level="Linearizable")
+        MilvusConf(consistency_level="Linearizable", registry_database="registry_db")
 
 
 def test_neo4j_pool_lifecycle_fields():

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_database_conf.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_database_conf.py
@@ -1,6 +1,6 @@
 import pytest
 import yaml
-from pydantic import SecretStr
+from pydantic import SecretStr, ValidationError
 
 from memmachine_server.common.configuration.database_conf import (
     DatabasesConf,
@@ -121,7 +121,7 @@ def db_conf_dict() -> dict:
                     "prefer_grpc": True,
                     "api_key": "test-key",
                     "is_distributed": True,
-                    "registry_replication_factor": 3,
+                    "registry_database": "local_sqlite",
                 },
             },
             "my_milvus": {
@@ -205,7 +205,7 @@ def test_parse_valid_storage_dict(db_conf_dict):
     assert qdrant_conf.prefer_grpc is True
     assert qdrant_conf.api_key == SecretStr("test-key")
     assert qdrant_conf.is_distributed is True
-    assert qdrant_conf.registry_replication_factor == 3
+    assert qdrant_conf.registry_database == "local_sqlite"
 
     # Milvus check
     milvus_conf = storage_conf.milvus_confs["my_milvus"]
@@ -358,26 +358,38 @@ def test_neo4j_uri_with_special_host():
 
 
 def test_qdrant_conf_defaults():
-    conf = QdrantConf()
+    conf = QdrantConf(registry_database="registry_db")
     assert conf.host == "localhost"
     assert conf.port == 6333
     assert conf.grpc_port == 6334
     assert conf.prefer_grpc is False
     assert conf.https is False
     assert conf.is_distributed is False
-    assert conf.registry_replication_factor == 1
+    assert conf.registry_database == "registry_db"
     assert conf.api_key.get_secret_value() == ""
+
+
+def test_qdrant_conf_requires_registry_database():
+    with pytest.raises(ValidationError):
+        QdrantConf.model_validate({})
 
 
 def test_qdrant_conf_api_key_from_env(monkeypatch):
     monkeypatch.setenv("QDRANT_API_KEY", "env-qdrant-key")
-    conf = QdrantConf(api_key=SecretStr("$QDRANT_API_KEY"))
+    conf = QdrantConf(
+        api_key=SecretStr("$QDRANT_API_KEY"), registry_database="registry_db"
+    )
     assert conf.api_key == SecretStr("env-qdrant-key")
 
 
 def test_qdrant_build_config():
     config = SupportedDB.QDRANT.build_config(
-        {"host": "qdrant.local", "port": 9333, "is_distributed": True}
+        {
+            "host": "qdrant.local",
+            "port": 9333,
+            "is_distributed": True,
+            "registry_database": "registry_db",
+        }
     )
     assert isinstance(config, QdrantConf)
     assert config.host == "qdrant.local"

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import SecretStr
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from memmachine_server.common.configuration.database_conf import (
     DatabasesConf,
@@ -23,6 +23,10 @@ from memmachine_server.common.errors import (
 )
 from memmachine_server.common.resource_manager.database_manager import DatabaseManager
 from memmachine_server.common.vector_graph_store import VectorGraphStore
+from memmachine_server.common.vector_store import VectorStoreCollectionConfig
+from memmachine_server.common.vector_store.collection_registry import (
+    CollectionRegistryEntry,
+)
 
 requires_pymilvus = pytest.mark.skipif(
     importlib.util.find_spec("pymilvus") is None,
@@ -296,7 +300,9 @@ def _qdrant_only_conf() -> MagicMock:
     conf.relational_db_confs = {}
     conf.nebula_graph_confs = {}
     conf.qdrant_confs = {
-        "qdrant1": QdrantConf(host="localhost", port=6333),
+        "qdrant1": QdrantConf(
+            host="localhost", port=6333, registry_database="registry_db"
+        ),
     }
     conf.sqlite_vector_store_confs = {}
     conf.sqlite_vec_vector_store_confs = {}
@@ -314,6 +320,7 @@ async def test_qdrant_client_kwargs_forwarded():
         prefer_grpc=True,
         https=True,
         api_key=SecretStr("secret-key"),
+        registry_database="registry_db",
     )
 
     mock_client = AsyncMock()
@@ -331,6 +338,11 @@ async def test_qdrant_client_kwargs_forwarded():
             "qdrant_client.AsyncQdrantClient",
             return_value=mock_client,
         ) as mock_cls,
+        patch.object(
+            DatabaseManager,
+            "_build_qdrant_collection_registry",
+            new=AsyncMock(),
+        ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
@@ -365,6 +377,11 @@ async def test_qdrant_api_key_omitted_when_empty():
             "qdrant_client.AsyncQdrantClient",
             return_value=mock_client,
         ) as mock_cls,
+        patch.object(
+            DatabaseManager,
+            "_build_qdrant_collection_registry",
+            new=AsyncMock(),
+        ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
@@ -379,11 +396,12 @@ async def test_qdrant_creates_vector_store():
     conf = _qdrant_only_conf()
     conf.qdrant_confs["qdrant1"] = QdrantConf(
         is_distributed=True,
-        registry_replication_factor=3,
+        registry_database="registry_db",
     )
 
     mock_client = AsyncMock()
     mock_client.close = AsyncMock()
+    mock_registry = MagicMock()
 
     with (
         patch(
@@ -396,6 +414,11 @@ async def test_qdrant_creates_vector_store():
             "qdrant_client.AsyncQdrantClient",
             return_value=mock_client,
         ),
+        patch.object(
+            DatabaseManager,
+            "_build_qdrant_collection_registry",
+            new=AsyncMock(return_value=mock_registry),
+        ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
@@ -404,11 +427,88 @@ async def test_qdrant_creates_vector_store():
     mock_params_cls.assert_called_once_with(
         client=mock_client,
         is_distributed=True,
-        registry_replication_factor=3,
+        registry=mock_registry,
     )
     mock_store_cls.assert_called_once_with(mock_params_cls.return_value)
     mock_store_cls.return_value.startup.assert_awaited_once()
     assert "qdrant1" in builder.vector_stores
+
+
+@pytest.mark.asyncio
+async def test_qdrant_registry_database_not_configured():
+    """A registry_database naming no relational database fails with a clear error."""
+    conf = _qdrant_only_conf()
+    conf.relational_db_confs = {}
+
+    mock_client = AsyncMock()
+    mock_client.close = AsyncMock()
+
+    with patch(
+        "qdrant_client.AsyncQdrantClient",
+        return_value=mock_client,
+    ):
+        builder = DatabaseManager(conf)
+        with pytest.raises(QdrantConfigurationError, match="registry_database"):
+            await builder.async_get_qdrant_client("qdrant1")
+
+    mock_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_qdrant_conf_name_unusable_as_registry_name(tmp_path):
+    """A qdrant conf entry name that cannot name a registry table fails clearly."""
+    conf = _qdrant_only_conf()
+    conf.qdrant_confs = {
+        "qdrant-1": QdrantConf(registry_database="registry_db"),
+    }
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/registry.db")
+    mock_client = AsyncMock()
+    mock_client.close = AsyncMock()
+
+    with (
+        patch(
+            "qdrant_client.AsyncQdrantClient",
+            return_value=mock_client,
+        ),
+        patch.object(
+            DatabaseManager,
+            "async_get_sql_engine",
+            new=AsyncMock(return_value=engine),
+        ),
+    ):
+        builder = DatabaseManager(conf)
+        with pytest.raises(QdrantConfigurationError, match="Rename"):
+            await builder.async_get_qdrant_client("qdrant-1")
+
+    mock_client.close.assert_awaited_once()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_qdrant_builds_registry_on_named_database(tmp_path):
+    """The collection registry is built and started on the named engine."""
+    conf = _qdrant_only_conf()
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/registry.db")
+
+    with patch.object(
+        DatabaseManager,
+        "async_get_sql_engine",
+        new=AsyncMock(return_value=engine),
+    ):
+        builder = DatabaseManager(conf)
+        registry = await builder._build_qdrant_collection_registry(
+            "qdrant1", conf.qdrant_confs["qdrant1"]
+        )
+
+    entry = CollectionRegistryEntry(
+        config=VectorStoreCollectionConfig(vector_dimensions=3),
+        native_collection_name="ns__digest",
+        partition_key="name#generation",
+    )
+    await registry.register(namespace="ns", name="name", entry=entry)
+    assert await registry.get(namespace="ns", name="name") == entry
+    await engine.dispose()
 
 
 @pytest.mark.asyncio
@@ -430,6 +530,11 @@ async def test_get_vector_store_qdrant():
         patch(
             "qdrant_client.AsyncQdrantClient",
             return_value=mock_client,
+        ),
+        patch.object(
+            DatabaseManager,
+            "_build_qdrant_collection_registry",
+            new=AsyncMock(),
         ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
@@ -480,6 +585,11 @@ async def test_qdrant_close():
         patch(
             "qdrant_client.AsyncQdrantClient",
             return_value=mock_client,
+        ),
+        patch.object(
+            DatabaseManager,
+            "_build_qdrant_collection_registry",
+            new=AsyncMock(),
         ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
@@ -478,7 +478,9 @@ async def test_qdrant_conf_name_unusable_as_registry_name(tmp_path):
         ),
     ):
         builder = DatabaseManager(conf)
-        with pytest.raises(QdrantConfigurationError, match="Rename"):
+        with pytest.raises(
+            QdrantConfigurationError, match="cannot build its collection registry"
+        ):
             await builder.async_get_qdrant_client("qdrant-1")
 
     mock_client.close.assert_awaited_once()
@@ -618,7 +620,7 @@ def _milvus_only_conf() -> MagicMock:
     conf.nebula_graph_confs = {}
     conf.qdrant_confs = {}
     conf.milvus_confs = {
-        "milvus1": MilvusConf(uri="./milvus.db"),
+        "milvus1": MilvusConf(uri="./milvus.db", registry_database="registry_db"),
     }
     conf.sqlite_vector_store_confs = {}
     conf.sqlite_vec_vector_store_confs = {}
@@ -635,6 +637,7 @@ async def test_milvus_client_kwargs_forwarded():
         token=SecretStr("secret-token"),
         db_name="memory",
         consistency_level="Strong",
+        registry_database="registry_db",
     )
 
     mock_client = MagicMock()
@@ -649,6 +652,11 @@ async def test_milvus_client_kwargs_forwarded():
             "memmachine_server.common.vector_store.milvus_vector_store.MilvusVectorStore",
         ) as mock_store_cls,
         patch("pymilvus.MilvusClient", return_value=mock_client) as mock_cls,
+        patch.object(
+            DatabaseManager,
+            "_build_collection_registry",
+            new=AsyncMock(),
+        ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
@@ -677,6 +685,11 @@ async def test_milvus_token_and_db_name_omitted_when_empty():
             "memmachine_server.common.vector_store.milvus_vector_store.MilvusVectorStore",
         ) as mock_store_cls,
         patch("pymilvus.MilvusClient", return_value=mock_client) as mock_cls,
+        patch.object(
+            DatabaseManager,
+            "_build_collection_registry",
+            new=AsyncMock(),
+        ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
@@ -690,10 +703,13 @@ async def test_milvus_token_and_db_name_omitted_when_empty():
 async def test_milvus_creates_vector_store():
     """async_get_milvus_client creates a MilvusVectorStore and stores it."""
     conf = _milvus_only_conf()
-    conf.milvus_confs["milvus1"] = MilvusConf(consistency_level="Strong")
+    conf.milvus_confs["milvus1"] = MilvusConf(
+        consistency_level="Strong", registry_database="registry_db"
+    )
 
     mock_client = MagicMock()
     mock_client.close = MagicMock()
+    mock_registry = MagicMock()
 
     with (
         patch(
@@ -703,6 +719,11 @@ async def test_milvus_creates_vector_store():
             "memmachine_server.common.vector_store.milvus_vector_store.MilvusVectorStore",
         ) as mock_store_cls,
         patch("pymilvus.MilvusClient", return_value=mock_client),
+        patch.object(
+            DatabaseManager,
+            "_build_collection_registry",
+            new=AsyncMock(return_value=mock_registry),
+        ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
@@ -710,6 +731,7 @@ async def test_milvus_creates_vector_store():
 
     mock_params_cls.assert_called_once_with(
         client=mock_client,
+        registry=mock_registry,
         consistency_level="Strong",
     )
     mock_store_cls.assert_called_once_with(mock_params_cls.return_value)
@@ -735,6 +757,11 @@ async def test_get_vector_store_milvus():
             "memmachine_server.common.vector_store.milvus_vector_store.MilvusVectorStore",
         ) as mock_store_cls,
         patch("pymilvus.MilvusClient", return_value=mock_client),
+        patch.object(
+            DatabaseManager,
+            "_build_collection_registry",
+            new=AsyncMock(),
+        ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
@@ -783,6 +810,11 @@ async def test_milvus_close():
             "memmachine_server.common.vector_store.milvus_vector_store.MilvusVectorStore",
         ) as mock_store_cls,
         patch("pymilvus.MilvusClient", return_value=mock_client),
+        patch.object(
+            DatabaseManager,
+            "_build_collection_registry",
+            new=AsyncMock(),
+        ),
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_semantic_manager_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_semantic_manager_vector_store.py
@@ -21,7 +21,9 @@ from memmachine_server.semantic_memory.storage.vector_store_semantic_storage imp
 async def test_semantic_manager_builds_vector_store_backend(sqlalchemy_sqlite_engine):
     vector_store = MagicMock()
     vector_collection = MagicMock()
-    vector_store.open_or_create_collection = AsyncMock(return_value=vector_collection)
+    # First open misses; the manager then creates and re-opens.
+    vector_store.open_collection = AsyncMock(side_effect=[None, vector_collection])
+    vector_store.create_collection = AsyncMock()
 
     resource_manager = MagicMock()
     resource_manager.get_sql_engine = AsyncMock(return_value=sqlalchemy_sqlite_engine)
@@ -49,6 +51,7 @@ async def test_semantic_manager_builds_vector_store_backend(sqlalchemy_sqlite_en
         "semantic_db", validate=True
     )
     resource_manager.get_vector_store.assert_awaited_once_with("semantic_vectors")
-    vector_store.open_or_create_collection.assert_awaited_once()
+    vector_store.create_collection.assert_awaited_once()
+    assert vector_store.open_collection.await_count == 2
 
     await storage.cleanup()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -14,7 +14,11 @@ pymilvus = pytest.importorskip("pymilvus")
 DataType = pymilvus.DataType
 MilvusClient = pymilvus.MilvusClient
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import (
+    ConcurrencyScope,
+    PropertyValue,
+    SimilarityMetric,
+)
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -539,3 +543,7 @@ class TestPartitionIsolation:
 
         await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
         await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
+
+
+def test_concurrency_scope_is_process(store):
+    assert store.concurrency_scope == ConcurrencyScope.PROCESS

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -27,6 +27,10 @@ from memmachine_server.common.filter.filter_parser import (
     Not,
     Or,
 )
+from memmachine_server.common.vector_store.collection_registry.sqlalchemy_collection_registry import (
+    SQLAlchemyCollectionRegistry,
+    SQLAlchemyCollectionRegistryParams,
+)
 from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
@@ -62,10 +66,25 @@ def _make_record(
 
 
 @pytest_asyncio.fixture
-async def store(tmp_path):
+async def collection_registry(sqlalchemy_sqlite_engine):
+    registry = SQLAlchemyCollectionRegistry(
+        SQLAlchemyCollectionRegistryParams(
+            engine=sqlalchemy_sqlite_engine, name="milvus_test"
+        )
+    )
+    await registry.startup()
+    return registry
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path, collection_registry):
     client = MilvusClient(uri=str(tmp_path / "test_milvus.db"))
     vector_store = MilvusVectorStore(
-        MilvusVectorStoreParams(client=client, consistency_level="Session")
+        MilvusVectorStoreParams(
+            client=client,
+            registry=collection_registry,
+            consistency_level="Session",
+        )
     )
     await vector_store.startup()
     yield vector_store
@@ -107,31 +126,6 @@ class TestCollectionLifecycle:
         coll = await store.open_collection(namespace=NAMESPACE, name="lifecycle")
         assert isinstance(coll, MilvusVectorStoreCollection)
         await store.delete_collection(namespace=NAMESPACE, name="lifecycle")
-
-    @pytest.mark.asyncio
-    async def test_registry_lookup_requests_primary_key(self, store, monkeypatch):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="registry_fields",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-
-        captured_output_fields = None
-        original_get = MilvusClient.get
-
-        def tracked_get(self, *args, **kwargs):
-            nonlocal captured_output_fields
-            captured_output_fields = kwargs.get("output_fields")
-            return original_get(self, *args, **kwargs)
-
-        monkeypatch.setattr(MilvusClient, "get", tracked_get)
-        coll = await store.open_collection(namespace=NAMESPACE, name="registry_fields")
-
-        assert coll is not None
-        assert captured_output_fields is not None
-        assert "id" in captured_output_fields
-        assert "config" in captured_output_fields
-        await store.delete_collection(namespace=NAMESPACE, name="registry_fields")
 
     @pytest.mark.asyncio
     async def test_duplicate_name_raises(self, store, collection):
@@ -545,5 +539,6 @@ class TestPartitionIsolation:
         await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
 
 
-def test_concurrency_scope_is_process(store):
-    assert store.concurrency_scope == ConcurrencyScope.PROCESS
+def test_concurrency_scope_governed_by_registry(store):
+    # The test registry runs on file-backed SQLite.
+    assert store.concurrency_scope == ConcurrencyScope.MACHINE

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -27,7 +27,6 @@ from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from memmachine_server.common.vector_store.milvus_vector_store import (
     MilvusVectorStore,
@@ -142,21 +141,6 @@ class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_delete_nonexistent_is_idempotent(self, store):
         await store.delete_collection(namespace=NAMESPACE, name="nonexistent")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_raises_on_config_mismatch(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="mismatch",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        with pytest.raises(VectorStoreCollectionConfigMismatchError):
-            await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name="mismatch",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1),
-            )
-        await store.delete_collection(namespace=NAMESPACE, name="mismatch")
 
     @pytest.mark.asyncio
     async def test_same_config_shares_native_collection(self, store):

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -10,7 +10,11 @@ import pytest
 import pytest_asyncio
 from qdrant_client import AsyncQdrantClient
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import (
+    ConcurrencyScope,
+    PropertyValue,
+    SimilarityMetric,
+)
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -1136,6 +1140,32 @@ class TestMetrics:
         assert call_labels[1]["labels"]["status"] == "ok"
 
         await store.delete_collection(namespace=NAMESPACE, name="metrics_test")
+
+
+# ── Concurrency scope ──
+
+
+@pytest.mark.asyncio
+async def test_concurrency_scope_governed_by_registry(store):
+    # The test registry runs on file-backed SQLite.
+    assert store.concurrency_scope == ConcurrencyScope.MACHINE
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_concurrency_scope_cluster_with_pg_registry(
+    in_memory_qdrant_client, sqlalchemy_pg_engine
+):
+    registry = SQLAlchemyCollectionRegistry(
+        SQLAlchemyCollectionRegistryParams(
+            engine=sqlalchemy_pg_engine, name="qdrant_pg_scope"
+        )
+    )
+    await registry.startup()
+    store = QdrantVectorStore(
+        QdrantVectorStoreParams(client=in_memory_qdrant_client, registry=registry)
+    )
+    assert store.concurrency_scope == ConcurrencyScope.CLUSTER
 
 
 # ── Collection registry integration ──

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -1,5 +1,6 @@
 """Tests for QdrantVectorStore."""
 
+import asyncio
 import math
 from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import MagicMock
@@ -19,6 +20,10 @@ from memmachine_server.common.filter.filter_parser import (
     Or,
 )
 from memmachine_server.common.metrics_factory import MetricsFactory
+from memmachine_server.common.vector_store.collection_registry.sqlalchemy_collection_registry import (
+    SQLAlchemyCollectionRegistry,
+    SQLAlchemyCollectionRegistryParams,
+)
 from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
@@ -53,8 +58,21 @@ def any_qdrant_client(request):
 
 
 @pytest_asyncio.fixture
-async def store(any_qdrant_client):
-    params = QdrantVectorStoreParams(client=any_qdrant_client)
+async def collection_registry(sqlalchemy_sqlite_engine):
+    registry = SQLAlchemyCollectionRegistry(
+        SQLAlchemyCollectionRegistryParams(
+            engine=sqlalchemy_sqlite_engine, name="qdrant_test"
+        )
+    )
+    await registry.startup()
+    return registry
+
+
+@pytest_asyncio.fixture
+async def store(any_qdrant_client, collection_registry):
+    params = QdrantVectorStoreParams(
+        client=any_qdrant_client, registry=collection_registry
+    )
     s = QdrantVectorStore(params)
     await s.startup()
     yield s
@@ -1117,13 +1135,14 @@ class TestPartitionIsolation:
 @pytest.mark.integration
 class TestMetrics:
     @pytest.mark.asyncio
-    async def test_metrics_collection(self, qdrant_client):
+    async def test_metrics_collection(self, qdrant_client, collection_registry):
         mock_factory = MagicMock(spec=MetricsFactory)
         mock_histogram = MagicMock(spec=MetricsFactory.Histogram)
         mock_factory.get_histogram.return_value = mock_histogram
 
         params = QdrantVectorStoreParams(
             client=qdrant_client,
+            registry=collection_registry,
             metrics_factory=mock_factory,
         )
         store = QdrantVectorStore(params)
@@ -1156,13 +1175,169 @@ class TestMetrics:
         await store.delete_collection(namespace=NAMESPACE, name="metrics_test")
 
 
+# ── Collection registry integration ──
+
+
+class TestRegistryIntegration:
+    """The config registry, not Qdrant, is the collection metadata authority."""
+
+    CONFIG = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
+    OTHER_CONFIG = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1)
+
+    def _second_store(self, client, registry) -> QdrantVectorStore:
+        return QdrantVectorStore(
+            QdrantVectorStoreParams(client=client, registry=registry)
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_registry_collections_in_qdrant(self, any_qdrant_client, store):
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=self.CONFIG
+        )
+
+        collections = await any_qdrant_client.get_collections()
+        assert all(
+            not collection.name.endswith("__registry")
+            for collection in collections.collections
+        )
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+
+    @pytest.mark.asyncio
+    async def test_stores_sharing_a_registry_share_collections(
+        self, any_qdrant_client, collection_registry, store
+    ):
+        other_store = self._second_store(any_qdrant_client, collection_registry)
+
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=self.CONFIG
+        )
+
+        with pytest.raises(VectorStoreCollectionAlreadyExistsError):
+            await other_store.create_collection(
+                namespace=NAMESPACE, name=NAME, config=self.CONFIG
+            )
+
+        coll = await other_store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert coll is not None
+        assert coll.config == self.CONFIG
+
+        await other_store.delete_collection(namespace=NAMESPACE, name=NAME)
+        assert await store.open_collection(namespace=NAMESPACE, name=NAME) is None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_open_or_create_mismatched_configs(
+        self, any_qdrant_client, collection_registry, store
+    ):
+        other_store = self._second_store(any_qdrant_client, collection_registry)
+
+        results = await asyncio.gather(
+            store.open_or_create_collection(
+                namespace=NAMESPACE, name=NAME, config=self.CONFIG
+            ),
+            other_store.open_or_create_collection(
+                namespace=NAMESPACE, name=NAME, config=self.OTHER_CONFIG
+            ),
+            return_exceptions=True,
+        )
+
+        errors = [result for result in results if isinstance(result, Exception)]
+        assert len(errors) == 1
+        assert isinstance(errors[0], VectorStoreCollectionConfigMismatchError)
+
+        winners = [result for result in results if not isinstance(result, Exception)]
+        assert len(winners) == 1
+        stored = await store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert stored is not None
+        assert stored.config == winners[0].config
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+
+    @pytest.mark.asyncio
+    async def test_registry_keys_are_unambiguous(self, store):
+        # ("a__b", "c") and ("a", "b__c") must be distinct collections,
+        # so the registry key separator cannot be an identifier character.
+        await store.create_collection(namespace="a__b", name="c", config=self.CONFIG)
+        await store.create_collection(
+            namespace="a", name="b__c", config=self.OTHER_CONFIG
+        )
+
+        coll_a = await store.open_collection(namespace="a__b", name="c")
+        coll_b = await store.open_collection(namespace="a", name="b__c")
+        assert coll_a is not None
+        assert coll_b is not None
+        assert coll_a.config == self.CONFIG
+        assert coll_b.config == self.OTHER_CONFIG
+
+        await store.delete_collection(namespace="a__b", name="c")
+        assert await store.open_collection(namespace="a", name="b__c") is not None
+        await store.delete_collection(namespace="a", name="b__c")
+
+    @pytest.mark.asyncio
+    async def test_recreation_mints_a_fresh_generation(
+        self, collection_registry, store
+    ):
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=self.CONFIG
+        )
+        first_entry = await collection_registry.get(namespace=NAMESPACE, name=NAME)
+        assert first_entry is not None
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=self.CONFIG
+        )
+        second_entry = await collection_registry.get(namespace=NAMESPACE, name=NAME)
+        assert second_entry is not None
+
+        assert second_entry.native_collection_name == first_entry.native_collection_name
+        assert second_entry.partition_key != first_entry.partition_key
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+
+    @pytest.mark.asyncio
+    async def test_held_handle_after_delete_cannot_resurrect_records(self, store):
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=self.CONFIG
+        )
+        held = await store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert held is not None
+
+        live_record = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
+        await held.upsert(records=[live_record])
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+
+        # A handle held across the deletion writes into the dead generation.
+        stale_record = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+        await held.upsert(records=[stale_record])
+
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=self.CONFIG
+        )
+        reopened = await store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert reopened is not None
+
+        assert (
+            await reopened.get(record_uuids=[live_record.uuid, stale_record.uuid]) == []
+        )
+        query_results = list(
+            await reopened.query(query_vectors=[_normalize([0.0, 1.0, 0.0])], limit=10)
+        )
+        assert query_results[0].matches == []
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+
+
 # ── Distributed sharding ──
 
 
 @pytest_asyncio.fixture
-async def distributed_store(distributed_qdrant_client):
+async def distributed_store(distributed_qdrant_client, collection_registry):
     params = QdrantVectorStoreParams(
-        client=distributed_qdrant_client, is_distributed=True
+        client=distributed_qdrant_client,
+        is_distributed=True,
+        registry=collection_registry,
     )
     s = QdrantVectorStore(params)
     await s.startup()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -28,7 +28,6 @@ from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from memmachine_server.common.vector_store.qdrant_vector_store import (
     QdrantVectorStore,
@@ -161,42 +160,6 @@ class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_delete_nonexistent_is_idempotent(self, store):
         await store.delete_collection(namespace=NAMESPACE, name="nonexistent")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_creates_when_missing(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="new", config=config
-        )
-        assert isinstance(coll, QdrantVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="new")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_opens_when_exists(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        assert isinstance(coll, QdrantVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="existing")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_raises_on_config_mismatch(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="mismatch",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        with pytest.raises(VectorStoreCollectionConfigMismatchError):
-            await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name="mismatch",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1),
-            )
-        await store.delete_collection(namespace=NAMESPACE, name="mismatch")
 
     @pytest.mark.asyncio
     async def test_same_config_shares_native_collection(self, store):
@@ -1226,16 +1189,14 @@ class TestRegistryIntegration:
         assert await store.open_collection(namespace=NAMESPACE, name=NAME) is None
 
     @pytest.mark.asyncio
-    async def test_concurrent_open_or_create_mismatched_configs(
+    async def test_concurrent_create_mismatched_configs(
         self, any_qdrant_client, collection_registry, store
     ):
         other_store = self._second_store(any_qdrant_client, collection_registry)
 
         results = await asyncio.gather(
-            store.open_or_create_collection(
-                namespace=NAMESPACE, name=NAME, config=self.CONFIG
-            ),
-            other_store.open_or_create_collection(
+            store.create_collection(namespace=NAMESPACE, name=NAME, config=self.CONFIG),
+            other_store.create_collection(
                 namespace=NAMESPACE, name=NAME, config=self.OTHER_CONFIG
             ),
             return_exceptions=True,
@@ -1243,13 +1204,11 @@ class TestRegistryIntegration:
 
         errors = [result for result in results if isinstance(result, Exception)]
         assert len(errors) == 1
-        assert isinstance(errors[0], VectorStoreCollectionConfigMismatchError)
+        assert isinstance(errors[0], VectorStoreCollectionAlreadyExistsError)
 
-        winners = [result for result in results if not isinstance(result, Exception)]
-        assert len(winners) == 1
         stored = await store.open_collection(namespace=NAMESPACE, name=NAME)
         assert stored is not None
-        assert stored.config == winners[0].config
+        assert stored.config in (self.CONFIG, self.OTHER_CONFIG)
 
         await store.delete_collection(namespace=NAMESPACE, name=NAME)
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlalchemy_collection_registry.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlalchemy_collection_registry.py
@@ -8,6 +8,7 @@ from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import NullPool, StaticPool
 
+from memmachine_server.common.data_types import ConcurrencyScope
 from memmachine_server.common.vector_store import VectorStoreCollectionConfig
 from memmachine_server.common.vector_store.collection_registry import (
     CollectionAlreadyRegisteredError,
@@ -287,3 +288,11 @@ def test_version_1_rows_stay_readable():
     assert entry.config.vector_dimensions == 3
     assert entry.native_collection_name == "test_namespace__digest"
     assert entry.partition_key == "test_name#generation"
+
+
+@pytest.mark.asyncio
+async def test_concurrency_scope_matches_dialect(sqlalchemy_engine, registry):
+    if sqlalchemy_engine.dialect.name == "postgresql":
+        assert registry.concurrency_scope == ConcurrencyScope.CLUSTER
+    else:
+        assert registry.concurrency_scope == ConcurrencyScope.MACHINE

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlalchemy_collection_registry.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlalchemy_collection_registry.py
@@ -1,0 +1,289 @@
+"""Tests for SQLAlchemyCollectionRegistry — SQLite (unit) and PostgreSQL (integration)."""
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import inspect
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool, StaticPool
+
+from memmachine_server.common.vector_store import VectorStoreCollectionConfig
+from memmachine_server.common.vector_store.collection_registry import (
+    CollectionAlreadyRegisteredError,
+    CollectionRegistryEntry,
+)
+from memmachine_server.common.vector_store.collection_registry.sqlalchemy_collection_registry import (
+    SQLAlchemyCollectionRegistry,
+    SQLAlchemyCollectionRegistryParams,
+)
+
+REGISTRY_NAME = "test_registry"
+NAMESPACE = "test_namespace"
+NAME = "test_name"
+
+ENTRY = CollectionRegistryEntry(
+    config=VectorStoreCollectionConfig(vector_dimensions=3),
+    native_collection_name="test_namespace__digest",
+    partition_key="test_name#generation",
+)
+OTHER_ENTRY = CollectionRegistryEntry(
+    config=VectorStoreCollectionConfig(vector_dimensions=4),
+    native_collection_name="test_namespace__otherdigest",
+    partition_key="test_name#othergeneration",
+)
+
+
+def _build_registry(engine, name=REGISTRY_NAME):
+    return SQLAlchemyCollectionRegistry(
+        SQLAlchemyCollectionRegistryParams(engine=engine, name=name)
+    )
+
+
+@pytest_asyncio.fixture
+async def registry(sqlalchemy_engine):
+    registry = _build_registry(sqlalchemy_engine)
+    await registry.startup()
+    yield registry
+    async with sqlalchemy_engine.begin() as connection:
+        await connection.run_sync(registry._table.metadata.drop_all)
+
+
+@pytest.mark.asyncio
+async def test_startup_is_idempotent(sqlalchemy_engine, registry):
+    await registry.startup()
+
+    other_instance = _build_registry(sqlalchemy_engine)
+    await other_instance.startup()
+
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+    assert await other_instance.get(namespace=NAMESPACE, name=NAME) == ENTRY
+
+
+@pytest.mark.asyncio
+async def test_register_and_get_round_trip(registry):
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+
+    stored_entry = await registry.get(namespace=NAMESPACE, name=NAME)
+    assert stored_entry == ENTRY
+    assert isinstance(stored_entry, CollectionRegistryEntry)
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_none(registry):
+    assert await registry.get(namespace=NAMESPACE, name="missing") is None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_register_raises(registry):
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+
+    with pytest.raises(CollectionAlreadyRegisteredError) as exc_info:
+        await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+    assert exc_info.value.namespace == NAMESPACE
+    assert exc_info.value.name == NAME
+
+
+@pytest.mark.asyncio
+async def test_duplicate_register_with_different_entry_raises(registry):
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+
+    with pytest.raises(CollectionAlreadyRegisteredError):
+        await registry.register(namespace=NAMESPACE, name=NAME, entry=OTHER_ENTRY)
+
+    assert await registry.get(namespace=NAMESPACE, name=NAME) == ENTRY
+
+
+@pytest.mark.asyncio
+async def test_get_or_register_registers_when_missing(registry):
+    stored_entry, registered = await registry.get_or_register(
+        namespace=NAMESPACE, name=NAME, entry=ENTRY
+    )
+
+    assert registered
+    assert stored_entry == ENTRY
+    assert await registry.get(namespace=NAMESPACE, name=NAME) == ENTRY
+
+
+@pytest.mark.asyncio
+async def test_get_or_register_returns_stored_entry_unchanged(registry):
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+
+    stored_entry, registered = await registry.get_or_register(
+        namespace=NAMESPACE, name=NAME, entry=OTHER_ENTRY
+    )
+
+    assert not registered
+    assert stored_entry == ENTRY
+    assert await registry.get(namespace=NAMESPACE, name=NAME) == ENTRY
+
+
+@pytest.mark.asyncio
+async def test_deregister_is_idempotent(registry):
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+
+    await registry.deregister(namespace=NAMESPACE, name=NAME)
+    assert await registry.get(namespace=NAMESPACE, name=NAME) is None
+
+    await registry.deregister(namespace=NAMESPACE, name=NAME)
+
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+    assert await registry.get(namespace=NAMESPACE, name=NAME) == ENTRY
+
+
+@pytest.mark.asyncio
+async def test_registries_are_isolated(sqlalchemy_engine, registry):
+    other_registry = _build_registry(sqlalchemy_engine, name="test_other")
+    await other_registry.startup()
+
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+    await other_registry.register(namespace=NAMESPACE, name=NAME, entry=OTHER_ENTRY)
+
+    assert await registry.get(namespace=NAMESPACE, name=NAME) == ENTRY
+    assert await other_registry.get(namespace=NAMESPACE, name=NAME) == OTHER_ENTRY
+
+    await other_registry.deregister(namespace=NAMESPACE, name=NAME)
+    assert await registry.get(namespace=NAMESPACE, name=NAME) == ENTRY
+    assert await other_registry.get(namespace=NAMESPACE, name=NAME) is None
+
+    async with sqlalchemy_engine.begin() as connection:
+        await connection.run_sync(other_registry._table.metadata.drop_all)
+
+
+@pytest.mark.asyncio
+async def test_registry_table_name_is_derived_from_name(sqlalchemy_engine, registry):
+    await registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY)
+
+    async with sqlalchemy_engine.connect() as connection:
+        table_names = await connection.run_sync(
+            lambda sync_connection: inspect(sync_connection).get_table_names()
+        )
+    assert f"collection_registry_{REGISTRY_NAME}" in table_names
+
+
+@pytest.mark.asyncio
+async def test_collection_keys_are_unambiguous(registry):
+    # ("a__b", "c") and ("a", "b__c") must be distinct collections,
+    # so the storage key separator cannot be an identifier character.
+    await registry.register(namespace="a__b", name="c", entry=ENTRY)
+    await registry.register(namespace="a", name="b__c", entry=OTHER_ENTRY)
+
+    assert await registry.get(namespace="a__b", name="c") == ENTRY
+    assert await registry.get(namespace="a", name="b__c") == OTHER_ENTRY
+
+    await registry.deregister(namespace="a__b", name="c")
+    assert await registry.get(namespace="a", name="b__c") == OTHER_ENTRY
+
+
+class TestValidation:
+    @pytest.mark.asyncio
+    async def test_invalid_namespace_raises(self, registry):
+        with pytest.raises(ValueError, match="Namespace"):
+            await registry.get(namespace="Bad-Namespace", name=NAME)
+
+    @pytest.mark.asyncio
+    async def test_invalid_name_raises(self, registry):
+        with pytest.raises(ValueError, match="Name"):
+            await registry.register(namespace=NAMESPACE, name="", entry=ENTRY)
+
+    @pytest.mark.parametrize(
+        "name",
+        ["", "Uppercase", "hyphen-ated", "dotted.name", "x" * 33],
+    )
+    def test_invalid_registry_name_raises(self, sqlalchemy_engine, name):
+        with pytest.raises(ValueError, match="Registry name"):
+            _build_registry(sqlalchemy_engine, name=name)
+
+    def test_static_pool_engine_raises(self):
+        engine = create_async_engine(
+            "sqlite+aiosqlite://",
+            poolclass=StaticPool,
+        )
+        with pytest.raises(Exception, match="StaticPool"):
+            _build_registry(engine)
+
+    def test_ephemeral_sqlite_engine_raises(self):
+        # NullPool to sidestep the StaticPool default for async SQLite memory DBs,
+        # exercising the ephemeral check itself.
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", poolclass=NullPool)
+        with pytest.raises(ValueError, match="ephemeral"):
+            _build_registry(engine)
+
+
+class TestConcurrency:
+    """Concurrency tests using a second registry instance over the same engine."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_register_same_collection(
+        self, sqlalchemy_engine, registry
+    ):
+        other_instance = _build_registry(sqlalchemy_engine)
+
+        results = await asyncio.gather(
+            registry.register(namespace=NAMESPACE, name=NAME, entry=ENTRY),
+            other_instance.register(namespace=NAMESPACE, name=NAME, entry=OTHER_ENTRY),
+            return_exceptions=True,
+        )
+
+        errors = [result for result in results if isinstance(result, Exception)]
+        assert len(errors) == 1
+        assert isinstance(errors[0], CollectionAlreadyRegisteredError)
+        assert await registry.get(namespace=NAMESPACE, name=NAME) is not None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_get_or_register_mismatched_entries(
+        self, sqlalchemy_engine, registry
+    ):
+        other_instance = _build_registry(sqlalchemy_engine)
+
+        results = await asyncio.gather(
+            registry.get_or_register(namespace=NAMESPACE, name=NAME, entry=ENTRY),
+            other_instance.get_or_register(
+                namespace=NAMESPACE, name=NAME, entry=OTHER_ENTRY
+            ),
+        )
+
+        stored_entries = [stored_entry for stored_entry, _ in results]
+        assert stored_entries[0] == stored_entries[1]
+        assert stored_entries[0] in (ENTRY, OTHER_ENTRY)
+
+        registered_flags = [registered for _, registered in results]
+        assert sorted(registered_flags) == [False, True]
+
+        assert await registry.get(namespace=NAMESPACE, name=NAME) == stored_entries[0]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_register_distinct_collections(
+        self, sqlalchemy_engine, registry
+    ):
+        other_instance = _build_registry(sqlalchemy_engine)
+
+        await asyncio.gather(
+            registry.register(namespace=NAMESPACE, name="test_name_a", entry=ENTRY),
+            other_instance.register(
+                namespace=NAMESPACE, name="test_name_b", entry=ENTRY
+            ),
+        )
+
+        assert await registry.get(namespace=NAMESPACE, name="test_name_a") == ENTRY
+        assert await registry.get(namespace=NAMESPACE, name="test_name_b") == ENTRY
+
+
+def test_version_1_rows_stay_readable():
+    """
+    Guards the add-optional-only evolution rule: an entry row exactly as
+    version 1 code wrote it must always validate under the current model.
+    """
+    version_1_row = {
+        "config": {
+            "vector_dimensions": 3,
+            "similarity_metric": "cosine",
+            "indexed_properties_schema": {"name": "str"},
+        },
+        "native_collection_name": "test_namespace__digest",
+        "partition_key": "test_name#generation",
+    }
+    entry = CollectionRegistryEntry.model_validate(version_1_row)
+    assert entry.config.vector_dimensions == 3
+    assert entry.native_collection_name == "test_namespace__digest"
+    assert entry.partition_key == "test_name#generation"

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -21,7 +21,6 @@ from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from memmachine_server.common.vector_store.sqlite_vec_vector_store import (
     SQLiteVecVectorStore,
@@ -37,6 +36,14 @@ pytestmark = pytest.mark.skipif(
 NAMESPACE = "test_namespace"
 NAME = "test_name"
 VECTOR_DIM = 3
+
+
+async def _create_and_open(store, *, namespace, name, config):
+    """Create a collection and open a handle to it."""
+    await store.create_collection(namespace=namespace, name=name, config=config)
+    coll = await store.open_collection(namespace=namespace, name=name)
+    assert coll is not None
+    return coll
 
 
 def _normalize(vector: list[float]) -> list[float]:
@@ -134,42 +141,6 @@ class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_delete_nonexistent_is_idempotent(self, store):
         await store.delete_collection(namespace=NAMESPACE, name="nonexistent")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_creates_when_missing(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="new", config=config
-        )
-        assert isinstance(coll, SQLiteVecVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="new")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_opens_when_exists(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        assert isinstance(coll, SQLiteVecVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="existing")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_raises_on_config_mismatch(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="mismatch",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        with pytest.raises(VectorStoreCollectionConfigMismatchError):
-            await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name="mismatch",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1),
-            )
-        await store.delete_collection(namespace=NAMESPACE, name="mismatch")
 
     @pytest.mark.asyncio
     async def test_open_nonexistent_returns_none(self, store):
@@ -830,11 +801,11 @@ class TestPartitionIsolation:
     async def test_delete_collection_does_not_affect_sibling(self, store):
         """Deleting one collection doesn't break a sibling sharing tables."""
         config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll_a = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="sibling_a", config=config
+        coll_a = await _create_and_open(
+            store, namespace=NAMESPACE, name="sibling_a", config=config
         )
-        coll_b = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="sibling_b", config=config
+        coll_b = await _create_and_open(
+            store, namespace=NAMESPACE, name="sibling_b", config=config
         )
 
         v1 = _normalize([1.0, 0.0, 0.0])
@@ -862,8 +833,8 @@ class TestEuclideanMetric:
             vector_dimensions=2,
             similarity_metric=SimilarityMetric.EUCLIDEAN,
         )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="euclidean", config=config
         )
         r1 = _make_record(vector=[0.0, 0.0])
         r2 = _make_record(vector=[3.0, 4.0])
@@ -882,8 +853,8 @@ class TestNoProperties:
     @pytest.mark.asyncio
     async def test_collection_without_properties(self, store):
         config = VectorStoreCollectionConfig(vector_dimensions=2)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="no_props", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="no_props", config=config
         )
         r1 = _make_record(vector=[1.0, 0.0])
         await coll.upsert(records=[r1])
@@ -938,8 +909,8 @@ class TestScoreSemantics:
             vector_dimensions=2,
             similarity_metric=SimilarityMetric.EUCLIDEAN,
         )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean_score", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="euclidean_score", config=config
         )
         r1 = _make_record(vector=[0.0, 0.0])
         r2 = _make_record(vector=[3.0, 4.0])

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -9,7 +9,7 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.data_types import ConcurrencyScope, SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -982,3 +982,7 @@ class TestFilterEdgeCases:
         assert r1.uuid in uuids
         assert r3.uuid in uuids
         assert r2.uuid not in uuids
+
+
+def test_concurrency_scope_is_process(store):
+    assert store.concurrency_scope == ConcurrencyScope.PROCESS

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -9,7 +9,7 @@ import pytest_asyncio
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.data_types import ConcurrencyScope, SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -1452,3 +1452,7 @@ class TestIndexFileDurability:
 
         await store2.shutdown()
         await engine2.dispose()
+
+
+def test_concurrency_scope_is_process(store):
+    assert store.concurrency_scope == ConcurrencyScope.PROCESS

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -21,7 +21,6 @@ from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from memmachine_server.common.vector_store.sqlite_vector_store import (
     IndexLoadError,
@@ -38,6 +37,14 @@ from memmachine_server.common.vector_store.vector_search_engine.usearch_engine i
 NAMESPACE = "test_namespace"
 NAME = "test_name"
 VECTOR_DIM = 3
+
+
+async def _create_and_open(store, *, namespace, name, config):
+    """Create a collection and open a handle to it."""
+    await store.create_collection(namespace=namespace, name=name, config=config)
+    coll = await store.open_collection(namespace=namespace, name=name)
+    assert coll is not None
+    return coll
 
 
 def _normalize(vector: list[float]) -> list[float]:
@@ -140,42 +147,6 @@ class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_delete_nonexistent_is_idempotent(self, store):
         await store.delete_collection(namespace=NAMESPACE, name="nonexistent")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_creates_when_missing(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="new", config=config
-        )
-        assert isinstance(coll, SQLiteVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="new")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_opens_when_exists(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        assert isinstance(coll, SQLiteVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="existing")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_raises_on_config_mismatch(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="mismatch",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        with pytest.raises(VectorStoreCollectionConfigMismatchError):
-            await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name="mismatch",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1),
-            )
-        await store.delete_collection(namespace=NAMESPACE, name="mismatch")
 
     @pytest.mark.asyncio
     async def test_open_nonexistent_returns_none(self, store):
@@ -836,11 +807,11 @@ class TestPartitionIsolation:
     async def test_delete_collection_does_not_affect_sibling(self, store):
         """Deleting one collection doesn't break a sibling sharing tables."""
         config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll_a = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="sibling_a", config=config
+        coll_a = await _create_and_open(
+            store, namespace=NAMESPACE, name="sibling_a", config=config
         )
-        coll_b = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="sibling_b", config=config
+        coll_b = await _create_and_open(
+            store, namespace=NAMESPACE, name="sibling_b", config=config
         )
 
         v1 = _normalize([1.0, 0.0, 0.0])
@@ -868,8 +839,8 @@ class TestEuclideanMetric:
             vector_dimensions=2,
             similarity_metric=SimilarityMetric.EUCLIDEAN,
         )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="euclidean", config=config
         )
         r1 = _make_record(vector=[0.0, 0.0])
         r2 = _make_record(vector=[3.0, 4.0])
@@ -889,8 +860,8 @@ class TestNoProperties:
     @pytest.mark.asyncio
     async def test_collection_without_properties(self, store):
         config = VectorStoreCollectionConfig(vector_dimensions=2)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="no_props", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="no_props", config=config
         )
         r1 = _make_record(vector=[1.0, 0.0])
         await coll.upsert(records=[r1])
@@ -912,8 +883,8 @@ class TestDotProductMetric:
             vector_dimensions=VECTOR_DIM,
             similarity_metric=SimilarityMetric.DOT,
         )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="dot", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="dot", config=config
         )
         v1 = _normalize([1.0, 0.0, 0.0])
         v2 = _normalize([0.0, 1.0, 0.0])
@@ -971,8 +942,8 @@ class TestScoreSemantics:
             vector_dimensions=2,
             similarity_metric=SimilarityMetric.EUCLIDEAN,
         )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean_score", config=config
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name="euclidean_score", config=config
         )
         r1 = _make_record(vector=[0.0, 0.0])
         r2 = _make_record(vector=[3.0, 4.0])
@@ -1128,8 +1099,8 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         records = [
             _make_record(vector=_normalize([1.0, 0.0, 0.0])),
@@ -1159,8 +1130,8 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         records = [
             _make_record(vector=_normalize([1.0, 0.0, 0.0])),
@@ -1192,8 +1163,8 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         r1 = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
         r2 = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
@@ -1224,8 +1195,8 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         r1 = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
         r2 = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
@@ -1260,8 +1231,8 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=2)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
 
         # Upsert 1 record: below threshold, pending op should remain.
@@ -1283,8 +1254,8 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         records = [
             _make_record(vector=_normalize([1.0, 0.0, 0.0])),
@@ -1347,9 +1318,7 @@ class TestIndexFileDurability:
         """A freshly created collection has index_saved=False."""
         db_path = tmp_path / "test.db"
         store, engine = await _fresh_store(db_path, tmp_path)
-        await store.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        await _create_and_open(store, namespace=NAMESPACE, name=NAME, config=CONFIG)
 
         assert await _get_index_saved(engine, NAMESPACE, NAME) is False
 
@@ -1362,8 +1331,8 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store, engine = await _fresh_store(db_path, tmp_path, save_threshold=1)
 
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
 
@@ -1378,8 +1347,8 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store, engine = await _fresh_store(db_path, tmp_path, save_threshold=1000)
 
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
 
@@ -1397,8 +1366,8 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
         await store1.shutdown()
@@ -1428,8 +1397,8 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
         await store1.shutdown()
@@ -1456,8 +1425,8 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=1000)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
+        coll = await _create_and_open(
+            store1, namespace=NAMESPACE, name=NAME, config=CONFIG
         )
         await coll.upsert(
             records=[

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
@@ -11,6 +11,7 @@ import pytest_asyncio
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from memmachine_server.common.data_types import ConcurrencyScope
 from memmachine_server.common.filter.filter_parser import Comparison
 from memmachine_server.common.payload_codec.payload_codec_config import (
     PlaintextPayloadCodecConfig,
@@ -991,3 +992,11 @@ async def test_pg_mixed_context_types(
 
     result = await partition.get_segment_contexts([s_none.uuid])
     assert result[s_none.uuid][0].context == NullContext()
+
+
+@pytest.mark.asyncio
+async def test_concurrency_scope_matches_dialect(store: SQLAlchemySegmentStore) -> None:
+    if store._engine.dialect.name == "postgresql":
+        assert store.concurrency_scope == ConcurrencyScope.CLUSTER
+    else:
+        assert store.concurrency_scope == ConcurrencyScope.MACHINE

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
@@ -116,11 +116,20 @@ def store(request) -> SQLAlchemySegmentStore:
     return request.getfixturevalue(request.param)
 
 
+async def _create_and_open_partition(store, partition_key, config):
+    """Create a partition and open a handle to it."""
+    await store.create_partition(partition_key, config)
+    partition = await store.open_partition(partition_key)
+    assert partition is not None
+    return partition
+
+
 @pytest_asyncio.fixture
 async def partition(
     store: SQLAlchemySegmentStore,
 ) -> SQLAlchemySegmentStorePartition:
-    return await store.open_or_create_partition(
+    return await _create_and_open_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -481,13 +490,15 @@ async def test_contexts_session_isolation(store: SQLAlchemySegmentStore) -> None
     s_seed = _seg(event_uuid=ep, offset=1, ts_offset_seconds=1)
     s_after = _seg(event_uuid=ep, offset=2, ts_offset_seconds=2)
 
-    other_partition = await store.open_or_create_partition(
+    other_partition = await _create_and_open_partition(
+        store,
         "other_session",
         _plaintext_partition_config(),
     )
     await other_partition.add_segments(_links(s_other))
 
-    partition = await store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -672,12 +683,11 @@ async def test_delete_segments_partial(
 
 
 async def _get_partition(engine: AsyncEngine) -> SQLAlchemySegmentStorePartition:
-    """Create a partition handle that shares the engine."""
+    """Open a second handle to the existing partition over a shared engine."""
     store = SQLAlchemySegmentStore(SQLAlchemySegmentStoreParams(engine=engine))
-    return await store.open_or_create_partition(
-        PARTITION_KEY,
-        _plaintext_partition_config(),
-    )
+    partition = await store.open_partition(PARTITION_KEY)
+    assert partition is not None
+    return partition
 
 
 @pytest.mark.asyncio
@@ -686,6 +696,7 @@ async def test_concurrent_add_disjoint(
 ) -> None:
     """Concurrent additions with disjoint segments should not interfere."""
     engine = store._engine
+    await store.create_partition(PARTITION_KEY, _plaintext_partition_config())
 
     async def add_batch(batch_id: int) -> None:
         part = await _get_partition(engine)
@@ -712,7 +723,8 @@ async def test_concurrent_reads_during_writes(
 ) -> None:
     """Reads should not fail or block indefinitely while writes are happening."""
     engine = store._engine
-    partition = await store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -752,7 +764,8 @@ async def test_concurrent_context_reads_during_deletes(
 ) -> None:
     """get_segment_contexts should not crash if segments are deleted concurrently."""
     engine = store._engine
-    partition = await store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -797,10 +810,11 @@ async def test_concurrent_context_reads_during_deletes(
 
 
 @pytest.mark.asyncio
-async def test_open_or_create_partition_defaults_to_plaintext_config(
+async def test_create_partition_defaults_to_plaintext_config(
     store: SQLAlchemySegmentStore,
 ) -> None:
-    partition = await store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        store,
         "plaintext_default",
         _plaintext_partition_config(),
     )
@@ -835,32 +849,9 @@ async def test_open_partition_existing(store: SQLAlchemySegmentStore) -> None:
 
 
 @pytest.mark.asyncio
-async def test_open_or_create_partition_creates(store: SQLAlchemySegmentStore) -> None:
-    partition = await store.open_or_create_partition(
-        "fresh",
-        _plaintext_partition_config(),
-    )
-    assert partition is not None
-    # Verify it was actually created.
-    opened = await store.open_partition("fresh")
-    assert opened is not None
-
-
-@pytest.mark.asyncio
-async def test_open_or_create_partition_idempotent(
-    store: SQLAlchemySegmentStore,
-) -> None:
-    await store.create_partition("idem", _plaintext_partition_config())
-    partition = await store.open_or_create_partition(
-        "idem",
-        _plaintext_partition_config(),
-    )
-    assert partition is not None
-
-
-@pytest.mark.asyncio
 async def test_delete_partition_removes_data(store: SQLAlchemySegmentStore) -> None:
-    partition = await store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        store,
         "to_delete",
         _plaintext_partition_config(),
     )
@@ -877,7 +868,8 @@ async def test_delete_partition_removes_data(store: SQLAlchemySegmentStore) -> N
 async def test_delete_partition_cascades_segments(
     store: SQLAlchemySegmentStore,
 ) -> None:
-    partition = await store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        store,
         "cascade_test",
         _plaintext_partition_config(),
     )
@@ -888,7 +880,8 @@ async def test_delete_partition_cascades_segments(
     await store.delete_partition("cascade_test")
 
     # Re-create the partition and verify data is gone.
-    new_partition = await store.open_or_create_partition(
+    new_partition = await _create_and_open_partition(
+        store,
         "cascade_test",
         _plaintext_partition_config(),
     )
@@ -932,7 +925,8 @@ async def test_pg_context_preserved_via_lateral_join(
     pg_store: SQLAlchemySegmentStore,
 ) -> None:
     """Context is preserved when retrieved via the LATERAL join path (multiple seeds)."""
-    partition = await pg_store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        pg_store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -971,7 +965,8 @@ async def test_pg_mixed_context_types(
     pg_store: SQLAlchemySegmentStore,
 ) -> None:
     """Different context types (producer, None) round-trip correctly on PG."""
-    partition = await pg_store.open_or_create_partition(
+    partition = await _create_and_open_partition(
+        pg_store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )

--- a/packages/server/src/memmachine_server/common/configuration/database_conf.py
+++ b/packages/server/src/memmachine_server/common/configuration/database_conf.py
@@ -297,6 +297,15 @@ class MilvusConf(YamlSerializableMixin, WithValueFromEnv):
             "Supported values: Strong, Session, Bounded, Eventually."
         ),
     )
+    registry_database: str = Field(
+        ...,
+        description=(
+            "Name of a configured relational database (a `databases` entry with "
+            "provider `postgres` or `sqlite`) that stores the collection registry. "
+            "All processes sharing this Milvus instance must use the same "
+            "registry database."
+        ),
+    )
 
     @field_validator("uri", mode="before")
     @classmethod

--- a/packages/server/src/memmachine_server/common/configuration/database_conf.py
+++ b/packages/server/src/memmachine_server/common/configuration/database_conf.py
@@ -258,11 +258,13 @@ class QdrantConf(YamlSerializableMixin, ApiKeyMixin):
             "If True, native collections use custom sharding."
         ),
     )
-    registry_replication_factor: int = Field(
-        default=1,
+    registry_database: str = Field(
+        ...,
         description=(
-            "Replication factor for registry collections. Write consistency factor "
-            "is set to match so all replicas confirm writes."
+            "Name of a configured relational database (a `databases` entry with "
+            "provider `postgres` or `sqlite`) that stores the collection registry. "
+            "All processes sharing this Qdrant instance must use the same "
+            "registry database."
         ),
     )
 

--- a/packages/server/src/memmachine_server/common/data_types.py
+++ b/packages/server/src/memmachine_server/common/data_types.py
@@ -1,7 +1,7 @@
 """Common data types for MemMachine."""
 
 from datetime import datetime
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Final
 
 PropertyValue = bool | int | float | str | datetime
@@ -24,6 +24,25 @@ FilterValue = bool | int | float | str | datetime | list[int] | list[str]
 
 OrderedValue = int | float | datetime
 """Type for values that can be ordered/sorted."""
+
+
+class ConcurrencyScope(IntEnum):
+    """
+    Widest safe deployment boundary for concurrent resource management.
+
+    The scope within which concurrent instances of a component may safely
+    manage the same resources. Ordered by breadth, so the effective scope
+    of a composed system is the minimum of its parts' scopes.
+    """
+
+    PROCESS = 1
+    """Concurrent management is safe only within a single process."""
+
+    MACHINE = 2
+    """Concurrent management is safe across processes on one machine."""
+
+    CLUSTER = 3
+    """Concurrent management is safe across machines."""
 
 
 class SimilarityMetric(Enum):

--- a/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
@@ -545,34 +545,41 @@ class DatabaseManager:
 
     # --- Qdrant ---
 
+    async def _build_collection_registry(
+        self, registry_name: str, registry_database: str
+    ) -> CollectionRegistry:
+        """
+        Build and start a collection registry on a named relational database.
+
+        Raises ValueError for an unknown database name or an unusable
+        registry name; callers wrap it in their backend's configuration
+        error with backend-specific guidance.
+        """
+        engine = await self.async_get_sql_engine(registry_database)
+        registry = SQLAlchemyCollectionRegistry(
+            SQLAlchemyCollectionRegistryParams(engine=engine, name=registry_name)
+        )
+        await registry.startup()
+        return registry
+
     async def _build_qdrant_collection_registry(
         self, name: str, conf: QdrantConf
     ) -> CollectionRegistry:
         """Build and start the collection registry for a Qdrant instance."""
-        try:
-            engine = await self.async_get_sql_engine(conf.registry_database)
-        except ValueError as e:
-            raise QdrantConfigurationError(
-                f"Qdrant config '{name}': registry_database "
-                f"'{conf.registry_database}' is not a configured relational database.",
-            ) from e
-
         # One registry per Qdrant instance, so instances sharing a registry
         # database get separate tables.
-        registry_name = f"qdrant_{name}"
         try:
-            registry = SQLAlchemyCollectionRegistry(
-                SQLAlchemyCollectionRegistryParams(engine=engine, name=registry_name)
+            return await self._build_collection_registry(
+                f"qdrant_{name}", conf.registry_database
             )
         except ValueError as e:
             raise QdrantConfigurationError(
-                f"Qdrant config name '{name}' cannot name a collection registry "
-                f"({registry_name!r} is not a valid registry name). "
-                "Rename the qdrant databases entry to match [a-z0-9_]+ "
-                "and be at most 25 bytes.",
+                f"Qdrant config '{name}': cannot build its collection registry "
+                f"on registry_database '{conf.registry_database}'. "
+                "The registry_database must name a configured relational "
+                "database, and the qdrant entry name must match [a-z0-9_]+ "
+                f"and be at most 25 bytes. Cause: {e}",
             ) from e
-        await registry.startup()
-        return registry
 
     @staticmethod
     async def _close_qdrant_client(name: str, client: "AsyncQdrantClient") -> None:
@@ -701,11 +708,27 @@ class DatabaseManager:
                 MilvusVectorStoreParams,
             )
 
-            params = MilvusVectorStoreParams(
-                client=client,
-                consistency_level=conf.consistency_level,
-            )
             try:
+                # One registry per Milvus instance, so instances sharing a
+                # registry database get separate tables.
+                try:
+                    registry = await self._build_collection_registry(
+                        f"milvus_{name}", conf.registry_database
+                    )
+                except ValueError as e:
+                    raise MilvusConfigurationError(
+                        f"Milvus config '{name}': cannot build its collection "
+                        f"registry on registry_database "
+                        f"'{conf.registry_database}'. "
+                        "The registry_database must name a configured relational "
+                        "database, and the milvus entry name must match "
+                        f"[a-z0-9_]+ and be at most 25 bytes. Cause: {e}",
+                    ) from e
+                params = MilvusVectorStoreParams(
+                    client=client,
+                    registry=registry,
+                    consistency_level=conf.consistency_level,
+                )
                 store = MilvusVectorStore(params)
                 await store.startup()
             except Exception:

--- a/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from memmachine_server.common.configuration.database_conf import (
     DatabasesConf,
     Neo4jConf,
+    QdrantConf,
     SQLiteVectorStoreConf,
     SQLiteVectorStoreEngine,
 )
@@ -30,6 +31,13 @@ from memmachine_server.common.vector_graph_store.neo4j_vector_graph_store import
     Neo4jVectorGraphStoreParams,
 )
 from memmachine_server.common.vector_store import VectorStore
+from memmachine_server.common.vector_store.collection_registry import (
+    CollectionRegistry,
+)
+from memmachine_server.common.vector_store.collection_registry.sqlalchemy_collection_registry import (
+    SQLAlchemyCollectionRegistry,
+    SQLAlchemyCollectionRegistryParams,
+)
 from memmachine_server.common.vector_store.vector_search_engine import (
     VectorSearchEngine,
 )
@@ -537,6 +545,35 @@ class DatabaseManager:
 
     # --- Qdrant ---
 
+    async def _build_qdrant_collection_registry(
+        self, name: str, conf: QdrantConf
+    ) -> CollectionRegistry:
+        """Build and start the collection registry for a Qdrant instance."""
+        try:
+            engine = await self.async_get_sql_engine(conf.registry_database)
+        except ValueError as e:
+            raise QdrantConfigurationError(
+                f"Qdrant config '{name}': registry_database "
+                f"'{conf.registry_database}' is not a configured relational database.",
+            ) from e
+
+        # One registry per Qdrant instance, so instances sharing a registry
+        # database get separate tables.
+        registry_name = f"qdrant_{name}"
+        try:
+            registry = SQLAlchemyCollectionRegistry(
+                SQLAlchemyCollectionRegistryParams(engine=engine, name=registry_name)
+            )
+        except ValueError as e:
+            raise QdrantConfigurationError(
+                f"Qdrant config name '{name}' cannot name a collection registry "
+                f"({registry_name!r} is not a valid registry name). "
+                "Rename the qdrant databases entry to match [a-z0-9_]+ "
+                "and be at most 25 bytes.",
+            ) from e
+        await registry.startup()
+        return registry
+
     @staticmethod
     async def _close_qdrant_client(name: str, client: "AsyncQdrantClient") -> None:
         try:
@@ -584,12 +621,13 @@ class DatabaseManager:
                 QdrantVectorStoreParams,
             )
 
-            params = QdrantVectorStoreParams(
-                client=client,
-                is_distributed=conf.is_distributed,
-                registry_replication_factor=conf.registry_replication_factor,
-            )
             try:
+                registry = await self._build_qdrant_collection_registry(name, conf)
+                params = QdrantVectorStoreParams(
+                    client=client,
+                    is_distributed=conf.is_distributed,
+                    registry=registry,
+                )
                 store = QdrantVectorStore(params)
                 await store.startup()
             except Exception:

--- a/packages/server/src/memmachine_server/common/resource_manager/semantic_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/semantic_manager.py
@@ -1,6 +1,7 @@
 """Manager for semantic memory resources and services."""
 
 import asyncio
+import contextlib
 from typing import cast
 
 from pydantic import InstanceOf
@@ -15,7 +16,10 @@ from memmachine_server.common.episode_store import EpisodeStorage
 from memmachine_server.common.errors import ResourceNotReadyError
 from memmachine_server.common.language_model import LanguageModel
 from memmachine_server.common.resource_manager import CommonResourceManager
-from memmachine_server.common.vector_store import VectorStoreCollectionConfig
+from memmachine_server.common.vector_store import (
+    VectorStoreCollectionAlreadyExistsError,
+    VectorStoreCollectionConfig,
+)
 from memmachine_server.semantic_memory.config_store.caching_semantic_config_storage import (
     CachingSemanticConfigStorage,
 )
@@ -147,27 +151,44 @@ class SemanticResourceManager:
         if vector_dimensions is None:
             vector_dimensions = (await self._get_default_embedder()).dimensions
 
-        collection = await vector_store.open_or_create_collection(
+        collection_config = VectorStoreCollectionConfig(
+            vector_dimensions=vector_dimensions,
+            similarity_metric=self._conf.vector_similarity_metric,
+            indexed_properties_schema={
+                "feature_id": str,
+                "set_id": str,
+                "set": str,
+                "semantic_category_id": str,
+                "category_name": str,
+                "category": str,
+                "tag_id": str,
+                "tag": str,
+                "feature": str,
+                "feature_name": str,
+                "value": str,
+            },
+        )
+        collection = await vector_store.open_collection(
             namespace=_VECTOR_STORE_NAMESPACE,
             name=_VECTOR_STORE_COLLECTION_NAME,
-            config=VectorStoreCollectionConfig(
-                vector_dimensions=vector_dimensions,
-                similarity_metric=self._conf.vector_similarity_metric,
-                indexed_properties_schema={
-                    "feature_id": str,
-                    "set_id": str,
-                    "set": str,
-                    "semantic_category_id": str,
-                    "category_name": str,
-                    "category": str,
-                    "tag_id": str,
-                    "tag": str,
-                    "feature": str,
-                    "feature_name": str,
-                    "value": str,
-                },
-            ),
         )
+        if collection is None:
+            # Tolerate concurrent creation: the collection then exists.
+            with contextlib.suppress(VectorStoreCollectionAlreadyExistsError):
+                await vector_store.create_collection(
+                    namespace=_VECTOR_STORE_NAMESPACE,
+                    name=_VECTOR_STORE_COLLECTION_NAME,
+                    config=collection_config,
+                )
+            collection = await vector_store.open_collection(
+                namespace=_VECTOR_STORE_NAMESPACE,
+                name=_VECTOR_STORE_COLLECTION_NAME,
+            )
+            if collection is None:
+                raise ResourceNotReadyError(
+                    "Vector store collection could not be opened after creation.",
+                    "semantic_memory",
+                )
         storage = VectorStoreSemanticStorage(sql_engine, collection)
         await storage.startup()
         return storage

--- a/packages/server/src/memmachine_server/common/vector_store/__init__.py
+++ b/packages/server/src/memmachine_server/common/vector_store/__init__.py
@@ -5,7 +5,6 @@ from .data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from .vector_store import VectorStore, VectorStoreCollection
 
@@ -16,5 +15,4 @@ __all__ = [
     "VectorStoreCollection",
     "VectorStoreCollectionAlreadyExistsError",
     "VectorStoreCollectionConfig",
-    "VectorStoreCollectionConfigMismatchError",
 ]

--- a/packages/server/src/memmachine_server/common/vector_store/collection_registry/__init__.py
+++ b/packages/server/src/memmachine_server/common/vector_store/collection_registry/__init__.py
@@ -1,0 +1,13 @@
+"""Collection registry interface and implementations."""
+
+from .collection_registry import (
+    CollectionAlreadyRegisteredError,
+    CollectionRegistry,
+    CollectionRegistryEntry,
+)
+
+__all__ = [
+    "CollectionAlreadyRegisteredError",
+    "CollectionRegistry",
+    "CollectionRegistryEntry",
+]

--- a/packages/server/src/memmachine_server/common/vector_store/collection_registry/collection_registry.py
+++ b/packages/server/src/memmachine_server/common/vector_store/collection_registry/collection_registry.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 
 from pydantic import BaseModel, Field
 
+from memmachine_server.common.data_types import ConcurrencyScope
 from memmachine_server.common.vector_store.data_types import (
     VectorStoreCollectionConfig,
 )
@@ -86,6 +87,18 @@ class CollectionRegistry(ABC):
 
     Namespaces and names follow the VectorStore naming constraints.
     """
+
+    @property
+    @abstractmethod
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """
+        Widest boundary for concurrent use of this registry.
+
+        Instances of the registry's vector store deployed within the
+        declared scope observe the same registered collections,
+        and registration stays atomic between them.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/collection_registry/collection_registry.py
+++ b/packages/server/src/memmachine_server/common/vector_store/collection_registry/collection_registry.py
@@ -1,0 +1,182 @@
+"""
+Abstract base class for a vector store collection registry.
+
+Defines the interface for registering, retrieving,
+and deregistering logical collections.
+"""
+
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel, Field
+
+from memmachine_server.common.vector_store.data_types import (
+    VectorStoreCollectionConfig,
+)
+
+
+class CollectionRegistryEntry(BaseModel):
+    """
+    Registered identity of a logical vector store collection.
+
+    Stores the collection's resolved identity alongside its config:
+    the native collection name is fixed at registration,
+    so later changes to config serialization
+    cannot silently repoint the collection at a new native collection,
+    and the partition key carries a per-registration generation,
+    so records written through handles held across a deregistration
+    stay invisible and are never resurrected by a re-registration.
+
+    One entry format is shared by all vector store backends;
+    extend it by adding optional fields with defaults
+    rather than with backend-specific entry types.
+    A new field's default must reproduce the behavior
+    that existed before the field:
+    stored entries predating it are read through that default.
+    A change that cannot be expressed that way is breaking:
+    introduce an entry format version field (default 1) at that point --
+    the rule above guarantees pre-existing entries classify correctly --
+    and migrate deliberately.
+    """
+
+    config: VectorStoreCollectionConfig = Field(
+        ...,
+        description="Configuration for the collection",
+    )
+    native_collection_name: str = Field(
+        ...,
+        description="Native collection storing the records",
+    )
+    partition_key: str = Field(
+        ...,
+        description=("Generation-scoped partition key for the collection's records"),
+    )
+
+
+class CollectionAlreadyRegisteredError(Exception):
+    """Raised when registering a collection that is already registered."""
+
+    def __init__(self, namespace: str, name: str) -> None:
+        """Initialize with the namespace and name of the existing collection."""
+        self.namespace = namespace
+        self.name = name
+        super().__init__(f"Collection ({namespace!r}, {name!r}) is already registered.")
+
+
+class CollectionRegistry(ABC):
+    """
+    Abstract base class for a vector store collection registry.
+
+    A collection registry is a durable catalog of a vector store's
+    logical collections: a mapping from (namespace, name)
+    to an immutable CollectionRegistryEntry.
+    It is the metadata authority that makes collection lifecycle
+    operations atomic across processes sharing the same backing store;
+    the vector store holds a registry dedicated to it
+    and cannot reach any other registry through it.
+
+    Entries are immutable:
+    a collection holds the entry it was registered with
+    until it is deregistered.
+    Implementations must make registration atomic
+    across processes sharing the same backing store.
+
+    Stored entries are canonicalized by serialization,
+    so a returned entry may differ from the object it was registered from
+    (e.g. defaults filled in), but is identical for every reader.
+
+    Namespaces and names follow the VectorStore naming constraints.
+    """
+
+    @abstractmethod
+    async def startup(self) -> None:
+        """Prepare the registry's backing storage. Idempotent."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def shutdown(self) -> None:
+        """Shutdown."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def register(
+        self, *, namespace: str, name: str, entry: CollectionRegistryEntry
+    ) -> None:
+        """
+        Atomically register a collection.
+
+        Args:
+            namespace (str):
+                Namespace of the collection.
+            name (str):
+                Name of the collection within the namespace.
+            entry (CollectionRegistryEntry):
+                Registered identity of the collection.
+
+        Raises:
+            CollectionAlreadyRegisteredError:
+                If the collection is already registered,
+                regardless of whether its stored entry
+                matches the provided entry.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get(self, *, namespace: str, name: str) -> CollectionRegistryEntry | None:
+        """
+        Get the stored entry for a collection.
+
+        Args:
+            namespace (str):
+                Namespace of the collection.
+            name (str):
+                Name of the collection within the namespace.
+
+        Returns:
+            CollectionRegistryEntry | None:
+                The stored entry, or None if the collection is not registered.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_or_register(
+        self, *, namespace: str, name: str, entry: CollectionRegistryEntry
+    ) -> tuple[CollectionRegistryEntry, bool]:
+        """
+        Atomically register a collection if it is not registered.
+
+        Never compares entries:
+        if the collection is already registered,
+        its stored entry is returned unchanged
+        regardless of the provided entry.
+        Callers enforce their own config equality policy.
+
+        Args:
+            namespace (str):
+                Namespace of the collection.
+            name (str):
+                Name of the collection within the namespace.
+            entry (CollectionRegistryEntry):
+                Registered identity to store if the collection
+                is not registered.
+
+        Returns:
+            tuple[CollectionRegistryEntry, bool]:
+                The stored entry,
+                and whether this call registered the collection.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def deregister(self, *, namespace: str, name: str) -> None:
+        """
+        Deregister a collection.
+
+        It is idempotent.
+
+        Args:
+            namespace (str):
+                Namespace of the collection.
+            name (str):
+                Name of the collection within the namespace.
+        """
+        raise NotImplementedError

--- a/packages/server/src/memmachine_server/common/vector_store/collection_registry/sqlalchemy_collection_registry.py
+++ b/packages/server/src/memmachine_server/common/vector_store/collection_registry/sqlalchemy_collection_registry.py
@@ -1,0 +1,273 @@
+"""SQLAlchemy-backed collection registry implementation."""
+
+import re
+from typing import override
+
+from pydantic import (
+    BaseModel,
+    Field,
+    InstanceOf,
+    JsonValue,
+    TypeAdapter,
+    field_validator,
+)
+from sqlalchemy import (
+    JSON,
+    Column,
+    Insert,
+    MetaData,
+    String,
+    Table,
+    delete,
+    insert,
+    select,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.pool import StaticPool
+
+from memmachine_server.common.vector_store.utils import validate_identifier
+
+from .collection_registry import (
+    CollectionAlreadyRegisteredError,
+    CollectionRegistry,
+    CollectionRegistryEntry,
+)
+
+_JSON_AUTO = JSON().with_variant(JSONB, "postgresql")
+
+_TABLE_NAME_PREFIX = "collection_registry_"
+
+# Registry names become SQL identifier components:
+# prefix (20 bytes) + name (32 bytes) stays within
+# PostgreSQL's 63-byte identifier limit.
+_REGISTRY_NAME_RE = re.compile(r"^[a-z0-9_]+$")
+_MAX_REGISTRY_NAME_BYTES = 32
+
+_MAX_KEY_LENGTH = 255
+
+_SUPPORTED_DIALECTS = ("postgresql", "sqlite")
+
+_ENTRY_ADAPTER: TypeAdapter[CollectionRegistryEntry] = TypeAdapter(
+    CollectionRegistryEntry
+)
+
+
+class SQLAlchemyCollectionRegistryParams(BaseModel):
+    """
+    Parameters for SQLAlchemyCollectionRegistry.
+
+    Attributes:
+        engine (AsyncEngine):
+            Async SQLAlchemy engine.
+            Must use a PostgreSQL or SQLite dialect.
+        name (str):
+            Name identifying which vector store this is the registry for.
+            Determines the registry's table name,
+            so it must match `[a-z0-9_]+`
+            and be at most 32 bytes.
+    """
+
+    engine: InstanceOf[AsyncEngine] = Field(
+        ...,
+        description="Async SQLAlchemy engine with a PostgreSQL or SQLite dialect",
+    )
+    name: str = Field(
+        ...,
+        description=(
+            "Name identifying which vector store this is the registry for; "
+            "determines the registry's table name, "
+            "so it must match [a-z0-9_]+ and be at most 32 bytes"
+        ),
+    )
+
+    @field_validator("engine")
+    @classmethod
+    def _validate_engine(cls, engine: AsyncEngine) -> AsyncEngine:
+        assert not isinstance(engine.pool, StaticPool), (
+            "Engine uses StaticPool, which shares one connection across sessions. "
+            "Use a multi-connection pool instead."
+        )
+        db = engine.url.database
+        if engine.dialect.name == "sqlite" and (db is None or db == ":memory:"):
+            raise ValueError(
+                "Engine uses ephemeral SQLite, where each connection gets a separate database. "
+                "Use a file path instead."
+            )
+        if engine.dialect.name not in _SUPPORTED_DIALECTS:
+            raise ValueError(
+                f"Engine dialect {engine.dialect.name!r} is not supported. "
+                f"Supported dialects: {', '.join(_SUPPORTED_DIALECTS)}."
+            )
+        return engine
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, name: str) -> str:
+        if not _REGISTRY_NAME_RE.match(name):
+            raise ValueError(
+                f"Registry name {name!r} must match [a-z0-9_]+ "
+                "(lowercase alphanumeric and underscores only)"
+            )
+        if len(name.encode()) > _MAX_REGISTRY_NAME_BYTES:
+            raise ValueError(
+                f"Registry name {name!r} must be at most "
+                f"{_MAX_REGISTRY_NAME_BYTES} bytes"
+            )
+        return name
+
+
+class SQLAlchemyCollectionRegistry(CollectionRegistry):
+    """
+    Asynchronous SQLAlchemy-backed implementation of CollectionRegistry.
+
+    Each registry owns a dedicated table named after the registry
+    (`collection_registry_<name>`),
+    so registries sharing a database never collide
+    and an instance can only reach its own registry.
+
+    Registration is atomic across processes:
+    the table's primary key is the arbiter,
+    via plain INSERT for register
+    and native INSERT .. ON CONFLICT DO NOTHING for get_or_register.
+    """
+
+    def __init__(self, params: SQLAlchemyCollectionRegistryParams) -> None:
+        """Initialize the collection registry with the provided parameters."""
+        super().__init__()
+        self._engine = params.engine
+        self._name = params.name
+
+        self._table = Table(
+            _TABLE_NAME_PREFIX + params.name,
+            MetaData(),
+            Column("key", String(_MAX_KEY_LENGTH), primary_key=True),
+            Column("entry", _JSON_AUTO, nullable=False),
+        )
+
+    @staticmethod
+    def _key(namespace: str, name: str) -> str:
+        """
+        Build the storage key for a collection.
+
+        The separator is outside the identifier charset ([a-z0-9_]+),
+        so distinct (namespace, name) pairs can never produce the same key.
+        """
+        return f"{namespace}/{name}"
+
+    @staticmethod
+    def _validate_collection_identifiers(namespace: str, name: str) -> None:
+        """Validate a collection's namespace and name."""
+        if not validate_identifier(namespace):
+            raise ValueError(
+                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
+            )
+        if not validate_identifier(name):
+            raise ValueError(
+                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
+            )
+
+    def _insert_ignoring_conflicts(self, key: str, dumped_entry: JsonValue) -> Insert:
+        """Build a dialect-native INSERT that ignores primary key conflicts."""
+        if self._engine.dialect.name == "postgresql":
+            return (
+                postgresql_insert(self._table)
+                .values(key=key, entry=dumped_entry)
+                .on_conflict_do_nothing()
+            )
+        return (
+            sqlite_insert(self._table)
+            .values(key=key, entry=dumped_entry)
+            .on_conflict_do_nothing()
+        )
+
+    @override
+    async def startup(self) -> None:
+        """Idempotently create the registry's table."""
+        async with self._engine.begin() as connection:
+            await connection.run_sync(self._table.metadata.create_all)
+
+    @override
+    async def shutdown(self) -> None:
+        """No-op; engine lifecycle is managed externally."""
+
+    @override
+    async def register(
+        self, *, namespace: str, name: str, entry: CollectionRegistryEntry
+    ) -> None:
+        """Atomically register a collection in the registry table."""
+        SQLAlchemyCollectionRegistry._validate_collection_identifiers(namespace, name)
+        dumped_entry = _ENTRY_ADAPTER.dump_python(entry, mode="json")
+        try:
+            async with self._engine.begin() as connection:
+                await connection.execute(
+                    insert(self._table).values(
+                        key=SQLAlchemyCollectionRegistry._key(namespace, name),
+                        entry=dumped_entry,
+                    )
+                )
+        except IntegrityError as err:
+            raise CollectionAlreadyRegisteredError(namespace, name) from err
+
+    @override
+    async def get(self, *, namespace: str, name: str) -> CollectionRegistryEntry | None:
+        """Get the stored entry for a collection."""
+        SQLAlchemyCollectionRegistry._validate_collection_identifiers(namespace, name)
+        async with self._engine.connect() as connection:
+            result = await connection.execute(
+                select(self._table.c.entry).where(
+                    self._table.c.key
+                    == SQLAlchemyCollectionRegistry._key(namespace, name)
+                )
+            )
+            row = result.one_or_none()
+        if row is None:
+            return None
+        return _ENTRY_ADAPTER.validate_python(row.entry)
+
+    @override
+    async def get_or_register(
+        self, *, namespace: str, name: str, entry: CollectionRegistryEntry
+    ) -> tuple[CollectionRegistryEntry, bool]:
+        """Atomically register a collection if it is not registered."""
+        SQLAlchemyCollectionRegistry._validate_collection_identifiers(namespace, name)
+
+        stored_entry = await self.get(namespace=namespace, name=name)
+        if stored_entry is not None:
+            return stored_entry, False
+
+        dumped_entry = _ENTRY_ADAPTER.dump_python(entry, mode="json")
+        async with self._engine.begin() as connection:
+            result = await connection.execute(
+                self._insert_ignoring_conflicts(
+                    SQLAlchemyCollectionRegistry._key(namespace, name),
+                    dumped_entry,
+                )
+            )
+            registered = result.rowcount == 1
+        if registered:
+            return _ENTRY_ADAPTER.validate_python(dumped_entry), True
+
+        # Lost a concurrent registration race; the winner's entry is stored.
+        stored_entry = await self.get(namespace=namespace, name=name)
+        if stored_entry is None:
+            raise RuntimeError(
+                f"Collection ({namespace!r}, {name!r}) in registry {self._name!r} "
+                "was deregistered during concurrent registration"
+            )
+        return stored_entry, False
+
+    @override
+    async def deregister(self, *, namespace: str, name: str) -> None:
+        """Idempotently deregister a collection."""
+        SQLAlchemyCollectionRegistry._validate_collection_identifiers(namespace, name)
+        async with self._engine.begin() as connection:
+            await connection.execute(
+                delete(self._table).where(
+                    self._table.c.key
+                    == SQLAlchemyCollectionRegistry._key(namespace, name)
+                )
+            )

--- a/packages/server/src/memmachine_server/common/vector_store/collection_registry/sqlalchemy_collection_registry.py
+++ b/packages/server/src/memmachine_server/common/vector_store/collection_registry/sqlalchemy_collection_registry.py
@@ -29,6 +29,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.pool import StaticPool
 
+from memmachine_server.common.data_types import ConcurrencyScope
 from memmachine_server.common.vector_store.utils import validate_identifier
 
 from .collection_registry import (
@@ -147,6 +148,14 @@ class SQLAlchemyCollectionRegistry(CollectionRegistry):
             Column("key", String(_MAX_KEY_LENGTH), primary_key=True),
             Column("entry", _JSON_AUTO, nullable=False),
         )
+
+    @property
+    @override
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """CLUSTER on PostgreSQL; MACHINE on file-backed SQLite."""
+        if self._engine.dialect.name == "postgresql":
+            return ConcurrencyScope.CLUSTER
+        return ConcurrencyScope.MACHINE
 
     @staticmethod
     def _key(namespace: str, name: str) -> str:

--- a/packages/server/src/memmachine_server/common/vector_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_store/data_types.py
@@ -85,28 +85,6 @@ class VectorStoreCollectionAlreadyExistsError(Exception):
         super().__init__(f"Collection ({namespace!r}, {name!r}) already exists.")
 
 
-class VectorStoreCollectionConfigMismatchError(Exception):
-    """Raised when opening a collection with a different configuration than it was created with."""
-
-    def __init__(
-        self,
-        namespace: str,
-        name: str,
-        existing_config: VectorStoreCollectionConfig,
-        requested_config: VectorStoreCollectionConfig,
-    ) -> None:
-        """Initialize with the namespace, name, and configurations."""
-        self.namespace = namespace
-        self.name = name
-        self.existing_config = existing_config
-        self.requested_config = requested_config
-        super().__init__(
-            f"Collection ({namespace!r}, {name!r}) already exists with a different configuration. "
-            f"Existing config: {existing_config.model_dump_json()}, "
-            f"requested config: {requested_config.model_dump_json()}."
-        )
-
-
 class Record(BaseModel):
     """
     A record in the vector store.

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -49,7 +49,6 @@ from .data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from .utils import validate_filter, validate_identifier
 from .vector_store import VectorStore, VectorStoreCollection
@@ -760,42 +759,6 @@ class MilvusVectorStore(VectorStore):
                 raise VectorStoreCollectionAlreadyExistsError(namespace, name)
             await self._create_native_collection(namespace, config)
             await self._register_collection(namespace, name, config)
-
-    @override
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> MilvusVectorStoreCollection:
-        """Open the collection if it exists, or create and return it."""
-        if not validate_identifier(namespace):
-            raise ValueError(
-                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        if not validate_identifier(name):
-            raise ValueError(
-                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        self._validate_metric(config.similarity_metric)
-        async with (
-            self._client_name_locks[(namespace, name)],
-            self._tracker("open_or_create_collection"),
-        ):
-            entry = await self._get_registry_entry(namespace, name)
-            if entry is not None:
-                existing_config = MilvusVectorStore._parse_entry(entry)
-                if existing_config != config:
-                    raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
-                    )
-                return self._build_collection_handle(namespace, name, existing_config)
-
-            await self._ensure_namespace_registry_collection(namespace)
-            await self._create_native_collection(namespace, config)
-            await self._register_collection(namespace, name, config)
-            return self._build_collection_handle(namespace, name, config)
 
     @override
     async def open_collection(

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -14,7 +14,11 @@ from pydantic import BaseModel, Field, InstanceOf
 from pymilvus import DataType, MilvusClient
 from pymilvus.exceptions import MilvusException
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import (
+    ConcurrencyScope,
+    PropertyValue,
+    SimilarityMetric,
+)
 from memmachine_server.common.filter.filter_parser import (
     And as FilterAnd,
 )
@@ -512,6 +516,12 @@ class MilvusVectorStore(VectorStore):
         self._client_name_locks = MilvusVectorStore._name_locks.setdefault(
             self._client, defaultdict(asyncio.Lock)
         )
+
+    @property
+    @override
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """Collection bookkeeping is guarded only by in-process locks."""
+        return ConcurrencyScope.PROCESS
 
     @override
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any, ClassVar, cast, override
-from uuid import UUID
+from uuid import UUID, uuid4
 from weakref import WeakKeyDictionary
 
 from pydantic import BaseModel, Field, InstanceOf
@@ -47,6 +47,11 @@ from memmachine_server.common.properties_json import (
 )
 from memmachine_server.common.utils import compute_similarity, ensure_tz_aware
 
+from .collection_registry import (
+    CollectionAlreadyRegisteredError,
+    CollectionRegistry,
+    CollectionRegistryEntry,
+)
 from .data_types import (
     QueryMatch,
     QueryResult,
@@ -66,8 +71,11 @@ _PROPERTY_FILTER_PREFIX = "_p_"
 
 _MAX_UUID_LENGTH = 36
 _MAX_PRIMARY_ID_LENGTH = 128
-_MAX_PARTITION_KEY_LENGTH = 32
-_REGISTRY_VECTOR_DIMENSION = 2
+# Partition keys are generation-scoped: a name (at most 32 bytes),
+# "#", and a 32-character hex generation. 80 leaves headroom while
+# keeping primary ids (partition key + ":" + a 36-character UUID)
+# within _MAX_PRIMARY_ID_LENGTH.
+_MAX_PARTITION_KEY_LENGTH = 80
 _FALSE_EXPR = f'{_ID_FIELD} == "__memmachine_no_match__"'
 
 
@@ -424,6 +432,10 @@ class MilvusVectorStoreParams(BaseModel):
 
     Attributes:
         client (MilvusClient): Milvus client instance.
+        registry (CollectionRegistry):
+            Registry cataloging this store's logical collections.
+            Must be dedicated to this Milvus vector store
+            and shared by every process using it.
         consistency_level (str): Collection consistency level for newly created collections.
         metrics_factory (MetricsFactory | None): Metrics factory for collecting usage metrics.
     """
@@ -431,6 +443,14 @@ class MilvusVectorStoreParams(BaseModel):
     client: InstanceOf[MilvusClient] = Field(
         ...,
         description="Milvus client instance",
+    )
+    registry: InstanceOf[CollectionRegistry] = Field(
+        ...,
+        description=(
+            "Registry cataloging this store's logical collections. "
+            "Must be dedicated to this Milvus vector store "
+            "and shared by every process using it"
+        ),
     )
     consistency_level: str = Field(
         default="Session",
@@ -451,12 +471,6 @@ class MilvusVectorStore(VectorStore):
         SimilarityMetric.EUCLIDEAN: "L2",
     }
 
-    _REGISTRY_SUFFIX: ClassVar[str] = "__registry"
-    _REGISTRY_VECTOR_DIMENSIONS: ClassVar[str] = "vector_dimensions"
-    _REGISTRY_SIMILARITY_METRIC: ClassVar[str] = "similarity_metric"
-    _REGISTRY_INDEXED_PROPERTIES_SCHEMA: ClassVar[str] = "indexed_properties_schema"
-    _REGISTRY_CONFIG: ClassVar[str] = "config"
-
     _name_locks: ClassVar[
         WeakKeyDictionary[
             MilvusClient,
@@ -466,20 +480,16 @@ class MilvusVectorStore(VectorStore):
 
     @staticmethod
     def _is_already_exists_error(error: Exception) -> bool:
-        """Check if an exception indicates a resource already exists."""
-        message = str(error).lower()
-        return "already exist" in message or "already exists" in message
+        """
+        Check if an exception indicates a resource already exists.
 
-    @staticmethod
-    def _is_not_found_error(error: Exception) -> bool:
-        """Check if an exception indicates a resource was not found."""
-        message = str(error).lower()
-        return "not found" in message or "can't find" in message
-
-    @staticmethod
-    def _registry_collection_name(namespace: str) -> str:
-        """Return the registry collection name for a namespace."""
-        return f"memmachine_{namespace}{MilvusVectorStore._REGISTRY_SUFFIX}"
+        Milvus reports collection-already-exists with the generic error
+        code 1, so the message is the only discriminating signal
+        (verified against pymilvus 2.x and Milvus Lite).
+        """
+        if not isinstance(error, MilvusException):
+            return False
+        return "already exist" in str(error).lower()
 
     @staticmethod
     def _build_native_collection_name(
@@ -508,6 +518,7 @@ class MilvusVectorStore(VectorStore):
         """Initialize the vector store with the provided parameters."""
         super().__init__()
         self._client = params.client
+        self._registry: CollectionRegistry = params.registry
         self._consistency_level = params.consistency_level
         self._tracker = OperationTracker(
             params.metrics_factory,
@@ -520,8 +531,8 @@ class MilvusVectorStore(VectorStore):
     @property
     @override
     def concurrency_scope(self) -> ConcurrencyScope:
-        """Collection bookkeeping is guarded only by in-process locks."""
-        return ConcurrencyScope.PROCESS
+        """Milvus is shareable across machines; the registry's scope governs."""
+        return min(ConcurrencyScope.CLUSTER, self._registry.concurrency_scope)
 
     @override
     async def startup(self) -> None:
@@ -531,126 +542,31 @@ class MilvusVectorStore(VectorStore):
     async def shutdown(self) -> None:
         """No-op; client lifecycle is managed externally."""
 
-    async def _ensure_namespace_registry_collection(self, namespace: str) -> None:
-        """Idempotently create the registry collection for a namespace."""
-        registry_collection_name = MilvusVectorStore._registry_collection_name(
-            namespace
-        )
-        if await asyncio.to_thread(
-            self._client.has_collection, registry_collection_name
-        ):
-            return
-
-        def _create_registry() -> None:
-            schema = self._client.create_schema(
-                auto_id=False,
-                enable_dynamic_field=False,
-            )
-            schema.add_field(
-                field_name=_ID_FIELD,
-                datatype=DataType.VARCHAR,
-                is_primary=True,
-                max_length=_MAX_PARTITION_KEY_LENGTH,
-            )
-            schema.add_field(
-                field_name=_VECTOR_FIELD,
-                datatype=DataType.FLOAT_VECTOR,
-                dim=_REGISTRY_VECTOR_DIMENSION,
-            )
-            schema.add_field(
-                field_name=self._REGISTRY_CONFIG,
-                datatype=DataType.JSON,
-            )
-
-            index_params = self._client.prepare_index_params()
-            index_params.add_index(
-                field_name=_VECTOR_FIELD,
-                index_type="AUTOINDEX",
-                metric_type="COSINE",
-            )
-
-            self._client.create_collection(
-                collection_name=registry_collection_name,
-                schema=schema,
-                index_params=index_params,
-                consistency_level=self._consistency_level,
-            )
-
-        try:
-            await asyncio.to_thread(_create_registry)
-        except MilvusException as exc:
-            if not MilvusVectorStore._is_already_exists_error(exc):
-                raise
-
-    async def _get_registry_entry(
-        self, namespace: str, name: str
-    ) -> dict[str, Any] | None:
-        """Retrieve the registry entry for a logical collection name."""
-        registry_collection_name = MilvusVectorStore._registry_collection_name(
-            namespace
-        )
-        if not await asyncio.to_thread(
-            self._client.has_collection, registry_collection_name
-        ):
-            return None
-
-        filter_expr = f"{_ID_FIELD} == {_expr_string(name)}"
-        try:
-            result = await asyncio.to_thread(
-                self._client.get,
-                collection_name=registry_collection_name,
-                ids=[name],
-                output_fields=[_ID_FIELD, self._REGISTRY_CONFIG],
-            )
-        except MilvusException as exc:
-            if MilvusVectorStore._is_not_found_error(exc):
-                return None
-            raise
-
-        entries = list(result)
-        if not entries:
-            return None
-        entry = entries[0]
-        entry_id = entry.get(_ID_FIELD)
-        if entry_id is not None and entry_id != name:
-            return None
-        config = cast(dict[str, Any], entry.get(self._REGISTRY_CONFIG))
-        if config is None:
-            # Older clients may not include the primary key in get() output unless queried.
-            rows = await asyncio.to_thread(
-                self._client.query,
-                collection_name=registry_collection_name,
-                filter=filter_expr,
-                output_fields=[_ID_FIELD, self._REGISTRY_CONFIG],
-            )
-            rows = list(rows)
-            if not rows:
-                return None
-            config = cast(dict[str, Any], rows[0][self._REGISTRY_CONFIG])
-        return config
-
     @staticmethod
-    def _parse_entry(entry: Mapping[str, Any]) -> VectorStoreCollectionConfig:
-        """Parse a VectorStoreCollectionConfig from a registry entry."""
-        return VectorStoreCollectionConfig(
-            vector_dimensions=entry[MilvusVectorStore._REGISTRY_VECTOR_DIMENSIONS],
-            similarity_metric=entry[MilvusVectorStore._REGISTRY_SIMILARITY_METRIC],
-            indexed_properties_schema=entry[
-                MilvusVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA
-            ],
+    def _build_collection_entry(
+        namespace: str, name: str, config: VectorStoreCollectionConfig
+    ) -> CollectionRegistryEntry:
+        """Build a registry entry with a fresh generation for a new collection."""
+        return CollectionRegistryEntry(
+            config=config,
+            native_collection_name=MilvusVectorStore._build_native_collection_name(
+                namespace, config
+            ),
+            # "#" is outside the identifier charset ([a-z0-9_]+),
+            # so generationed partition keys can never collide
+            # with each other or with plain names.
+            partition_key=f"{name}#{uuid4().hex}",
         )
 
     def _build_collection_handle(
-        self, namespace: str, name: str, config: VectorStoreCollectionConfig
+        self, entry: CollectionRegistryEntry
     ) -> MilvusVectorStoreCollection:
-        """Build a MilvusVectorStoreCollection handle."""
+        """Build a MilvusVectorStoreCollection handle from a registry entry."""
         return MilvusVectorStoreCollection(
             client=self._client,
-            collection_name=MilvusVectorStore._build_native_collection_name(
-                namespace, config
-            ),
-            partition_key=name,
-            config=config,
+            collection_name=entry.native_collection_name,
+            partition_key=entry.partition_key,
+            config=entry.config,
             tracker=self._tracker,
         )
 
@@ -719,29 +635,6 @@ class MilvusVectorStore(VectorStore):
             if not MilvusVectorStore._is_already_exists_error(exc):
                 raise
 
-    async def _register_collection(
-        self, namespace: str, name: str, config: VectorStoreCollectionConfig
-    ) -> None:
-        """Write the logical collection entry to the registry."""
-        registry_name = MilvusVectorStore._registry_collection_name(namespace)
-        await asyncio.to_thread(
-            self._client.insert,
-            collection_name=registry_name,
-            data=[
-                {
-                    _ID_FIELD: name,
-                    _VECTOR_FIELD: [0.0] * _REGISTRY_VECTOR_DIMENSION,
-                    self._REGISTRY_CONFIG: {
-                        self._REGISTRY_VECTOR_DIMENSIONS: config.vector_dimensions,
-                        self._REGISTRY_SIMILARITY_METRIC: config.similarity_metric.value,
-                        self._REGISTRY_INDEXED_PROPERTIES_SCHEMA: config.model_dump(
-                            mode="json"
-                        )["indexed_properties_schema"],
-                    },
-                }
-            ],
-        )
-
     @override
     async def create_collection(
         self,
@@ -764,11 +657,18 @@ class MilvusVectorStore(VectorStore):
             self._client_name_locks[(namespace, name)],
             self._tracker("create_collection"),
         ):
-            await self._ensure_namespace_registry_collection(namespace)
-            if await self._get_registry_entry(namespace, name) is not None:
-                raise VectorStoreCollectionAlreadyExistsError(namespace, name)
+            entry = MilvusVectorStore._build_collection_entry(namespace, name, config)
             await self._create_native_collection(namespace, config)
-            await self._register_collection(namespace, name, config)
+            # The registry entry is the atomic commit point.
+            # A crash or a lost creation race before it leaves only an empty
+            # native collection, shared by config and adopted by the next
+            # creation with the same config.
+            try:
+                await self._registry.register(
+                    namespace=namespace, name=name, entry=entry
+                )
+            except CollectionAlreadyRegisteredError as e:
+                raise VectorStoreCollectionAlreadyExistsError(namespace, name) from e
 
     @override
     async def open_collection(
@@ -783,12 +683,10 @@ class MilvusVectorStore(VectorStore):
             raise ValueError(
                 f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
             )
-        entry = await self._get_registry_entry(namespace, name)
+        entry = await self._registry.get(namespace=namespace, name=name)
         if entry is None:
             return None
-        return self._build_collection_handle(
-            namespace, name, MilvusVectorStore._parse_entry(entry)
-        )
+        return self._build_collection_handle(entry)
 
     @override
     async def close_collection(self, *, collection: VectorStoreCollection) -> None:
@@ -796,7 +694,12 @@ class MilvusVectorStore(VectorStore):
 
     @override
     async def delete_collection(self, *, namespace: str, name: str) -> None:
-        """Delete a logical collection from the Milvus vector store."""
+        """
+        Delete a logical collection from the Milvus vector store.
+
+        A crash between data deletion and deregistration leaves the
+        collection registered but empty; retrying the deletion completes it.
+        """
         if not validate_identifier(namespace):
             raise ValueError(
                 f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
@@ -809,23 +712,22 @@ class MilvusVectorStore(VectorStore):
             self._client_name_locks[(namespace, name)],
             self._tracker("delete_collection"),
         ):
-            entry = await self._get_registry_entry(namespace, name)
+            entry = await self._registry.get(namespace=namespace, name=name)
             if entry is None:
                 return
 
-            config = MilvusVectorStore._parse_entry(entry)
-            native_collection_name = MilvusVectorStore._build_native_collection_name(
-                namespace, config
-            )
-            registry_name = MilvusVectorStore._registry_collection_name(namespace)
-
+            # Delete partition data, then the registry entry:
+            # a crash in between leaves a registered-but-empty collection,
+            # and retrying the delete is idempotent.
+            # Records written through handles held across this deletion land
+            # under the dead generation's partition key: invisible to every
+            # reader, and never resurrected by a re-creation, which mints a
+            # fresh generation.
             await asyncio.to_thread(
                 self._client.delete,
-                collection_name=native_collection_name,
-                filter=f"{_PARTITION_KEY_FIELD} == {_expr_string(name)}",
+                collection_name=entry.native_collection_name,
+                filter=(
+                    f"{_PARTITION_KEY_FIELD} == {_expr_string(entry.partition_key)}"
+                ),
             )
-            await asyncio.to_thread(
-                self._client.delete,
-                collection_name=registry_name,
-                ids=[name],
-            )
+            await self._registry.deregister(namespace=namespace, name=name)

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -55,7 +55,6 @@ from .data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from .utils import validate_filter, validate_identifier
 from .vector_store import VectorStore, VectorStoreCollection
@@ -776,50 +775,6 @@ class QdrantVectorStore(VectorStore):
                 )
             except CollectionAlreadyRegisteredError as e:
                 raise VectorStoreCollectionAlreadyExistsError(namespace, name) from e
-
-    @override
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> QdrantVectorStoreCollection:
-        """Open the collection if it exists, or create and return it."""
-        if not validate_identifier(namespace):
-            raise ValueError(
-                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        if not validate_identifier(name):
-            raise ValueError(
-                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        async with (
-            self._client_name_locks[(namespace, name)],
-            self._tracker("open_or_create_collection"),
-        ):
-            existing_entry = await self._registry.get(namespace=namespace, name=name)
-            if existing_entry is not None:
-                if existing_entry.config != config:
-                    raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_entry.config, config
-                    )
-                return self._build_collection_handle(existing_entry)
-
-            entry = QdrantVectorStore._build_collection_entry(namespace, name, config)
-            await self._create_native_collection(namespace, config)
-            if self._is_distributed:
-                await self._ensure_shard_key(
-                    entry.native_collection_name, entry.partition_key
-                )
-            stored_entry, registered = await self._registry.get_or_register(
-                namespace=namespace, name=name, entry=entry
-            )
-            if not registered and stored_entry.config != config:
-                raise VectorStoreCollectionConfigMismatchError(
-                    namespace, name, stored_entry.config, config
-                )
-            return self._build_collection_handle(stored_entry)
 
     @override
     async def open_collection(

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -16,6 +16,7 @@ from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.http.exceptions import ResponseHandlingException, UnexpectedResponse
 
 from memmachine_server.common.data_types import (
+    ConcurrencyScope,
     OrderedValue,
     PropertyValue,
     SimilarityMetric,
@@ -641,6 +642,12 @@ class QdrantVectorStore(VectorStore):
         self._client_name_locks = QdrantVectorStore._name_locks.setdefault(
             self._client, defaultdict(asyncio.Lock)
         )
+
+    @property
+    @override
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """Qdrant is shareable across machines; the registry's scope governs."""
+        return min(ConcurrencyScope.CLUSTER, self._registry.concurrency_scope)
 
     @override
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -3,10 +3,10 @@
 import asyncio
 import hashlib
 from collections import defaultdict
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
 from datetime import datetime
 from typing import Any, ClassVar, cast, override
-from uuid import UUID, uuid5
+from uuid import UUID, uuid4
 from weakref import WeakKeyDictionary
 
 import grpc
@@ -44,6 +44,11 @@ from memmachine_server.common.filter.filter_parser import (
 from memmachine_server.common.metrics_factory import MetricsFactory, OperationTracker
 from memmachine_server.common.utils import ensure_tz_aware
 
+from .collection_registry import (
+    CollectionAlreadyRegisteredError,
+    CollectionRegistry,
+    CollectionRegistryEntry,
+)
 from .data_types import (
     QueryMatch,
     QueryResult,
@@ -504,10 +509,10 @@ class QdrantVectorStoreParams(BaseModel):
             so each logical collection maps to a dedicated shard key.
             This enables logical collection deletion via shard drop
             instead of filter-based deletion.
-        registry_replication_factor (int):
-            Replication factor for registry collections. Write consistency factor is
-            set to match so all replicas confirm writes before returning, guaranteeing
-            read-your-writes from any available replica.
+        registry (CollectionRegistry):
+            Registry cataloging this store's logical collections.
+            Must be dedicated to this Qdrant vector store
+            and shared by every process using it.
         metrics_factory (MetricsFactory | None):
             An instance of MetricsFactory for collecting usage metrics
             (default: None).
@@ -528,12 +533,12 @@ class QdrantVectorStoreParams(BaseModel):
             "instead of filter-based deletion"
         ),
     )
-    registry_replication_factor: int = Field(
-        1,
+    registry: InstanceOf[CollectionRegistry] = Field(
+        ...,
         description=(
-            "Replication factor for registry collections. Write consistency factor is "
-            "set to match so all replicas confirm writes before returning, guaranteeing "
-            "read-your-writes from any available replica"
+            "Registry cataloging this store's logical collections. "
+            "Must be dedicated to this Qdrant vector store "
+            "and shared by every process using it"
         ),
     )
     metrics_factory: InstanceOf[MetricsFactory] | None = Field(
@@ -564,19 +569,9 @@ class QdrantVectorStore(VectorStore):
         datetime: models.PayloadSchemaType.DATETIME,
     }
 
-    # Registry collection keys (stored on registry points, one per logical collection)
-    _REGISTRY_SUFFIX: ClassVar[str] = "__registry"
-    _REGISTRY_NAME: ClassVar[str] = "name"
-    _REGISTRY_VECTOR_DIMENSIONS: ClassVar[str] = "vector_dimensions"
-    _REGISTRY_SIMILARITY_METRIC: ClassVar[str] = "similarity_metric"
-    _REGISTRY_INDEXED_PROPERTIES_SCHEMA: ClassVar[str] = "indexed_properties_schema"
-
-    # Fixed UUID namespace for deterministic registry point IDs.
-    _REGISTRY_UUID_NAMESPACE: ClassVar[UUID] = UUID(
-        "a3c1f6d2-4b8e-4f2a-9c7d-1e5f8a0b3d6c"
-    )
-
     # Keyed by client so locks are garbage-collected when the client is.
+    # Serializes lifecycle operations on a logical collection within this
+    # process only; cross-process exclusion comes from the config registry.
     _name_locks: ClassVar[
         WeakKeyDictionary[
             AsyncQdrantClient,
@@ -586,35 +581,40 @@ class QdrantVectorStore(VectorStore):
 
     @staticmethod
     def _is_already_exists_error(error: Exception) -> bool:
-        """Check if an exception indicates a resource already exists."""
-        if isinstance(error, UnexpectedResponse):
-            return error.status_code == 409
-        if isinstance(error, grpc.aio.AioRpcError):
-            return error.code() == grpc.StatusCode.ALREADY_EXISTS
-        if isinstance(error, ValueError):
-            return "already exists" in str(error).lower()
-        return False
+        """
+        Check if an exception indicates a resource already exists.
+
+        Typed status codes are the authority; the message check is a last
+        resort for responses without a distinctive code (the local
+        :memory: client raises bare ValueError, and some server errors
+        carry only a message).
+        """
+        if isinstance(error, UnexpectedResponse) and error.status_code == 409:
+            return True
+        if (
+            isinstance(error, grpc.aio.AioRpcError)
+            and error.code() == grpc.StatusCode.ALREADY_EXISTS
+        ):
+            return True
+        return "already exists" in str(error).lower()
 
     @staticmethod
     def _is_not_found_error(error: Exception) -> bool:
-        """Check if an exception indicates a resource was not found."""
-        if isinstance(error, UnexpectedResponse):
-            return error.status_code == 404
-        if isinstance(error, grpc.aio.AioRpcError):
-            return error.code() == grpc.StatusCode.NOT_FOUND
-        if isinstance(error, ValueError):
-            return "not found" in str(error).lower()
-        return False
+        """
+        Check if an exception indicates a resource was not found.
 
-    @staticmethod
-    def _registry_collection_name(namespace: str) -> str:
-        """Return the registry collection name for a namespace."""
-        return f"{namespace}{QdrantVectorStore._REGISTRY_SUFFIX}"
-
-    @staticmethod
-    def _registry_point_uuid(name: str) -> UUID:
-        """Return a deterministic UUID for a logical collection name."""
-        return uuid5(QdrantVectorStore._REGISTRY_UUID_NAMESPACE, name)
+        Typed status codes are the authority; the message check is a last
+        resort for responses without a distinctive code.
+        """
+        if isinstance(error, UnexpectedResponse) and error.status_code == 404:
+            return True
+        if (
+            isinstance(error, grpc.aio.AioRpcError)
+            and error.code() == grpc.StatusCode.NOT_FOUND
+        ):
+            return True
+        message = str(error).lower()
+        return "not found" in message or "does not exist" in message
 
     @staticmethod
     def _build_native_collection_name(
@@ -630,7 +630,7 @@ class QdrantVectorStore(VectorStore):
         self._client: AsyncQdrantClient = params.client
         self._is_distributed = params.is_distributed
 
-        self._registry_replication_factor = params.registry_replication_factor
+        self._registry: CollectionRegistry = params.registry
 
         self._hnsw_m = 16
 
@@ -651,85 +651,33 @@ class QdrantVectorStore(VectorStore):
     async def shutdown(self) -> None:
         """No-op; client lifecycle is managed externally."""
 
-    async def _ensure_namespace_registry_collection(self, namespace: str) -> None:
-        """Idempotently create the registry collection for a namespace."""
-        registry_collection_name = QdrantVectorStore._registry_collection_name(
-            namespace
-        )
-        try:
-            await self._client.create_collection(
-                collection_name=registry_collection_name,
-                vectors_config=models.VectorParams(
-                    size=1,
-                    distance=models.Distance.COSINE,
-                ),
-                hnsw_config=models.HnswConfigDiff(
-                    m=0,
-                ),
-                replication_factor=self._registry_replication_factor,
-                write_consistency_factor=self._registry_replication_factor,
-            )
-        except (UnexpectedResponse, grpc.aio.AioRpcError, ValueError) as e:
-            if not QdrantVectorStore._is_already_exists_error(e):
-                raise
-
-    async def _get_registry_entry(
-        self, namespace: str, name: str
-    ) -> dict[str, Any] | None:
-        """
-        Retrieve the registry entry for a logical collection name.
-
-        Verifies the stored name matches
-        to guard against SHA-1 collisions in the uuid5 point ID.
-        """
-        registry_collection_name = QdrantVectorStore._registry_collection_name(
-            namespace
-        )
-        point_uuid = QdrantVectorStore._registry_point_uuid(name)
-        try:
-            points = await self._client.retrieve(
-                collection_name=registry_collection_name,
-                ids=[point_uuid],
-                with_payload=True,
-            )
-        except (UnexpectedResponse, grpc.aio.AioRpcError, ValueError) as e:
-            if QdrantVectorStore._is_not_found_error(e):
-                return None
-            raise
-
-        if not points:
-            return None
-
-        payload = cast(dict[str, Any], points[0].payload)
-        if payload.get(QdrantVectorStore._REGISTRY_NAME) != name:
-            return None
-
-        return payload
-
     @staticmethod
-    def _parse_entry(entry: Mapping[str, Any]) -> VectorStoreCollectionConfig:
-        """Parse a VectorStoreCollectionConfig from a registry entry."""
-        return VectorStoreCollectionConfig(
-            vector_dimensions=entry[QdrantVectorStore._REGISTRY_VECTOR_DIMENSIONS],
-            similarity_metric=entry[QdrantVectorStore._REGISTRY_SIMILARITY_METRIC],
-            indexed_properties_schema=entry[
-                QdrantVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA
-            ],
+    def _build_collection_entry(
+        namespace: str, name: str, config: VectorStoreCollectionConfig
+    ) -> CollectionRegistryEntry:
+        """Build a registry entry with a fresh generation for a new collection."""
+        return CollectionRegistryEntry(
+            config=config,
+            native_collection_name=QdrantVectorStore._build_native_collection_name(
+                namespace, config
+            ),
+            # "#" is outside the identifier charset ([a-z0-9_]+),
+            # so generationed partition keys can never collide
+            # with each other or with plain names.
+            partition_key=f"{name}#{uuid4().hex}",
         )
 
     def _build_collection_handle(
-        self, namespace: str, name: str, config: VectorStoreCollectionConfig
+        self, entry: CollectionRegistryEntry
     ) -> QdrantVectorStoreCollection:
-        """Build a QdrantVectorStoreCollection handle."""
+        """Build a QdrantVectorStoreCollection handle from a registry entry."""
         return QdrantVectorStoreCollection(
             client=self._client,
-            collection_name=QdrantVectorStore._build_native_collection_name(
-                namespace, config
-            ),
-            partition_key=name,
-            config=config,
+            collection_name=entry.native_collection_name,
+            partition_key=entry.partition_key,
+            config=entry.config,
             tracker=self._tracker,
-            shard_key=name if self._is_distributed else None,
+            shard_key=entry.partition_key if self._is_distributed else None,
         )
 
     async def _create_native_collection(
@@ -787,33 +735,8 @@ class QdrantVectorStore(VectorStore):
                 native_collection_name, shard_key=shard_key
             )
         except (UnexpectedResponse, grpc.aio.AioRpcError) as e:
-            if "already exists" not in str(e).lower():
+            if not QdrantVectorStore._is_already_exists_error(e):
                 raise
-
-    async def _register_collection(
-        self, namespace: str, name: str, config: VectorStoreCollectionConfig
-    ) -> None:
-        """Write the logical collection entry to the registry."""
-        registry_name = QdrantVectorStore._registry_collection_name(namespace)
-        point_uuid = QdrantVectorStore._registry_point_uuid(name)
-        await self._client.upsert(
-            collection_name=registry_name,
-            points=[
-                models.PointStruct(
-                    id=point_uuid,
-                    vector=[0.0],
-                    payload={
-                        QdrantVectorStore._REGISTRY_NAME: name,
-                        QdrantVectorStore._REGISTRY_VECTOR_DIMENSIONS: config.vector_dimensions,
-                        QdrantVectorStore._REGISTRY_SIMILARITY_METRIC: config.similarity_metric.value,
-                        QdrantVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA: config.model_dump(
-                            mode="json"
-                        )["indexed_properties_schema"],
-                    },
-                ),
-            ],
-            wait=True,
-        )
 
     @override
     async def create_collection(
@@ -836,16 +759,23 @@ class QdrantVectorStore(VectorStore):
             self._client_name_locks[(namespace, name)],
             self._tracker("create_collection"),
         ):
-            await self._ensure_namespace_registry_collection(namespace)
-            if await self._get_registry_entry(namespace, name) is not None:
-                raise VectorStoreCollectionAlreadyExistsError(namespace, name)
+            entry = QdrantVectorStore._build_collection_entry(namespace, name, config)
             await self._create_native_collection(namespace, config)
             if self._is_distributed:
-                native_collection_name = (
-                    QdrantVectorStore._build_native_collection_name(namespace, config)
+                await self._ensure_shard_key(
+                    entry.native_collection_name, entry.partition_key
                 )
-                await self._ensure_shard_key(native_collection_name, name)
-            await self._register_collection(namespace, name, config)
+            # The registry entry is the atomic commit point.
+            # A crash or a lost creation race before it leaves only an empty
+            # native collection (shared by config and adopted by the next
+            # creation with the same config) and, in distributed mode, an
+            # unused shard key.
+            try:
+                await self._registry.register(
+                    namespace=namespace, name=name, entry=entry
+                )
+            except CollectionAlreadyRegisteredError as e:
+                raise VectorStoreCollectionAlreadyExistsError(namespace, name) from e
 
     @override
     async def open_or_create_collection(
@@ -868,24 +798,28 @@ class QdrantVectorStore(VectorStore):
             self._client_name_locks[(namespace, name)],
             self._tracker("open_or_create_collection"),
         ):
-            entry = await self._get_registry_entry(namespace, name)
-            if entry is not None:
-                existing_config = QdrantVectorStore._parse_entry(entry)
-                if existing_config != config:
+            existing_entry = await self._registry.get(namespace=namespace, name=name)
+            if existing_entry is not None:
+                if existing_entry.config != config:
                     raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
+                        namespace, name, existing_entry.config, config
                     )
-                return self._build_collection_handle(namespace, name, existing_config)
+                return self._build_collection_handle(existing_entry)
 
-            await self._ensure_namespace_registry_collection(namespace)
+            entry = QdrantVectorStore._build_collection_entry(namespace, name, config)
             await self._create_native_collection(namespace, config)
             if self._is_distributed:
-                native_collection_name = (
-                    QdrantVectorStore._build_native_collection_name(namespace, config)
+                await self._ensure_shard_key(
+                    entry.native_collection_name, entry.partition_key
                 )
-                await self._ensure_shard_key(native_collection_name, name)
-            await self._register_collection(namespace, name, config)
-            return self._build_collection_handle(namespace, name, config)
+            stored_entry, registered = await self._registry.get_or_register(
+                namespace=namespace, name=name, entry=entry
+            )
+            if not registered and stored_entry.config != config:
+                raise VectorStoreCollectionConfigMismatchError(
+                    namespace, name, stored_entry.config, config
+                )
+            return self._build_collection_handle(stored_entry)
 
     @override
     async def open_collection(
@@ -900,12 +834,10 @@ class QdrantVectorStore(VectorStore):
             raise ValueError(
                 f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
             )
-        entry = await self._get_registry_entry(namespace, name)
+        entry = await self._registry.get(namespace=namespace, name=name)
         if entry is None:
             return None
-        return self._build_collection_handle(
-            namespace, name, QdrantVectorStore._parse_entry(entry)
-        )
+        return self._build_collection_handle(entry)
 
     @override
     async def close_collection(self, *, collection: VectorStoreCollection) -> None:
@@ -913,7 +845,12 @@ class QdrantVectorStore(VectorStore):
 
     @override
     async def delete_collection(self, *, namespace: str, name: str) -> None:
-        """Delete a logical collection from the Qdrant vector store."""
+        """
+        Delete a logical collection from the Qdrant vector store.
+
+        A crash between data deletion and deregistration leaves the
+        collection registered but empty; retrying the deletion completes it.
+        """
         if not validate_identifier(namespace):
             raise ValueError(
                 f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
@@ -926,38 +863,31 @@ class QdrantVectorStore(VectorStore):
             self._client_name_locks[(namespace, name)],
             self._tracker("delete_collection"),
         ):
-            entry = await self._get_registry_entry(namespace, name)
+            entry = await self._registry.get(namespace=namespace, name=name)
             if entry is None:
                 return
 
-            config = QdrantVectorStore._parse_entry(entry)
-            native_collection_name = QdrantVectorStore._build_native_collection_name(
-                namespace, config
-            )
-
-            # Delete partition data, then registry entry.
+            # Delete partition data, then the registry entry:
+            # a crash in between leaves a registered-but-empty collection,
+            # and retrying the delete is idempotent.
+            # Records written through handles held across this deletion land
+            # under the dead generation's partition key: invisible to every
+            # reader, and never resurrected by a re-creation, which mints a
+            # fresh generation.
             if self._is_distributed:
                 try:
                     await self._client.delete_shard_key(
-                        native_collection_name, shard_key=name
+                        entry.native_collection_name, shard_key=entry.partition_key
                     )
                 except (UnexpectedResponse, grpc.aio.AioRpcError) as e:
-                    if "does not exist" not in str(e).lower():
+                    if not QdrantVectorStore._is_not_found_error(e):
                         raise
             else:
                 await self._client.delete(
-                    collection_name=native_collection_name,
+                    collection_name=entry.native_collection_name,
                     points_selector=models.FilterSelector(
-                        filter=_partition_filter(name),
+                        filter=_partition_filter(entry.partition_key),
                     ),
                 )
 
-            registry_name = QdrantVectorStore._registry_collection_name(namespace)
-            point_uuid = QdrantVectorStore._registry_point_uuid(name)
-            await self._client.delete(
-                collection_name=registry_name,
-                points_selector=models.PointIdsList(
-                    points=[point_uuid],
-                ),
-                wait=True,
-            )
+            await self._registry.deregister(namespace=namespace, name=name)

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -33,7 +33,11 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase, MappedColumn, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import (
+    ConcurrencyScope,
+    PropertyValue,
+    SimilarityMetric,
+)
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
 from memmachine_server.common.properties_json import (
@@ -483,6 +487,12 @@ class SQLiteVecVectorStore(VectorStore):
                 await aio_connection.enable_load_extension(False)
 
             dbapi_connection.run_async(_load_extension)
+
+    @property
+    @override
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """Collection bookkeeping is check-then-write within one process."""
+        return ConcurrencyScope.PROCESS
 
     @override
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -47,7 +47,6 @@ from .data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from .utils import validate_filter, validate_identifier
 from .vector_store import VectorStore, VectorStoreCollection
@@ -519,54 +518,6 @@ class SQLiteVecVectorStore(VectorStore):
                     config_json=config.model_dump(mode="json"),
                 )
             )
-
-    @override
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> VectorStoreCollection:
-        if not validate_identifier(namespace) or not validate_identifier(name):
-            raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
-        self._validate_metric(config.similarity_metric)
-
-        async with self._create_session() as session, session.begin():
-            existing_config = await self._get_stored_config(session, namespace, name)
-            if existing_config is not None:
-                if existing_config != config:
-                    raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
-                    )
-
-                records_table, vector_table_name = await self._ensure_collection_tables(
-                    session, namespace, name, existing_config
-                )
-                return SQLiteVecVectorStoreCollection(
-                    create_session=self._create_session,
-                    config=existing_config,
-                    records_table=records_table,
-                    vector_table_name=vector_table_name,
-                )
-
-            records_table, vector_table_name = await self._ensure_collection_tables(
-                session, namespace, name, config
-            )
-            session.add(
-                _CollectionRow(
-                    namespace=namespace,
-                    name=name,
-                    config_json=config.model_dump(mode="json"),
-                )
-            )
-
-        return SQLiteVecVectorStoreCollection(
-            create_session=self._create_session,
-            config=config,
-            records_table=records_table,
-            vector_table_name=vector_table_name,
-        )
 
     @override
     async def open_collection(

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -41,7 +41,11 @@ from sqlalchemy.orm import DeclarativeBase, MappedColumn, Session, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 from sqlalchemy.sql.elements import ColumnElement
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import (
+    ConcurrencyScope,
+    PropertyValue,
+    SimilarityMetric,
+)
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
 from memmachine_server.common.properties_json import (
@@ -704,6 +708,12 @@ class SQLiteVectorStore(VectorStore):
             raise RuntimeError(
                 "VectorStore has not been started. Call startup() first."
             )
+
+    @property
+    @override
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """Search engine state lives in process memory."""
+        return ConcurrencyScope.PROCESS
 
     @override
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -55,7 +55,6 @@ from .data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
 )
 from .utils import validate_filter, validate_identifier
 from .vector_search_engine import VectorSearchEngine
@@ -825,66 +824,6 @@ class SQLiteVectorStore(VectorStore):
                     config_json=config.model_dump(mode="json"),
                 )
             )
-
-    @override
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> VectorStoreCollection:
-        self._require_started()
-        if not validate_identifier(namespace) or not validate_identifier(name):
-            raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
-
-        index_path = self._index_path(namespace, name)
-
-        async with self._create_session() as session, session.begin():
-            existing_config = await self._get_stored_config(session, namespace, name)
-            if existing_config is not None:
-                if existing_config != config:
-                    raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
-                    )
-                records_table, search_engine = await self._ensure_collection_resources(
-                    session, namespace, name, existing_config
-                )
-                return SQLiteVectorStoreCollection(
-                    create_session=self._create_session,
-                    sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
-                    records_table=records_table,
-                    search_engine=search_engine,
-                    namespace=namespace,
-                    name=name,
-                    config=existing_config,
-                    index_path=str(index_path) if index_path is not None else None,
-                    save_threshold=self._save_threshold,
-                )
-
-            self._clear_search_engine_state(namespace, name)
-            records_table, search_engine = await self._ensure_collection_resources(
-                session, namespace, name, config
-            )
-            session.add(
-                _CollectionRow(
-                    namespace=namespace,
-                    name=name,
-                    config_json=config.model_dump(mode="json"),
-                )
-            )
-
-        return SQLiteVectorStoreCollection(
-            create_session=self._create_session,
-            sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
-            records_table=records_table,
-            search_engine=search_engine,
-            namespace=namespace,
-            name=name,
-            config=config,
-            index_path=str(index_path) if index_path is not None else None,
-            save_threshold=self._save_threshold,
-        )
 
     @override
     async def open_collection(

--- a/packages/server/src/memmachine_server/common/vector_store/vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_store.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from uuid import UUID
 
+from memmachine_server.common.data_types import ConcurrencyScope
 from memmachine_server.common.filter.filter_parser import (
     FilterExpr,
 )
@@ -31,6 +32,24 @@ class VectorStoreCollection(ABC):
 
     The schema exists to support indexing on fixed-type record properties.
     Record properties not declared in the schema may have mixed-type values.
+
+    Visibility: a returned write is durably accepted,
+    but is not guaranteed to be visible to a subsequent query,
+    from this instance or any other.
+    Consumers must not build on read-your-writes.
+
+    Authority: stored properties and property filters operate on
+    the collection's own copy of a record,
+    with no freshness guarantee relative to any external source of truth.
+    Consumers whose records are governed by an external authority
+    must re-validate results against it.
+
+    Lifetime: a handle is valid only while its collection exists.
+    Once the collection is deleted the handle is invalid,
+    and a write through it
+    must never become visible in a collection
+    subsequently created with the same namespace and name.
+    This holds at every concurrency scope.
     """
 
     @property
@@ -149,8 +168,10 @@ class VectorStore(ABC):
     Abstract base class for a vector store.
 
     A given logical collection identified by a (namespace, name) pair
-    must be managed by at most one process at a time.
-    The consumer is responsible for sharding names across processes.
+    may be managed concurrently by multiple VectorStore instances
+    only within this store's declared concurrency_scope.
+    Beyond that scope, at most one instance may manage a collection,
+    and the consumer is responsible for sharding names accordingly.
 
     Different namespaces are fully independent (separate native collections).
     Multiple logical collections with the same (namespace, vector dimensions, similarity metric, indexed properties schema)
@@ -161,6 +182,18 @@ class VectorStore(ABC):
           (lowercase alphanumeric and underscores only).
         - Each identifier must be at most 32 bytes.
     """
+
+    @property
+    @abstractmethod
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """
+        Widest boundary for concurrently managing the same collection.
+
+        Instances of this store deployed within the declared scope
+        (and configured against the same backing services)
+        may concurrently manage the same logical collections.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_store.py
@@ -203,36 +203,6 @@ class VectorStore(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> VectorStoreCollection:
-        """
-        Open the collection if it exists, or create it if it does not.
-
-        Args:
-            namespace (str):
-                Groups related collections and guarantees storage
-                isolation at the native collection level.
-            name (str):
-                Name to identify the collection within a namespace.
-            config (VectorStoreCollectionConfig):
-                Configuration for the collection.
-
-        Returns:
-            VectorStoreCollection:
-                A handle to the opened or created collection.
-
-        Raises:
-            VectorStoreCollectionConfigMismatchError: If a collection with the same
-                (namespace, name) already exists with a different configuration.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     async def open_collection(
         self, *, namespace: str, name: str
     ) -> VectorStoreCollection | None:

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/__init__.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/__init__.py
@@ -3,7 +3,6 @@
 from .data_types import (
     SegmentStorePartitionAlreadyExistsError,
     SegmentStorePartitionConfig,
-    SegmentStorePartitionConfigMismatchError,
 )
 from .segment_store import (
     SegmentStore,
@@ -15,5 +14,4 @@ __all__ = [
     "SegmentStorePartition",
     "SegmentStorePartitionAlreadyExistsError",
     "SegmentStorePartitionConfig",
-    "SegmentStorePartitionConfigMismatchError",
 ]

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/data_types.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/data_types.py
@@ -46,26 +46,6 @@ class SegmentStorePartitionConfig(BaseModel):
         return value
 
 
-class SegmentStorePartitionConfigMismatchError(Exception):
-    """Raised when opening a partition with a different configuration than it was created with."""
-
-    def __init__(
-        self,
-        partition_key: str,
-        existing_config: SegmentStorePartitionConfig,
-        requested_config: SegmentStorePartitionConfig,
-    ) -> None:
-        """Initialize with the partition key and configurations."""
-        self.partition_key = partition_key
-        self.existing_config = existing_config
-        self.requested_config = requested_config
-        super().__init__(
-            f"Partition {partition_key!r} already exists with a different configuration. "
-            f"Existing config: {existing_config.model_dump_json()}, "
-            f"requested config: {requested_config.model_dump_json()}."
-        )
-
-
 class SegmentStorePartitionAlreadyExistsError(Exception):
     """Raised when creating a partition that already exists."""
 

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
@@ -176,31 +176,6 @@ class SegmentStore(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def open_or_create_partition(
-        self,
-        partition_key: str,
-        config: SegmentStorePartitionConfig,
-    ) -> SegmentStorePartition:
-        """
-        Open the partition if it exists, or create it if it does not.
-
-        Args:
-            partition_key (str):
-                The key of the partition.
-            config (SegmentStorePartitionConfig):
-                Configuration for the partition.
-
-        Returns:
-            SegmentStorePartition:
-                A partition-scoped handle.
-
-        Raises:
-            SegmentStorePartitionConfigMismatchError:
-                If the partition already exists with a different configuration.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     async def close_partition(
         self, segment_store_partition: SegmentStorePartition
     ) -> None:

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
 from uuid import UUID
 
+from memmachine_server.common.data_types import ConcurrencyScope
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.episodic_memory.event_memory.data_types import (
     Segment,
@@ -125,10 +126,28 @@ class SegmentStore(ABC):
 
     Manages partition-scoped handles.
 
+    A given partition may be managed concurrently
+    by multiple SegmentStore instances
+    only within this store's declared concurrency_scope.
+    Beyond that scope, at most one instance may manage a partition,
+    and the consumer is responsible for sharding keys accordingly.
+
     Partition keys must match `[a-z0-9_]+`
     (lowercase alphanumeric and underscores only)
     and be at most 32 bytes.
     """
+
+    @property
+    @abstractmethod
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """
+        Widest boundary for concurrently managing the same partition.
+
+        Instances of this store deployed within the declared scope
+        (and configured against the same backing services)
+        may concurrently manage the same partitions.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
@@ -52,6 +52,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 from sqlalchemy.sql.elements import ColumnElement
 
+from memmachine_server.common.data_types import ConcurrencyScope
 from memmachine_server.common.filter.filter_parser import (
     FilterExpr,
     demangle_user_metadata_key,
@@ -785,6 +786,14 @@ class SQLAlchemySegmentStore(SegmentStore):
                 cursor.close()
 
     # Lifecycle
+
+    @property
+    @override
+    def concurrency_scope(self) -> ConcurrencyScope:
+        """CLUSTER on PostgreSQL; MACHINE on file-backed SQLite."""
+        if self._is_postgresql:
+            return ConcurrencyScope.CLUSTER
+        return ConcurrencyScope.MACHINE
 
     @override
     async def startup(self) -> None:

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
@@ -90,7 +90,6 @@ from memmachine_server.episodic_memory.event_memory.data_types import (
 from memmachine_server.episodic_memory.event_memory.segment_store.data_types import (
     SegmentStorePartitionAlreadyExistsError,
     SegmentStorePartitionConfig,
-    SegmentStorePartitionConfigMismatchError,
 )
 from memmachine_server.episodic_memory.event_memory.segment_store.segment_store import (
     SegmentStore,
@@ -850,73 +849,6 @@ class SQLAlchemySegmentStore(SegmentStore):
             return await self._partition_from_partition_row(partition_row)
 
     @override
-    async def open_or_create_partition(
-        self,
-        partition_key: str,
-        config: SegmentStorePartitionConfig,
-    ) -> SQLAlchemySegmentStorePartition:
-        SQLAlchemySegmentStore._validate_partition_key(partition_key)
-        async with self._tracker("open_or_create_partition"):
-            return await self._open_or_create_partition(partition_key, config)
-
-    async def _open_or_create_partition(
-        self,
-        partition_key: str,
-        config: SegmentStorePartitionConfig,
-    ) -> SQLAlchemySegmentStorePartition:
-        try:
-            async with self._create_session() as session, session.begin():
-                if self._is_postgresql:
-                    await session.execute(
-                        SQLAlchemySegmentStore._PG_LOCK_PARTITIONS_TABLE
-                    )
-
-                partition_row = await SQLAlchemySegmentStore._get_partition_row(
-                    session, partition_key
-                )
-                if partition_row is None:
-                    payload_codec = await self._load_payload_codec(config)
-                    await session.execute(
-                        insert(PartitionRow).values(
-                            partition_key=partition_key,
-                            payload_codec_config=encode_payload_codec_config(
-                                config.payload_codec_config
-                            ),
-                        )
-                    )
-                    if self._is_postgresql:
-                        connection = await session.connection()
-                        await SQLAlchemySegmentStore._create_pg_child_tables(
-                            connection, partition_key
-                        )
-
-                    return SQLAlchemySegmentStorePartition(
-                        partition_key=partition_key,
-                        engine=self._engine,
-                        config=config,
-                        payload_codec=payload_codec,
-                        tracker=self._tracker,
-                    )
-
-                SQLAlchemySegmentStore._raise_if_partition_config_mismatch(
-                    partition_row, config
-                )
-                return await self._partition_from_partition_row(partition_row)
-
-        except IntegrityError:
-            pass  # Concurrent creation: partition now exists.
-
-        async with self._create_session() as session:
-            partition_row = await SQLAlchemySegmentStore._get_partition_row(
-                session, partition_key
-            )
-        if partition_row is None:
-            raise RuntimeError(f"Partition {partition_key!r} could not be opened")
-
-        self._raise_if_partition_config_mismatch(partition_row, config)
-        return await self._partition_from_partition_row(partition_row)
-
-    @override
     async def close_partition(
         self, segment_store_partition: SegmentStorePartition
     ) -> None:
@@ -1022,24 +954,6 @@ class SQLAlchemySegmentStore(SegmentStore):
                 select(PartitionRow).where(PartitionRow.partition_key == partition_key)
             )
         ).scalar_one_or_none()
-
-    @staticmethod
-    def _raise_if_partition_config_mismatch(
-        partition_row: PartitionRow,
-        config: SegmentStorePartitionConfig,
-    ) -> None:
-        """Raise if an existing partition row does not match the requested config."""
-        existing_config = SegmentStorePartitionConfig(
-            payload_codec_config=decode_payload_codec_config(
-                partition_row.payload_codec_config
-            )
-        )
-        if existing_config != config:
-            raise SegmentStorePartitionConfigMismatchError(
-                partition_row.partition_key,
-                existing_config,
-                config,
-            )
 
     @staticmethod
     async def _create_pg_child_tables(

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
@@ -1,5 +1,6 @@
 """Helpers for building long-term memory from configuration."""
 
+import contextlib
 import hashlib
 import logging
 import re
@@ -22,7 +23,10 @@ from memmachine_server.common.data_types import (
     PropertyValue,
 )
 from memmachine_server.common.resource_manager import CommonResourceManager
-from memmachine_server.common.vector_store import VectorStoreCollectionConfig
+from memmachine_server.common.vector_store import (
+    VectorStoreCollectionAlreadyExistsError,
+    VectorStoreCollectionConfig,
+)
 from memmachine_server.episodic_memory.event_memory.deriver import Deriver
 from memmachine_server.episodic_memory.event_memory.deriver.text_deriver import (
     SentenceTextDeriver,
@@ -30,6 +34,7 @@ from memmachine_server.episodic_memory.event_memory.deriver.text_deriver import 
 )
 from memmachine_server.episodic_memory.event_memory.event_memory import EventMemory
 from memmachine_server.episodic_memory.event_memory.segment_store import (
+    SegmentStorePartitionAlreadyExistsError,
     SegmentStorePartitionConfig,
 )
 from memmachine_server.episodic_memory.event_memory.segmenter import Segmenter
@@ -122,11 +127,13 @@ async def _event_params(
                 **user_schema,
             },
         )
-        await vector_store.create_collection(
-            namespace=_EVENT_BACKEND_NAMESPACE,
-            name=partition_key,
-            config=collection_config,
-        )
+        # Tolerate concurrent creation: the collection then exists.
+        with contextlib.suppress(VectorStoreCollectionAlreadyExistsError):
+            await vector_store.create_collection(
+                namespace=_EVENT_BACKEND_NAMESPACE,
+                name=partition_key,
+                config=collection_config,
+            )
         collection = await vector_store.open_collection(
             namespace=_EVENT_BACKEND_NAMESPACE,
             name=partition_key,
@@ -137,10 +144,20 @@ async def _event_params(
                 f"partition {partition_key!r}"
             )
 
-    partition = await segment_store.open_or_create_partition(
-        partition_key,
-        SegmentStorePartitionConfig(),
-    )
+    partition = await segment_store.open_partition(partition_key)
+    if partition is None:
+        # Tolerate concurrent creation: the partition then exists.
+        with contextlib.suppress(SegmentStorePartitionAlreadyExistsError):
+            await segment_store.create_partition(
+                partition_key,
+                SegmentStorePartitionConfig(),
+            )
+        partition = await segment_store.open_partition(partition_key)
+        if partition is None:
+            raise RuntimeError(
+                f"Failed to open segment store partition after creation for "
+                f"partition {partition_key!r}"
+            )
 
     segmenter = _build_segmenter(config.segmenter)
     deriver = _build_deriver(config.deriver)

--- a/packages/server/src/memmachine_server/installation/configuration_wizard.py
+++ b/packages/server/src/memmachine_server/installation/configuration_wizard.py
@@ -494,7 +494,11 @@ class ConfigurationWizard:
             case self.QDRANT_VECTOR_STORE_ID:
                 # Localhost defaults assume `docker run -p 6333:6333 qdrant/qdrant`
                 # or similar; user can edit cfg.yml to point at a remote Qdrant.
-                databases.qdrant_confs = {self.QDRANT_VECTOR_STORE_ID: QdrantConf()}
+                databases.qdrant_confs = {
+                    self.QDRANT_VECTOR_STORE_ID: QdrantConf(
+                        registry_database=self.SQLITE_DB_ID,
+                    )
+                }
             case self.MILVUS_VECTOR_STORE_ID:
                 # Local file defaults use Milvus Lite. Users can edit cfg.yml
                 # to point at a Milvus server or Zilliz Cloud URI/token.

--- a/packages/server/src/memmachine_server/installation/configuration_wizard.py
+++ b/packages/server/src/memmachine_server/installation/configuration_wizard.py
@@ -505,6 +505,7 @@ class ConfigurationWizard:
                 databases.milvus_confs = {
                     self.MILVUS_VECTOR_STORE_ID: MilvusConf(
                         uri="memmachine_milvus.db",
+                        registry_database=self.SQLITE_DB_ID,
                     )
                 }
             case self.SQLITE_VECTOR_STORE_ID:

--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -123,6 +123,7 @@ resources:
     #   provider: milvus
     #   config:
     #     uri: event_milvus.db
+    #     registry_database: sqlite_test
     #     # token: $MILVUS_TOKEN
     #     # db_name: default
     #     consistency_level: Session       # Strong, Session, Bounded, Eventually
@@ -130,6 +131,7 @@ resources:
     #   provider: milvus
     #   config:
     #     uri: semantic_milvus.db
+    #     registry_database: sqlite_test
     #     # token: $MILVUS_TOKEN
     #     # db_name: default
     #     consistency_level: Session

--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -102,6 +102,7 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        registry_database: sqlite_test  # relational database (databases entry) storing collection metadata; must be the same for every process sharing this Qdrant
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
     # VectorStore for vector-backed semantic memory.
     # Wire it via `semantic_memory.vector_collection`.
@@ -113,6 +114,7 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        registry_database: sqlite_test  # relational database (databases entry) storing collection metadata; must be the same for every process sharing this Qdrant
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
     #
     # Alternative: Milvus. The local .db URI uses Milvus Lite; replace it with

--- a/sample_configs/episodic_memory_config.gpu.sample
+++ b/sample_configs/episodic_memory_config.gpu.sample
@@ -101,6 +101,7 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        registry_database: sqlite_test  # relational database (databases entry) storing collection metadata; must be the same for every process sharing this Qdrant
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
     # VectorStore for vector-backed semantic memory.
     # Wire it via `semantic_memory.vector_collection`.
@@ -112,6 +113,7 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        registry_database: sqlite_test  # relational database (databases entry) storing collection metadata; must be the same for every process sharing this Qdrant
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
     #
     # Alternative: Milvus. The local .db URI uses Milvus Lite; replace it with

--- a/sample_configs/episodic_memory_config.gpu.sample
+++ b/sample_configs/episodic_memory_config.gpu.sample
@@ -122,6 +122,7 @@ resources:
     #   provider: milvus
     #   config:
     #     uri: event_milvus.db
+    #     registry_database: sqlite_test
     #     # token: $MILVUS_TOKEN
     #     # db_name: default
     #     consistency_level: Session       # Strong, Session, Bounded, Eventually
@@ -129,6 +130,7 @@ resources:
     #   provider: milvus
     #   config:
     #     uri: semantic_milvus.db
+    #     registry_database: sqlite_test
     #     # token: $MILVUS_TOKEN
     #     # db_name: default
     #     consistency_level: Session

--- a/sample_configs/episodic_memory_config.nebula.sample
+++ b/sample_configs/episodic_memory_config.nebula.sample
@@ -118,6 +118,7 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        registry_database: sqlite_test  # relational database (databases entry) storing collection metadata; must be the same for every process sharing this Qdrant
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
     #
     # Alternative: Milvus. The local .db URI uses Milvus Lite; replace it with

--- a/sample_configs/episodic_memory_config.nebula.sample
+++ b/sample_configs/episodic_memory_config.nebula.sample
@@ -127,6 +127,7 @@ resources:
     #   provider: milvus
     #   config:
     #     uri: event_milvus.db
+    #     registry_database: sqlite_test
     #     # token: $MILVUS_TOKEN
     #     # db_name: default
     #     consistency_level: Session       # Strong, Session, Bounded, Eventually


### PR DESCRIPTION
### Purpose of the change

Move MilvusVectorStore's collection metadata onto the SQL-backed collection registry from #1526, the same swap #1527 made for Qdrant. Milvus kept the same bookkeeping shape (per-namespace `memmachine_<ns>__registry` Milvus collections with dummy-vector rows) with the same non-atomic read-check-write lifecycle guarded only by per-process locks — and the same cross-process races (#1525). Keeping a bespoke in-Milvus registry was self-containment that was no longer worth its hacks once the shared primitive existed.

**Stacked on the concurrency-scope PR (4/5)**; only the last commit is new to this PR.

### Description

**`milvus_vector_store.py`**: all `__registry` machinery is deleted (`_REGISTRY_*` constants, the dummy-vector registry collections, `_ensure_namespace_registry_collection`, `_get_registry_entry`, the hand-rolled `_parse_entry`, `_register_collection`, `_is_not_found_error`). `MilvusVectorStoreParams` gains a required `registry: CollectionRegistry`. The lifecycle follows the Qdrant design exactly:

- Create: native-first, register-last — the registry insert is the atomic commit point; a crash or lost race leaves only an empty config-shared native collection, adopted by the next same-config creation.
- Delete: data-first, deregister-last; records written through handles held across the deletion land under the dead generation's partition key — invisible, never resurrected by a re-creation.
- `AlreadyExists` now holds across processes sharing the registry database; `_name_locks` remain as in-process serialization only.

Milvus-specific notes: native naming is unchanged (`memmachine_{ns}__{sha256(config)}`); there is no shard-key machinery — the generationed partition key is only the partition key field value; the native schema's partition-key VARCHAR is resized for generationed keys, and native primary ids (`{partition_key}:{uuid}`) now embed the generation, keeping ids unique across generations.

**Concurrency scope**: `MilvusVectorStore.concurrency_scope` widens from `PROCESS` to `min(CLUSTER, registry scope)`. Milvus's default `Session` consistency (process B may read stale data relative to process A's writes) sits within the `VectorStoreCollection` visibility contract — no read-your-writes is promised — but deployments wanting stronger data-plane visibility should set `consistency_level` accordingly.

**Configuration**: `MilvusConf.registry_database` (required) names a configured relational database entry; the wiring builds the registry `milvus_<conf name>` via a `_build_collection_registry` helper now shared with Qdrant. Sample configs, docs, and the installation wizard updated.

**Design doc**: `design/collection_registry_backends.md` (the Qdrant doc, extended and renamed).

### Breaking changes

- `MilvusConf.registry_database` is required: existing Milvus users add one line of YAML. Stale `memmachine_<ns>__registry` Milvus collections are no longer read; as with Qdrant, this is mostly self-healing (native names unchanged, re-creation with an unchanged config re-registers the same native collection), with the same derived-schema drift caveat, and stale registry collections can be dropped manually.

### Fixes/Closes

Related to #1525.

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test

Milvus suite (Milvus Lite) runs with a registry over SQLite; the Milvus-side registry white-box test is removed with the machinery it tested; the scope assertion updates to governed-by-registry (`MACHINE` over the SQLite test registry). DatabaseManager and configuration tests updated for `registry_database` and the shared registry-builder helper.

**Test Results:** full server suite 1899 passed; targeted vector-store + resource-manager integration run 555 passed; `ruff check`, `ruff format --check`, `ty check packages` clean (no new diagnostics).

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [ ] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Further comments

With Qdrant and Milvus both on the registry, the remaining `PROCESS`-scoped stores are the SQLite-backed ones, whose limitation is in-process search-engine state rather than metadata — the registry deliberately does not chase that.

