### PR TITLE
Fix: Incarnation-scope SQLite vector store collection resources

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from memmachine_server.common.data_types import SimilarityMetric
@@ -1011,3 +1012,51 @@ class TestFilterEdgeCases:
         assert r1.uuid in uuids
         assert r3.uuid in uuids
         assert r2.uuid not in uuids
+
+
+# ── Collection incarnations ──
+
+INCARNATION_CONFIG = VectorStoreCollectionConfig(
+    vector_dimensions=VECTOR_DIM,
+    similarity_metric=SimilarityMetric.COSINE,
+)
+
+
+def test_table_names_carry_the_incarnation():
+    """Distinct incarnations must name distinct tables."""
+    assert (
+        SQLiteVecVectorStore._collection_prefix("ns", "nm", "abc")
+        == "vector_store_sqlite_vec_2_ns_2_nm_abc"
+    )
+    assert SQLiteVecVectorStore._collection_prefix(
+        "ns", "nm", "abc"
+    ) != SQLiteVecVectorStore._collection_prefix("ns", "nm", "def")
+
+
+class TestCollectionIncarnations:
+    """A handle must never reach a collection recreated under its name."""
+
+    @pytest.mark.asyncio
+    async def test_stale_handle_cannot_write_to_recreated_collection(self, store):
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=INCARNATION_CONFIG
+        )
+        stale = await store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert stale is not None
+        await stale.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+        await store.create_collection(
+            namespace=NAMESPACE, name=NAME, config=INCARNATION_CONFIG
+        )
+
+        resurrected = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+        with pytest.raises(OperationalError):
+            await stale.upsert(records=[resurrected])
+
+        fresh = await store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert fresh is not None
+        results = await fresh.query(
+            query_vectors=[_normalize([0.0, 1.0, 0.0])], limit=10
+        )
+        assert not results[0].matches

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 import pytest
 import pytest_asyncio
 from sqlalchemy import func, select, update
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from memmachine_server.common.data_types import SimilarityMetric
@@ -1480,6 +1481,91 @@ class TestIndexFileDurability:
             query_vectors=[_normalize([1.0, 0.0, 0.0])], limit=10
         )
         assert len(results[0].matches) == 2
+
+        await store2.shutdown()
+        await engine2.dispose()
+
+
+# ── Collection incarnations ──
+
+
+def test_resource_names_carry_the_incarnation():
+    """Distinct incarnations must name distinct resources."""
+    assert (
+        SQLiteVectorStore._collection_prefix("ns", "nm", "abc")
+        == "vector_store_sqlite_2_ns_2_nm_abc"
+    )
+    assert SQLiteVectorStore._collection_prefix(
+        "ns", "nm", "abc"
+    ) != SQLiteVectorStore._collection_prefix("ns", "nm", "def")
+
+
+class TestCollectionIncarnations:
+    """A handle must never reach a collection recreated under its name."""
+
+    @pytest.mark.asyncio
+    async def test_stale_handle_cannot_write_to_recreated_collection(self, store):
+        await store.create_collection(namespace=NAMESPACE, name=NAME, config=CONFIG)
+        stale = await store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert stale is not None
+        await stale.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+        await store.create_collection(namespace=NAMESPACE, name=NAME, config=CONFIG)
+
+        resurrected = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+        with pytest.raises(OperationalError):
+            await stale.upsert(records=[resurrected])
+
+        fresh = await store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert fresh is not None
+        results = await fresh.query(
+            query_vectors=[_normalize([0.0, 1.0, 0.0])], limit=10
+        )
+        assert not results[0].matches
+
+    @pytest.mark.asyncio
+    async def test_stale_handle_does_not_clobber_recreated_index(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        store, engine = await _fresh_store(db_path, tmp_path, save_threshold=1)
+        await store.create_collection(namespace=NAMESPACE, name=NAME, config=CONFIG)
+        stale = await store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert stale is not None
+        await stale.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+        await store.create_collection(namespace=NAMESPACE, name=NAME, config=CONFIG)
+        fresh = await store.open_collection(namespace=NAMESPACE, name=NAME)
+        assert fresh is not None
+        kept = _make_record(vector=_normalize([0.0, 0.0, 1.0]))
+        await fresh.upsert(records=[kept])
+
+        index_directory = tmp_path / "indexes"
+        before = {
+            path.name: path.read_bytes() for path in index_directory.glob("*.idx")
+        }
+
+        resurrected = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+        with pytest.raises(OperationalError):
+            await stale.upsert(records=[resurrected])
+
+        after = {path.name: path.read_bytes() for path in index_directory.glob("*.idx")}
+        assert after == before
+
+        # Dispose without shutdown: a clean shutdown would rewrite the index
+        # from the live engine and hide a clobbered file.
+        await engine.dispose()
+
+        store2, engine2 = await _fresh_store(db_path, tmp_path, save_threshold=1)
+        collection = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        assert collection is not None
+        results = await collection.query(
+            query_vectors=[_normalize([0.0, 0.0, 1.0]), _normalize([0.0, 1.0, 0.0])],
+            limit=10,
+        )
+        uuids = {match.record.uuid for result in results for match in result.matches}
+        assert kept.uuid in uuids
+        assert resurrected.uuid not in uuids
 
         await store2.shutdown()
         await engine2.dispose()

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -9,7 +9,7 @@ since sqlite-vec ANN indexes may not support them.
 import struct
 from collections.abc import Iterable, Mapping, Sequence
 from typing import ClassVar, override
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import aiosqlite
 import sqlite_vec
@@ -65,6 +65,11 @@ class _CollectionRow(BaseSQLiteVecVectorStore):
     config_json: MappedColumn[dict[str, JsonValue]] = mapped_column(
         JSON, nullable=False
     )
+    # Distinguishes incarnations of one (namespace, name).
+    # Table names embed it, so a handle held across a deletion
+    # addresses the tables of the incarnation it was opened on
+    # rather than those of the collection that replaces it.
+    incarnation: MappedColumn[str] = mapped_column(String(32), nullable=False)
 
 
 class SQLiteVecVectorStoreCollection(VectorStoreCollection):
@@ -490,7 +495,6 @@ class SQLiteVecVectorStore(VectorStore):
         async with self._engine.begin() as connection:
             await connection.run_sync(BaseSQLiteVecVectorStore.metadata.create_all)
 
-    @override
     async def shutdown(self) -> None:
         pass
 
@@ -506,16 +510,19 @@ class SQLiteVecVectorStore(VectorStore):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
         self._validate_metric(config.similarity_metric)
 
+        incarnation = uuid4().hex
         async with self._create_session() as session, session.begin():
-            existing_config = await self._get_stored_config(session, namespace, name)
-            if existing_config is not None:
+            if await self._get_stored_collection(session, namespace, name) is not None:
                 raise VectorStoreCollectionAlreadyExistsError(namespace, name)
 
-            await self._ensure_collection_tables(session, namespace, name, config)
+            await self._ensure_collection_tables(
+                session, namespace, name, incarnation, config
+            )
             session.add(
                 _CollectionRow(
                     namespace=namespace,
                     name=name,
+                    incarnation=incarnation,
                     config_json=config.model_dump(mode="json"),
                 )
             )
@@ -533,15 +540,16 @@ class SQLiteVecVectorStore(VectorStore):
         self._validate_metric(config.similarity_metric)
 
         async with self._create_session() as session, session.begin():
-            existing_config = await self._get_stored_config(session, namespace, name)
-            if existing_config is not None:
+            stored = await self._get_stored_collection(session, namespace, name)
+            if stored is not None:
+                existing_config, incarnation = stored
                 if existing_config != config:
                     raise VectorStoreCollectionConfigMismatchError(
                         namespace, name, existing_config, config
                     )
 
                 records_table, vector_table_name = await self._ensure_collection_tables(
-                    session, namespace, name, existing_config
+                    session, namespace, name, incarnation, existing_config
                 )
                 return SQLiteVecVectorStoreCollection(
                     create_session=self._create_session,
@@ -550,13 +558,15 @@ class SQLiteVecVectorStore(VectorStore):
                     vector_table_name=vector_table_name,
                 )
 
+            incarnation = uuid4().hex
             records_table, vector_table_name = await self._ensure_collection_tables(
-                session, namespace, name, config
+                session, namespace, name, incarnation, config
             )
             session.add(
                 _CollectionRow(
                     namespace=namespace,
                     name=name,
+                    incarnation=incarnation,
                     config_json=config.model_dump(mode="json"),
                 )
             )
@@ -576,12 +586,13 @@ class SQLiteVecVectorStore(VectorStore):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
 
         async with self._create_session() as session:
-            existing = await self._get_stored_config(session, namespace, name)
-        if existing is None:
+            stored = await self._get_stored_collection(session, namespace, name)
+        if stored is None:
             return None
+        existing, incarnation = stored
 
-        records_table = self._records_table(namespace, name)
-        vector_table_name = self._vector_table_name(namespace, name)
+        records_table = self._records_table(namespace, name, incarnation)
+        vector_table_name = self._vector_table_name(namespace, name, incarnation)
         return SQLiteVecVectorStoreCollection(
             create_session=self._create_session,
             config=existing,
@@ -599,12 +610,13 @@ class SQLiteVecVectorStore(VectorStore):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
 
         async with self._create_session() as session, session.begin():
-            existing = await self._get_stored_config(session, namespace, name)
-            if existing is None:
+            stored = await self._get_stored_collection(session, namespace, name)
+            if stored is None:
                 return
+            _, incarnation = stored
 
-            records_table = self._records_table(namespace, name)
-            vector_table_name = self._vector_table_name(namespace, name)
+            records_table = self._records_table(namespace, name, incarnation)
+            vector_table_name = self._vector_table_name(namespace, name, incarnation)
 
             await session.execute(text(f"DROP TABLE IF EXISTS [{vector_table_name}]"))
             await session.execute(text(f"DROP TABLE IF EXISTS [{records_table.name}]"))
@@ -621,18 +633,28 @@ class SQLiteVecVectorStore(VectorStore):
     # Helpers.
 
     @staticmethod
-    def _collection_prefix(namespace: str, name: str) -> str:
+    def _collection_prefix(namespace: str, name: str, incarnation: str) -> str:
+        """
+        Unique prefix for one incarnation of a logical collection.
+
+        The incarnation is appended so that deleting and recreating a
+        collection yields differently named tables, leaving a handle
+        opened on the previous incarnation addressing dropped tables.
+        Collections predating incarnations carry an empty one and keep
+        their original names.
+        """
         return (
-            f"vector_store_sqlite_vec_{len(namespace)}_{namespace}_{len(name)}_{name}"
+            f"vector_store_sqlite_vec_{len(namespace)}_{namespace}"
+            f"_{len(name)}_{name}_{incarnation}"
         )
 
     @staticmethod
-    def _records_table_name(namespace: str, name: str) -> str:
-        return f"{SQLiteVecVectorStore._collection_prefix(namespace, name)}_rc"
+    def _records_table_name(namespace: str, name: str, incarnation: str) -> str:
+        return f"{SQLiteVecVectorStore._collection_prefix(namespace, name, incarnation)}_rc"
 
     @staticmethod
-    def _vector_table_name(namespace: str, name: str) -> str:
-        return f"{SQLiteVecVectorStore._collection_prefix(namespace, name)}_vc"
+    def _vector_table_name(namespace: str, name: str, incarnation: str) -> str:
+        return f"{SQLiteVecVectorStore._collection_prefix(namespace, name, incarnation)}_vc"
 
     @staticmethod
     def _validate_metric(similarity_metric: SimilarityMetric) -> None:
@@ -649,24 +671,27 @@ class SQLiteVecVectorStore(VectorStore):
                 f"got {similarity_metric.value!r}"
             )
 
-    async def _get_stored_config(
+    async def _get_stored_collection(
         self, session: AsyncSession, namespace: str, name: str
-    ) -> VectorStoreCollectionConfig | None:
-        stored_config = (
+    ) -> tuple[VectorStoreCollectionConfig, str] | None:
+        """Get a collection's stored config and incarnation."""
+        row = (
             await session.execute(
-                select(_CollectionRow.config_json).where(
+                select(_CollectionRow.config_json, _CollectionRow.incarnation).where(
                     _CollectionRow.namespace == namespace,
                     _CollectionRow.name == name,
                 )
             )
-        ).scalar_one_or_none()
-        if stored_config is None:
+        ).one_or_none()
+        if row is None:
             return None
-        return VectorStoreCollectionConfig.model_validate(stored_config)
+        return VectorStoreCollectionConfig.model_validate(
+            row.config_json
+        ), row.incarnation
 
-    def _records_table(self, namespace: str, name: str) -> Table:
+    def _records_table(self, namespace: str, name: str, incarnation: str) -> Table:
         return Table(
-            self._records_table_name(namespace, name),
+            self._records_table_name(namespace, name, incarnation),
             self._sa_metadata,
             Column("rowid", Integer, primary_key=True, autoincrement=True),
             Column("uuid", Uuid, nullable=False, unique=True),
@@ -679,10 +704,11 @@ class SQLiteVecVectorStore(VectorStore):
         session: AsyncSession,
         namespace: str,
         name: str,
+        incarnation: str,
         config: VectorStoreCollectionConfig,
     ) -> tuple[Table, str]:
-        records_table = self._records_table(namespace, name)
-        vector_table_name = self._vector_table_name(namespace, name)
+        records_table = self._records_table(namespace, name, incarnation)
+        vector_table_name = self._vector_table_name(namespace, name, incarnation)
         distance_metric_value = self._SIMILARITY_METRIC_TO_SQLITE_VEC_DISTANCE[
             config.similarity_metric
         ]

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import override
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import numpy as np
 from pydantic import BaseModel, Field, InstanceOf, JsonValue, field_validator
@@ -96,6 +96,11 @@ class _CollectionRow(BaseSQLiteVectorStore):
     index_saved: MappedColumn[bool] = mapped_column(
         Boolean, nullable=False, default=False
     )
+    # Distinguishes incarnations of one (namespace, name).
+    # Native resource names embed it, so a handle held across a deletion
+    # addresses the resources of the incarnation it was opened on
+    # rather than those of the collection that replaces it.
+    incarnation: MappedColumn[str] = mapped_column(String(32), nullable=False)
 
 
 class _PendingOperationRow(BaseSQLiteVectorStore):
@@ -130,6 +135,7 @@ class _PendingOperationRow(BaseSQLiteVectorStore):
     )  # "upsert" or "delete"
     vector: MappedColumn[bytes | None] = mapped_column(LargeBinary, nullable=True)
     applied: MappedColumn[bool] = mapped_column(Boolean, nullable=False, default=False)
+    incarnation: MappedColumn[str] = mapped_column(String(32), nullable=False)
 
 
 async def _save_collection_index(
@@ -137,6 +143,7 @@ async def _save_collection_index(
     create_session: async_sessionmaker[AsyncSession],
     namespace: str,
     name: str,
+    incarnation: str,
     search_engine: VectorSearchEngine,
     path: str,
 ) -> None:
@@ -150,6 +157,7 @@ async def _save_collection_index(
             delete(_PendingOperationRow).where(
                 _PendingOperationRow.namespace == namespace,
                 _PendingOperationRow.name == name,
+                _PendingOperationRow.incarnation == incarnation,
                 _PendingOperationRow.applied.is_(True),
             )
         )
@@ -158,6 +166,7 @@ async def _save_collection_index(
             .where(
                 _CollectionRow.namespace == namespace,
                 _CollectionRow.name == name,
+                _CollectionRow.incarnation == incarnation,
                 _CollectionRow.index_saved.is_(False),
             )
             .values(index_saved=True)
@@ -223,6 +232,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         search_engine: VectorSearchEngine,
         namespace: str,
         name: str,
+        incarnation: str,
         config: VectorStoreCollectionConfig,
         index_path: str | None,
         save_threshold: int,
@@ -235,6 +245,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
         self._namespace = namespace
         self._name = name
+        self._incarnation = incarnation
 
         self._config = config
 
@@ -257,6 +268,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                     select(func.count()).where(
                         _PendingOperationRow.namespace == self._namespace,
                         _PendingOperationRow.name == self._name,
+                        _PendingOperationRow.incarnation == self._incarnation,
                         _PendingOperationRow.applied.is_(True),
                     )
                 )
@@ -267,6 +279,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 create_session=self._create_session,
                 namespace=self._namespace,
                 name=self._name,
+                incarnation=self._incarnation,
                 search_engine=self._search_engine,
                 path=self._index_path,
             )
@@ -318,6 +331,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                     "operation_type": "upsert",
                     "vector": np.array(record.vector, dtype=np.float32).tobytes(),
                     "applied": False,
+                    "incarnation": self._incarnation,
                 }
                 for record in records
             ]
@@ -330,6 +344,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                             "operation_type": upsert_pending_operation.excluded.operation_type,
                             "vector": upsert_pending_operation.excluded.vector,
                             "applied": upsert_pending_operation.excluded.applied,
+                            "incarnation": upsert_pending_operation.excluded.incarnation,
                         },
                     ),
                     pending_operation_values,
@@ -359,6 +374,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                     .where(
                         _PendingOperationRow.namespace == self._namespace,
                         _PendingOperationRow.name == self._name,
+                        _PendingOperationRow.incarnation == self._incarnation,
                         _PendingOperationRow.record_row_id.in_(
                             list(engine_vectors.keys())
                         ),
@@ -563,6 +579,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                     set_={
                         "operation_type": upsert_pending_operation.excluded.operation_type,
                         "applied": upsert_pending_operation.excluded.applied,
+                        "incarnation": upsert_pending_operation.excluded.incarnation,
                     },
                 ),
                 [
@@ -572,6 +589,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                         "record_row_id": record_row_id,
                         "operation_type": "delete",
                         "applied": False,
+                        "incarnation": self._incarnation,
                     }
                     for record_row_id in record_row_ids
                 ],
@@ -590,6 +608,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 .where(
                     _PendingOperationRow.namespace == self._namespace,
                     _PendingOperationRow.name == self._name,
+                    _PendingOperationRow.incarnation == self._incarnation,
                     _PendingOperationRow.record_row_id.in_(record_row_ids),
                     _PendingOperationRow.applied.is_(False),
                 )
@@ -681,7 +700,7 @@ class SQLiteVectorStore(VectorStore):
         self._create_session = async_sessionmaker(
             self._sqlalchemy_engine, expire_on_commit=False
         )
-        self._search_engines: dict[tuple[str, str], VectorSearchEngine] = {}
+        self._search_engines: dict[tuple[str, str, str], VectorSearchEngine] = {}
         self._sa_metadata = MetaData()
 
         self._sync_sqlalchemy_engine = create_engine(
@@ -731,27 +750,42 @@ class SQLiteVectorStore(VectorStore):
         if not pending_operations:
             return
 
-        operations_by_collection: dict[tuple[str, str], list[_PendingOperationRow]] = (
-            defaultdict(list)
-        )
+        operations_by_collection: dict[
+            tuple[str, str, str], list[_PendingOperationRow]
+        ] = defaultdict(list)
         for operation in pending_operations:
-            operations_by_collection[(operation.namespace, operation.name)].append(
-                operation
+            operations_by_collection[
+                (operation.namespace, operation.name, operation.incarnation)
+            ].append(operation)
+
+        for (
+            namespace,
+            name,
+            incarnation,
+        ), operations in operations_by_collection.items():
+            await self._replay_collection_operations(
+                namespace, name, incarnation, operations
             )
 
-        for (namespace, name), operations in operations_by_collection.items():
-            await self._replay_collection_operations(namespace, name, operations)
-
     async def _replay_collection_operations(
-        self, namespace: str, name: str, operations: Iterable[_PendingOperationRow]
+        self,
+        namespace: str,
+        name: str,
+        incarnation: str,
+        operations: Iterable[_PendingOperationRow],
     ) -> None:
         async with self._create_session() as session:
-            config = await self._get_stored_config(session, namespace, name)
-        if config is None:
+            stored = await self._get_stored_collection(session, namespace, name)
+        if stored is None:
+            return
+        config, current_incarnation = stored
+        if incarnation != current_incarnation:
+            # Left by a handle to a deleted incarnation;
+            # replaying them would resurrect its records here.
             return
 
         search_engine = await self._get_or_create_vector_search_engine(
-            namespace, name, config
+            namespace, name, incarnation, config
         )
 
         upserted_vectors: dict[int, list[float]] = {}
@@ -777,6 +811,7 @@ class SQLiteVectorStore(VectorStore):
                 .where(
                     _PendingOperationRow.namespace == namespace,
                     _PendingOperationRow.name == name,
+                    _PendingOperationRow.incarnation == incarnation,
                     _PendingOperationRow.record_row_id.in_(all_row_ids),
                 )
                 .values(applied=True)
@@ -786,13 +821,18 @@ class SQLiteVectorStore(VectorStore):
     async def shutdown(self) -> None:
         self._require_started()
         if self._index_directory is not None:
-            for (namespace, name), search_engine in self._search_engines.items():
-                path = self._index_path(namespace, name)
+            for (
+                namespace,
+                name,
+                incarnation,
+            ), search_engine in self._search_engines.items():
+                path = self._index_path(namespace, name, incarnation)
                 assert path is not None
                 await _save_collection_index(
                     create_session=self._create_session,
                     namespace=namespace,
                     name=name,
+                    incarnation=incarnation,
                     search_engine=search_engine,
                     path=str(path),
                 )
@@ -811,17 +851,19 @@ class SQLiteVectorStore(VectorStore):
         if not validate_identifier(namespace) or not validate_identifier(name):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
 
+        incarnation = uuid4().hex
         async with self._create_session() as session, session.begin():
-            existing_config = await self._get_stored_config(session, namespace, name)
-            if existing_config is not None:
+            if await self._get_stored_collection(session, namespace, name) is not None:
                 raise VectorStoreCollectionAlreadyExistsError(namespace, name)
 
-            self._clear_search_engine_state(namespace, name)
-            await self._ensure_collection_resources(session, namespace, name, config)
+            await self._ensure_collection_resources(
+                session, namespace, name, incarnation, config
+            )
             session.add(
                 _CollectionRow(
                     namespace=namespace,
                     name=name,
+                    incarnation=incarnation,
                     config_json=config.model_dump(mode="json"),
                 )
             )
@@ -838,18 +880,18 @@ class SQLiteVectorStore(VectorStore):
         if not validate_identifier(namespace) or not validate_identifier(name):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
 
-        index_path = self._index_path(namespace, name)
-
         async with self._create_session() as session, session.begin():
-            existing_config = await self._get_stored_config(session, namespace, name)
-            if existing_config is not None:
+            stored = await self._get_stored_collection(session, namespace, name)
+            if stored is not None:
+                existing_config, incarnation = stored
                 if existing_config != config:
                     raise VectorStoreCollectionConfigMismatchError(
                         namespace, name, existing_config, config
                     )
                 records_table, search_engine = await self._ensure_collection_resources(
-                    session, namespace, name, existing_config
+                    session, namespace, name, incarnation, existing_config
                 )
+                index_path = self._index_path(namespace, name, incarnation)
                 return SQLiteVectorStoreCollection(
                     create_session=self._create_session,
                     sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
@@ -857,23 +899,26 @@ class SQLiteVectorStore(VectorStore):
                     search_engine=search_engine,
                     namespace=namespace,
                     name=name,
+                    incarnation=incarnation,
                     config=existing_config,
                     index_path=str(index_path) if index_path is not None else None,
                     save_threshold=self._save_threshold,
                 )
 
-            self._clear_search_engine_state(namespace, name)
+            incarnation = uuid4().hex
             records_table, search_engine = await self._ensure_collection_resources(
-                session, namespace, name, config
+                session, namespace, name, incarnation, config
             )
             session.add(
                 _CollectionRow(
                     namespace=namespace,
                     name=name,
+                    incarnation=incarnation,
                     config_json=config.model_dump(mode="json"),
                 )
             )
 
+        index_path = self._index_path(namespace, name, incarnation)
         return SQLiteVectorStoreCollection(
             create_session=self._create_session,
             sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
@@ -881,6 +926,7 @@ class SQLiteVectorStore(VectorStore):
             search_engine=search_engine,
             namespace=namespace,
             name=name,
+            incarnation=incarnation,
             config=config,
             index_path=str(index_path) if index_path is not None else None,
             save_threshold=self._save_threshold,
@@ -898,16 +944,17 @@ class SQLiteVectorStore(VectorStore):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
 
         async with self._create_session() as session:
-            existing = await self._get_stored_config(session, namespace, name)
-        if existing is None:
+            stored = await self._get_stored_collection(session, namespace, name)
+        if stored is None:
             return None
+        existing, incarnation = stored
 
-        records_table = self._records_table(namespace, name)
+        records_table = self._records_table(namespace, name, incarnation)
         search_engine = await self._get_or_create_vector_search_engine(
-            namespace, name, existing
+            namespace, name, incarnation, existing
         )
 
-        index_path = self._index_path(namespace, name)
+        index_path = self._index_path(namespace, name, incarnation)
         return SQLiteVectorStoreCollection(
             create_session=self._create_session,
             sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
@@ -915,6 +962,7 @@ class SQLiteVectorStore(VectorStore):
             search_engine=search_engine,
             namespace=namespace,
             name=name,
+            incarnation=incarnation,
             config=existing,
             index_path=str(index_path) if index_path is not None else None,
             save_threshold=self._save_threshold,
@@ -931,11 +979,12 @@ class SQLiteVectorStore(VectorStore):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
 
         async with self._create_session() as session:
-            existing = await self._get_stored_config(session, namespace, name)
-        if existing is None:
+            stored = await self._get_stored_collection(session, namespace, name)
+        if stored is None:
             return
+        _, incarnation = stored
 
-        records_table = self._records_table(namespace, name)
+        records_table = self._records_table(namespace, name, incarnation)
         async with self._create_session() as session, session.begin():
             connection = await session.connection()
             await connection.run_sync(
@@ -951,24 +1000,33 @@ class SQLiteVectorStore(VectorStore):
 
         self._sa_metadata.remove(records_table)
 
-        # If unlink fails, the orphan is harmless.
-        # _clear_search_engine_state will clean it up if a new collection with the same name is created.
-        index_path = self._index_path(namespace, name)
-        if index_path is not None and index_path.exists():
-            index_path.unlink()
-        self._search_engines.pop((namespace, name), None)
+        # If unlink fails, the orphan is harmless:
+        # the next collection of this name gets a fresh incarnation
+        # and therefore a different index path.
+        self._clear_search_engine_state(namespace, name, incarnation)
 
     # Helpers.
 
     @staticmethod
-    def _collection_prefix(namespace: str, name: str) -> str:
-        """Unique prefix for a logical collection's native resources."""
-        return f"vector_store_sqlite_{len(namespace)}_{namespace}_{len(name)}_{name}"
+    def _collection_prefix(namespace: str, name: str, incarnation: str) -> str:
+        """
+        Unique prefix for one incarnation of a logical collection.
 
-    def _records_table(self, namespace: str, name: str) -> Table:
+        The incarnation is appended so that deleting and recreating a
+        collection yields differently named resources, leaving a handle
+        opened on the previous incarnation addressing dropped tables.
+        Collections predating incarnations carry an empty one and keep
+        their original names.
+        """
+        return (
+            f"vector_store_sqlite_{len(namespace)}_{namespace}"
+            f"_{len(name)}_{name}_{incarnation}"
+        )
+
+    def _records_table(self, namespace: str, name: str, incarnation: str) -> Table:
         """Get or create a SQLAlchemy Table for a per-collection records table."""
         return Table(
-            f"{self._collection_prefix(namespace, name)}_rc",
+            f"{self._collection_prefix(namespace, name, incarnation)}_rc",
             self._sa_metadata,
             Column("row_id", Integer, primary_key=True, autoincrement=True),
             Column("uuid", Uuid, nullable=False, unique=True),
@@ -976,44 +1034,51 @@ class SQLiteVectorStore(VectorStore):
             extend_existing=True,
         )
 
-    def _index_path(self, namespace: str, name: str) -> Path | None:
+    def _index_path(self, namespace: str, name: str, incarnation: str) -> Path | None:
         """Return the on-disk index path for a collection, or None if in-memory."""
         if self._index_directory is None:
             return None
-        return self._index_directory / f"{self._collection_prefix(namespace, name)}.idx"
+        prefix = self._collection_prefix(namespace, name, incarnation)
+        return self._index_directory / f"{prefix}.idx"
 
-    def _clear_search_engine_state(self, namespace: str, name: str) -> None:
+    def _clear_search_engine_state(
+        self, namespace: str, name: str, incarnation: str
+    ) -> None:
         """Remove any in-memory engine and on-disk index for a collection."""
-        self._search_engines.pop((namespace, name), None)
-        index_path = self._index_path(namespace, name)
+        self._search_engines.pop((namespace, name, incarnation), None)
+        index_path = self._index_path(namespace, name, incarnation)
         if index_path is not None and index_path.exists():
             index_path.unlink()
 
-    async def _get_stored_config(
+    async def _get_stored_collection(
         self,
         session: AsyncSession,
         namespace: str,
         name: str,
-    ) -> VectorStoreCollectionConfig | None:
+    ) -> tuple[VectorStoreCollectionConfig, str] | None:
+        """Get a collection's stored config and incarnation."""
         row = (
             await session.execute(
-                select(_CollectionRow.config_json).where(
+                select(_CollectionRow.config_json, _CollectionRow.incarnation).where(
                     _CollectionRow.namespace == namespace,
                     _CollectionRow.name == name,
                 )
             )
-        ).scalar_one_or_none()
+        ).one_or_none()
         if row is None:
             return None
-        return VectorStoreCollectionConfig.model_validate(row)
+        return VectorStoreCollectionConfig.model_validate(
+            row.config_json
+        ), row.incarnation
 
     async def _get_or_create_vector_search_engine(
         self,
         namespace: str,
         name: str,
+        incarnation: str,
         config: VectorStoreCollectionConfig,
     ) -> VectorSearchEngine:
-        cache_key = (namespace, name)
+        cache_key = (namespace, name, incarnation)
         if cache_key in self._search_engines:
             return self._search_engines[cache_key]
 
@@ -1021,7 +1086,7 @@ class SQLiteVectorStore(VectorStore):
             config.vector_dimensions, config.similarity_metric
         )
 
-        index_path = self._index_path(namespace, name)
+        index_path = self._index_path(namespace, name, incarnation)
         if index_path is not None:
             async with self._create_session() as session:
                 saved = (
@@ -1029,6 +1094,7 @@ class SQLiteVectorStore(VectorStore):
                         select(_CollectionRow.index_saved).where(
                             _CollectionRow.namespace == namespace,
                             _CollectionRow.name == name,
+                            _CollectionRow.incarnation == incarnation,
                         )
                     )
                 ).scalar_one_or_none()
@@ -1049,11 +1115,12 @@ class SQLiteVectorStore(VectorStore):
         session: AsyncSession,
         namespace: str,
         name: str,
+        incarnation: str,
         config: VectorStoreCollectionConfig,
     ) -> tuple[Table, VectorSearchEngine]:
-        records_table = self._records_table(namespace, name)
+        records_table = self._records_table(namespace, name, incarnation)
         search_engine = await self._get_or_create_vector_search_engine(
-            namespace, name, config
+            namespace, name, incarnation, config
         )
 
         connection = await session.connection()


### PR DESCRIPTION
### Purpose of the change

Both SQLite-backed vector stores let a collection handle reach the collection that replaces it. Native resource names derive from (namespace, name) alone, so deleting a collection and creating one with the same name rebuilds resources under the same names, and a handle opened before the deletion keeps addressing them.

Measured before this change, single-process, no concurrency involved:

| Store | write through a stale handle | reaches the recreated collection |
| --- | --- | --- |
| `SQLiteVecVectorStore` | succeeds | yes, immediately |
| `SQLiteVectorStore` | succeeds | yes, after the next index save |
| `QdrantVectorStore` | succeeds | no |
| `MilvusVectorStore` | succeeds | no |

`SQLiteVectorStore` is the worse case. `SQLiteVectorStoreCollection` captures `index_path` and `search_engine` at open time and `_maybe_save_index` writes that engine to that path, so a handle to a deleted collection rewrites the *live* index file of its replacement:

```
index after recreate + legitimate write C: (268 bytes, sha 376ae8b8a2a4)
index after write through the STALE handle: (424 bytes, sha 41d3bffdce74)
stale handle rewrote the live index file:  True
after restart, collection contains: B (stale write) = True, C (legitimate) = True
```

The stale write's row also lands in the replacement's records table, and its `_PendingOperationRow` carries the same (namespace, name) — and those rows are replayed on startup "applied or not", which is how the record survives a restart. `_save_collection_index` was likewise unscoped, so a stale handle could delete the replacement's applied pending operations and flip its `index_saved`, which marks the on-disk index as part of the durable contract.

### Description

An `incarnation` is minted per creation, stored on `_CollectionRow`, and made part of everything that was previously keyed by (namespace, name):

- `_collection_prefix`, and so the records table and (for sqlite-vec) the vec0 virtual table
- the on-disk index path and the `_search_engines` cache key
- `_PendingOperationRow.incarnation`, the save-threshold count, the "mark applied" updates, and the startup replay, which now skips operations whose incarnation is not the collection's current one
- `_save_collection_index`, so its pending-operation delete and `index_saved` update touch only the incarnation that saved

A stale handle therefore addresses dropped tables and fails loudly rather than writing into the replacement.

This deliberately does not take a `CollectionRegistry` dependency. The registry exists to give a backend a transactional metadata authority it does not have; these stores already are one — `_CollectionRow` lives in the same engine as the per-collection tables and `create_collection` does the DDL and the metadata write in one transaction. Delegating would split one authority into two and reintroduce a crash window that the registry-backed stores accept only because they have no alternative.

### Breaking changes

Existing databases are not migrated. Collections created by an earlier version keep resource names this version does not address, so their data is not reachable after upgrade. That is deliberate: migration is deferred along with the wider question of where the server runs DDL, and older data stays with older server versions for now.

### Fixes/Closes

Fixes #1536.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Unit Test

Seven new tests across the two stores: a stale handle cannot write to a recreated collection; a stale handle does not clobber the recreated collection's index file, verified by bytes before and after and by reopening the database without a clean shutdown (a clean shutdown rewrites the index from the live engine and hides the damage); a database predating the column is migrated on startup and stays usable; and the unsuffixed name form is pinned as a compatibility contract.

**Test Results:** full server suite 1876 passed, 3 skipped; vector store suite 300 passed; `ruff check`, `ruff format --check` clean; `ty check packages` unchanged at 20 baseline diagnostics, none in the touched files.

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [ ] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Further comments

Independent of the collection-registry stack (#1526, #1527, #1530, #1531, #1533) and based on `main` so it can merge on its own. #1531 states the invariant this restores as a `VectorStoreCollection` contract and currently names these two stores as known non-conformance; whichever lands second should drop that note.

Terminology follows #1545, which introduces the same concept in the segment store: "incarnation" rather than "generation", since the value is a random uuid and `generation`/`epoch` invite the assumption that incarnations are ordered and comparable. The branch name still says `generation`; renaming it would break this PR's head ref, so it stays.

Two adjacent items are deliberately left out. `SQLiteVecVectorStore.create_collection` still reads, checks, then inserts although its primary key could arbitrate directly, which is a separate defect from this one. And a shared conformance test running this sequence against every `VectorStore` implementation would be worth having, but it needs the container-backed suites and belongs in its own change.


