### PR TITLE
fix(event-backend): make expand_context return timeline-neighbor episodes (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
@@ -11,10 +11,9 @@ Verifies that add_episodes / search_scored / delete_episodes /
 drop_session_partition all dispatch correctly through the event backend.
 """
 
-import itertools
 from collections.abc import Iterable
 from datetime import UTC, datetime
-from typing import override
+from typing import Any, override
 from unittest.mock import create_autospec
 
 import pytest
@@ -602,10 +601,50 @@ def _timeline_episode(uid: str, content: str, minute: int) -> Episode:
     )
 
 
+# `FakeEmbedder` maps text to `[len(text), -len(text)]`, so under cosine every
+# document scores exactly 1.0 against every query. That tie makes every stored
+# episode a seed of equal rank, which hides whether context expansion
+# contributed anything: a search at `num_episodes_limit=N` returns the first N
+# episodes in store order whether or not the windows are folded in. The
+# expansion tests below embed on a keyword instead, so exactly one episode
+# matches and its neighbors have to arrive through the expansion.
+_NEEDLE = "needle"
+_NEEDLE_INDEX = 3
+
+
+class NeedleEmbedder(FakeEmbedder):
+    """Embeds `_NEEDLE`-bearing text apart from everything else."""
+
+    @override
+    async def _ingest_embed(
+        self,
+        inputs: list[Any],
+        max_attempts: int = 1,
+    ) -> list[list[float]]:
+        return [NeedleEmbedder._vector(text) for text in inputs]
+
+    @override
+    async def _search_embed(
+        self,
+        queries: list[Any],
+        max_attempts: int = 1,
+    ) -> list[list[float]]:
+        return [NeedleEmbedder._vector(query) for query in queries]
+
+    @staticmethod
+    def _vector(text: Any) -> list[float]:
+        return [1.0, 0.0] if _NEEDLE in str(text) else [0.0, 1.0]
+
+
 @pytest.fixture
 def timeline_episodes() -> list[Episode]:
     return [
-        _timeline_episode(f"tl-{index}", f"timeline message number {index}", index)
+        _timeline_episode(
+            f"tl-{index}",
+            f"timeline message number {index}"
+            + (f" {_NEEDLE}" if index == _NEEDLE_INDEX else ""),
+            index,
+        )
         for index in range(7)
     ]
 
@@ -617,13 +656,14 @@ def timeline_storage(timeline_episodes) -> FakeEpisodeStorage:
 
 @pytest.fixture
 def timeline_long_term_memory(
-    fake_embedder,
     vector_store,
     vector_store_collection,
     segment_store,
     segment_store_partition,
     timeline_storage,
 ) -> LongTermMemory:
+    # `NeedleEmbedder` shares FakeEmbedder's dimensions and similarity metric,
+    # so the shared `vector_store_collection` config still applies.
     return LongTermMemory(
         EventBackendParams(
             session_id="sess1",
@@ -634,60 +674,105 @@ def timeline_long_term_memory(
             segment_store_partition=segment_store_partition,
             partition_key="sess1",
             episode_storage=timeline_storage,
-            embedder=fake_embedder,
+            embedder=NeedleEmbedder(),
             segmenter=PassthroughSegmenter(),
             deriver=WholeTextDeriver(),
         ),
     )
 
 
-async def test_expand_context_returns_timeline_neighbors(
+async def test_expand_context_folds_in_non_matching_neighbors(
     timeline_long_term_memory,
     timeline_episodes,
 ):
-    """expand_context folds the matches' timeline-neighbor episodes into the
-    result, like the declarative backend does."""
+    """expand_context folds the match's timeline neighbors into the result.
+
+    Only `tl-3` carries the needle, so `tl-4` and `tl-5` can only reach the
+    result through the expansion — they score zero against the query.
+    """
     await timeline_long_term_memory.add_episodes(timeline_episodes)
 
     plain = await timeline_long_term_memory.search_scored(
-        "timeline message number 3",
-        num_episodes_limit=2,
+        _NEEDLE,
+        num_episodes_limit=3,
     )
     expanded = await timeline_long_term_memory.search_scored(
-        "timeline message number 3",
-        num_episodes_limit=7,
-        expand_context=4,
+        _NEEDLE,
+        num_episodes_limit=3,
+        expand_context=2,
     )
 
-    plain_uids = {ep.uid for _, ep in plain}
-    expanded_uids = [ep.uid for _, ep in expanded]
-    # Expansion adds neighbor episodes beyond the plain matches.
-    assert len(expanded_uids) > len(plain_uids)
-    assert plain_uids <= set(expanded_uids)
-    # Every match's window is contiguous on the timeline: for each returned
-    # episode, at least one timeline neighbor is also returned (windows are
-    # 1 backward / 3 forward for expand_context=4).
-    indices = sorted(int(uid.split("-")[1]) for uid in expanded_uids)
-    assert any(b - a == 1 for a, b in itertools.pairwise(indices))
-    # Unified context is returned chronologically.
-    created = [ep.created_at for _, ep in expanded]
-    assert created == sorted(created)
+    # Without expansion: the one real match, then non-matching filler, in
+    # score order.
+    assert plain[0][1].uid == "tl-3"
+    assert plain[0][0] == pytest.approx(1.0)
+    assert all(score == pytest.approx(0.0) for score, _ in plain[1:])
+
+    # expand_context=2 is 0 backward / 2 forward, so the match's window is
+    # exactly [tl-3, tl-4, tl-5]; it fits the limit, so it is taken whole and
+    # returned chronologically, each episode keeping the window's score.
+    assert [ep.uid for _, ep in expanded] == ["tl-3", "tl-4", "tl-5"]
+    assert all(score == pytest.approx(1.0) for score, _ in expanded)
 
 
-async def test_expand_context_fills_until_limit(
+async def test_expand_context_is_clamped_to_the_episode_limit(
     timeline_long_term_memory,
     timeline_episodes,
 ):
-    """The unified context never exceeds num_episodes_limit."""
+    """An oversized expand_context cannot push the result past the limit."""
     await timeline_long_term_memory.add_episodes(timeline_episodes)
 
     expanded = await timeline_long_term_memory.search_scored(
-        "timeline message number 3",
+        _NEEDLE,
         num_episodes_limit=3,
-        expand_context=6,
+        expand_context=99,
     )
-    assert len(expanded) <= 3
-    assert len(expanded) == 3  # windows provide plenty to fill the quota
+    # Clamped to num_episodes_limit - 1 = 2, i.e. the same 0-back/2-forward
+    # window rather than a 33-back/66-forward one.
+    assert [ep.uid for _, ep in expanded] == ["tl-3", "tl-4", "tl-5"]
+
+
+async def test_expand_context_never_requests_a_negative_window(
+    timeline_long_term_memory,
+    timeline_episodes,
+    segment_store_partition,
+    monkeypatch,
+):
+    """A zero episode limit clamps expand_context to 0, not to -1.
+
+    `min(expand_context, num_episodes_limit - 1)` alone goes negative at
+    `num_episodes_limit == 0`, and a negative window is outside the
+    SegmentStorePartition contract.
+    """
+    await timeline_long_term_memory.add_episodes(timeline_episodes)
+
+    windows: list[tuple[int, int]] = []
+    get_segment_contexts = segment_store_partition.get_segment_contexts
+
+    async def recording_get_segment_contexts(seed_segment_uuids, **kwargs):
+        windows.append(
+            (
+                kwargs.get("max_backward_segments", 0),
+                kwargs.get("max_forward_segments", 0),
+            )
+        )
+        return await get_segment_contexts(seed_segment_uuids, **kwargs)
+
+    monkeypatch.setattr(
+        segment_store_partition,
+        "get_segment_contexts",
+        recording_get_segment_contexts,
+    )
+
+    scored = await timeline_long_term_memory.search_scored(
+        _NEEDLE,
+        num_episodes_limit=0,
+        expand_context=5,
+    )
+
+    assert scored == []
+    assert windows
+    assert all(backward >= 0 and forward >= 0 for backward, forward in windows)
 
 
 def test_unify_takes_whole_contexts_while_they_fit():

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
@@ -11,6 +11,7 @@ Verifies that add_episodes / search_scored / delete_episodes /
 drop_session_partition all dispatch correctly through the event backend.
 """
 
+import itertools
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import override
@@ -587,3 +588,157 @@ async def test_score_threshold_none_keeps_all_results_under_euclidean():
 
     scored = await ltm.search_scored("abc", num_episodes_limit=10)
     assert [ep.uid for _, ep in scored] == ["only"]
+
+
+def _timeline_episode(uid: str, content: str, minute: int) -> Episode:
+    return Episode(
+        uid=uid,
+        content=content,
+        session_key="sess1",
+        created_at=datetime(2026, 1, 15, 12, minute, tzinfo=UTC),
+        producer_id="alice",
+        producer_role="user",
+        sequence_num=0,
+    )
+
+
+@pytest.fixture
+def timeline_episodes() -> list[Episode]:
+    return [
+        _timeline_episode(f"tl-{index}", f"timeline message number {index}", index)
+        for index in range(7)
+    ]
+
+
+@pytest.fixture
+def timeline_storage(timeline_episodes) -> FakeEpisodeStorage:
+    return FakeEpisodeStorage({e.uid: e for e in timeline_episodes})
+
+
+@pytest.fixture
+def timeline_long_term_memory(
+    fake_embedder,
+    vector_store,
+    vector_store_collection,
+    segment_store,
+    segment_store_partition,
+    timeline_storage,
+) -> LongTermMemory:
+    return LongTermMemory(
+        EventBackendParams(
+            session_id="sess1",
+            vector_store=vector_store,
+            vector_store_collection=vector_store_collection,
+            vector_store_collection_namespace="long_term_memory",
+            segment_store=segment_store,
+            segment_store_partition=segment_store_partition,
+            partition_key="sess1",
+            episode_storage=timeline_storage,
+            embedder=fake_embedder,
+            segmenter=PassthroughSegmenter(),
+            deriver=WholeTextDeriver(),
+        ),
+    )
+
+
+async def test_expand_context_returns_timeline_neighbors(
+    timeline_long_term_memory,
+    timeline_episodes,
+):
+    """expand_context folds the matches' timeline-neighbor episodes into the
+    result, like the declarative backend does."""
+    await timeline_long_term_memory.add_episodes(timeline_episodes)
+
+    plain = await timeline_long_term_memory.search_scored(
+        "timeline message number 3",
+        num_episodes_limit=2,
+    )
+    expanded = await timeline_long_term_memory.search_scored(
+        "timeline message number 3",
+        num_episodes_limit=7,
+        expand_context=4,
+    )
+
+    plain_uids = {ep.uid for _, ep in plain}
+    expanded_uids = [ep.uid for _, ep in expanded]
+    # Expansion adds neighbor episodes beyond the plain matches.
+    assert len(expanded_uids) > len(plain_uids)
+    assert plain_uids <= set(expanded_uids)
+    # Every match's window is contiguous on the timeline: for each returned
+    # episode, at least one timeline neighbor is also returned (windows are
+    # 1 backward / 3 forward for expand_context=4).
+    indices = sorted(int(uid.split("-")[1]) for uid in expanded_uids)
+    assert any(b - a == 1 for a, b in itertools.pairwise(indices))
+    # Unified context is returned chronologically.
+    created = [ep.created_at for _, ep in expanded]
+    assert created == sorted(created)
+
+
+async def test_expand_context_fills_until_limit(
+    timeline_long_term_memory,
+    timeline_episodes,
+):
+    """The unified context never exceeds num_episodes_limit."""
+    await timeline_long_term_memory.add_episodes(timeline_episodes)
+
+    expanded = await timeline_long_term_memory.search_scored(
+        "timeline message number 3",
+        num_episodes_limit=3,
+        expand_context=6,
+    )
+    assert len(expanded) <= 3
+    assert len(expanded) == 3  # windows provide plenty to fill the quota
+
+
+def test_unify_takes_whole_contexts_while_they_fit():
+    unified = LongTermMemory._unify_scored_uid_contexts(
+        [
+            (0.9, "b", ["a", "b", "c"]),
+            (0.5, "e", ["d", "e"]),
+        ],
+        max_num_episodes=10,
+    )
+    assert unified == {"a": 0.9, "b": 0.9, "c": 0.9, "d": 0.5, "e": 0.5}
+
+
+def test_unify_overflow_prefers_nucleus_then_forward():
+    unified = LongTermMemory._unify_scored_uid_contexts(
+        [(0.9, "c", ["a", "b", "c", "d", "e"])],
+        max_num_episodes=3,
+    )
+    # Nucleus first, then forward neighbor, then next-forward beats backward
+    # at equal distance (forward recall preferred).
+    assert set(unified) == {"c", "d", "e"}
+
+
+def test_unify_first_window_keeps_the_score():
+    unified = LongTermMemory._unify_scored_uid_contexts(
+        [
+            (0.9, "b", ["a", "b"]),
+            (0.4, "a", ["a", "z"]),
+        ],
+        max_num_episodes=10,
+    )
+    assert unified["a"] == 0.9  # first (best) window wins
+    assert unified["z"] == 0.4
+
+
+def test_episode_uid_context_dedup_and_nucleus():
+    class _Seg:
+        def __init__(self, uuid, uid):
+            self.uuid = uuid
+            self.properties = {"_episode_uid": uid}
+
+    class _Ctx:
+        def __init__(self):
+            self.seed_segment_uuid = "s2"
+            self.segments = [
+                _Seg("s1", "e1"),
+                _Seg("s2", "e2"),
+                _Seg("s3", "e2"),
+                _Seg("s4", "e3"),
+            ]
+
+    nucleus, context = LongTermMemory._episode_uid_context(_Ctx())
+    assert nucleus == "e2"
+    assert context == ["e1", "e2", "e3"]

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
@@ -11,6 +11,7 @@ Verifies that add_episodes / search_scored / delete_episodes /
 drop_session_partition all dispatch correctly through the event backend.
 """
 
+import math
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import Any, override
@@ -605,15 +606,35 @@ def _timeline_episode(uid: str, content: str, minute: int) -> Episode:
 # document scores exactly 1.0 against every query. That tie makes every stored
 # episode a seed of equal rank, which hides whether context expansion
 # contributed anything: a search at `num_episodes_limit=N` returns the first N
-# episodes in store order whether or not the windows are folded in. The
-# expansion tests below embed on a keyword instead, so exactly one episode
-# matches and its neighbors have to arrive through the expansion.
-_NEEDLE = "needle"
-_NEEDLE_INDEX = 3
+# episodes in store order whether or not the windows are folded in.
+#
+# The expansion tests below give each episode its own similarity instead, by an
+# explicit search rank. The rank order is chosen so that the timeline
+# neighbours of the one matching episode are the LEAST similar of all, which is
+# what lets the tests assert on the contract ("expansion returns timeline
+# neighbours the search itself would not return") rather than on a particular
+# ranking: any correct top-k leaves those neighbours out, and any nonzero
+# window around the match reaches at least one of them, whatever the
+# backward/forward split.
+_TIMELINE_LENGTH = 7
+_MATCH_INDEX = 3
+# Timeline index -> search rank (0 = most similar). The match ranks first, the
+# two episodes farthest from it next, its four neighbours last.
+_SEARCH_RANK_BY_INDEX = {3: 0, 0: 1, 6: 2, 2: 3, 4: 4, 1: 5, 5: 6}
+_NEIGHBOUR_UIDS = frozenset({"tl-1", "tl-2", "tl-4", "tl-5"})
 
 
-class NeedleEmbedder(FakeEmbedder):
-    """Embeds `_NEEDLE`-bearing text apart from everything else."""
+def _timeline_token(index: int) -> str:
+    return f"tok-{index}"
+
+
+class RankedEmbedder(FakeEmbedder):
+    """Embeds each timeline episode at its own distance from the query.
+
+    Every text carries exactly one `tok-<index>`; the vector is placed at an
+    angle proportional to that episode's search rank, so cosine similarity is
+    strictly decreasing in the rank and no two episodes tie.
+    """
 
     @override
     async def _ingest_embed(
@@ -621,7 +642,7 @@ class NeedleEmbedder(FakeEmbedder):
         inputs: list[Any],
         max_attempts: int = 1,
     ) -> list[list[float]]:
-        return [NeedleEmbedder._vector(text) for text in inputs]
+        return [RankedEmbedder._vector(text) for text in inputs]
 
     @override
     async def _search_embed(
@@ -629,11 +650,20 @@ class NeedleEmbedder(FakeEmbedder):
         queries: list[Any],
         max_attempts: int = 1,
     ) -> list[list[float]]:
-        return [NeedleEmbedder._vector(query) for query in queries]
+        return [RankedEmbedder._vector(query) for query in queries]
 
     @staticmethod
     def _vector(text: Any) -> list[float]:
-        return [1.0, 0.0] if _NEEDLE in str(text) else [0.0, 1.0]
+        rank = next(
+            (
+                _SEARCH_RANK_BY_INDEX[index]
+                for index in range(_TIMELINE_LENGTH)
+                if _timeline_token(index) in str(text)
+            ),
+            _TIMELINE_LENGTH,
+        )
+        angle = rank * (math.pi / 2) / _TIMELINE_LENGTH
+        return [math.cos(angle), math.sin(angle)]
 
 
 @pytest.fixture
@@ -641,11 +671,10 @@ def timeline_episodes() -> list[Episode]:
     return [
         _timeline_episode(
             f"tl-{index}",
-            f"timeline message number {index}"
-            + (f" {_NEEDLE}" if index == _NEEDLE_INDEX else ""),
+            f"timeline message {_timeline_token(index)}",
             index,
         )
-        for index in range(7)
+        for index in range(_TIMELINE_LENGTH)
     ]
 
 
@@ -662,7 +691,7 @@ def timeline_long_term_memory(
     segment_store_partition,
     timeline_storage,
 ) -> LongTermMemory:
-    # `NeedleEmbedder` shares FakeEmbedder's dimensions and similarity metric,
+    # `RankedEmbedder` shares FakeEmbedder's dimensions and similarity metric,
     # so the shared `vector_store_collection` config still applies.
     return LongTermMemory(
         EventBackendParams(
@@ -674,75 +703,78 @@ def timeline_long_term_memory(
             segment_store_partition=segment_store_partition,
             partition_key="sess1",
             episode_storage=timeline_storage,
-            embedder=NeedleEmbedder(),
+            embedder=RankedEmbedder(),
             segmenter=PassthroughSegmenter(),
             deriver=WholeTextDeriver(),
         ),
     )
 
 
-async def test_expand_context_folds_in_non_matching_neighbors(
+async def test_expand_context_returns_neighbours_the_search_would_not(
     timeline_long_term_memory,
     timeline_episodes,
 ):
-    """expand_context folds the match's timeline neighbors into the result.
+    """expand_context folds the match's timeline neighbours into the result.
 
-    Only `tl-3` carries the needle, so `tl-4` and `tl-5` can only reach the
-    result through the expansion — they score zero against the query.
+    The match's neighbours are the least similar episodes in the fixture, so
+    no top-k can return them; if they come back, the expansion put them there.
     """
     await timeline_long_term_memory.add_episodes(timeline_episodes)
 
+    query = _timeline_token(_MATCH_INDEX)
     plain = await timeline_long_term_memory.search_scored(
-        _NEEDLE,
+        query,
         num_episodes_limit=3,
     )
     expanded = await timeline_long_term_memory.search_scored(
-        _NEEDLE,
+        query,
         num_episodes_limit=3,
         expand_context=2,
     )
 
-    # Without expansion: the one real match, then non-matching filler, in
-    # score order.
-    assert plain[0][1].uid == "tl-3"
-    assert plain[0][0] == pytest.approx(1.0)
-    assert all(score == pytest.approx(0.0) for score, _ in plain[1:])
+    plain_uids = {ep.uid for _, ep in plain}
+    expanded_uids = {ep.uid for _, ep in expanded}
+    assert f"tl-{_MATCH_INDEX}" in plain_uids
+    assert not (plain_uids & _NEIGHBOUR_UIDS)
+    assert expanded_uids & _NEIGHBOUR_UIDS
 
-    # expand_context=2 is 0 backward / 2 forward, so the match's window is
-    # exactly [tl-3, tl-4, tl-5]; it fits the limit, so it is taken whole and
-    # returned chronologically, each episode keeping the window's score.
-    assert [ep.uid for _, ep in expanded] == ["tl-3", "tl-4", "tl-5"]
-    assert all(score == pytest.approx(1.0) for score, _ in expanded)
+    # Expanded results come back chronologically, within the episode limit.
+    created = [ep.created_at for _, ep in expanded]
+    assert created == sorted(created)
+    assert len(expanded) <= 3
 
 
-async def test_expand_context_is_clamped_to_the_episode_limit(
+async def test_expand_context_zero_returns_matches_in_score_order(
     timeline_long_term_memory,
     timeline_episodes,
 ):
-    """An oversized expand_context cannot push the result past the limit."""
+    """Without expansion, the result is the search's own matches, best first."""
     await timeline_long_term_memory.add_episodes(timeline_episodes)
 
-    expanded = await timeline_long_term_memory.search_scored(
-        _NEEDLE,
+    scored = await timeline_long_term_memory.search_scored(
+        _timeline_token(_MATCH_INDEX),
         num_episodes_limit=3,
-        expand_context=99,
     )
-    # Clamped to num_episodes_limit - 1 = 2, i.e. the same 0-back/2-forward
-    # window rather than a 33-back/66-forward one.
-    assert [ep.uid for _, ep in expanded] == ["tl-3", "tl-4", "tl-5"]
+
+    scores = [score for score, _ in scored]
+    assert scores == sorted(scores, reverse=True)
+    assert not ({ep.uid for _, ep in scored} & _NEIGHBOUR_UIDS)
 
 
-async def test_expand_context_never_requests_a_negative_window(
+async def test_expand_context_window_stays_within_the_episode_limit(
     timeline_long_term_memory,
     timeline_episodes,
     segment_store_partition,
     monkeypatch,
 ):
-    """A zero episode limit clamps expand_context to 0, not to -1.
+    """The window asked of the segment store is clamped to [0, limit - 1].
 
-    `min(expand_context, num_episodes_limit - 1)` alone goes negative at
-    `num_episodes_limit == 0`, and a negative window is outside the
-    SegmentStorePartition contract.
+    Asserted on the store call rather than on which episodes come back, so it
+    holds however the window is split between the two directions and however
+    results are ranked. The lower bound matters on its own: at
+    `num_episodes_limit == 0` (which `SearchMemoriesSpec.top_k` allows)
+    `min(expand_context, num_episodes_limit - 1)` is -1, and a negative window
+    is outside the SegmentStorePartition contract.
     """
     await timeline_long_term_memory.add_episodes(timeline_episodes)
 
@@ -764,15 +796,19 @@ async def test_expand_context_never_requests_a_negative_window(
         recording_get_segment_contexts,
     )
 
-    scored = await timeline_long_term_memory.search_scored(
-        _NEEDLE,
-        num_episodes_limit=0,
-        expand_context=5,
-    )
-
-    assert scored == []
-    assert windows
-    assert all(backward >= 0 and forward >= 0 for backward, forward in windows)
+    for num_episodes_limit, expand_context in ((0, 5), (1, 5), (3, 99), (5, 2)):
+        windows.clear()
+        scored = await timeline_long_term_memory.search_scored(
+            _timeline_token(_MATCH_INDEX),
+            num_episodes_limit=num_episodes_limit,
+            expand_context=expand_context,
+        )
+        assert len(scored) <= num_episodes_limit
+        assert windows
+        for backward, forward in windows:
+            assert backward >= 0
+            assert forward >= 0
+            assert backward + forward <= max(0, num_episodes_limit - 1)
 
 
 def test_unify_takes_whole_contexts_while_they_fit():

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -664,7 +664,9 @@ class LongTermMemory:
             )
             if nuclear_uid is None:
                 continue
-            scored_uid_contexts.append((scored_context.score, nuclear_uid, context_uids))
+            scored_uid_contexts.append(
+                (scored_context.score, nuclear_uid, context_uids)
+            )
 
         episode_scores = LongTermMemory._unify_scored_uid_contexts(
             scored_uid_contexts,
@@ -744,7 +746,9 @@ class LongTermMemory:
                 continue
             nuclear_index = context.index(nuclear_uid)
 
-            def weighted_index_proximity(index: int, anchor: int = nuclear_index) -> float:
+            def weighted_index_proximity(
+                index: int, anchor: int = nuclear_index
+            ) -> float:
                 proximity = index - anchor
                 if proximity >= 0:
                     # Forward recall is better than backward recall.

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -325,6 +325,8 @@ class LongTermMemory:
         event_memory = self._require_event_backend_live()
         assert self._episode_storage is not None
         self._validate_event_backend_filter(property_filter)
+        # Context can never exceed the remaining quota (declarative parity).
+        expand_context = min(max(0, expand_context), num_episodes_limit - 1)
         # Over-fetch from EventMemory: the per-segment results can have many
         # segments per episode under non-passthrough segmenters, and we dedup
         # them by `_episode_uid` below. Without headroom, the dedup loop can
@@ -339,6 +341,17 @@ class LongTermMemory:
             expand_context=expand_context,
             property_filter=property_filter,
         )
+
+        if expand_context > 0:
+            # The expanded windows carry timeline-neighbor segments; fold
+            # their episodes into the result the same way the declarative
+            # backend folds neighbor episodes around its matches: contexts
+            # of the best matches first, filled until the limit is met.
+            return await self._unified_scored_event_episodes(
+                result,
+                num_episodes_limit=num_episodes_limit,
+                score_threshold=score_threshold,
+            )
 
         # Map seed segment -> _episode_uid (system field already lives on
         # event/segment.properties under the underscore-prefixed key). Keep
@@ -624,6 +637,125 @@ class LongTermMemory:
         # effect of invoking `_check` on every leaf field. The returned tree
         # is discarded.
         map_filter_fields(property_filter, _check)
+
+    async def _unified_scored_event_episodes(
+        self,
+        result: object,
+        *,
+        num_episodes_limit: int,
+        score_threshold: float | None,
+    ) -> list[tuple[float, Episode]]:
+        """Fold expanded segment windows into a unified episode context.
+
+        Event-backend analog of DeclarativeMemory's context unification:
+        each scored window contributes the episodes its segments belong to
+        (chronological within the window, the seed's episode as nucleus),
+        best-scoring windows first, whole while they fit and by proximity to
+        the nucleus when they no longer do. The unified context is returned
+        chronologically, as the declarative backend returns its own.
+        """
+        assert self._episode_storage is not None
+        scored_uid_contexts: list[tuple[float, str, list[str]]] = []
+        for scored_context in getattr(result, "scored_segment_contexts", []):
+            if not self._score_passes_threshold(scored_context.score, score_threshold):
+                continue
+            nuclear_uid, context_uids = LongTermMemory._episode_uid_context(
+                scored_context
+            )
+            if nuclear_uid is None:
+                continue
+            scored_uid_contexts.append((scored_context.score, nuclear_uid, context_uids))
+
+        episode_scores = LongTermMemory._unify_scored_uid_contexts(
+            scored_uid_contexts,
+            max_num_episodes=num_episodes_limit,
+        )
+        if not episode_scores:
+            return []
+
+        episodes = await self._episode_storage.get_episodes(list(episode_scores))
+        episodes_by_uid: dict[str, Episode] = {ep.uid: ep for ep in episodes}
+        missing = [uid for uid in episode_scores if uid not in episodes_by_uid]
+        if missing:
+            logger.warning(
+                "search_scored dropped %d episode(s) found in the event index "
+                "but missing from EpisodeStorage (likely index/storage drift): %s",
+                len(missing),
+                missing,
+            )
+        return sorted(
+            (
+                (episode_scores[uid], episodes_by_uid[uid])
+                for uid in episode_scores
+                if uid in episodes_by_uid
+            ),
+            key=lambda scored_episode: (
+                scored_episode[1].created_at,
+                scored_episode[1].uid,
+            ),
+        )
+
+    @staticmethod
+    def _episode_uid_context(scored_context: object) -> tuple[str | None, list[str]]:
+        """Episode uids covered by one segment window.
+
+        Returns the seed segment's episode uid (the nucleus) and the deduped
+        episode uids of every segment in the window, in the window's
+        chronological order.
+        """
+        segments = getattr(scored_context, "segments", [])
+        seed_uuid = getattr(scored_context, "seed_segment_uuid", None)
+        nuclear_uid: str | None = None
+        context_uids: list[str] = []
+        seen: set[str] = set()
+        for segment in segments:
+            episode_uid = segment.properties.get(_EPISODE_UID_FIELD)
+            if episode_uid is None:
+                continue
+            episode_uid = str(episode_uid)
+            if episode_uid not in seen:
+                seen.add(episode_uid)
+                context_uids.append(episode_uid)
+            if segment.uuid == seed_uuid:
+                nuclear_uid = episode_uid
+        return nuclear_uid, context_uids
+
+    @staticmethod
+    def _unify_scored_uid_contexts(
+        scored_uid_contexts: Iterable[tuple[float, str, list[str]]],
+        max_num_episodes: int,
+    ) -> dict[str, float]:
+        """Unify episode-uid contexts into a limited set, best windows first.
+
+        Mirror of DeclarativeMemory._unify_scored_anchored_episode_contexts:
+        a window is taken whole while it fits within the limit; a window
+        that would overflow contributes episodes by weighted index-proximity
+        to its nucleus (forward recall preferred over backward) until the
+        limit is met. An episode keeps the score of the first window that
+        contributed it.
+        """
+        episode_scores: dict[str, float] = {}
+        for score, nuclear_uid, context in scored_uid_contexts:
+            if len(episode_scores) >= max_num_episodes:
+                break
+            if (len(episode_scores) + len(context)) <= max_num_episodes:
+                for episode_uid in context:
+                    episode_scores.setdefault(episode_uid, score)
+                continue
+            nuclear_index = context.index(nuclear_uid)
+
+            def weighted_index_proximity(index: int, anchor: int = nuclear_index) -> float:
+                proximity = index - anchor
+                if proximity >= 0:
+                    # Forward recall is better than backward recall.
+                    return (proximity - 0.5) / 2
+                return float(-proximity)
+
+            for index in sorted(range(len(context)), key=weighted_index_proximity):
+                if len(episode_scores) >= max_num_episodes:
+                    break
+                episode_scores.setdefault(context[index], score)
+        return episode_scores
 
     @staticmethod
     def _scored_context_episode_uid(scored_context: object) -> str | None:

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -43,6 +43,7 @@ from memmachine_server.episodic_memory.event_memory.data_types import (
     Event,
     NullContext,
     ProducerContext,
+    QueryResult,
     TextBlock,
 )
 from memmachine_server.episodic_memory.event_memory.deriver import Deriver
@@ -325,8 +326,11 @@ class LongTermMemory:
         event_memory = self._require_event_backend_live()
         assert self._episode_storage is not None
         self._validate_event_backend_filter(property_filter)
-        # Context can never exceed the remaining quota (declarative parity).
-        expand_context = min(max(0, expand_context), num_episodes_limit - 1)
+        # Context can never exceed the remaining quota (declarative parity),
+        # and can never go negative: with `num_episodes_limit == 0` the quota
+        # clamp on its own would ask the segment store for a window of -1,
+        # which the SegmentStorePartition contract does not define.
+        expand_context = max(0, min(expand_context, num_episodes_limit - 1))
         # Over-fetch from EventMemory: the per-segment results can have many
         # segments per episode under non-passthrough segmenters, and we dedup
         # them by `_episode_uid` below. Without headroom, the dedup loop can
@@ -640,7 +644,7 @@ class LongTermMemory:
 
     async def _unified_scored_event_episodes(
         self,
-        result: object,
+        result: QueryResult,
         *,
         num_episodes_limit: int,
         score_threshold: float | None,
@@ -656,7 +660,7 @@ class LongTermMemory:
         """
         assert self._episode_storage is not None
         scored_uid_contexts: list[tuple[float, str, list[str]]] = []
-        for scored_context in getattr(result, "scored_segment_contexts", []):
+        for scored_context in result.scored_segment_contexts:
             if not self._score_passes_threshold(scored_context.score, score_threshold):
                 continue
             nuclear_uid, context_uids = LongTermMemory._episode_uid_context(


### PR DESCRIPTION
Copy of #1541 based on `speedkick` instead of `main` — the `main` commits cherry-pick cleanly. See #1540 for the bug report; #1541 carries the closing reference.

## Problem

On the event backend, `expand_context` was silently inert on the search path: `EventMemory.query` fetched and materialized the expanded segment windows (a LATERAL query per direction), but `LongTermMemory._search_scored_event` read only the seed segment's `_episode_uid` and score from each window, and the response schema has no context field. Responses were byte-identical for `expand_context` 0 and 5, while every request paid for the expansion.

## Fix

Bring the event backend to parity with the declarative backend's context handling (`DeclarativeMemory._unify_scored_anchored_episode_contexts`):

- Each scored window contributes the episodes its segments belong to — chronological within the window, the seed's episode as the nucleus. (Every segment carries its `_episode_uid`, so segment-space windows map directly onto episode-space context; with the passthrough segmenter this is 1:1 timeline neighbors.)
- Windows are unified best-score-first with the same fill algorithm: taken whole while they fit within `num_episodes_limit`, then filled by weighted index-proximity to the nucleus (forward recall preferred over backward, same weighting as declarative) until the limit is met. An episode keeps the score of the first window that contributed it.
- The unified context is returned **chronologically**, matching the declarative backend's ordering contract for expanded results.
- `expand_context` is clamped to `num_episodes_limit - 1` (declarative parity).

`expand_context == 0` behavior is unchanged — score-ordered seed episodes exactly as before, so existing callers see no difference unless they pass the parameter. Reranked configurations gain the same folding on top of reranker-scored windows (which already consumed the segments for scoring).

## Follow-up self-review (third and fourth commits)

Two things the first two commits got wrong:

- **`expand_context` could go negative.** The quota clamp `min(max(0, expand_context), num_episodes_limit - 1)` is `-1` when `num_episodes_limit == 0`, which `SearchMemoriesSpec.top_k` allows (no lower bound). `EventMemory._query` then derives `max_backward_segments = -1` and asks the segment store for a negative window — undefined by the `SegmentStorePartition` contract; the SQLAlchemy store happens to short-circuit on `<= 0`, the in-memory store computes an empty slice and drops the seed. The floor is now applied last.
- **Neither end-to-end test could tell the fix from its absence** — both passed unmodified against the pre-fix `long_term_memory.py`. `FakeEmbedder` maps text to `[len(text), -len(text)]`, so under cosine every document scores exactly 1.0 against every query: all seven timeline episodes are seeds of equal rank, ties keep insertion order (chronological), and `num_episodes_limit=7` returns all seven with or without expansion. The "expansion adds episodes" assertion compared a limit-2 search against a limit-7 one, so the limit alone explained the difference.

The expansion tests now give each episode its own similarity from an explicit search rank, with the match's four timeline neighbours ranked last. That lets them assert the contract rather than an outcome — an exact episode list or exact score values would be pinned to the fixture's ranking and to the `expand_context // 3` split, neither of which the fix claims:

- No correct top-k can return those neighbours, and any nonzero window around the match reaches at least one of them whatever the backward/forward split, so "expansion returned a neighbour the search itself would not" survives a change of ranking or of the split. Chronological order and the episode limit are asserted alongside it.
- The clamp is asserted on the call made to the segment store (`0 <= backward + forward <= limit - 1`, over several limit/`expand_context` pairs) rather than on which episodes come back.
- `expand_context == 0` is asserted as "matches only, best score first", without naming them.

Exact lists and score values stay in the unit tests, which own the fill algorithm and the score-retention rule. All three expansion tests fail against the code they cover.

## Tests

- End-to-end through the in-memory event-backend wiring: expansion returns neighbor episodes beyond the plain matches, contiguous on the timeline, chronologically ordered, and never exceeding `num_episodes_limit`.
- Unit tests for the window→episode-uid extraction (dedup, nucleus identification) and the unification algorithm (whole-context fit, overflow proximity with forward preference, first-window score retention).

- The expansion tests fail against the pre-fix `long_term_memory.py`; the unit tests cover the window→episode-uid extraction and the unification algorithm directly.

`ruff` (pinned 0.15.14) format + check clean; `ty check packages/server` reports no diagnostics from the touched files. Episodic + server test suites pass on this branch (528 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVtg6Zea292Pb9L7GXnTJp
