### PR TITLE
fix(server): warm the search path at startup, not on the first request

### DIFF
--- a/packages/server/src/memmachine_server/main/memmachine.py
+++ b/packages/server/src/memmachine_server/main/memmachine.py
@@ -4,7 +4,8 @@ import asyncio
 import contextlib
 import logging
 from asyncio import Task
-from collections.abc import Callable, Coroutine, Iterable, Mapping
+from collections.abc import Awaitable, Callable, Coroutine, Iterable, Mapping
+from functools import partial
 from typing import Any, Final, Protocol
 
 from memmachine_common.api import MemoryType
@@ -420,6 +421,58 @@ class MemMachine:
             logger.info(
                 "Semantic memory is disabled; skipping semantic service startup."
             )
+
+        await self._warm_request_path()
+
+    async def _warm_request_path(self) -> None:
+        """Resolve the resources a search needs, so the first search does not.
+
+        Each resource is lazy-loaded behind a lock, and resolving one imports its
+        module tree and builds pydantic schemas for it. Deferred to the first
+        request that needs it, that work blocks the event loop for seconds - and
+        it is paid once per uvicorn worker, because each worker is a separate
+        process. Kubernetes has already routed traffic by then: the health
+        endpoint touches none of this, so it answers in milliseconds while a
+        search on the same worker takes seconds.
+
+        Failures here are logged and swallowed. Every one of these is retried
+        lazily on the request path anyway, so a store that happens to be
+        unreachable at boot should cost a slow first request, not a process that
+        refuses to start.
+        """
+        ltm = self._conf.episodic_memory.long_term_memory
+        warmers: list[tuple[str, Callable[[], Awaitable[object]]]] = [
+            ("episode storage", self._resources.get_episode_storage),
+            ("episodic memory manager", self._resources.get_episodic_memory_manager),
+        ]
+        # The long-term-memory config is polymorphic over the backend, so read
+        # the resource names defensively rather than assuming a concrete class.
+        for label, getter, name in (
+            ("embedder", self._resources.get_embedder, getattr(ltm, "embedder", None)),
+            ("reranker", self._resources.get_reranker, getattr(ltm, "reranker", None)),
+            (
+                "vector store",
+                self._resources.get_vector_store,
+                getattr(ltm, "vector_store", None),
+            ),
+            (
+                "segment store",
+                self._resources.get_segment_store,
+                getattr(ltm, "segment_store", None),
+            ),
+        ):
+            if name:
+                warmers.append((label, partial(getter, name)))
+
+        for label, warm in warmers:
+            try:
+                await warm()
+            except Exception:
+                logger.warning(
+                    "Could not warm %s at startup; the first request will pay for it",
+                    label,
+                    exc_info=True,
+                )
 
     async def stop(self) -> None:
         """


### PR DESCRIPTION
Every resource a search needs is lazy-loaded behind a lock, so the first search
into a fresh worker imports its module tree and builds pydantic schemas for it.
That work is synchronous, so it blocks the event loop, and it is paid **once per
uvicorn worker** because each worker is a separate process.

Kubernetes has already routed traffic by then: `/api/v2/health` touches none of
it and answers in about a millisecond while a search on the same worker takes
seconds. In effect the readiness probe reports ready before the process can
serve its main endpoint.

`start()` already resolves the session data manager. This extends that to the
rest of the search path — episode storage, the episodic memory manager, and the
embedder, reranker, vector store and segment store named by the long-term-memory
config — so the cost lands in front of the readiness probe.

Failures are logged and swallowed: each of these is retried lazily on the request
path anyway, so a store that happens to be unreachable at boot should cost a slow
first request rather than a process that will not start. The long-term-memory
config is polymorphic over the backend, so resource names are read with `getattr`
rather than assuming a concrete class.

## Measured

Deployed platform, k3s, four uvicorn workers, 12k episodes, Qdrant and PostgreSQL
on separate hosts. First search after a restart:

| | first search after restart | mean |
|---|---|---|
| stock | 2.22 / 2.69 / 3.15 / 2.74 s | **2.70 s** |
| with this change | 1.40 / 0.92 / 1.00 s | **1.11 s** |

Reproduced a second way — this change built into an image rather than mounted —
at **1.51 s**, so the effect holds across two delivery mechanisms.

No `Could not warm` warnings, so every resource resolved cleanly. **Rollout to
Ready was unchanged** (41.8 / 43.8 s against 43.1 / 42.8 s): the startup probe’s
10 s period absorbs the shift, so this is free at the current probe cadence.

## What it does not fix

Partition creation is session-scoped, so a new project’s first search still pays
its own first touch. Measured on a cold pod after this change,
`get_session_info` and `open_or_create_partition` still run once per worker — but
at **4.1 ms and 6.3 ms**, against ~2,020 ms before. Those two seconds were never
these operations doing work; they were this import stall, charged to whichever
spans happened to be open when it landed.

## Caveats for review

- **Not built and tested from this branch alone.** The image that produced the
  numbers above carried this change *and* the asyncpg-timeout fix, on top of the
  Qdrant wiring from #1532. Individually this branch is unbuilt.
- **#1532 should land first.** Without its `EXTRAS` build arg, an image built for
  testing has no `qdrant_client` and 500s on search.
- `ruff check` and `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)