### PR TITLE
feat: add OrcaRouter as a first-class language model provider

### DIFF
--- a/docs/install_guide/install_guide.mdx
+++ b/docs/install_guide/install_guide.mdx
@@ -189,6 +189,11 @@ resources:
         model: "llama3"
         api_key: "EMPTY"
         base_url: "http://host.docker.internal:11434/v1"
+    orcarouter_model:
+      provider: orcarouter
+      config:
+        model: "orcarouter/auto"
+        api_key: <ORCAROUTER_API_KEY>
   rerankers:
     my_reranker_id:
       provider: "rrf-hybrid"
@@ -306,6 +311,11 @@ resources:
         model: "llama3"
         api_key: "EMPTY"
         base_url: "http://host.docker.internal:11434/v1"
+    orcarouter_model:
+      provider: orcarouter
+      config:
+        model: "orcarouter/auto"
+        api_key: <ORCAROUTER_API_KEY>
   rerankers:
     my_reranker_id:
       provider: "rrf-hybrid"

--- a/docs/open_source/configuration.mdx
+++ b/docs/open_source/configuration.mdx
@@ -500,6 +500,11 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
             model: "llama3"
             api_key: "EMPTY"
             base_url: "http://host.docker.internal:11434/v1"
+        orcarouter_model:
+          provider: orcarouter
+          config:
+            model: "orcarouter/auto"
+            api_key: <ORCAROUTER_API_KEY>
     ```
 </Tab>
 <Tab title="With Comments">
@@ -525,16 +530,21 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
             model: "llama3" # Model name
             api_key: "EMPTY" # API key for OpenAI. for Ollama, this is always "EMPTY"
             base_url: "http://host.docker.internal:11434/v1" # The base URL for the model
+        orcarouter_model: # Language Model ID
+          provider: orcarouter # The language model provider type
+          config: # A dictionary containing provider-specific configuration
+            model: "orcarouter/auto" # Model name (or an OrcaRouter router id)
+            api_key: <ORCAROUTER_API_KEY> # API key for OrcaRouter.
     ```
 </Tab>
 </Tabs>
     **Parameters for each language model ID (`openai_model`, `aws_model`, `ollama_model`):**
     | Parameter         | Description                                                          | Default                  |
     |-------------------|----------------------------------------------------------------------|--------------------------|
-    | `provider`        | The language model provider type: `openai-responses`, `openai-chat-completions`, `amazon-bedrock`. | *Required*               |
+    | `provider`        | The language model provider type: `openai-responses`, `openai-chat-completions`, `amazon-bedrock`, `orcarouter`. | *Required*               |
     | `config`          | A dictionary containing provider-specific configuration.             | *Required*               |
-    | `config.model`    | Model name (e.g., `gpt-4o-mini` for OpenAI).                         | Depends on provider      |
-    | `config.api_key`  | API key for OpenAI.                                                  | *Required for OpenAI*    |
+    | `config.model`    | Model name (e.g., `gpt-4o-mini` for OpenAI, `orcarouter/auto` for OrcaRouter). | Depends on provider      |
+    | `config.api_key`  | API key for OpenAI/OrcaRouter.                                       | *Required for OpenAI/OrcaRouter* |
     | `config.base_url`  | The base URL for the model                                          | Depends on provider      |
     | `config.region`   | AWS region for Bedrock.                                              | *Required for Bedrock*   |
     | `config.aws_access_key_id` | AWS access key ID for Bedrock.                              | *Required for Bedrock*   |

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1143,7 +1143,7 @@
           "Resources"
         ],
         "summary": "Add Language Model Endpoint",
-        "description": "Add a new language model configuration at runtime.\n\n    Creates a new language model with the specified configuration and attempts\n    to initialize it immediately. This allows adding models without restarting\n    the server. The configuration is persisted to the configuration file.\n\n    **Security Warning**: API keys and credentials are stored in plain text in\n    the configuration file. Only use this API in protected environments. To\n    avoid storing secrets in plain text, use environment variable references\n    (e.g., `\"api_key\": \"$OPENAI_API_KEY\"`) which will be resolved at runtime.\n\n    Supported providers:\n    - `openai-responses`: OpenAI models using the Responses API (requires api_key, model)\n    - `openai-chat-completions`: OpenAI models using Chat Completions API (requires api_key, model)\n    - `amazon-bedrock`: AWS Bedrock models (requires region, model_id)\n\n    The response indicates whether the model was successfully initialized:\n    - `success: true, status: ready`: Model is available for use\n    - `success: false, status: failed`: Initialization failed (check error field)\n\n    If initialization fails, the model configuration is still stored and can\n    be retried later using the retry endpoint when the underlying service\n    becomes available.\n\n    Returns 422 if the provider type or configuration is invalid.",
+        "description": "Add a new language model configuration at runtime.\n\n    Creates a new language model with the specified configuration and attempts\n    to initialize it immediately. This allows adding models without restarting\n    the server. The configuration is persisted to the configuration file.\n\n    **Security Warning**: API keys and credentials are stored in plain text in\n    the configuration file. Only use this API in protected environments. To\n    avoid storing secrets in plain text, use environment variable references\n    (e.g., `\"api_key\": \"$OPENAI_API_KEY\"`) which will be resolved at runtime.\n\n    Supported providers:\n    - `openai-responses`: OpenAI models using the Responses API (requires api_key, model)\n    - `openai-chat-completions`: OpenAI models using Chat Completions API (requires api_key, model)\n    - `amazon-bedrock`: AWS Bedrock models (requires region, model_id)\n    - `orcarouter`: OrcaRouter models (requires api_key, model)\n\n    The response indicates whether the model was successfully initialized:\n    - `success: true, status: ready`: Model is available for use\n    - `success: false, status: failed`: Initialization failed (check error field)\n\n    If initialization fails, the model configuration is still stored and can\n    be retried later using the retry endpoint when the underlying service\n    becomes available.\n\n    Returns 422 if the provider type or configuration is invalid.",
         "operationId": "add_language_model",
         "requestBody": {
           "content": {
@@ -2243,10 +2243,11 @@
             "enum": [
               "openai-responses",
               "openai-chat-completions",
-              "amazon-bedrock"
+              "amazon-bedrock",
+              "orcarouter"
             ],
             "title": "Provider",
-            "description": "\n    The language model provider type (e.g., 'openai-responses', 'openai-chat-completions', 'amazon-bedrock')."
+            "description": "\n    The language model provider type (e.g., 'openai-responses', 'openai-chat-completions', 'amazon-bedrock', 'orcarouter')."
           },
           "config": {
             "additionalProperties": true,

--- a/packages/common/src/memmachine_common/api/config_spec.py
+++ b/packages/common/src/memmachine_common/api/config_spec.py
@@ -402,6 +402,27 @@ class AddAmazonBedrockLanguageModelConfig(BaseModel):
     ]
 
 
+class AddOrcaRouterLanguageModelConfig(BaseModel):
+    """Configuration for adding an OrcaRouter language model."""
+
+    api_key: Annotated[
+        str,
+        Field(..., description=SpecDoc.API_KEY_ORCAROUTER),
+    ]
+    model: Annotated[
+        str,
+        Field(default="orcarouter/auto", description=SpecDoc.MODEL_NAME),
+    ]
+    base_url: Annotated[
+        str | None,
+        Field(default=None, description=SpecDoc.ORCAROUTER_BASE_URL),
+    ]
+    max_retry_interval_seconds: Annotated[
+        int,
+        Field(default=120, description=SpecDoc.MAX_RETRY_INTERVAL),
+    ]
+
+
 class AddLanguageModelSpec(BaseModel):
     """Specification for adding a new language model."""
 
@@ -410,7 +431,12 @@ class AddLanguageModelSpec(BaseModel):
         Field(..., description=SpecDoc.LM_NAME),
     ]
     provider: Annotated[
-        Literal["openai-responses", "openai-chat-completions", "amazon-bedrock"],
+        Literal[
+            "openai-responses",
+            "openai-chat-completions",
+            "amazon-bedrock",
+            "orcarouter",
+        ],
         Field(..., description=SpecDoc.LM_PROVIDER_TYPE),
     ]
     config: Annotated[

--- a/packages/common/src/memmachine_common/api/doc.py
+++ b/packages/common/src/memmachine_common/api/doc.py
@@ -330,6 +330,9 @@ class SpecDoc:
     API_KEY_OPENAI = """
     OpenAI API key for authentication."""
 
+    API_KEY_ORCAROUTER = """
+    OrcaRouter API key for authentication."""
+
     MODEL_NAME = """
     The model name to use."""
 
@@ -338,6 +341,9 @@ class SpecDoc:
 
     API_BASE_URL = """
     Custom base URL for the API endpoint."""
+
+    ORCAROUTER_BASE_URL = """
+    OrcaRouter API base URL (defaults to 'https://api.orcarouter.ai/v1')."""
 
     MAX_INPUT_LENGTH = """
     Maximum input length in Unicode code points."""
@@ -376,7 +382,7 @@ class SpecDoc:
     Unique name/identifier for the language model."""
 
     LM_PROVIDER_TYPE = """
-    The language model provider type (e.g., 'openai-responses', 'openai-chat-completions', 'amazon-bedrock')."""
+    The language model provider type (e.g., 'openai-responses', 'openai-chat-completions', 'amazon-bedrock', 'orcarouter')."""
 
     INFERENCE_CONFIG = """
     Inference configuration for the model."""
@@ -891,6 +897,7 @@ class RouterDoc:
     - `openai-responses`: OpenAI models using the Responses API (requires api_key, model)
     - `openai-chat-completions`: OpenAI models using Chat Completions API (requires api_key, model)
     - `amazon-bedrock`: AWS Bedrock models (requires region, model_id)
+    - `orcarouter`: OrcaRouter models (requires api_key, model)
 
     The response indicates whether the model was successfully initialized:
     - `success: true, status: ready`: Model is available for use

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_language_model_conf.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_language_model_conf.py
@@ -9,6 +9,7 @@ from memmachine_server.common.configuration.language_model_conf import (
     LanguageModelsConf,
     OpenAIChatCompletionsLanguageModelConf,
     OpenAIResponsesLanguageModelConf,
+    OrcaRouterLanguageModelConf,
 )
 
 
@@ -49,6 +50,17 @@ def ollama_model_conf() -> dict:
 
 
 @pytest.fixture
+def orcarouter_model_conf() -> dict:
+    return {
+        "provider": "orcarouter",
+        "config": {
+            "model": "orcarouter/auto",
+            "api_key": "orca-key",
+        },
+    }
+
+
+@pytest.fixture
 def full_model_conf(openai_model_conf, aws_model_conf, ollama_model_conf) -> dict:
     return {
         "language_models": {
@@ -83,6 +95,14 @@ def test_valid_openai_chat_completions_model(ollama_model_conf):
     assert conf.max_retry_interval_seconds == 120
 
 
+def test_valid_orcarouter_model(orcarouter_model_conf):
+    conf = OrcaRouterLanguageModelConf(**orcarouter_model_conf["config"])
+    assert conf.model == "orcarouter/auto"
+    assert conf.api_key == SecretStr("orca-key")
+    assert conf.base_url == "https://api.orcarouter.ai/v1"
+    assert conf.max_retry_interval_seconds == 120
+
+
 def test_full_language_model_conf(full_model_conf):
     conf = LanguageModelsConf.parse(full_model_conf)
 
@@ -101,12 +121,32 @@ def test_full_language_model_conf(full_model_conf):
     assert chat_completions_conf.model == "llama3"
 
 
+def test_full_language_model_conf_with_orcarouter(
+    full_model_conf, orcarouter_model_conf
+):
+    full_model_conf["language_models"]["orca_model"] = orcarouter_model_conf
+    conf = LanguageModelsConf.parse(full_model_conf)
+
+    assert "orca_model" in conf.orcarouter_language_model_confs
+    orca_conf = conf.orcarouter_language_model_confs["orca_model"]
+    assert orca_conf.model == "orcarouter/auto"
+    assert orca_conf.base_url == "https://api.orcarouter.ai/v1"
+
+
 def test_get_language_model_names(full_model_conf):
     conf = LanguageModelsConf.parse(full_model_conf)
 
     assert conf.get_openai_responses_language_model_name() == "openai_model"
     assert conf.get_amazon_bedrock_language_model_name() == "aws_model"
     assert conf.get_openai_chat_completions_language_model_name() == "ollama_model"
+
+
+def test_get_orcarouter_language_model_name(full_model_conf, orcarouter_model_conf):
+    full_model_conf["language_models"]["orca_model"] = orcarouter_model_conf
+    conf = LanguageModelsConf.parse(full_model_conf)
+
+    assert conf.get_orcarouter_language_model_name() == "orca_model"
+    assert conf.contains_language_model("orca_model")
 
 
 def test_serialize_deserialize_language_model_conf(full_model_conf):
@@ -125,6 +165,23 @@ def test_serialize_deserialize_language_model_conf(full_model_conf):
     )
 
 
+def test_serialize_deserialize_orcarouter_language_model_conf(
+    full_model_conf, orcarouter_model_conf
+):
+    full_model_conf["language_models"]["orca_model"] = orcarouter_model_conf
+    conf = LanguageModelsConf.parse(full_model_conf)
+    yaml_str = conf.to_yaml()
+    conf_cp = LanguageModelsConf.parse(yaml.safe_load(yaml_str))
+    assert conf == conf_cp
+    assert len(conf.orcarouter_language_model_confs) == len(
+        conf_cp.orcarouter_language_model_confs
+    )
+    assert (
+        conf_cp.orcarouter_language_model_confs["orca_model"].base_url
+        == "https://api.orcarouter.ai/v1"
+    )
+
+
 def test_missing_required_field_openai_model():
     conf_dict: dict[str, Any] = {"model": "gpt-4o-mini"}
     with pytest.raises(ValidationError) as exc_info:
@@ -140,6 +197,17 @@ def test_invalid_base_url_in_openai_chat_completions_model():
     }
     with pytest.raises(ValidationError) as exc_info:
         OpenAIChatCompletionsLanguageModelConf(**conf_dict)
+    assert "invalid base url" in str(exc_info.value).lower()
+
+
+def test_invalid_base_url_in_orcarouter_model():
+    conf_dict: dict[str, Any] = {
+        "model": "orcarouter/auto",
+        "api_key": "orca-key",
+        "base_url": "invalid-url",
+    }
+    with pytest.raises(ValidationError) as exc_info:
+        OrcaRouterLanguageModelConf(**conf_dict)
     assert "invalid base url" in str(exc_info.value).lower()
 
 

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_language_model_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_language_model_manager.py
@@ -6,6 +6,7 @@ from memmachine_server.common.configuration.language_model_conf import (
     LanguageModelsConf,
     OpenAIChatCompletionsLanguageModelConf,
     OpenAIResponsesLanguageModelConf,
+    OrcaRouterLanguageModelConf,
 )
 from memmachine_server.common.resource_manager.language_model_manager import (
     LanguageModelManager,
@@ -40,6 +41,13 @@ def mock_conf():
                 model="llama3",
                 api_key=SecretStr("DUMMY_OLLAMA_API_KEY"),
                 base_url="http://localhost:11434/v1",
+            ),
+        },
+        orcarouter_language_model_confs={
+            "orca_model": OrcaRouterLanguageModelConf(
+                model="orcarouter/auto",
+                api_key=SecretStr("DUMMY_ORCAROUTER_API_KEY"),
+                base_url="https://api.orcarouter.ai/v1",
             ),
         },
     )
@@ -77,4 +85,15 @@ async def test_build_openai_chat_completions_model(mock_conf):
     assert "ollama_model" in builder._language_models
 
     model = builder.get_language_model("ollama_model")
+    assert model is not None
+
+
+@pytest.mark.asyncio
+async def test_build_orcarouter_model(mock_conf):
+    builder = LanguageModelManager(mock_conf)
+    await builder.build_all()
+
+    assert "orca_model" in builder._language_models
+
+    model = builder.get_language_model("orca_model")
     assert model is not None

--- a/packages/server/src/memmachine_server/common/configuration/language_model_conf.py
+++ b/packages/server/src/memmachine_server/common/configuration/language_model_conf.py
@@ -18,6 +18,8 @@ from memmachine_server.common.language_model.amazon_bedrock_language_model impor
 
 DEFAULT_OLLAMA_BASE_URL = "http://host.docker.internal:11434/v1"
 
+DEFAULT_ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+
 
 def _clean_empty_lm_config(conf: dict) -> dict:
     """Remove empty strings and None values from config."""
@@ -84,6 +86,50 @@ class OpenAIChatCompletionsLanguageModelConf(
     max_retry_interval_seconds: int = Field(
         default=120,
         description="Maximal retry interval in seconds when retrying API calls",
+        gt=0,
+    )
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, v: str) -> str:
+        """Ensure the base URL includes a scheme and host."""
+        if v is not None:
+            parsed_url = urlparse(v)
+            if not parsed_url.scheme or not parsed_url.netloc:
+                raise ValueError(f"Invalid base URL: base_url={v}")
+        return v
+
+
+class OrcaRouterLanguageModelConf(
+    MetricsFactoryIdMixin, YamlSerializableMixin, ApiKeyMixin
+):
+    """Configuration for OrcaRouter-backed language models.
+
+    OrcaRouter (https://www.orcarouter.ai) exposes an OpenAI-compatible
+    endpoint at ``https://api.orcarouter.ai/v1`` that routes to many models,
+    so this conf mirrors ``OpenAIChatCompletionsLanguageModelConf`` while
+    defaulting ``base_url`` to the OrcaRouter endpoint. Set ``model`` to an
+    OrcaRouter model or router id such as ``orcarouter/auto``.
+    """
+
+    model: str = Field(
+        default="orcarouter/auto",
+        min_length=1,
+        description="OrcaRouter model or router id (e.g. 'orcarouter/auto').",
+    )
+    api_key: SecretStr = Field(
+        ...,
+        description="OrcaRouter API key for authentication, can reference an "
+        "environment variable using `$ENV` or `${ENV}` syntax.",
+    )
+    base_url: str | None = Field(
+        default=DEFAULT_ORCAROUTER_BASE_URL,
+        description="OrcaRouter API base URL.",
+        examples=[DEFAULT_ORCAROUTER_BASE_URL],
+    )
+    max_retry_interval_seconds: int = Field(
+        default=120,
+        description="Maximal retry interval in seconds when retrying API calls.",
         gt=0,
     )
 
@@ -224,6 +270,7 @@ class LanguageModelsConf(BaseModel):
     ] = {}
     amazon_bedrock_language_model_confs: dict[str, AmazonBedrockLanguageModelConf] = {}
     litellm_language_model_confs: dict[str, LiteLLMLanguageModelConf] = {}
+    orcarouter_language_model_confs: dict[str, OrcaRouterLanguageModelConf] = {}
 
     def get_openai_responses_language_model_name(self) -> str | None:
         """Get the name of the first OpenAI Responses language model, if any."""
@@ -249,9 +296,21 @@ class LanguageModelsConf(BaseModel):
             return next(iter(self.litellm_language_model_confs))
         return None
 
+    def get_orcarouter_language_model_name(self) -> str | None:
+        """Get the name of the first OrcaRouter language model, if any."""
+        if self.orcarouter_language_model_confs:
+            return next(iter(self.orcarouter_language_model_confs))
+        return None
+
     def get_litellm_language_model_conf(self, name: str) -> "LiteLLMLanguageModelConf":
         """Get LiteLLM language model configuration by name."""
         return self.litellm_language_model_confs[name]
+
+    def get_orcarouter_language_model_conf(
+        self, name: str
+    ) -> OrcaRouterLanguageModelConf:
+        """Get OrcaRouter language model configuration by name."""
+        return self.orcarouter_language_model_confs[name]
 
     def get_openai_responses_language_model_conf(
         self, name: str
@@ -278,12 +337,14 @@ class LanguageModelsConf(BaseModel):
             or language_model_id in self.openai_chat_completions_language_model_confs
             or language_model_id in self.amazon_bedrock_language_model_confs
             or language_model_id in self.litellm_language_model_confs
+            or language_model_id in self.orcarouter_language_model_confs
         )
 
     OPENAI_RESPONSE: ClassVar[str] = "openai-responses"
     OPEN_CHAT_COMPLETION: ClassVar[str] = "openai-chat-completions"
     AMAZON_BEDROCK: ClassVar[str] = "amazon-bedrock"
     LITELLM: ClassVar[str] = "litellm"
+    ORCAROUTER: ClassVar[str] = "orcarouter"
     PROVIDER_KEY: ClassVar[str] = "provider"
     CONFIG_KEY: ClassVar[str] = "config"
 
@@ -309,6 +370,9 @@ class LanguageModelsConf(BaseModel):
         for lm_id, cfg in self.litellm_language_model_confs.items():
             add_language_model(lm_id, self.LITELLM, cfg.to_yaml_dict())
 
+        for lm_id, cfg in self.orcarouter_language_model_confs.items():
+            add_language_model(lm_id, self.ORCAROUTER, cfg.to_yaml_dict())
+
         return language_models
 
     def to_yaml(self) -> str:
@@ -332,6 +396,7 @@ class LanguageModelsConf(BaseModel):
             {},
             {},
         )
+        orcarouter_dict: dict[str, OrcaRouterLanguageModelConf] = {}
 
         for lm_id, resource_definition in lm.items():
             provider = resource_definition.get("provider")
@@ -348,6 +413,8 @@ class LanguageModelsConf(BaseModel):
                 aws_bedrock_dict[lm_id] = AmazonBedrockLanguageModelConf(**conf)
             elif provider == "litellm":
                 litellm_dict[lm_id] = LiteLLMLanguageModelConf(**conf)
+            elif provider == "orcarouter":
+                orcarouter_dict[lm_id] = OrcaRouterLanguageModelConf(**conf)
             else:
                 raise ValueError(
                     f"Unknown language model provider '{provider}' for language model id '{lm_id}'",
@@ -358,4 +425,5 @@ class LanguageModelsConf(BaseModel):
             amazon_bedrock_language_model_confs=aws_bedrock_dict,
             openai_chat_completions_language_model_confs=openai_chat_completions_dict,
             litellm_language_model_confs=litellm_dict,
+            orcarouter_language_model_confs=orcarouter_dict,
         )

--- a/packages/server/src/memmachine_server/common/resource_manager/language_model_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/language_model_manager.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from pydantic import SecretStr
 
 from memmachine_server.common.configuration.language_model_conf import (
+    DEFAULT_ORCAROUTER_BASE_URL,
     AmazonBedrockLanguageModelConf,
     LanguageModelsConf,
     LiteLLMLanguageModelConf,
     OpenAIChatCompletionsLanguageModelConf,
     OpenAIResponsesLanguageModelConf,
+    OrcaRouterLanguageModelConf,
 )
 from memmachine_server.common.errors import InvalidLanguageModelError
 from memmachine_server.common.language_model.language_model import LanguageModel
@@ -41,6 +44,7 @@ class LanguageModelManager(BaseResourceManager[LanguageModel]):
             or name in self.conf.openai_chat_completions_language_model_confs
             or name in self.conf.amazon_bedrock_language_model_confs
             or name in self.conf.litellm_language_model_confs
+            or name in self.conf.orcarouter_language_model_confs
         )
 
     def _get_not_found_error(self, name: str) -> Exception:
@@ -54,6 +58,7 @@ class LanguageModelManager(BaseResourceManager[LanguageModel]):
         names.update(self.conf.openai_chat_completions_language_model_confs)
         names.update(self.conf.amazon_bedrock_language_model_confs)
         names.update(self.conf.litellm_language_model_confs)
+        names.update(self.conf.orcarouter_language_model_confs)
         return names
 
     async def build_all(self) -> dict[str, LanguageModel]:
@@ -90,6 +95,9 @@ class LanguageModelManager(BaseResourceManager[LanguageModel]):
         if name in self.conf.litellm_language_model_confs:
             del self.conf.litellm_language_model_confs[name]
             removed = True
+        if name in self.conf.orcarouter_language_model_confs:
+            del self.conf.orcarouter_language_model_confs[name]
+            removed = True
         return removed
 
     def add_language_model_config(
@@ -99,62 +107,51 @@ class LanguageModelManager(BaseResourceManager[LanguageModel]):
         config: OpenAIResponsesLanguageModelConf
         | OpenAIChatCompletionsLanguageModelConf
         | AmazonBedrockLanguageModelConf
-        | LiteLLMLanguageModelConf,
+        | LiteLLMLanguageModelConf
+        | OrcaRouterLanguageModelConf,
     ) -> None:
         """
         Add a new language model configuration at runtime.
 
         Args:
             name: The name/id for the language model.
-            provider: The provider type ('openai-responses', 'openai-chat-completions', 'amazon-bedrock', 'litellm').
+            provider: The provider type ('openai-responses', 'openai-chat-completions', 'amazon-bedrock', 'litellm', 'orcarouter').
             config: The provider-specific configuration object.
 
         """
         # Clear any previous errors for this name
         self.clear_build_error(name)
 
-        if provider == "openai-responses":
-            from memmachine_server.common.configuration.language_model_conf import (
+        provider_to_conf: dict[str, tuple[type, dict[str, Any]]] = {
+            "openai-responses": (
                 OpenAIResponsesLanguageModelConf,
-            )
-
-            if not isinstance(config, OpenAIResponsesLanguageModelConf):
-                raise ValueError(
-                    "Expected OpenAIResponsesLanguageModelConf for provider 'openai-responses'"
-                )
-            self.conf.openai_responses_language_model_confs[name] = config
-        elif provider == "openai-chat-completions":
-            from memmachine_server.common.configuration.language_model_conf import (
+                self.conf.openai_responses_language_model_confs,
+            ),
+            "openai-chat-completions": (
                 OpenAIChatCompletionsLanguageModelConf,
-            )
-
-            if not isinstance(config, OpenAIChatCompletionsLanguageModelConf):
-                raise ValueError(
-                    "Expected OpenAIChatCompletionsLanguageModelConf for provider 'openai-chat-completions'"
-                )
-            self.conf.openai_chat_completions_language_model_confs[name] = config
-        elif provider == "amazon-bedrock":
-            from memmachine_server.common.configuration.language_model_conf import (
+                self.conf.openai_chat_completions_language_model_confs,
+            ),
+            "amazon-bedrock": (
                 AmazonBedrockLanguageModelConf,
-            )
-
-            if not isinstance(config, AmazonBedrockLanguageModelConf):
-                raise ValueError(
-                    "Expected AmazonBedrockLanguageModelConf for provider 'amazon-bedrock'"
-                )
-            self.conf.amazon_bedrock_language_model_confs[name] = config
-        elif provider == "litellm":
-            from memmachine_server.common.configuration.language_model_conf import (
+                self.conf.amazon_bedrock_language_model_confs,
+            ),
+            "litellm": (
                 LiteLLMLanguageModelConf,
-            )
+                self.conf.litellm_language_model_confs,
+            ),
+            "orcarouter": (
+                OrcaRouterLanguageModelConf,
+                self.conf.orcarouter_language_model_confs,
+            ),
+        }
 
-            if not isinstance(config, LiteLLMLanguageModelConf):
-                raise ValueError(
-                    "Expected LiteLLMLanguageModelConf for provider 'litellm'"
-                )
-            self.conf.litellm_language_model_confs[name] = config
-        else:
+        if provider not in provider_to_conf:
             raise ValueError(f"Unknown language model provider: {provider}")
+
+        conf_type, confs = provider_to_conf[provider]
+        if type(config) is not conf_type:
+            raise ValueError(f"Expected {conf_type.__name__} for provider '{provider}'")
+        confs[name] = config
 
     @staticmethod
     async def _validate_language_model(
@@ -186,6 +183,8 @@ class LanguageModelManager(BaseResourceManager[LanguageModel]):
             ret = self._build_amazon_bedrock_language_model(name)
         elif name in self.conf.litellm_language_model_confs:
             ret = self._build_litellm_language_model(name)
+        elif name in self.conf.orcarouter_language_model_confs:
+            ret = self._build_orcarouter_language_model(name)
         if ret is None:
             raise InvalidLanguageModelError(
                 f"Language model with name {name} not found."
@@ -305,6 +304,28 @@ class LanguageModelManager(BaseResourceManager[LanguageModel]):
                 api_version=conf.api_version,
                 drop_params=conf.drop_params,
                 extra_kwargs=conf.extra_kwargs,
+                max_retry_interval_seconds=conf.max_retry_interval_seconds,
+                metrics_factory=conf.get_metrics_factory(),
+            ),
+        )
+
+    def _build_orcarouter_language_model(self, name: str) -> LanguageModel:
+        import openai
+
+        from memmachine_server.common.language_model.openai_chat_completions_language_model import (
+            OpenAIChatCompletionsLanguageModel,
+            OpenAIChatCompletionsLanguageModelParams,
+        )
+
+        conf = self.conf.orcarouter_language_model_confs[name]
+
+        return OpenAIChatCompletionsLanguageModel(
+            OpenAIChatCompletionsLanguageModelParams(
+                client=openai.AsyncOpenAI(
+                    api_key=conf.api_key.get_secret_value(),
+                    base_url=conf.base_url or DEFAULT_ORCAROUTER_BASE_URL,
+                ),
+                model=conf.model,
                 max_retry_interval_seconds=conf.max_retry_interval_seconds,
                 metrics_factory=conf.get_metrics_factory(),
             ),

--- a/packages/server/src/memmachine_server/server/api_v2/config_service.py
+++ b/packages/server/src/memmachine_server/server/api_v2/config_service.py
@@ -43,6 +43,7 @@ from memmachine_server.common.configuration.language_model_conf import (
     LanguageModelsConf,
     OpenAIChatCompletionsLanguageModelConf,
     OpenAIResponsesLanguageModelConf,
+    OrcaRouterLanguageModelConf,
 )
 from memmachine_server.common.configuration.reranker_conf import RerankersConf
 from memmachine_server.common.resource_manager.resource_manager import (
@@ -103,6 +104,8 @@ def _get_language_model_provider(manager_conf: LanguageModelsConf, name: str) ->
         return "openai-chat-completions"
     if name in manager_conf.amazon_bedrock_language_model_confs:
         return "amazon-bedrock"
+    if name in manager_conf.orcarouter_language_model_confs:
+        return "orcarouter"
     return "unknown"
 
 
@@ -151,6 +154,7 @@ def _create_language_model_config(
     OpenAIResponsesLanguageModelConf
     | OpenAIChatCompletionsLanguageModelConf
     | AmazonBedrockLanguageModelConf
+    | OrcaRouterLanguageModelConf
 ):
     """Create a language model configuration object from provider and config dict."""
     if provider == "openai-responses":
@@ -169,6 +173,11 @@ def _create_language_model_config(
             if key in config and config[key] is not None:
                 config[key] = SecretStr(config[key])
         return AmazonBedrockLanguageModelConf(**config)
+    if provider == "orcarouter":
+        # Convert api_key to SecretStr
+        if "api_key" in config:
+            config["api_key"] = SecretStr(config["api_key"])
+        return OrcaRouterLanguageModelConf(**config)
     raise ValueError(f"Unknown language model provider: {provider}")
 
 

--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -204,6 +204,11 @@ resources:
         model: "qwen-flash"
         api_key: <YOUR_API_KEY>
         base_url: "https://api.openai.com/v1"
+    orcarouter_model:
+      provider: orcarouter
+      config:
+        model: "orcarouter/auto"
+        api_key: <ORCAROUTER_API_KEY>
   rerankers:
     my_reranker_id:
       provider: "rrf-hybrid"

--- a/sample_configs/episodic_memory_config.gpu.sample
+++ b/sample_configs/episodic_memory_config.gpu.sample
@@ -203,6 +203,11 @@ resources:
         model: "qwen-flash"
         api_key: <YOUR_API_KEY>
         base_url: "https://api.openai.com/v1"
+    orcarouter_model:
+      provider: orcarouter
+      config:
+        model: "orcarouter/auto"
+        api_key: <ORCAROUTER_API_KEY>
   rerankers:
     my_reranker_id:
       provider: "rrf-hybrid"

--- a/sample_configs/episodic_memory_config.nebula.sample
+++ b/sample_configs/episodic_memory_config.nebula.sample
@@ -200,6 +200,11 @@ resources:
         model: "qwen-flash"
         api_key: <YOUR_API_KEY>
         base_url: "https://api.openai.com/v1"
+    orcarouter_model:
+      provider: orcarouter
+      config:
+        model: "orcarouter/auto"
+        api_key: <ORCAROUTER_API_KEY>
 
   rerankers:
     my_reranker_id:


### PR DESCRIPTION
Adding [OrcaRouter](https://www.orcarouter.ai) as a first-class `orcarouter` provider in MemMachine's language model registry lets anyone running MemMachine's memory layer point their summarization and generation models at an OpenAI-compatible gateway that routes across many models from a single endpoint — with no custom base-URL plumbing.

MemMachine positions itself as *"the open-source memory layer for AI agents"* and advertises itself as **LLM agnostic** — working with OpenAI, Anthropic, Bedrock, Ollama, and any LLM provider. Today that flexibility is wired through the `resources.language_models` registry, where each entry names a provider (`openai-responses`, `openai-chat-completions`, `amazon-bedrock`, `litellm`). This PR mirrors the existing `openai-chat-completions` adapter: a new `orcarouter` provider that reuses MemMachine's `OpenAIChatCompletionsLanguageModel` and defaults `base_url` to `https://api.orcarouter.ai/v1`, so users can configure it exactly like the Ollama/OpenAI-compatible entries already in the sample configs.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

What changed:
- `OrcaRouterLanguageModelConf` with a default model of `orcarouter/auto` and default base URL `https://api.orcarouter.ai/v1`
- Registration in `LanguageModelsConf` (parse, serialize, getters, `contains_language_model`)
- Build path in `LanguageModelManager._build_orcarouter_language_model` and runtime add/remove/status in the config service and API spec (`config_spec`, `doc`)
- Docs: install guide, `docs/open_source/configuration.mdx`, and the three `sample_configs/*.sample` files
- Regenerated `docs/openapi.json` provider enum
- Unit tests for config parse/round-trip/getters and manager build

Verification:
- `ruff check` and `ruff format --check` clean on all changed files
- `pytest packages/server/server_tests/...` — 293 passed (including new OrcaRouter tests)
- L3 live test against `https://api.orcarouter.ai/v1` with model `orcarouter/auto` returned a valid completion (200)

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
