### PR TITLE
fix(db): bound asyncpg statement and connect time so a dead socket recovers

### DIFF
--- a/packages/server/src/memmachine_server/common/configuration/database_conf.py
+++ b/packages/server/src/memmachine_server/common/configuration/database_conf.py
@@ -448,6 +448,25 @@ class SqlAlchemyConf(YamlSerializableMixin, PasswordMixin):
             "that were reset server-side. Internal default is False."
         ),
     )
+    command_timeout: float | None = Field(
+        default=60.0,
+        description=(
+            "Seconds a single statement may run before the driver cancels it "
+            "(asyncpg only). Without it a connection whose peer has stopped "
+            "responding is not an error but a wait: the kernel retransmits with "
+            "exponential backoff for around fifteen minutes, and the request - "
+            "including `pool_pre_ping`'s own liveness check, which is written "
+            "into the same dead socket - blocks for all of it. Set to null to "
+            "restore the unbounded behaviour."
+        ),
+    )
+    connect_timeout: float | None = Field(
+        default=10.0,
+        description=(
+            "Seconds to wait for a new connection to be established "
+            "(asyncpg only). Set to null to wait indefinitely."
+        ),
+    )
 
     @property
     def schema_part(self) -> str:

--- a/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from memmachine_server.common.configuration.database_conf import (
     DatabasesConf,
     Neo4jConf,
+    SqlAlchemyConf,
     SQLiteVectorStoreConf,
     SQLiteVectorStoreEngine,
 )
@@ -43,6 +44,33 @@ if TYPE_CHECKING:
     from qdrant_client import AsyncQdrantClient
 
 logger = logging.getLogger(__name__)
+
+
+def _sql_engine_kwargs(conf: SqlAlchemyConf) -> dict[str, Any]:
+    """Build create_async_engine keywords, omitting anything left unset."""
+    kwargs: dict[str, Any] = {"echo": False, "future": True}
+    for attr in (
+        "pool_size",
+        "max_overflow",
+        "pool_timeout",
+        "pool_recycle",
+        "pool_pre_ping",
+    ):
+        value = getattr(conf, attr)
+        if value is not None:
+            kwargs[attr] = value
+
+    # Gate on the driver, not the dialect: these reach asyncpg.connect() and
+    # mean nothing to aiosqlite or aiomysql.
+    if conf.driver == "asyncpg":
+        connect_args: dict[str, float] = {}
+        if conf.command_timeout is not None:
+            connect_args["command_timeout"] = conf.command_timeout
+        if conf.connect_timeout is not None:
+            connect_args["timeout"] = conf.connect_timeout
+        if connect_args:
+            kwargs["connect_args"] = connect_args
+    return kwargs
 
 
 class DatabaseManager:
@@ -325,22 +353,7 @@ class DatabaseManager:
             if not conf:
                 raise ValueError(f"SQL config '{name}' not found.")
 
-            engine_kwargs: dict[str, bool | int] = {
-                "echo": False,
-                "future": True,
-            }
-            if conf.pool_size is not None:
-                engine_kwargs["pool_size"] = conf.pool_size
-            if conf.max_overflow is not None:
-                engine_kwargs["max_overflow"] = conf.max_overflow
-            if conf.pool_timeout is not None:
-                engine_kwargs["pool_timeout"] = conf.pool_timeout
-            if conf.pool_recycle is not None:
-                engine_kwargs["pool_recycle"] = conf.pool_recycle
-            if conf.pool_pre_ping is not None:
-                engine_kwargs["pool_pre_ping"] = conf.pool_pre_ping
-
-            engine = create_async_engine(conf.uri, **engine_kwargs)
+            engine = create_async_engine(conf.uri, **_sql_engine_kwargs(conf))
             if validate:
                 await self.validate_sql_engine(name, engine)
             self.sql_engines[name] = engine


### PR DESCRIPTION
A pooled connection whose peer stops responding is not an error, it is a wait.
The kernel retransmits with exponential backoff — observed at `tcp_retries2`
attempt 13, `Send-Q` stuck at 34 bytes and unchanged over 20 seconds — and
asyncpg has no deadline of its own, so the request blocks for the whole of it.

`pool_pre_ping` does not help: its liveness `SELECT` is written into the same
dead socket and waits with everything else.

**The failure this produces is worse than a slow request.** The pool never
discards the dead connections, so the process stays wedged *after the network
recovers* and only a restart clears it. Seen twice on a benchmark deployment:
searches timing out indefinitely while `/api/v2/health` answered in about a
millisecond, four uvicorn workers idle in `select()`, no lock contention in
Postgres, and a fresh connection from the same pod completing in **18 ms**.

`create_async_engine` was passed no `connect_args`, so nothing bounded either the
statement or the connect. This adds `command_timeout` and `connect_timeout`,
defaulted to 60 s and 10 s and settable to null for the old behaviour. Both are
gated on `driver == "asyncpg"`: they reach `asyncpg.connect()` and mean nothing to
aiosqlite or aiomysql.

The keyword assembly moves into a helper, because adding a branch to
`async_get_sql_engine` pushed it past ruff’s complexity limit and the repeated
"if not None" lines were asking for it.

## Verified by fault injection

`iptables DROP` on the pod’s traffic to Postgres:5432, so pooled connections wedge
exactly as they did in the incident:

| | under the fault | **after the fault is removed** |
|---|---|---|
| stock | no response at 150 s (cap) | **still hung, no response at 90 s** |
| with this change | 500 after 194 s | **200 in 1.5 s** |

**The recovery is the point.** The stock build stays wedged once the network is
healthy again, which is what forced the restarts.

## What this does not claim

Under a *total* outage the request still takes ~194 s to fail rather than ~60 s.
A search touches three separate stores, so it pays a timeout per store: the bound
is roughly `command_timeout` × stores touched, not `command_timeout`. Lowering the
default would shorten it proportionally.

**60 s is chosen, not tuned.** It is generous against real query times here, which
are milliseconds, and is left configurable rather than optimised. Reviewers who
know the workload better should push back on it.

## Caveats for review

- **Not built and tested from this branch alone** — the image used for the fault
  injection carried this change and the startup-warming fix together, on top of
  the Qdrant wiring from #1532.
- `ruff check` and `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)