### PR TITLE
Add a deployment sizing calculator under tools/sizing

### DIFF
--- a/tools/sizing/README.md
+++ b/tools/sizing/README.md
@@ -1,0 +1,477 @@
+# MemMachine deployment sizing calculator
+
+Work out what hardware a MemMachine deployment needs to serve a given amount of
+traffic.
+
+You give it a **design peak** — the worst rate the system must sustain for five
+minutes, in operations per second — and a traffic mix, and it tells you how many
+API servers, vector-store machines and PostgreSQL servers to order, how many
+embedding and agent-model GPU cards, how much RAM and disk the stored episodes
+will take, how many PostgreSQL connections the deployment will open, and how
+much network bandwidth it will use.
+
+## Two things that sound alike and are not
+
+Read this before you set anything. Two ideas in this calculator use words that
+look similar, and a reader who mixes them up will size the deployment wrongly.
+
+**Agent-mode search is a property of a request.** It is the `agent_mode` flag on
+a MemMachine search. A search sent with that flag on does not do one lookup; it
+fans out into a multi-hop retrieval of about 22 embedding calls, 22 vector
+searches, 44 database reads and one or two language-model calls. It is set per
+request. It is the third share of the traffic mix, and the flag that sets it is
+`--agent`. It is a **cost** multiplier: it says how expensive a request is.
+
+**An automated client is a property of a caller.** It is a program that sends
+requests in a loop rather than a person typing in a chat window. One in a
+five-second tool loop is assumed to send about 0.4 operations per second, where
+a human chat session sends 0.011 to 0.028. It is a population count on the
+`users` subcommand, and the flag that sets it is `--automated`. It is a **rate**
+multiplier: it says how fast a caller sends requests.
+
+The two are independent. A person can send agent-mode searches, and an automated
+client can send nothing but plain searches. That is why each population carries
+its own traffic mix: see [`users`](#users--a-caller-population-to-the-capacity-it-needs).
+
+Every number in the report's tables of findings carries one of four labels, so
+you can always see how much weight it will bear:
+
+| Label | Meaning |
+| --- | --- |
+| `measured` | It came out of a real benchmark run, and the label names that run: its date, the configuration it ran with, or both. |
+| `derived` | The program computed it from measured numbers and from the assumptions below. |
+| `estimate` | Nobody has measured it. Benchmark it before ordering hardware against it. |
+| `assumption` | A planning choice, not a finding. |
+
+Two tables are different. The **Qdrant node choice** table and the
+**sensitivity** table show what-ifs rather than findings — one row of each is
+the answer and the rest are what the alternatives would have cost — so their
+rows carry no label of their own, and the note above each table says where its
+numbers come from instead.
+
+The JSON, from `--json` or from `/api/calc`, carries the numbers without
+labels; its top-level `run_name` field is the name of the run (`pilot`,
+`target`, `scale`, `custom` or `web`), not one of the four labels above.
+
+## What it does not do
+
+- **It does not price high availability.** A second copy of every vector, a
+  PostgreSQL standby, a second gateway — none of these are in the counts. They
+  are a separate decision, and a replication factor of 2 doubles both the hot
+  vector RAM and the vector-store machine count.
+- **It does not price a cross-encoder reranker.** The measured throughput anchor
+  was taken with the `rrf-hybrid` reranker, which runs on the API server's own
+  CPU. A cross-encoder scores every query-and-result pair on a GPU; it would add
+  GPU cards and it would invalidate the anchor.
+- **It does not choose a machine class for PostgreSQL or the vector store.**
+  Only the API server has one that was benchmarked. The RAM of a vector-store
+  machine is sized by the model, so the report gives it; the vCPU of either
+  machine, and the RAM of the PostgreSQL machine, are undecided and the report
+  says so rather than repeating the API server's figures.
+- **It does not measure your deployment.** It is arithmetic over a small set of
+  named inputs. Meter your real operations per second per API key and feed the
+  metered rate back in.
+
+## Requirements
+
+Python 3.10 or newer, and nothing else. The calculator is a single file that
+imports only the standard library.
+
+## Running it
+
+Use [uv](https://docs.astral.sh/uv/) with `--no-project`. The calculator needs
+no dependencies, and `--no-project` tells uv to ignore this repository's own
+project environment rather than build it just to run one script:
+
+```bash
+cd tools/sizing
+uv run --no-project python memmachine_sizing.py --help
+```
+
+Plain `python memmachine_sizing.py --help` works just as well if you already
+have an interpreter on your path.
+
+## Subcommands
+
+### `tier` — the full report for one named tier
+
+Three tiers are built in: `pilot` (20 ops/s), `target` (100 ops/s) and `scale`
+(1,000 ops/s).
+
+```bash
+uv run --no-project python memmachine_sizing.py tier target
+```
+
+Prints the inputs, the per-second demand, the machine counts, how the API server
+count was reached, storage, the vector-store machine choice, PostgreSQL,
+network, how many callers of each kind the capacity holds, and a sensitivity
+table showing what
+the agent-mode search rate costs. That table always holds the run's own
+agent-mode rate as well as the four fixed ones, and marks it `<- this run`,
+because a rate of 2.04 and a rate of 2.0 both print as "2.0" and are two
+different sizings. Add `--json` for the raw result.
+
+Any work at all costs a machine. A traffic mix with no adds in it stores
+nothing, and so does a retention of zero days, but both still search vectors, so
+the order is never fewer than one vector-store machine.
+
+### `calc` — the full report for any rate
+
+```bash
+uv run --no-project python memmachine_sizing.py calc --ops 250 --agent 4 --plain 51
+```
+
+The same report for any design peak, traffic mix, retention period and vector
+shape. `--ops` is required.
+
+### `users` — a caller population to the capacity it needs
+
+```bash
+uv run --no-project python memmachine_sizing.py users --humans 5000 --automated 40
+```
+
+Converts a population of callers into the capacity it needs. There are two kinds
+of caller: **human chat sessions**, people typing, at 0.011 to 0.028 operations
+per second each; and **automated clients**, programs sending requests in a loop,
+at 0.4 operations per second each. `--automated` counts callers. It has nothing
+to do with `--agent`, which is the agent-mode share of the requests themselves.
+
+Each population carries its own traffic mix, because the kind of caller and the
+kind of request go together in practice: automated clients may use agent-mode
+search on nearly every call while people rarely do. Give each one three numbers,
+`adds/plain/agent-mode`, separated by `/` or by `,`:
+
+```bash
+uv run --no-project python memmachine_sizing.py users \
+  --humans 5000 --automated 200 --human-mix 48/50/2 --automated-mix 20/20/60
+```
+
+Both mixes default to the model's own default mix, `45/45/10`, so leaving them
+off changes nothing.
+
+The report gives four things: the operations per second each population demands,
+the two mixes and the **blended mix** across the whole population, the smallest
+tier that holds the demand, and the machines that demand needs. The blended mix
+is the two mixes averaged, each weighted by the operations its population demands
+at the busy end of the human rate — the rate the report tells you to plan for.
+That blended mix, and not the program's default mix, is what sizes the machines,
+so a population that is mostly automated clients doing multi-hop retrieval orders
+more hardware than the same operations per second at the default mix would.
+
+The same headcount can need a pilot tier or a scale tier depending on how many of
+the callers are automated clients rather than people, and on how much agent-mode
+search each population does. A population of nobody demands no operations, and
+the report says there is nothing to size rather than naming a tier for it.
+
+`--agents`, which used to mean the count of automated clients, is refused by
+name. It was one letter from `--agent` and meant something completely different.
+
+### `validate` — the published figures for all three tiers
+
+```bash
+uv run --no-project python memmachine_sizing.py validate --out sizing-numbers.json
+```
+
+Prints the figures this program publishes for the `pilot`, `target` and `scale`
+tiers, together with every named constant listed in
+[Every input, and what it is set to](#every-input-and-what-it-is-set-to), as
+`name: value` lines — `name` here is the key, not one of the four labels above.
+It writes the same pairs to a JSON file: `sizing-numbers.json` in the current
+directory unless `--out` says otherwise. Use it to check figures quoted
+elsewhere against this program mechanically.
+
+Which keys it writes is decided by a named list in the program rather than by
+walking the model's internals, and the test suite pins that list, so a key that
+quietly disappears is a failing test. Two parts of it follow the inputs: there
+is one sensitivity entry per row of the printed sensitivity table, and forcing
+a vector-store machine size that is not one of the three offered adds that size
+to the comparison.
+
+It is not a dump of everything the model computes. The raw byte counts behind
+the GB and Mbps figures stay out. The chosen vector-store machine size is
+exported in full — its usable RAM, its total RAM bought and its fill — but the
+other sizes in the comparison are exported only as a machine count.
+
+### `serve` — the web form and a JSON endpoint
+
+```bash
+uv run --no-project python memmachine_sizing.py serve --port 8899
+```
+
+Serves an HTML form at `/` and the same figures as JSON at `/api/calc`. The page
+is self-contained: it loads no external stylesheets, fonts or scripts and needs
+no internet access. There is also a `/healthz` endpoint that answers `ok`.
+
+**This is a local development server, not a service.** It has no
+authentication, no rate limiting and no request logging you would want to keep,
+and it answers whoever can reach the port. Run it on your own machine and do
+not put it on an address the public can reach. It drops a connection that stays
+silent for 10 seconds (`SERVER_REQUEST_TIMEOUT_S`), so a client that connects
+and then sends nothing cannot hold a thread open indefinitely.
+
+The form binds to `127.0.0.1` unless `--host` says otherwise. It carries every
+input that `tier`, `calc` and `users` accept as a flag, so nothing has to be set
+by editing code. Leave the "RAM per vector-store machine" box empty — or type
+`automatic` — and the size is chosen for you, exactly as it is when `--node-gb`
+is not given.
+
+Below the sizing boxes are four more for a caller population: "Human chat
+sessions", "Automated clients" and a traffic mix for each. Leave both counts
+empty and the page says nothing about a population, exactly as it did before it
+could take one. Fill in either count and the page adds the same tables the
+`users` subcommand prints — the demand from each population, the blended mix and
+the machines that mix needs — above the sizing report. "Automated clients" counts
+callers that are programs; the "Agent-mode searches per 100 ops" box above it is
+the share of the requests themselves.
+
+Text that is not a number at all comes back as a 400 whose reason names the box
+it came from and quotes what was typed into it, and the page puts the cursor in
+that box. A number that is out of range — negative, zero, or above one of the
+sanity bounds — also comes back as a 400 with the reason, on the page and in the
+JSON alike, but that reason is worded in the model's own terms and no box is
+highlighted.
+
+Either way an input has one name across every message about it: the box
+labelled "Bytes per number" is called "bytes per number" whether what was typed
+in it is zero or too large, never "bytes per value". The value is quoted as it
+was given, so a refused 1,000,000,001 never prints as the 1,000,000,000 it is
+said to exceed.
+
+Every other sizing box has to be answered. A form submission always sends all
+eight of them, so an empty one means the reader cleared it, and the page says
+which box is blank rather than quietly sizing for the default. A parameter left
+out of the URL altogether is different, and still takes the default — which is
+why `/api/calc?ops=100` works. The "RAM per vector-store machine" box is the one
+place where empty is itself an answer, and the two population count boxes are
+the other: empty there means no callers of that kind.
+
+One misspelling is answered specially. `agents` is not a setting, and it is not
+answered with "did you mean agent?", because a reader who types `agents` almost
+certainly wants `automated`, the count of callers that are programs — not the
+agent-mode share of the traffic mix. The message says so.
+
+A setting the calculator does not know comes back as a 400 rather than being
+ignored. `/api/calc?ops=100&retention_day=1` — `retention_day` singular, a typo
+— names the setting it does not recognise and suggests `retention_days`, on the
+page and in the JSON alike, instead of quietly sizing for the 90-day default.
+The suggestion ignores case, so `OPS` and `Ops` are both answered with `ops`. A
+setting given twice in one web address is refused the same way, because there
+is no way to tell which value was meant.
+
+There is no favicon: `/favicon.ico` answers `204 No Content`, so a page load
+leaves nothing in the browser's console.
+
+```
+http://127.0.0.1:8899/api/calc?ops=100&add=45&plain=45&agent=10&retention_days=90&dims=1024&bytes_per_value=1
+```
+
+Add `&node_gb=512` to force the vector-store machine size:
+
+```
+http://127.0.0.1:8899/api/calc?ops=100&node_gb=512
+```
+
+Add `&humans=5000&automated=40` to size from a caller population instead, with
+`&human_mix=48/50/2&automated_mix=20/20/60` to give each population its own
+traffic mix. The answer then carries a `population` block alongside the sizing:
+
+```
+http://127.0.0.1:8899/api/calc?ops=100&humans=5000&automated=40&human_mix=48/50/2&automated_mix=20/20/60
+```
+
+## Every input, and what it is set to
+
+This is the whole model. Anything with a flag in the "How to set it" column is a
+knob you can turn from the command line, and every input that `tier`, `calc` and
+`users` accept as a flag is also a box on the web form. The flags under "Output
+and serving" control how a result is printed or served, not what is sized, so
+they are not boxes. Everything else is a named constant at the top of
+`memmachine_sizing.py`, and you change it by editing that file.
+
+| Input | How to set it | Default | Label |
+| --- | --- | --- | --- |
+| **Traffic** | | | |
+| Design peak, operations per second | `--ops` (`calc`), or the tier name (`tier`) | required for `calc`; `pilot` 20, `target` 100, `scale` 1,000 | assumption |
+| Built-in tier rates | `TIER_OPS_PER_S` | pilot 20, target 100, scale 1,000 ops/s | assumption |
+| Adds per 100 operations | `--add` | 45 | assumption — never measured |
+| Plain searches per 100 operations | `--plain` | 45 | assumption — never measured |
+| Agent-mode searches per 100 operations (a request flag, not a kind of caller) | `--agent` | 10 | assumption — never measured |
+| Agent-mode rates in the sensitivity table | `SENSITIVITY_AGENT_RATES` | 0, 2, 10, 25 per second | assumption (display only) |
+| **Fan-out per request** | | | |
+| Embedding calls per add | `ADD_EMBEDS` | 1 | derived — read from the MemMachine source, 30 Aug 2026 |
+| Vector writes per add | `ADD_VECTOR_WRITES` | 1 | derived — read from the source |
+| PostgreSQL statements per add | `ADD_POSTGRES_STATEMENTS` | 2 | derived — read from the source |
+| Language-model calls per add | `ADD_LLM_CALLS` | 0 | derived — read from the source |
+| Embedding calls per plain search | `PLAIN_EMBEDS` | 2 | derived — read from the source |
+| Embedding calls per plain search, once every request sends `types: ["episodic"]` | `PLAIN_EMBEDS_WITH_TYPES_FIX` | 1 | derived — read from the source |
+| Vector searches per plain search | `PLAIN_VECTOR_SEARCHES` | 1 | derived — read from the source |
+| PostgreSQL statements per plain search | `PLAIN_POSTGRES_STATEMENTS` | 2 | derived — read from the source |
+| Language-model calls per plain search | `PLAIN_LLM_CALLS` | 0 | derived — read from the source |
+| Embedding calls per agent-mode search | `AGENT_EMBEDS` | 22 | derived — read from the source |
+| Vector searches per agent-mode search | `AGENT_VECTOR_SEARCHES` | 22 | derived — read from the source |
+| PostgreSQL statements per agent-mode search | `AGENT_POSTGRES_STATEMENTS` | 44 | derived — read from the source |
+| Language-model calls per agent-mode search, low | `AGENT_LLM_CALLS_LOW` | 1 | estimate |
+| Language-model calls per agent-mode search, high | `AGENT_LLM_CALLS_HIGH` | 2 | estimate |
+| Language-model calls per agent-mode search, used for sizing | `AGENT_LLM_CALLS_PLANNING` | 1.5 | estimate — the midpoint |
+| **API servers** | | | |
+| Searches per second per server | `API_SEARCHES_PER_S_PER_SERVER` | 180 | measured 30 Aug 2026 |
+| Utilization ceiling | `API_UTILIZATION_CEILING` | 0.60 | assumption |
+| Worker processes per server | `API_WORKERS_PER_SERVER` | 8 | measured 30 Aug 2026 — 8 is the knee |
+| vCPU per API server | `API_SERVER_VCPU` | 16 | measured — the machine class benchmarked on 30 Aug 2026 |
+| RAM per API server | `API_SERVER_RAM_GB` | 32 GB | measured — the machine class benchmarked on 30 Aug 2026 |
+| Cost of one add, in plain-search-equivalents | `ADD_COST_IN_PLAIN_SEARCH_EQUIVALENTS` | 1.0 | estimate — rounds the order up |
+| **GPU cards** | | | |
+| Embedding requests per second per card, low | `EMBED_CARD_REQUESTS_PER_S_LOW` | 300 | estimate — never benchmarked |
+| Embedding requests per second per card, high | `EMBED_CARD_REQUESTS_PER_S_HIGH` | 500 | estimate — never benchmarked |
+| Language-model calls per second per card | `AGENT_LLM_CALLS_PER_S_PER_CARD` | 15 | estimate — never benchmarked |
+| GPU utilization ceiling | `GPU_UTILIZATION_CEILING` | 0.60 | assumption |
+| Spare cards per GPU role | `GPU_SPARE_CARDS` | 1 | assumption |
+| **Vector store** | | | |
+| Retention, days | `--retention-days` | 90 | assumption — a placeholder; retention is undecided |
+| Vector dimensions | `--dims` | 1,024 | assumption — a whole number, fixed before the first episode is ingested |
+| Bytes stored per number | `--bytes-per-value` | 1 (int8 quantized) | assumption — fix before the first episode is ingested |
+| RAM per vector-store machine | `--node-gb`, or the `node_gb` box on the web form | chosen automatically | assumption — the automatic choice buys the least total RAM |
+| Machine sizes offered | `QDRANT_NODE_RAM_OPTIONS_GB` | 256, 512, 768 GB | assumption |
+| Share of a machine's RAM that may be used | `QDRANT_NODE_FILL_LIMIT` | 0.70 | assumption |
+| Index overhead on hot vector RAM | `QDRANT_INDEX_OVERHEAD_FACTOR` | 1.5 | assumption |
+| Fill at which the report warns of a tight fit | `QDRANT_TIGHT_FIT_WARN_FRACTION` | 0.95 | assumption (display only — it changes no machine count) |
+| **Sanity bounds — a refusal limit only; no machine count moves because of these** | | | |
+| Largest design peak accepted | `MAX_OPS_PER_S` | 1,000,000,000 ops/s | assumption — far above the 1,000 ops/s scale tier |
+| Longest retention accepted | `MAX_RETENTION_DAYS` | 36,500 days (100 years) | assumption |
+| Most vector dimensions accepted | `MAX_VECTOR_DIMS` | 1,000,000 | assumption — models today are 384 to 4,096 |
+| Most bytes per number accepted | `MAX_BYTES_PER_VALUE` | 64 | assumption — int8 is 1, float64 is 8 |
+| Largest vector-store machine accepted | `MAX_NODE_GB` | 1,000,000 GB | assumption |
+| **Disk** | | | |
+| Bytes per number in the full-precision vector kept on disk | `ORIGINAL_VECTOR_BYTES_PER_VALUE` | 4 | estimate |
+| Identifier and payload bytes per episode on disk | `QDRANT_DISK_PAYLOAD_BYTES_PER_EPISODE` | 256 | estimate |
+| Segment and index overhead on vector-store disk | `QDRANT_DISK_OVERHEAD_FACTOR` | 1.3 | estimate |
+| Episode text, low case | `EPISODE_TEXT_BYTES_LOW` | 800 bytes | estimate |
+| Episode text, high case | `EPISODE_TEXT_BYTES_HIGH` | 2,400 bytes | estimate |
+| PostgreSQL row overhead per episode | `POSTGRES_ROW_OVERHEAD_BYTES` | 400 bytes | estimate |
+| PostgreSQL index bytes per episode | `POSTGRES_INDEX_BYTES_PER_EPISODE` | 300 bytes | estimate |
+| PostgreSQL bloat between vacuums | `POSTGRES_BLOAT_FACTOR` | 1.4 | estimate |
+| **PostgreSQL** | | | |
+| Connection pool size per worker | `POSTGRES_POOL_SIZE` | 5 | measured 30 Aug 2026 |
+| Connection overflow per worker | `POSTGRES_MAX_OVERFLOW` | 10 | measured 30 Aug 2026 |
+| Gateway connections per API server | `GATEWAY_CONNECTIONS_PER_API_SERVER` | 20 | assumption |
+| Chart default for `max_connections` | `POSTGRES_CHART_DEFAULT_MAX_CONNECTIONS` | 100 | measured — this default ran out of connections on 30 Aug 2026 |
+| Largest `max_connections` ever proven to work | `POSTGRES_PROVEN_MAX_CONNECTIONS` | 600 | measured 30 Aug 2026 — cleared every error |
+| PostgreSQL servers per deployment | `POSTGRES_SERVERS_PER_TIER` | 1 | assumption — never benchmarked at these statement rates |
+| **Network message sizes** | | | |
+| Add request | `NS_ADD_REQUEST_BYTES` | 1,200 bytes | estimate |
+| Add reply | `NS_ADD_RESPONSE_BYTES` | 300 bytes | estimate |
+| Search request | `NS_SEARCH_REQUEST_BYTES` | 600 bytes | estimate |
+| Bytes per episode returned to the caller | `NS_RESPONSE_BYTES_PER_EPISODE` | 900 bytes | estimate |
+| Episodes returned per plain search | `PLAIN_SEARCH_EPISODES_RETURNED` | 10 | measured configuration (`top_k` 10) |
+| Episodes returned per agent-mode search | `AGENT_SEARCH_EPISODES_RETURNED` | 20 | estimate |
+| Written answer in an agent-mode reply | `NS_AGENT_ANSWER_BYTES` | 2,000 bytes | estimate |
+| Embedding request | `EMBED_REQUEST_BYTES` | 1,000 bytes | estimate |
+| Embedding reply envelope | `EMBED_RESPONSE_ENVELOPE_BYTES` | 200 bytes | estimate |
+| Vector-store query envelope | `QDRANT_SEARCH_REQUEST_ENVELOPE_BYTES` | 300 bytes | estimate |
+| Candidates returned per vector search | `QDRANT_CANDIDATES_PER_SEARCH` | 50 | measured configuration (`vector_search_limit` 50) |
+| Bytes per candidate | `QDRANT_BYTES_PER_CANDIDATE` | 200 bytes | estimate |
+| Vector-store write envelope | `QDRANT_UPSERT_ENVELOPE_BYTES` | 500 bytes | estimate |
+| Vector-store write reply | `QDRANT_UPSERT_RESPONSE_BYTES` | 200 bytes | estimate |
+| PostgreSQL bytes per statement, both directions | `POSTGRES_BYTES_PER_STATEMENT` | 1,800 bytes | estimate |
+| Language-model prompt | `LLM_CALL_REQUEST_BYTES` | 8,000 bytes | estimate |
+| Language-model answer | `LLM_CALL_RESPONSE_BYTES` | 2,000 bytes | estimate |
+| TLS, HTTP and TCP framing overhead | `NETWORK_PROTOCOL_OVERHEAD_FACTOR` | 1.2 | estimate |
+| **Callers** — how fast a caller sends requests, which is a different question from what kind of request it sends | | | |
+| Human chat sessions in a population | `--humans` (`users`), or the `humans` box on the web form | required for `users`; blank on the form | input |
+| Automated clients in a population | `--automated` (`users`), or the `automated` box on the web form | 0 | input |
+| Traffic mix of the human chat sessions | `--human-mix` (`users`), or the `human_mix` box on the web form | `45/45/10` | assumption — never measured |
+| Traffic mix of the automated clients | `--automated-mix` (`users`), or the `automated_mix` box on the web form | `45/45/10` | assumption — never measured |
+| Operations per second per human chat session, low | `HUMAN_SESSION_OPS_PER_S_LOW` | 0.011 | estimate — never measured |
+| Operations per second per human chat session, high | `HUMAN_SESSION_OPS_PER_S_HIGH` | 0.028 | estimate — never measured |
+| Operations per second per automated client | `AUTOMATED_CLIENT_OPS_PER_S` | 0.4 (a 5-second tool loop) | estimate — never measured |
+| Operations per human prompt | `OPS_PER_HUMAN_PROMPT` | 2 | estimate — used only to describe the two rates above |
+| **Output and serving** | | | |
+| Where `validate` writes its JSON | `--out` (`validate`) | `sizing-numbers.json` in the current directory | input |
+| Raw JSON instead of a table | `--json` (`tier`, `calc`) | off | input |
+| Address the web server binds to | `--host` (`serve`) | `127.0.0.1` | input |
+| Port the web server binds to | `--port` (`serve`) | 8000 | input |
+| Seconds the web server waits on a silent connection | `SERVER_REQUEST_TIMEOUT_S` | 10 | assumption (serving only — it changes no machine count) |
+
+Units: **GB** means 10<sup>9</sup> bytes, **TB** means 10<sup>12</sup> bytes and
+**Mbps** means 10<sup>6</sup> bits per second, throughout.
+
+## The measured anchor
+
+One measurement carries most of the machine counts: **180 plain searches per
+second per API server**.
+
+It was measured on 30 August 2026 on a 16-vCPU AMD EPYC server (AWS c8a.4xlarge
+class), with 8 worker processes and 128 concurrent requests, using OpenAI
+`text-embedding-3-small` at about 180–190 ms per call, over a 12,000-episode
+corpus, at `top_k` 10 and `expand` 0, with the `rrf-hybrid` reranker enabled and
+with the vector store and PostgreSQL each on their own host.
+
+If that anchor is wrong, every API server count moves in direct proportion:
+halve it and the server count doubles.
+
+## What the model assumes
+
+**The traffic mix is an assumption nobody has measured.** The default split of
+45 adds, 45 plain searches and 10 agent-mode searches per 100 operations is a
+guess about how the service will be used. It is the second-largest lever in the
+whole model, because one agent-mode search costs about 22 plain searches — so
+the agent-mode share moves the hardware order more than any tuning does. Every
+report prints a sensitivity table showing what happens to the API server count
+as that share changes. Measure your own mix and pass it in with `--add`,
+`--plain` and `--agent`. Remember what that share is: agent-mode search is a
+request flag, not a kind of caller. If your traffic comes from two very
+different kinds of caller, give each one its own mix on the `users` subcommand
+with `--human-mix` and `--automated-mix`, and let it blend them for you.
+
+**The reranker costs nothing extra, because its cost is already in the anchor.**
+The 180/s figure was measured with `rrf-hybrid` switched on — reciprocal rank
+fusion over BM25 and identity, running on the API server's own CPU at roughly
+one core-millisecond per search. The model therefore adds nothing for it. Switch
+to a cross-encoder reranker and this stops being true: that scores every
+query-and-result pair on a GPU, so it adds cards to the order and invalidates
+the anchor.
+
+**The embedding-card rate has never been benchmarked.** The 300–500 embedding
+requests per second per H100-class card is the single largest unmeasured number
+in the model, and the embedding GPU count is wrong in direct proportion if it is
+wrong. Benchmark your own card with your own model before buying any GPU.
+
+**One add is charged as one plain search of API work.** The benchmark measured
+search only, so the cost of an add relative to a search is unknown. Charging
+them equally rounds the order up, not down.
+
+**Nothing here demonstrates five minutes of sustained service.** Every benchmark
+run started from a freshly restarted server, so these are clean-start numbers.
+A design peak is the worst rate the system must hold for five minutes; treat the
+anchor accordingly.
+
+## Tests
+
+```bash
+cd tools/sizing
+uv run --no-project python -m unittest -v
+```
+
+The tests are written from the model rather than from the code: nearly every
+expected number is worked out by hand and written as a literal, so a failure
+means the program and the model disagree.
+
+A few tests are different. They check that the command line and the web
+endpoint return the same numbers as the library function both of them call.
+Those catch a broken front door, not a broken model, and each one sits beside a
+hand-worked literal test of the same figures.
+
+The suite also checks that the calculator imports nothing outside the standard
+library, that every bad input exits with a message rather than a traceback,
+that the web server answers correctly, that every row of every labelled report
+table carries a label, and that every named constant in the table above reaches
+the file `validate` writes.
+
+The repository's linter must also be clean:
+
+```bash
+uv run --no-project --with ruff ruff check tools/sizing
+```
+
+Name the path: `tools` is in the `exclude` list in the repository's
+`pyproject.toml`, so `ruff check .` skips this directory entirely.

--- a/tools/sizing/memmachine_sizing.py
+++ b/tools/sizing/memmachine_sizing.py
@@ -1,0 +1,2898 @@
+#!/usr/bin/env python3
+"""MemMachine deployment sizing calculator.
+
+Work out what a MemMachine deployment needs to serve a given design peak: how
+many API servers, vector-store machines and PostgreSQL servers, how many
+embedding and agent-model GPU cards, how much storage, how many PostgreSQL
+connections and how much network bandwidth. Run ``validate`` to print the
+figures this program publishes for all three tiers, together with every named
+constant the model is built from, and to write them to a JSON file, so any
+figures quoted elsewhere can be checked against this program mechanically.
+
+Two different things in this program are easy to confuse, and a reader who
+confuses them will size the deployment wrongly.
+
+  Agent-mode search is a property of a REQUEST. It is the agent_mode flag on a
+  MemMachine search. A search sent with that flag on fans out into a multi-hop
+  retrieval that costs about 22 plain searches. It is set per request, not per
+  caller. In this program it is the third share of the traffic mix, and the
+  flag that sets it is --agent.
+
+  An automated client is a property of a CALLER. It is a program that sends
+  requests in a loop rather than a person typing in a chat window. It is
+  assumed to send about 0.4 operations per second, where a human chat session
+  sends 0.011 to 0.028. In this program it is a population count on the users
+  subcommand, and the flag that sets it is --automated.
+
+  One says how expensive a request is. The other says how fast a caller sends
+  requests. A caller of either kind can send requests of either kind, which is
+  why each population carries its own traffic mix.
+
+Everything the model uses is listed below. A reader should be able to audit the
+whole model from this docstring alone, without reading the code.
+
+Four labels are used throughout. Every number in the report's tables of
+findings carries one, and so does every constant listed below:
+
+  measured    - it came out of a real test, and the label names that test:
+                its date, the configuration it ran with, or both.
+  derived     - this program computed it from measured numbers and from the
+                assumptions listed here.
+  estimate    - nobody has measured it. Benchmark it before ordering hardware
+                against it.
+  assumption  - a planning choice, not a finding.
+
+Two tables in the report are the exception, because their rows are what-ifs
+rather than findings: the Qdrant node choice table and the sensitivity table.
+The note above each says where its numbers come from. The result dictionary
+that size_deployment returns, and the JSON built from it, carry the numbers
+without labels.
+
+--------------------------------------------------------------------------------
+MEASURED
+--------------------------------------------------------------------------------
+
+API server throughput: 180 plain searches per second per server.
+  Where it came from: a benchmark run of 30 August 2026. Every serving host was
+  a 16-vCPU AMD EPYC server (AWS c8a.4xlarge class): 16 vCPU (virtual CPU cores),
+  32 GiB of RAM, AMD EPYC Turin. The core API measured 178.66 searches per second
+  and the full platform measured 180.31, both at 8 uvicorn worker processes and
+  128 concurrent client requests. Other settings that produced the number: the
+  real OpenAI embedding endpoint (text-embedding-3-small, about 180-190 ms per
+  call), a corpus of 12,000 stored episodes, top_k 10, expand 0 (which makes the
+  internal vector_search_limit 50), the rrf-hybrid reranker enabled, and Qdrant
+  and PostgreSQL each on their own separate host. The platform figure was driven
+  from four client load-generator processes; a single load-generator process
+  measures itself, not the server, at that concurrency.
+  If it is wrong: every API server count below moves in direct proportion.
+  Halve the anchor and the server count doubles.
+
+Eight workers per 16-vCPU server is the knee.
+  Where it came from: the same run. Going from 8 to 16 worker processes bought
+  only 3-5% more throughput, and nothing at all on the steady-state rate. This
+  program assumes 8 workers per server, which is what sets the PostgreSQL
+  connection arithmetic below.
+  If it is wrong: the connection total changes, not the server count.
+
+PostgreSQL connection exhaustion, 30 August 2026.
+  Each worker process opens up to 15 connections (SQLAlchemy pool size 5 plus
+  max_overflow 10). At 8 workers that is 120 connections against PostgreSQL's
+  default max_connections of 100. The core filled the connection table, the
+  gateway could then not get its own connection to check API keys, and it
+  returned HTTP 401 Unauthorized on valid keys. Raising max_connections to 600
+  cleared every error in all 36 test runs. 600 is therefore the largest
+  connection limit this deployment has ever been proven to work at.
+  If it is wrong: nothing in the machine counts moves; the max_connections
+  recommendation does.
+
+The reranker cost is already inside the 180/s anchor.
+  The reranker used in the measured run is rrf-hybrid: reciprocal rank fusion
+  over BM25 and identity. It runs in the API server's own process on its own CPU,
+  at roughly one core-millisecond per search, and needs no GPU. Because the
+  anchor was measured with it switched on, its cost is already paid for in the
+  180/s figure and this program adds nothing for it. Two warnings. First, the
+  library-level benchmark of 30 August ran with no reranker at all, which is one
+  of several reasons the library and API numbers are not comparable. Second, a
+  cross-encoder reranker - the option to reach for when retrieval quality
+  matters more than throughput - is a completely different machine: it scores
+  every query-and-result pair on a GPU, so it would add GPU cards to the order
+  and it would invalidate the 180/s anchor entirely.
+
+--------------------------------------------------------------------------------
+DERIVED
+--------------------------------------------------------------------------------
+
+Fan-out per request. These counts were read from the MemMachine source code on
+30 August 2026. They are not guesses, but they are also not timings - they are
+how many internal calls one API request makes.
+
+  add             1 embedding call,  1 vector write,    2 PostgreSQL statements,
+                  0 language-model calls
+  plain search    2 embedding calls (1 once every request sends
+                  types: ["episodic"]), 1 vector search, 2 PostgreSQL statements,
+                  0 language-model calls
+  agent search   22 embedding calls, 22 vector searches, 44 PostgreSQL
+                  statements, 1 to 2 language-model calls. "Agent search" here
+                  means agent-mode search: a request flag, not a kind of
+                  caller.
+
+  If these are wrong: every demand figure in the program is wrong by the same
+  factor, and the machine counts follow.
+
+API server count. Work is measured in plain-search-equivalents per second:
+  work = vector searches/s + adds/s. One add is counted as one
+  plain-search-equivalent. That is an ESTIMATE that deliberately rounds up: the
+  30 August run measured search only and never measured an add, so the cost of an
+  add against the cost of a search is not known. Servers are then filled to at
+  most 60% of the measured anchor, which leaves headroom for spikes:
+  180 x 0.60 = 108 usable searches/s per server, and
+  servers = ceil(work / 108), always rounding up to a whole machine.
+
+Storage. Episodes stored = adds/s x 86,400 seconds x retention days.
+  Hot vector RAM in Qdrant = episodes x dimensions x bytes per value x 1.5, where
+  the 1.5 is index overhead. Throughout this program GB means 10^9 bytes, not
+  2^30 bytes - decimal gigabytes, the unit hardware is sold in.
+
+One year with nothing ever deleted. The report also publishes hot vector RAM,
+  Qdrant NVMe and PostgreSQL disk for a full year of adds with no deletion at
+  all: episodes in a year = adds/s x 86,400 x 365, multiplied by the same
+  per-episode byte sizes as the retained figures. These three numbers are a year
+  of adds and nothing else, so they do NOT move with the retention setting - at
+  retention 0 they are still a full year. They exist because they are the
+  numbers that make retention a requirement rather than an option.
+
+PostgreSQL connections = API servers x 8 workers x 15 connections per worker,
+  plus a gateway allowance of 20 connections per API server. That total is the
+  max_connections the tier needs. The program prints it next to PostgreSQL's
+  chart default of 100 and next to the 600 that cleared every error on
+  30 August, and it says plainly when the tier needs more connections than have
+  ever been proven to work.
+
+--------------------------------------------------------------------------------
+ESTIMATE - none of the following has ever been measured
+--------------------------------------------------------------------------------
+
+Embedding GPU card rate: 300 to 500 embedding requests per second per H100-class
+  card. Never benchmarked, on any card, with the planned model. Filled to 60%,
+  that is 180 to 300 usable requests per second per card. Cards needed =
+  ceil(demand / usable) + 1 spare card. The program sizes on the embedding
+  demand WITHOUT the types: ["episodic"] fix, because that is the larger and
+  therefore the safer of the two figures.
+  If it is wrong: the embedding GPU order is wrong in direct proportion. This is
+  the single largest unmeasured number in this model and it must be benchmarked
+  before any GPU is bought.
+
+Agent-model GPU: one 8B-class card serves 15 language-model calls per second.
+  This comes from an assumed range of 10 to 20 calls per second at the target
+  tier on a single card; 15 is the planning figure. One spare card is added.
+  If it is wrong: the agent-model card count moves in direct proportion.
+
+Language-model calls per agent-mode search: between 1 and 2. The program sizes
+  on 1.5, the midpoint, and reports the 1-to-2 range alongside it.
+
+One add costs at most one plain search of API work. Never measured; see the API
+  server count note above. It rounds the order up, not down.
+
+Per-call message sizes, used only for the network figures. Every one of these is
+  an estimate, declared as a named constant in the code so that the network
+  numbers can be reproduced by hand:
+    episode text about 800 bytes (a low case) to 2,400 bytes (a high case);
+    add request 1,200 bytes and its reply 300 bytes;
+    search request 600 bytes; 900 bytes per episode returned to the caller;
+    10 episodes returned per plain search (top_k 10, the measured configuration);
+    20 episodes plus a 2,000-byte written answer returned per agent-mode search;
+    embedding request 1,000 bytes, its reply the vector at 4 bytes per number
+      plus 200 bytes of envelope;
+    vector-store query the query vector at 4 bytes per number plus 300 bytes,
+      its reply 50 candidates (vector_search_limit 50, the measured
+      configuration) at 200 bytes each;
+    vector-store write the vector at 4 bytes per number plus 500 bytes, reply
+      200 bytes;
+    PostgreSQL 1,800 bytes per statement counting both directions;
+    one language-model call 8,000 bytes of prompt and 2,000 bytes of answer;
+    and a flat 1.2x multiplier for TLS, HTTP and TCP framing overhead.
+  The east-west total is built on the embedding demand WITHOUT the
+  types: ["episodic"] fix and on the 1.5-call planning figure for language-model
+  calls, which is the same pair of choices the embedding GPU count and the
+  agent-model GPU count are sized on, so the two sizing paths agree.
+  If these are wrong: only the network section moves. The conclusion that
+  network is not a constraint has a very large margin, so these would have to be
+  wrong by more than a factor of ten to change the answer. They are named here
+  because a bandwidth figure that cannot be reproduced from its own inputs
+  cannot be checked by anybody.
+
+Disk sizes, also estimates and also declared as named constants:
+    Qdrant NVMe per episode = dimensions x 4 bytes (the full-precision original
+      vector, which Qdrant keeps on disk even when the searchable copy in RAM is
+      quantized) plus 256 bytes of identifier and payload, all multiplied by 1.3
+      for segment and index overhead.
+    PostgreSQL per episode = episode text (800 bytes low, 2,400 bytes high) plus
+      400 bytes of row overhead plus 300 bytes of index, multiplied by 1.4 for
+      table bloat between vacuums. That gives a low-to-high range.
+
+Callers to capacity. There are two kinds of caller. A human chat session is a
+  person typing in a chat window, estimated at 0.011 to 0.028 operations per
+  second. At roughly two operations per prompt that is about 20 prompts an hour
+  at the low end (40 operations an hour, 0.011 ops/s) and about 50 prompts an
+  hour at the high end (about 101 operations an hour, 0.028 ops/s); neither
+  prompt rate has been measured. The rate counts operations of all three types,
+  split by that population's own traffic mix, so about one operation in ten of
+  a default session's traffic is an agent-mode search - without that, dividing
+  a tier's rate by a session rate made only of adds and plain searches would
+  count the agent-mode share twice. An automated client is a program that sends
+  requests in a loop rather than a person; one running a 5-second tool loop is
+  estimated at 0.4 operations per second. How many times a human that is comes
+  out of the constants themselves (0.4 / 0.028 = 14 and 0.4 / 0.011 = 36, so 14
+  to 36 times), rather than being written down where it could drift. The gap
+  between one request and the next has never been
+  measured for either. Meter real operations per second per API key from the
+  first day of the pilot and re-check the tier choice against it. A population
+  of nobody demands no operations, and the report says there is nothing to size
+  rather than naming the pilot tier for it.
+
+Each population carries its own traffic mix, because the kind of caller and the
+  kind of request are correlated: a room full of people asking one question at
+  a time is not the same traffic as a fleet of automated clients that use
+  agent-mode search on nearly every call. The users subcommand takes
+  --human-mix and --automated-mix, each three numbers as adds/plain/agent-mode,
+  and both default to the model's own default mix so that leaving them off
+  changes nothing. It then reports a blended mix: each population's mix
+  weighted by the operations that population demands, at the busy end of the
+  human rate, which is the rate the report tells you to plan for. That blended
+  mix, and not the global default, is what sizes the deployment for a
+  population.
+
+--------------------------------------------------------------------------------
+ASSUMPTIONS - choices, not findings
+--------------------------------------------------------------------------------
+
+Traffic mix: per 100 operations, 45 adds, 45 plain searches, 10 agent-mode
+  searches (a request flag, not a kind of caller). NOBODY HAS MEASURED THIS. It
+  is a planning assumption about how the service will be used, and it is the
+  second-biggest lever in the whole model
+  after the embedding card rate. The agent-mode share in particular sets the
+  hardware order more than any tuning does, because one agent-mode search costs
+  about 22 plain searches. The mix is adjustable on every subcommand of this
+  program, and the tier report always prints a sensitivity table showing what
+  happens to the API server count at 0, 2, 10 and 25 agent-mode searches per
+  second, plus the deployment's own agent-mode rate when that is not already one
+  of them - so the table always contains the row that matches the headline. That
+  row is marked "this run", because two rates that a rounded label cannot tell
+  apart, such as 2.0 and 2.04, are still two different sizings.
+
+Tiers: pilot 20 ops/s, target 100 ops/s, scale 1,000 ops/s. Each is a DESIGN
+  PEAK - the worst rate the system must sustain for five minutes - and not an
+  average. A design peak must be greater than zero: zero operations per second
+  is not a deployment to size, so the program refuses it with a message and
+  exit code 2 rather than printing a report that orders machines for no
+  traffic. It must also be below MAX_OPS_PER_S, and retention, dimensions,
+  bytes per number and the vector-store machine size each have a bound of
+  their own. Those bounds change no machine count. They are there so that a
+  number far larger than any deployment is refused by name, instead of passing
+  the finite check and then overflowing to infinity part-way through the byte
+  arithmetic - which used to come back as a complaint about "inf", a value
+  nobody had typed. Nothing in the 30 August run demonstrates five minutes of sustained
+  service: every test run started from a freshly restarted pod because of an
+  unresolved fault in which searches hang while the health endpoint still
+  answers. These are clean-start numbers.
+
+Utilization ceiling 60% on API servers and on GPU cards. One spare card on every
+  GPU role.
+
+Retention 90 days by default, purely as a placeholder. Retention is undecided and
+  it is the decision that moves storage the most. Vector dimensions default to
+  1,024 and storage to 1 byte per number (int8 quantization); both must be fixed
+  before the first episode is ingested, because changing either later means
+  re-embedding everything. Dimensions must be a whole number: a vector cannot
+  hold 1,024.7 numbers, and a fraction is refused rather than quietly cut down
+  to 1,024, precisely because the count has to be right before the first
+  episode is stored.
+
+Qdrant nodes are filled to at most 70% of their RAM, leaving room for the
+  operating system, for Qdrant's own metadata and for shards that come out
+  uneven. This fixes a real defect found in review: an earlier version of this
+  model filled seven 768 GB servers to 5.376 TB with a requirement of 5.375 TB,
+  which left no headroom at all. Node RAM options are 256, 512 and 768 GB.
+  Unless a size is forced - with --node-gb, or with the "RAM per vector-store
+  machine" box on the web form - the program prints the node count for all
+  three sizes and recommends the one that buys the least total RAM, breaking a
+  tie towards fewer machines. A forced size is used whatever it costs, and is
+  added to the comparison table when it is not one of the three. The report
+  names whichever of the two set it, so a reader of the web page is never told
+  they typed a command-line flag.
+  When the chosen size is more than 95%
+  full within that 70% allowance the report prints a WARNING and the result
+  carries a qdrant_tight_fit flag: at that point a small increase in retention
+  adds a whole extra machine, so the tier is one policy change away from a
+  bigger order. The 95% figure is a display threshold only - it changes no
+  machine count.
+  A deployment that searches or writes vectors at all orders at least one
+  vector-store machine, whatever the stored bytes come to. A search-only
+  traffic mix stores nothing, and so does a retention of zero days, and both
+  used to come back as zero machines beside a demand table asking for hundreds
+  of vector searches a second.
+
+The report states no machine class for the PostgreSQL and vector-store
+  machines. Only the API server has one that was measured. The RAM of a
+  vector-store machine is chosen by the model, so the report gives it; the vCPU
+  of either machine, and the RAM of the PostgreSQL machine, are undecided and
+  the report says so rather than borrowing the API server's figures.
+
+One PostgreSQL server per tier. This is an ASSUMPTION, not a derived count.
+  PostgreSQL was never benchmarked at these statement rates. What the 30 August
+  run did establish is that the failures seen were connection limits, not
+  compute.
+
+On the web form, an empty box is a blank answer and not a request for the
+  default. The command line takes the default for a flag that is left off, and
+  a bare /api/calc call with no parameters does the same; but a form
+  submission always sends all eight boxes, so an empty one means the reader
+  cleared it, and the page says which box is blank instead of inventing a
+  number. The "RAM per vector-store machine" box is the one exception, because
+  empty there already means "choose the size for me" and the hint under the
+  box says so.
+
+Availability additions - a second copy of every vector, a PostgreSQL standby, a
+  second gateway - are NOT priced in by this program. They are a separate
+  decision, and a replication factor of 2 doubles the hot vector RAM and the
+  Qdrant machine count.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import math
+import sys
+from dataclasses import dataclass
+from html import escape
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+# =============================================================================
+# CONSTANTS
+# Every constant is grouped and labelled measured / derived / estimate /
+# assumption. Nothing in this program uses a number that is not named here.
+# =============================================================================
+
+# --- Tiers ------------------------------------------------------------------
+# ASSUMPTION. Each rate is a design peak: the worst rate the system must sustain
+# for five minutes, not an average.
+TIER_OPS_PER_S = {"pilot": 20.0, "target": 100.0, "scale": 1000.0}
+TIER_ORDER = ("pilot", "target", "scale")
+
+# --- Sanity bounds on the inputs that scale the arithmetic -------------------
+# ASSUMPTION, and a refusal limit only: no machine count anywhere moves because
+# of these. They exist so that a number far larger than any deployment is
+# refused by name, rather than passing the finite check at the front of
+# size_deployment and overflowing to infinity part-way through the byte
+# arithmetic - which came back as a complaint about "inf", a value the reader
+# never typed. Every bound is far above the largest tier (1,000 operations/s)
+# and far below the point at which the arithmetic overflows.
+MAX_OPS_PER_S = 1e9                 # a billion operations a second
+MAX_RETENTION_DAYS = 36_500         # 100 years
+MAX_VECTOR_DIMS = 1_000_000         # embedding models today are 384 to 4,096
+MAX_BYTES_PER_VALUE = 64            # int8 is 1, float64 is 8
+MAX_NODE_GB = 1_000_000             # a petabyte of RAM in one machine
+
+# How much floating-point dust a machine count is allowed to absorb, as a
+# fraction of the count itself. See ceil_up.
+FLOAT_DUST_FRACTION = 1e-9
+
+# --- Traffic mix ------------------------------------------------------------
+# ASSUMPTION, never measured. Operations per 100 operations. The third share is
+# agent-mode search, which is a request flag and not a kind of caller.
+DEFAULT_MIX_ADD = 45.0
+DEFAULT_MIX_PLAIN = 45.0
+DEFAULT_MIX_AGENT = 10.0
+MIX_TOTAL = 100.0
+# How a whole mix is written where it has to fit in one flag or one box:
+# three numbers separated by "/" or by ",", so 45/45/10 and 45,45,10 are read
+# the same way. See parse_mix_text.
+MIX_TRIPLE_EXAMPLE = "45/45/10"
+
+# --- Fan-out per request ----------------------------------------------------
+# DERIVED by reading the MemMachine source code on 30 August 2026.
+ADD_EMBEDS = 1
+ADD_VECTOR_WRITES = 1
+ADD_POSTGRES_STATEMENTS = 2
+ADD_LLM_CALLS = 0
+
+PLAIN_EMBEDS = 2                    # 2 today
+PLAIN_EMBEDS_WITH_TYPES_FIX = 1     # 1 once every request sends types:["episodic"]
+PLAIN_VECTOR_SEARCHES = 1
+PLAIN_POSTGRES_STATEMENTS = 2
+PLAIN_LLM_CALLS = 0
+
+AGENT_EMBEDS = 22
+AGENT_VECTOR_SEARCHES = 22
+AGENT_POSTGRES_STATEMENTS = 44
+AGENT_LLM_CALLS_LOW = 1.0           # ESTIMATE: 1 to 2 language-model calls
+AGENT_LLM_CALLS_HIGH = 2.0
+AGENT_LLM_CALLS_PLANNING = 1.5      # ESTIMATE: the midpoint, used for sizing
+
+# --- API servers ------------------------------------------------------------
+# MEASURED 30 Aug 2026: 178.66 ops/s core API and 180.31 ops/s full platform,
+# both at 8 workers and 128 concurrent requests, real OpenAI
+# text-embedding-3-small at ~180-190 ms, 12,000-episode corpus, top_k 10,
+# expand 0, rrf-hybrid reranker on, Qdrant and PostgreSQL each on their own host,
+# every serving host an AWS c8a.4xlarge (16 vCPU, 32 GiB, AMD EPYC Turin).
+API_SEARCHES_PER_S_PER_SERVER = 180.0
+API_UTILIZATION_CEILING = 0.60      # ASSUMPTION: fill a server to at most 60%
+API_WORKERS_PER_SERVER = 8          # MEASURED 30 Aug 2026: 8 is the knee
+API_SERVER_VCPU = 16                # the machine class that was measured
+API_SERVER_RAM_GB = 32
+# ESTIMATE: one add costs at most one plain search of API work. Rounds up.
+ADD_COST_IN_PLAIN_SEARCH_EQUIVALENTS = 1.0
+
+# --- Embedding GPUs ---------------------------------------------------------
+# ESTIMATE, never benchmarked on any card with the planned model.
+EMBED_CARD_REQUESTS_PER_S_LOW = 300.0
+EMBED_CARD_REQUESTS_PER_S_HIGH = 500.0
+GPU_UTILIZATION_CEILING = 0.60      # ASSUMPTION
+GPU_SPARE_CARDS = 1                 # ASSUMPTION: one spare on every GPU role
+
+# --- Agent-model GPUs -------------------------------------------------------
+# ESTIMATE: an 8B-class card serves 10-20 language-model calls/s; plan on 15.
+AGENT_LLM_CALLS_PER_S_PER_CARD = 15.0
+
+# --- Vector store (Qdrant) --------------------------------------------------
+DEFAULT_VECTOR_DIMS = 1024          # ASSUMPTION, must be fixed before first ingest
+DEFAULT_BYTES_PER_VALUE = 1         # ASSUMPTION: int8 quantization
+QDRANT_INDEX_OVERHEAD_FACTOR = 1.5  # ASSUMPTION: index overhead on hot RAM
+QDRANT_NODE_RAM_OPTIONS_GB = (256, 512, 768)
+# How the report names the thing that forced the vector-store machine size.
+# The reader of the web page never typed a command-line flag, so the page must
+# not tell them they did.
+NODE_GB_SOURCE_CLI = "--node-gb"
+NODE_GB_SOURCE_WEB = "the RAM per vector-store machine box"
+QDRANT_NODE_FILL_LIMIT = 0.70       # ASSUMPTION: at most 70% of a node's RAM
+QDRANT_TIGHT_FIT_WARN_FRACTION = 0.95   # display only: warn when this full
+SECONDS_PER_DAY = 86400
+DEFAULT_RETENTION_DAYS = 90         # ASSUMPTION, placeholder - retention undecided
+BYTES_PER_GB = 1_000_000_000        # GB means 10^9 bytes throughout
+BYTES_PER_TB = 1_000_000_000_000
+
+# --- Disk -------------------------------------------------------------------
+# ESTIMATE. Qdrant keeps the full-precision original vector on disk even when the
+# searchable copy in RAM is quantized.
+ORIGINAL_VECTOR_BYTES_PER_VALUE = 4
+QDRANT_DISK_PAYLOAD_BYTES_PER_EPISODE = 256
+QDRANT_DISK_OVERHEAD_FACTOR = 1.3
+
+# ESTIMATE. PostgreSQL holds the episode text.
+EPISODE_TEXT_BYTES_LOW = 800
+EPISODE_TEXT_BYTES_HIGH = 2400
+POSTGRES_ROW_OVERHEAD_BYTES = 400
+POSTGRES_INDEX_BYTES_PER_EPISODE = 300
+POSTGRES_BLOAT_FACTOR = 1.4
+
+# --- PostgreSQL connections -------------------------------------------------
+# MEASURED 30 Aug 2026 (pool size 5 + max_overflow 10 per worker).
+POSTGRES_POOL_SIZE = 5
+POSTGRES_MAX_OVERFLOW = 10
+POSTGRES_CONNECTIONS_PER_WORKER = POSTGRES_POOL_SIZE + POSTGRES_MAX_OVERFLOW
+GATEWAY_CONNECTIONS_PER_API_SERVER = 20     # ASSUMPTION: gateway allowance
+POSTGRES_CHART_DEFAULT_MAX_CONNECTIONS = 100    # MEASURED: the default that failed
+POSTGRES_PROVEN_MAX_CONNECTIONS = 600           # MEASURED: cleared every error
+POSTGRES_SERVERS_PER_TIER = 1               # ASSUMPTION, never benchmarked
+
+# --- Network message sizes --------------------------------------------------
+# ESTIMATE, every one. Named here so the network figures can be checked by hand.
+NS_ADD_REQUEST_BYTES = 1200
+NS_ADD_RESPONSE_BYTES = 300
+NS_SEARCH_REQUEST_BYTES = 600
+NS_RESPONSE_BYTES_PER_EPISODE = 900
+PLAIN_SEARCH_EPISODES_RETURNED = 10     # top_k 10, the measured configuration
+AGENT_SEARCH_EPISODES_RETURNED = 20     # ESTIMATE
+NS_AGENT_ANSWER_BYTES = 2000            # ESTIMATE: the written answer
+
+EMBED_REQUEST_BYTES = 1000
+EMBED_RESPONSE_ENVELOPE_BYTES = 200
+QDRANT_SEARCH_REQUEST_ENVELOPE_BYTES = 300
+QDRANT_CANDIDATES_PER_SEARCH = 50       # vector_search_limit 50, measured config
+QDRANT_BYTES_PER_CANDIDATE = 200
+QDRANT_UPSERT_ENVELOPE_BYTES = 500
+QDRANT_UPSERT_RESPONSE_BYTES = 200
+POSTGRES_BYTES_PER_STATEMENT = 1800     # both directions
+LLM_CALL_REQUEST_BYTES = 8000
+LLM_CALL_RESPONSE_BYTES = 2000
+NETWORK_PROTOCOL_OVERHEAD_FACTOR = 1.2  # TLS, HTTP and TCP framing
+BITS_PER_BYTE = 8
+BITS_PER_MBIT = 1_000_000               # Mbps means 10^6 bits per second
+
+# --- Callers ----------------------------------------------------------------
+# ESTIMATE. The gap between one request and the next has never been measured.
+# These describe how fast a CALLER sends requests. Nothing here says anything
+# about what kind of request it sends: that is the traffic mix above.
+HUMAN_SESSION_OPS_PER_S_LOW = 0.011
+HUMAN_SESSION_OPS_PER_S_HIGH = 0.028
+# An automated client is a program that sends requests in a loop rather than a
+# person typing in a chat window. It is NOT the same thing as agent-mode
+# search, which is a flag on one request.
+AUTOMATED_CLIENT_OPS_PER_S = 0.4
+# Used only to describe where the two human figures come from: about two
+# operations per prompt, so 0.011 ops/s is about 20 prompts an hour and 0.028
+# ops/s is about 50. The spread between a human chat session and an automated
+# client is worked out from the constants above rather than written down, so it
+# cannot drift.
+OPS_PER_HUMAN_PROMPT = 2.0
+
+# The flag --agents used to mean "how many callers are programs". It was one
+# letter away from --agent, which is the agent-mode share of the traffic mix,
+# and the two mean completely different things. It is refused by name now
+# rather than being accepted quietly or read as the mix share.
+AGENT_VERSUS_AUTOMATED_SENTENCE = (
+    "An automated client is a CALLER - a program that sends requests in a "
+    "loop - while agent-mode search is a property of one REQUEST, not of who "
+    "sent it.")
+RETIRED_AGENTS_FLAG_MESSAGE = (
+    "--agents is no longer a flag. Use --automated for the number of "
+    "automated clients, and --agent for the agent-mode share of the traffic "
+    "mix. " + AGENT_VERSUS_AUTOMATED_SENTENCE)
+RETIRED_AGENTS_SETTING_MESSAGE = (
+    'the web address has a setting called "agents", which this calculator '
+    'does not know. Use "automated" for the number of automated clients, and '
+    '"agent" for the agent-mode share of the traffic mix. '
+    + AGENT_VERSUS_AUTOMATED_SENTENCE)
+
+# --- Sensitivity ------------------------------------------------------------
+# The agent-mode search rates the tier report always shows.
+SENSITIVITY_AGENT_RATES = (0.0, 2.0, 10.0, 25.0)
+
+# Where ``validate`` writes its JSON by default: a file in the current working
+# directory, overridable with --out.
+NUMBERS_FILE = "sizing-numbers.json"
+
+# --- Web server -------------------------------------------------------------
+
+# Seconds the server waits on one connection before dropping it. This is a
+# local development server, not a service: the timeout is here so a client
+# that connects and then goes quiet cannot hold a thread and a file descriptor
+# open indefinitely. It changes no machine count.
+SERVER_REQUEST_TIMEOUT_S = 10
+
+
+# =============================================================================
+# ERRORS AND SMALL HELPERS
+# =============================================================================
+
+
+class SizingError(ValueError):
+    """Bad input. The command line turns this into a message and exit code 2."""
+
+
+# Above this, a float can no longer hold every whole number, so its digits are
+# an artefact of the format rather than anything anyone typed. Such a value is
+# printed the short way, as 1e+307 rather than as 309 digits.
+LARGEST_EXACTLY_COUNTABLE = 1e16
+
+
+def as_given(value) -> str:
+    """A number printed as it was given, with nothing rounded away.
+
+    An ordinary whole number loses its ".0" and gains thousands separators;
+    anything else keeps every digit it has. Both the report, which echoes its
+    own inputs, and the errors, which quote the value they refuse, need this: a
+    rounded copy describes something the reader did not ask for. ":.0f" turned
+    half a byte per number into "0" above a table sized for half a byte, and
+    ":g" turned 1,000,000,001 into "1e+09", which is the very limit the message
+    says it exceeds.
+    """
+    if isinstance(value, int):
+        return f"{value:,}"
+    if (isinstance(value, float) and value.is_integer()
+            and abs(value) < LARGEST_EXACTLY_COUNTABLE):
+        return f"{int(value):,}"
+    return repr(value)
+
+
+def ceil_up(value: float, per_unit: float) -> int:
+    """Divide and always round up to a whole machine.
+
+    The tiny subtraction absorbs floating-point dust, so that a value that is
+    mathematically exactly 3.0 does not come out as 4. It is a fraction OF THE
+    ANSWER rather than a flat amount: a flat 1e-9 is dust next to 3 machines
+    but is larger than the whole answer for a very small workload, and it used
+    to turn any work below about 1.08e-7 searches per second into zero
+    machines. Any work at all has to run somewhere, so the answer is never
+    less than one machine once the work is greater than zero.
+    """
+    if not math.isfinite(per_unit) or per_unit <= 0:
+        raise SizingError("cannot divide by a capacity of zero or less")
+    if not math.isfinite(value):
+        raise SizingError(
+            f"cannot size for a quantity of {value:g} - every input must be a "
+            "finite number")
+    if value <= 0:
+        return 0
+    quotient = value / per_unit
+    return max(1, math.ceil(quotient - abs(quotient) * FLOAT_DUST_FRACTION))
+
+
+@dataclass(frozen=True)
+class TrafficMix:
+    """How 100 operations split between the three request types."""
+
+    add: float = DEFAULT_MIX_ADD
+    plain: float = DEFAULT_MIX_PLAIN
+    agent: float = DEFAULT_MIX_AGENT
+
+    def validate(self) -> None:
+        for name, value in (("add", self.add), ("plain", self.plain),
+                            ("agent", self.agent)):
+            if not math.isfinite(value):
+                raise SizingError(
+                    f"traffic mix: {name} is {value:g}, but a share must be a "
+                    "finite number")
+            if value < 0:
+                raise SizingError(
+                    f"traffic mix: {name} is {value}, but a share cannot be "
+                    "negative")
+        total = self.add + self.plain + self.agent
+        if abs(total - MIX_TOTAL) > 1e-6:
+            raise SizingError(
+                f"traffic mix must add up to {MIX_TOTAL:g} operations per 100, "
+                f"but {self.add:g} adds + {self.plain:g} plain searches + "
+                f"{self.agent:g} agent-mode searches = {total:g}")
+
+    def as_dict(self) -> dict:
+        return {"add": self.add, "plain": self.plain, "agent": self.agent}
+
+    def as_words(self) -> str:
+        """The mix as the report prints it, in the report's own wording."""
+        return (f"{as_given(self.add)} adds, {as_given(self.plain)} plain "
+                f"searches, {as_given(self.agent)} agent-mode searches")
+
+
+def number_or_none(text: str):
+    """One piece of text as a number, or None when it is not one."""
+    try:
+        return float(text)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def default_mix_text() -> str:
+    """The default traffic mix, written the way a mix flag or box takes it."""
+    return "/".join(as_given(share) for share in
+                    (DEFAULT_MIX_ADD, DEFAULT_MIX_PLAIN, DEFAULT_MIX_AGENT))
+
+
+def parse_mix_text(text: str, called: str) -> TrafficMix:
+    """Read a traffic mix written as three numbers, adds/plain/agent-mode.
+
+    Both 45/45/10 and 45,45,10 are accepted, because a reader who has just
+    typed a mix on the command line should not have to remember which
+    separator this program wanted. ``called`` is how the message names
+    whatever holds the text - a flag on the command line, a box on the web
+    form - so a refusal points at the thing the reader typed into.
+    """
+    typed = str(text).strip()
+    parts = [part.strip()
+             for part in typed.replace(",", "/").split("/")
+             if part.strip() != ""]
+    if len(parts) != 3:
+        raise SizingError(
+            f'{called} is "{typed}", but it must be three numbers written as '
+            "adds/plain/agent-mode, such as 45/45/10 or 45,45,10 - "
+            f"that is {len(parts)} number(s)")
+    numbers = [number_or_none(part) for part in parts]
+    if any(value is None for value in numbers):
+        bad = parts[numbers.index(None)]
+        raise SizingError(
+            f'{called} is "{typed}", but "{bad}" in it is not a number - '
+            f"write it as adds/plain/agent-mode, such as {MIX_TRIPLE_EXAMPLE}")
+    mix = TrafficMix(*numbers)
+    # The shares check names the mix but not what holds it, and a reader with
+    # two mix flags in one command has to be told which of them is wrong.
+    try:
+        mix.validate()
+    except SizingError as exc:
+        raise SizingError(f'{called} is "{typed}": {exc}') from None
+    return mix
+
+
+# =============================================================================
+# THE CALCULATION CORE
+# Pure arithmetic. Nothing in this section prints anything.
+# =============================================================================
+
+
+def api_servers_for_work(work_per_s: float) -> int:
+    """API servers needed for a given number of plain-search-equivalents/s."""
+    return ceil_up(work_per_s, api_usable_searches_per_server())
+
+
+def api_usable_searches_per_server() -> float:
+    """Searches per second one API server is planned to carry (derived)."""
+    return API_SEARCHES_PER_S_PER_SERVER * API_UTILIZATION_CEILING
+
+
+def embed_gpu_cards_for_demand(embeds_per_s: float,
+                               card_requests_per_s: float) -> int:
+    """Embedding GPU cards for a given demand, including one spare card.
+
+    A card is filled to at most GPU_UTILIZATION_CEILING of its rate. No
+    embedding demand at all needs no card, and therefore no spare either.
+    """
+    bare = ceil_up(embeds_per_s, card_requests_per_s * GPU_UTILIZATION_CEILING)
+    return bare + GPU_SPARE_CARDS if bare else 0
+
+
+def agent_gpu_cards_for_demand(llm_calls_per_s: float) -> int:
+    """Agent-model GPU cards for a given demand, including one spare card.
+
+    No language-model calls at all needs no card, and therefore no spare either.
+    """
+    bare = ceil_up(llm_calls_per_s, AGENT_LLM_CALLS_PER_S_PER_CARD)
+    return bare + GPU_SPARE_CARDS if bare else 0
+
+
+def qdrant_node_plan(hot_ram_bytes: float, node_gb=None,
+                     least_nodes: int = 0) -> dict:
+    """Pick a Qdrant node size and count.
+
+    Every node is filled to at most QDRANT_NODE_FILL_LIMIT of its RAM. With no
+    node size given, the program works out the count for all three offered
+    sizes and recommends the one that buys the least total RAM, breaking a tie
+    towards fewer machines. Give node_gb and that size is used instead, however
+    much total RAM it buys; a size that is not one of the three offered is
+    added to the table so the comparison still shows it.
+
+    least_nodes is the count no size may go below. The caller sets it to 1 when
+    the deployment searches or writes vectors at all, because that work has to
+    happen on a machine even when the stored bytes come to nothing: a search-
+    only traffic mix stores nothing, and so does a retention of zero days, and
+    both used to order zero vector-store machines next to hundreds of vector
+    searches a second.
+    """
+    sizes = list(QDRANT_NODE_RAM_OPTIONS_GB)
+    if node_gb is not None:
+        if not math.isfinite(node_gb) or node_gb <= 0:
+            raise SizingError(
+                f"RAM per vector-store machine is {as_given(node_gb)} GB, but "
+                "it must be greater than zero")
+        if not any(abs(node_gb - size) <= 1e-9 for size in sizes):
+            sizes.append(node_gb)
+        sizes.sort()
+    options = []
+    for ram_gb in sizes:
+        usable_bytes = ram_gb * BYTES_PER_GB * QDRANT_NODE_FILL_LIMIT
+        count = max(ceil_up(hot_ram_bytes, usable_bytes), least_nodes)
+        total_ram_gb = count * ram_gb
+        fill = (hot_ram_bytes / (count * usable_bytes)) if count else 0.0
+        options.append({
+            "node_ram_gb": ram_gb,
+            "usable_gb_per_node": usable_bytes / BYTES_PER_GB,
+            "nodes": count,
+            "total_ram_gb": total_ram_gb,
+            "fill_of_allowance": fill,
+            "share_of_node_ram": fill * QDRANT_NODE_FILL_LIMIT,
+        })
+    if node_gb is not None:
+        chosen = next(o for o in options
+                      if abs(o["node_ram_gb"] - node_gb) <= 1e-9)
+    else:
+        usable_options = [o for o in options if o["nodes"] > 0]
+        if usable_options:
+            chosen = min(usable_options,
+                         key=lambda o: (o["total_ram_gb"], o["nodes"],
+                                        o["node_ram_gb"]))
+        else:
+            chosen = dict(options[0])
+    return {
+        "options": options,
+        "node_ram_gb_forced": node_gb is not None,
+        "nodes": chosen["nodes"],
+        "node_ram_gb": chosen["node_ram_gb"],
+        "usable_gb_per_node": chosen["usable_gb_per_node"],
+        "total_ram_gb": chosen["total_ram_gb"],
+        "fill_of_allowance": chosen["fill_of_allowance"],
+        "tight_fit": chosen["fill_of_allowance"] >= QDRANT_TIGHT_FIT_WARN_FRACTION,
+    }
+
+
+def sensitivity_rates(agent_searches_per_s: float,
+                      base=SENSITIVITY_AGENT_RATES) -> tuple:
+    """The agent-mode rates the sensitivity table shows, in ascending order.
+
+    The fixed rates always appear. The deployment's own agent-mode rate is
+    added when it is not already one of them, so that the table always contains
+    the row that matches the headline machine count. Without this the scale
+    tier printed a table whose worst row was 25 agent-mode searches/s next to a
+    headline sized for 100.
+    """
+    rates = list(base)
+    if (math.isfinite(agent_searches_per_s) and agent_searches_per_s > 0
+            and not any(abs(agent_searches_per_s - r) <= 1e-9 for r in rates)):
+        rates.append(agent_searches_per_s)
+    return tuple(sorted(rates))
+
+
+def agent_sensitivity(adds_per_s: float, plain_per_s: float,
+                      agent_rates=SENSITIVITY_AGENT_RATES,
+                      this_run_rate=None) -> list:
+    """API server count against the agent-mode search rate.
+
+    Adds and plain searches are held fixed; only the agent-mode rate varies.
+    This is the table that shows why the agent-mode quota is a hardware
+    decision and not a product detail.
+
+    this_run_rate is the deployment's own agent-mode rate. The row at that rate
+    is flagged, because two rates a rounded label cannot tell apart - 2.0 and
+    2.04 both print as "2.0" - are still two different sizings, and the reader
+    has to be able to see which one is the traffic mix they asked about.
+    """
+    rows = []
+    for rate in agent_rates:
+        vector_searches = (plain_per_s * PLAIN_VECTOR_SEARCHES
+                           + rate * AGENT_VECTOR_SEARCHES)
+        work = vector_searches + adds_per_s * ADD_COST_IN_PLAIN_SEARCH_EQUIVALENTS
+        rows.append({
+            "agent_searches_per_s": rate,
+            "total_ops_per_s": adds_per_s + plain_per_s + rate,
+            "vector_searches_per_s": vector_searches,
+            "api_work_per_s": work,
+            "api_servers": api_servers_for_work(work),
+            "llm_calls_per_s_low": rate * AGENT_LLM_CALLS_LOW,
+            "llm_calls_per_s_high": rate * AGENT_LLM_CALLS_HIGH,
+            "is_this_run": (this_run_rate is not None
+                            and abs(rate - this_run_rate) <= 1e-9),
+        })
+    return rows
+
+
+def size_deployment(ops_per_s: float,
+                    mix: TrafficMix | None = None,
+                    retention_days: float = DEFAULT_RETENTION_DAYS,
+                    dims: int = DEFAULT_VECTOR_DIMS,
+                    bytes_per_value: float = DEFAULT_BYTES_PER_VALUE,
+                    node_gb=None,
+                    node_gb_source: str = NODE_GB_SOURCE_CLI,
+                    run_name: str = "custom") -> dict:
+    """Size one deployment. Returns a plain dictionary; prints nothing.
+
+    ops_per_s       design peak, operations per second
+    mix             how 100 operations split between adds, plain and agent-mode
+    retention_days  how long an episode is kept before deletion
+    dims            vector dimensions (numbers per vector)
+    bytes_per_value bytes stored per number (1 means int8 quantized)
+    node_gb         RAM of one vector-store machine in GB, or None to let the
+                    program choose the size that buys the least total RAM
+    node_gb_source  how the report should name whatever set node_gb, so that a
+                    web page does not tell its reader they typed a flag
+    run_name        what to call this run in the result - a tier name, or
+                    "custom" or "web". It is not one of the four provenance
+                    labels; the result dictionary carries no provenance.
+    """
+    mix = mix or TrafficMix()
+    mix.validate()
+
+    # One name per input, taken from the label on the web form, so that a box
+    # is never called one thing when it is empty and another when it is too
+    # large.
+    for field, value, limit, unit in (
+            ("the design peak", ops_per_s, MAX_OPS_PER_S, "operations/s"),
+            ("retention", retention_days, MAX_RETENTION_DAYS, "days"),
+            ("vector dimensions", dims, MAX_VECTOR_DIMS, "dimensions"),
+            ("bytes per number", bytes_per_value, MAX_BYTES_PER_VALUE,
+             "bytes")):
+        if not math.isfinite(value):
+            raise SizingError(
+                f"{field} is {as_given(value)} {unit}, but every input must be "
+                "a finite number - infinity and not-a-number are not "
+                "deployments to size")
+        if value > limit:
+            raise SizingError(
+                f"{field} is {as_given(value)} {unit}, which is larger than "
+                "this calculator will size - the most it accepts is "
+                f"{as_given(limit)} {unit}")
+    if ops_per_s <= 0:
+        raise SizingError(
+            f"the design peak is {as_given(ops_per_s)} operations/s, but it "
+            "must be greater than zero - there is no deployment to size at no "
+            "traffic")
+    if retention_days < 0:
+        raise SizingError(
+            f"retention is {as_given(retention_days)} days, but it cannot be "
+            "negative")
+    # A vector holds a whole number of numbers. Cutting 1024.7 down to 1024
+    # would size the deployment for a shape nobody asked for, and the report
+    # itself warns that the dimension count must be fixed before the first
+    # episode is ingested.
+    if not float(dims).is_integer():
+        raise SizingError(
+            f"vector dimensions is {as_given(dims)}, but it must be a whole "
+            "number of dimensions - a vector cannot hold part of a number")
+    dims = int(dims)
+    if dims <= 0:
+        raise SizingError(
+            f"vector dimensions is {as_given(dims)}, but it must be a positive "
+            "whole number")
+    if bytes_per_value <= 0:
+        raise SizingError(
+            f"bytes per number is {as_given(bytes_per_value)}, but it must be "
+            "greater than zero")
+    if node_gb is not None:
+        if not math.isfinite(node_gb):
+            raise SizingError(
+                f"RAM per vector-store machine is {as_given(node_gb)} GB, but "
+                "every input must be a finite number - infinity and "
+                "not-a-number are not machines to order")
+        if node_gb <= 0:
+            raise SizingError(
+                f"RAM per vector-store machine is {as_given(node_gb)} GB, but "
+                "it must be greater than zero")
+        if node_gb > MAX_NODE_GB:
+            raise SizingError(
+                f"RAM per vector-store machine is {as_given(node_gb)} GB, "
+                "which is larger than this calculator will size - the most it "
+                f"accepts is {as_given(MAX_NODE_GB)} GB")
+        # A whole number of GB stays a whole number, so that the reports and
+        # the JSON keys read "512 GB" and not "512.0 GB".
+        if float(node_gb).is_integer():
+            node_gb = int(node_gb)
+
+    # ---- request rates by type ---------------------------------------------
+    adds = ops_per_s * mix.add / MIX_TOTAL
+    plains = ops_per_s * mix.plain / MIX_TOTAL
+    agents = ops_per_s * mix.agent / MIX_TOTAL
+
+    # ---- demand -------------------------------------------------------------
+    embeds = (adds * ADD_EMBEDS + plains * PLAIN_EMBEDS + agents * AGENT_EMBEDS)
+    embeds_with_fix = (adds * ADD_EMBEDS + plains * PLAIN_EMBEDS_WITH_TYPES_FIX
+                       + agents * AGENT_EMBEDS)
+    vector_searches = (plains * PLAIN_VECTOR_SEARCHES
+                       + agents * AGENT_VECTOR_SEARCHES)
+    vector_writes = adds * ADD_VECTOR_WRITES
+    pg_statements = (adds * ADD_POSTGRES_STATEMENTS
+                     + plains * PLAIN_POSTGRES_STATEMENTS
+                     + agents * AGENT_POSTGRES_STATEMENTS)
+    llm_low = agents * AGENT_LLM_CALLS_LOW
+    llm_high = agents * AGENT_LLM_CALLS_HIGH
+    llm_planning = agents * AGENT_LLM_CALLS_PLANNING
+
+    demand = {
+        "adds_per_s": adds,
+        "plain_searches_per_s": plains,
+        "agent_searches_per_s": agents,
+        "embeds_per_s": embeds,
+        "embeds_per_s_with_types_fix": embeds_with_fix,
+        "vector_searches_per_s": vector_searches,
+        "vector_writes_per_s": vector_writes,
+        "postgres_statements_per_s": pg_statements,
+        "agent_llm_calls_per_s_low": llm_low,
+        "agent_llm_calls_per_s_high": llm_high,
+        "agent_llm_calls_per_s_planning": llm_planning,
+    }
+
+    # ---- API servers --------------------------------------------------------
+    api_work = vector_searches + adds * ADD_COST_IN_PLAIN_SEARCH_EQUIVALENTS
+    api_servers = api_servers_for_work(api_work)
+
+    # ---- embedding GPU cards ------------------------------------------------
+    # Sized on the demand WITHOUT the types fix: the larger, safer figure.
+    usable_low = EMBED_CARD_REQUESTS_PER_S_LOW * GPU_UTILIZATION_CEILING
+    usable_high = EMBED_CARD_REQUESTS_PER_S_HIGH * GPU_UTILIZATION_CEILING
+    cards_at_low_rate = ceil_up(embeds, usable_low)     # pessimistic card rate
+    embed_cards_low = embed_gpu_cards_for_demand(
+        embeds, EMBED_CARD_REQUESTS_PER_S_HIGH)
+    embed_cards_high = embed_gpu_cards_for_demand(
+        embeds, EMBED_CARD_REQUESTS_PER_S_LOW)
+
+    # ---- agent-model GPU cards ---------------------------------------------
+    agent_cards_needed = ceil_up(llm_planning, AGENT_LLM_CALLS_PER_S_PER_CARD)
+    agent_cards = agent_gpu_cards_for_demand(llm_planning)
+
+    # ---- storage ------------------------------------------------------------
+    episodes = adds * SECONDS_PER_DAY * retention_days
+    episodes_per_day = adds * SECONDS_PER_DAY
+    episodes_per_year = episodes_per_day * 365
+
+    # Bytes per stored episode. Each figure below is a count of episodes
+    # multiplied by one of these, so the retained figures and the
+    # one-year-with-no-deletion figures are worked out the same way and cannot
+    # drift apart.
+    hot_ram_bytes_per_episode = (dims * bytes_per_value
+                                 * QDRANT_INDEX_OVERHEAD_FACTOR)
+    nvme_bytes_per_episode = ((dims * ORIGINAL_VECTOR_BYTES_PER_VALUE
+                               + QDRANT_DISK_PAYLOAD_BYTES_PER_EPISODE)
+                              * QDRANT_DISK_OVERHEAD_FACTOR)
+    pg_bytes_per_episode_low = ((EPISODE_TEXT_BYTES_LOW
+                                 + POSTGRES_ROW_OVERHEAD_BYTES
+                                 + POSTGRES_INDEX_BYTES_PER_EPISODE)
+                                * POSTGRES_BLOAT_FACTOR)
+    pg_bytes_per_episode_high = ((EPISODE_TEXT_BYTES_HIGH
+                                  + POSTGRES_ROW_OVERHEAD_BYTES
+                                  + POSTGRES_INDEX_BYTES_PER_EPISODE)
+                                 * POSTGRES_BLOAT_FACTOR)
+
+    hot_ram_bytes = episodes * hot_ram_bytes_per_episode
+    nvme_bytes = episodes * nvme_bytes_per_episode
+    pg_bytes_low = episodes * pg_bytes_per_episode_low
+    pg_bytes_high = episodes * pg_bytes_per_episode_high
+    # Vector work has to run somewhere, so it costs a machine even when the
+    # stored bytes come to nothing.
+    does_vector_work = vector_searches > 0 or vector_writes > 0
+    qdrant = qdrant_node_plan(hot_ram_bytes, node_gb,
+                              least_nodes=1 if does_vector_work else 0)
+
+    # One year with nothing ever deleted. This is simply a year of adds, so it
+    # is worked out from episodes_per_year and does not move with the retention
+    # setting - at retention 0 it is still a full year of stored episodes.
+    year_hot_ram_bytes = episodes_per_year * hot_ram_bytes_per_episode
+    year_nvme_bytes = episodes_per_year * nvme_bytes_per_episode
+    year_pg_bytes_low = episodes_per_year * pg_bytes_per_episode_low
+    year_pg_bytes_high = episodes_per_year * pg_bytes_per_episode_high
+
+    storage = {
+        "retention_days": retention_days,
+        "vector_dims": dims,
+        "bytes_per_value": bytes_per_value,
+        "episodes_per_day": episodes_per_day,
+        "episodes_per_year": episodes_per_year,
+        "episodes_retained": episodes,
+        "hot_vector_ram_bytes": hot_ram_bytes,
+        "hot_vector_ram_gb": hot_ram_bytes / BYTES_PER_GB,
+        "qdrant_nvme_bytes": nvme_bytes,
+        "qdrant_nvme_gb": nvme_bytes / BYTES_PER_GB,
+        "postgres_bytes_low": pg_bytes_low,
+        "postgres_bytes_high": pg_bytes_high,
+        "postgres_gb_low": pg_bytes_low / BYTES_PER_GB,
+        "postgres_gb_high": pg_bytes_high / BYTES_PER_GB,
+        # One year with no deletion at all - the figure that makes retention a
+        # requirement rather than an option.
+        "unbounded_year_hot_vector_ram_bytes": year_hot_ram_bytes,
+        "unbounded_year_hot_vector_ram_gb": year_hot_ram_bytes / BYTES_PER_GB,
+        "unbounded_year_qdrant_nvme_bytes": year_nvme_bytes,
+        "unbounded_year_qdrant_nvme_gb": year_nvme_bytes / BYTES_PER_GB,
+        "unbounded_year_postgres_bytes_low": year_pg_bytes_low,
+        "unbounded_year_postgres_bytes_high": year_pg_bytes_high,
+        "unbounded_year_postgres_gb_low": year_pg_bytes_low / BYTES_PER_GB,
+        "unbounded_year_postgres_gb_high": year_pg_bytes_high / BYTES_PER_GB,
+    }
+
+    # ---- PostgreSQL connections --------------------------------------------
+    core_connections = (api_servers * API_WORKERS_PER_SERVER
+                        * POSTGRES_CONNECTIONS_PER_WORKER)
+    gateway_connections = api_servers * GATEWAY_CONNECTIONS_PER_API_SERVER
+    total_connections = core_connections + gateway_connections
+    postgres = {
+        "servers": POSTGRES_SERVERS_PER_TIER,
+        "statements_per_s": pg_statements,
+        "workers_per_api_server": API_WORKERS_PER_SERVER,
+        "connections_per_worker": POSTGRES_CONNECTIONS_PER_WORKER,
+        "core_connections": core_connections,
+        "gateway_connections": gateway_connections,
+        "total_connections": total_connections,
+        "max_connections_required": total_connections,
+        "chart_default_max_connections": POSTGRES_CHART_DEFAULT_MAX_CONNECTIONS,
+        "proven_max_connections": POSTGRES_PROVEN_MAX_CONNECTIONS,
+        "exceeds_chart_default": total_connections >
+        POSTGRES_CHART_DEFAULT_MAX_CONNECTIONS,
+        "exceeds_proven_setting": total_connections >
+        POSTGRES_PROVEN_MAX_CONNECTIONS,
+        "needs_connection_pooler": total_connections >
+        POSTGRES_PROVEN_MAX_CONNECTIONS,
+    }
+
+    # ---- network ------------------------------------------------------------
+    ns_bytes_per_s = (
+        adds * (NS_ADD_REQUEST_BYTES + NS_ADD_RESPONSE_BYTES)
+        + plains * (NS_SEARCH_REQUEST_BYTES
+                    + PLAIN_SEARCH_EPISODES_RETURNED * NS_RESPONSE_BYTES_PER_EPISODE)
+        + agents * (NS_SEARCH_REQUEST_BYTES + NS_AGENT_ANSWER_BYTES
+                    + AGENT_SEARCH_EPISODES_RETURNED * NS_RESPONSE_BYTES_PER_EPISODE)
+    ) * NETWORK_PROTOCOL_OVERHEAD_FACTOR
+
+    embed_call_bytes = (EMBED_REQUEST_BYTES
+                        + dims * ORIGINAL_VECTOR_BYTES_PER_VALUE
+                        + EMBED_RESPONSE_ENVELOPE_BYTES)
+    vector_search_bytes = (dims * ORIGINAL_VECTOR_BYTES_PER_VALUE
+                           + QDRANT_SEARCH_REQUEST_ENVELOPE_BYTES
+                           + QDRANT_CANDIDATES_PER_SEARCH
+                           * QDRANT_BYTES_PER_CANDIDATE)
+    vector_write_bytes = (dims * ORIGINAL_VECTOR_BYTES_PER_VALUE
+                          + QDRANT_UPSERT_ENVELOPE_BYTES
+                          + QDRANT_UPSERT_RESPONSE_BYTES)
+    llm_call_bytes = LLM_CALL_REQUEST_BYTES + LLM_CALL_RESPONSE_BYTES
+
+    ew_bytes_per_s = (
+        embeds * embed_call_bytes
+        + vector_searches * vector_search_bytes
+        + vector_writes * vector_write_bytes
+        + pg_statements * POSTGRES_BYTES_PER_STATEMENT
+        + llm_planning * llm_call_bytes
+    ) * NETWORK_PROTOCOL_OVERHEAD_FACTOR
+
+    def to_mbps(bytes_per_s: float) -> float:
+        return bytes_per_s * BITS_PER_BYTE / BITS_PER_MBIT
+
+    busiest_mbps = max(to_mbps(ns_bytes_per_s), to_mbps(ew_bytes_per_s))
+    network = {
+        "north_south_bytes_per_s": ns_bytes_per_s,
+        "east_west_bytes_per_s": ew_bytes_per_s,
+        "north_south_mbps": to_mbps(ns_bytes_per_s),
+        "east_west_mbps": to_mbps(ew_bytes_per_s),
+        "embed_bytes_per_call": embed_call_bytes,
+        "vector_search_bytes_per_call": vector_search_bytes,
+        "vector_write_bytes_per_call": vector_write_bytes,
+        "llm_bytes_per_call": llm_call_bytes,
+        "busiest_link_mbps": busiest_mbps,
+        # Headroom is measured against the busiest of the two directions, which
+        # is what the report says it is. East-west is the busier one with
+        # today's constants, but nothing in the model forces that to stay true.
+        # None, never a floating-point infinity: json.dumps writes an infinity
+        # as the bare token Infinity, which most JSON parsers reject.
+        "headroom_on_10gbe": (10000.0 / busiest_mbps
+                              if busiest_mbps > 0 else None),
+    }
+
+    # ---- users --------------------------------------------------------------
+    # ops_per_s is always greater than zero here, so none of these can divide
+    # by zero and none of them can be infinite.
+    users = {
+        "human_sessions_low": ops_per_s / HUMAN_SESSION_OPS_PER_S_HIGH,
+        "human_sessions_high": ops_per_s / HUMAN_SESSION_OPS_PER_S_LOW,
+        "automated_client_sessions": ops_per_s / AUTOMATED_CLIENT_OPS_PER_S,
+        "human_ops_per_s_low": HUMAN_SESSION_OPS_PER_S_LOW,
+        "human_ops_per_s_high": HUMAN_SESSION_OPS_PER_S_HIGH,
+        "automated_client_ops_per_s": AUTOMATED_CLIENT_OPS_PER_S,
+    }
+
+    machines = {
+        "api_servers": api_servers,
+        "api_server_spec": f"{API_SERVER_VCPU} vCPU, {API_SERVER_RAM_GB} GB",
+        "api_work_per_s": api_work,
+        "api_usable_searches_per_server": api_usable_searches_per_server(),
+        "postgres_servers": POSTGRES_SERVERS_PER_TIER,
+        "qdrant_servers": qdrant["nodes"],
+        "qdrant_node_ram_gb": qdrant["node_ram_gb"],
+        "qdrant_usable_gb_per_node": qdrant["usable_gb_per_node"],
+        "qdrant_total_ram_gb": qdrant["total_ram_gb"],
+        "qdrant_fill_of_allowance": qdrant["fill_of_allowance"],
+        "qdrant_node_ram_gb_forced": qdrant["node_ram_gb_forced"],
+        "qdrant_tight_fit": qdrant["tight_fit"],
+        "qdrant_options": qdrant["options"],
+        "embed_gpu_cards_low": embed_cards_low,
+        "embed_gpu_cards_high": embed_cards_high,
+        "embed_gpu_spare": GPU_SPARE_CARDS if cards_at_low_rate else 0,
+        "embed_usable_per_card_low": usable_low,
+        "embed_usable_per_card_high": usable_high,
+        "agent_gpu_cards": agent_cards,
+        "agent_gpu_spare": GPU_SPARE_CARDS if agent_cards_needed else 0,
+        "total_cpu_servers": (api_servers + POSTGRES_SERVERS_PER_TIER
+                              + qdrant["nodes"]),
+    }
+
+    return {
+        "run_name": run_name,
+        "inputs": {
+            "ops_per_s": ops_per_s,
+            "mix": mix.as_dict(),
+            "retention_days": retention_days,
+            "dims": dims,
+            "bytes_per_value": bytes_per_value,
+            "node_gb": node_gb,
+            "node_gb_source": node_gb_source,
+        },
+        "demand": demand,
+        "machines": machines,
+        "storage": storage,
+        "postgres": postgres,
+        "network": network,
+        "users": users,
+        "sensitivity": agent_sensitivity(adds, plains,
+                                         sensitivity_rates(agents),
+                                         this_run_rate=agents),
+    }
+
+
+def blend_mixes(human_ops_per_s: float, human_mix: TrafficMix,
+                automated_ops_per_s: float,
+                automated_mix: TrafficMix) -> TrafficMix:
+    """One traffic mix for a population made of two kinds of caller.
+
+    Each share is the two populations' shares averaged, weighted by the
+    operations each population demands. A population that sends nothing carries
+    no weight. With no traffic at all there is nothing to blend, so the human
+    mix is returned unchanged rather than a division by zero.
+    """
+    total = human_ops_per_s + automated_ops_per_s
+    if total <= 0:
+        return human_mix
+
+    def blended(human_share: float, automated_share: float) -> float:
+        return (human_ops_per_s * human_share
+                + automated_ops_per_s * automated_share) / total
+
+    return TrafficMix(
+        add=blended(human_mix.add, automated_mix.add),
+        plain=blended(human_mix.plain, automated_mix.plain),
+        agent=blended(human_mix.agent, automated_mix.agent))
+
+
+def ops_for_population(humans: float, automated: float,
+                       human_mix: TrafficMix | None = None,
+                       automated_mix: TrafficMix | None = None) -> dict:
+    """Convert a population of callers into the capacity it demands.
+
+    humans          concurrent human chat sessions - people typing
+    automated       concurrent automated clients - programs sending requests
+                    in a loop. This is a kind of CALLER. It is not agent-mode
+                    search, which is a flag on one request.
+    human_mix       how the human sessions' operations split between adds,
+                    plain searches and agent-mode searches
+    automated_mix   the same for the automated clients
+
+    Each population gets its own mix because the kind of caller and the kind of
+    request are correlated: automated clients may use agent-mode search on
+    nearly every call while people rarely do. Both mixes default to the model's
+    own default mix, so leaving them off changes nothing.
+
+    The blended mix is weighted at the busy end of the human rate, which is the
+    rate this report tells you to plan for, and it is what sizes the
+    deployment - the global default mix is not used once a population is given.
+    """
+    for field, value in (("human chat sessions", humans),
+                         ("automated clients", automated)):
+        if not math.isfinite(value):
+            raise SizingError(
+                f"the count of {field} is {value:g}, but a caller count must "
+                "be a finite number")
+    if humans < 0 or automated < 0:
+        raise SizingError("a caller count cannot be negative")
+    human_mix = human_mix or TrafficMix()
+    automated_mix = automated_mix or TrafficMix()
+    human_mix.validate()
+    automated_mix.validate()
+
+    human_low = humans * HUMAN_SESSION_OPS_PER_S_LOW
+    human_high = humans * HUMAN_SESSION_OPS_PER_S_HIGH
+    automated_ops = automated * AUTOMATED_CLIENT_OPS_PER_S
+    low = human_low + automated_ops
+    high = human_high + automated_ops
+    blended = blend_mixes(human_high, human_mix, automated_ops, automated_mix)
+
+    # The deployment this population needs, sized at the rate the report tells
+    # you to plan for and with the population's own blended mix. A population
+    # that makes no requests is not a deployment to size, and size_deployment
+    # refuses a design peak of zero for that reason, so there is nothing here.
+    sizing = None
+    if high > 0:
+        sizing = size_deployment(high, blended, run_name="population")
+
+    return {
+        "humans": humans,
+        "automated": automated,
+        "human_mix": human_mix.as_dict(),
+        "automated_mix": automated_mix.as_dict(),
+        "human_ops_per_s_low": human_low,
+        "human_ops_per_s_high": human_high,
+        "automated_ops_per_s": automated_ops,
+        "ops_per_s_low": low,
+        "ops_per_s_high": high,
+        "blended_mix": blended.as_dict(),
+        "tier_for_low": smallest_tier_holding(low),
+        "tier_for_high": smallest_tier_holding(high),
+        "sizing": sizing,
+    }
+
+
+def smallest_tier_holding(ops_per_s: float):
+    """Name the smallest tier whose design peak covers this rate, or None."""
+    for name in TIER_ORDER:
+        if TIER_OPS_PER_S[name] >= ops_per_s:
+            return name
+    return None
+
+
+# =============================================================================
+# PRESENTATION
+# Shared by the text report and the web page, so the two can never disagree.
+# =============================================================================
+
+
+def num(value: float, dp: int = 0) -> str:
+    return f"{value:,.{dp}f}"
+
+
+def gb(value_bytes: float) -> str:
+    """Format a byte count. GB means 10^9 bytes; TB means 10^12 bytes."""
+    if value_bytes >= BYTES_PER_TB:
+        return (f"{value_bytes / BYTES_PER_TB:,.2f} TB "
+                f"({value_bytes / BYTES_PER_GB:,.0f} GB)")
+    return f"{value_bytes / BYTES_PER_GB:,.2f} GB"
+
+
+def report_sections(r: dict) -> list:
+    """Build every section of the report as (title, note, headers, rows)."""
+    d = r["demand"]
+    m = r["machines"]
+    s = r["storage"]
+    p = r["postgres"]
+    n = r["network"]
+    u = r["users"]
+    i = r["inputs"]
+
+    sections = []
+
+    sections.append({
+        "title": "Inputs",
+        "note": "Everything the answer depends on. Change any of these and the "
+                "numbers below change.",
+        # Every input is echoed exactly as it was given. Rounding these to whole
+        # numbers described a deployment the tables below were not sized for:
+        # half a byte per number, which is int4 quantization, read as "0".
+        "headers": ["Item", "Value", "Label"],
+        "rows": [
+            ["Design peak", f"{as_given(i['ops_per_s'])} operations/s",
+             "assumption (worst rate sustained 5 minutes)"],
+            ["Traffic mix per 100 operations",
+             TrafficMix(**i["mix"]).as_words(),
+             ("assumption - never measured; agent-mode search is a "
+              "request flag, not a kind of caller")],
+            ["Retention", f"{as_given(i['retention_days'])} days",
+             "assumption - undecided, placeholder"],
+            ["Vector dimensions", as_given(i["dims"]),
+             "assumption - fix before first ingest"],
+            ["Bytes stored per number", as_given(i["bytes_per_value"]),
+             "assumption - 1 means int8 quantized"],
+            ["RAM per vector-store machine",
+             (f"{as_given(i['node_gb'])} GB, forced"
+              if i.get("node_gb") else "chosen automatically"),
+             ("assumption - set by hand" if i.get("node_gb") else
+              "assumption - the automatic choice buys the least total RAM")],
+        ],
+    })
+
+    sections.append({
+        "title": "Demand per second",
+        "note": "From the fan-out counts read from the code on 30 Aug 2026. "
+                "All derived.",
+        "headers": ["Item", "Per second", "Label"],
+        "rows": [
+            ["Adds", num(d["adds_per_s"], 1), "derived"],
+            ["Plain searches", num(d["plain_searches_per_s"], 1), "derived"],
+            ["Agent-mode searches", num(d["agent_searches_per_s"], 1), "derived"],
+            ["Embedding calls (today)", num(d["embeds_per_s"], 1), "derived"],
+            ["Embedding calls (with the types fix)",
+             num(d["embeds_per_s_with_types_fix"], 1), "derived"],
+            ["Vector searches", num(d["vector_searches_per_s"], 1), "derived"],
+            ["Vector writes", num(d["vector_writes_per_s"], 1), "derived"],
+            ["PostgreSQL statements", num(d["postgres_statements_per_s"], 1),
+             "derived"],
+            ["Agent language-model calls",
+             (f"{num(d['agent_llm_calls_per_s_low'], 1)} to "
+              f"{num(d['agent_llm_calls_per_s_high'], 1)} "
+              f"(planning on {num(d['agent_llm_calls_per_s_planning'], 1)})"),
+             "estimate - 1 to 2 calls per agent search"],
+        ],
+    })
+
+    embed_cards = (f"{m['embed_gpu_cards_low']}"
+                   if m["embed_gpu_cards_low"] == m["embed_gpu_cards_high"]
+                   else f"{m['embed_gpu_cards_low']} to {m['embed_gpu_cards_high']}")
+    sections.append({
+        "title": "Machines",
+        "note": "Counts always round up to a whole machine. GPU counts include "
+                "one spare card.",
+        "headers": ["Machine", "Count", "Spec each", "Basis"],
+        "rows": [
+            ["API server (gateway + MemMachine core)", num(m["api_servers"]),
+             m["api_server_spec"],
+             "derived from the 180/s anchor measured 30 Aug 2026"],
+            # Only the API server has a measured machine class. Naming its
+            # vCPU and RAM here as well would state a spec for two machines
+            # nobody has sized.
+            ["PostgreSQL server", num(m["postgres_servers"]),
+             "NVMe disk; vCPU and RAM undecided",
+             "assumption - never benchmarked at this statement rate"],
+            ["Qdrant server", num(m["qdrant_servers"]),
+             (f"{num(m['qdrant_node_ram_gb'])} GB RAM, NVMe disk; "
+              "vCPU undecided"),
+             "derived from retention and vector size"],
+            ["Embedding GPU card", embed_cards,
+             "H100-class (includes 1 spare)"
+             if m["embed_gpu_cards_high"] else "not needed at this rate",
+             "estimate - card rate never benchmarked"],
+            ["Agent-model GPU card", num(m["agent_gpu_cards"]),
+             "8B-class model (includes 1 spare)"
+             if m["agent_gpu_cards"] else "not needed at this mix (no "
+             "agent-mode traffic)",
+             "estimate - card rate never benchmarked"],
+            ["Total ordinary servers (not GPU)", num(m["total_cpu_servers"]),
+             "-", "derived"],
+        ],
+    })
+
+    sections.append({
+        "title": "How the API server count was reached",
+        "note": "Work is counted in plain-search-equivalents. One add is counted "
+                "as one plain-search-equivalent, which is an estimate that "
+                "rounds up: the 30 Aug run measured search only.",
+        "headers": ["Step", "Value", "Label"],
+        "rows": [
+            ["Vector searches/s", num(d["vector_searches_per_s"], 1), "derived"],
+            ["Plus adds/s counted as search-equivalents",
+             num(d["adds_per_s"], 1), "estimate"],
+            ["Work per second", num(m["api_work_per_s"], 1), "derived"],
+            ["Measured capacity per server",
+             f"{num(API_SEARCHES_PER_S_PER_SERVER, 0)} searches/s",
+             "measured 30 Aug 2026, 8 workers, 128 concurrent"],
+            ["Utilization ceiling",
+             f"{num(API_UTILIZATION_CEILING * 100, 0)}%", "assumption"],
+            ["Planned capacity per server",
+             f"{num(m['api_usable_searches_per_server'], 0)} searches/s",
+             "derived"],
+            ["Servers, rounded up", num(m["api_servers"]), "derived"],
+        ],
+    })
+
+    sections.append({
+        "title": "Storage",
+        "note": f"At {as_given(i['retention_days'])} days of retention, "
+                f"{as_given(i['dims'])}-number vectors, "
+                f"{as_given(i['bytes_per_value'])} byte(s) per number. "
+                "GB means 10^9 bytes and TB means 10^12 bytes throughout.",
+        "headers": ["Item", "Value", "Label"],
+        "rows": [
+            ["Episodes stored per day", num(s["episodes_per_day"], 0), "derived"],
+            ["Episodes stored per year", num(s["episodes_per_year"], 0), "derived"],
+            ["Episodes held at this retention", num(s["episodes_retained"], 0),
+             "derived"],
+            ["Hot vector RAM in Qdrant", gb(s["hot_vector_ram_bytes"]),
+             "derived (includes 1.5x index overhead)"],
+            ["Qdrant NVMe disk", gb(s["qdrant_nvme_bytes"]),
+             "estimate - from declared per-episode byte sizes"],
+            ["PostgreSQL disk",
+             f"{gb(s['postgres_bytes_low'])} to {gb(s['postgres_bytes_high'])}",
+             "estimate - from declared per-episode byte sizes"],
+            ["One year, nothing ever deleted: hot vector RAM",
+             gb(s["unbounded_year_hot_vector_ram_bytes"]), "derived"],
+            ["One year, nothing ever deleted: Qdrant NVMe",
+             gb(s["unbounded_year_qdrant_nvme_bytes"]), "estimate"],
+            ["One year, nothing ever deleted: PostgreSQL disk",
+             (f"{gb(s['unbounded_year_postgres_bytes_low'])} to "
+              f"{gb(s['unbounded_year_postgres_bytes_high'])}"), "estimate"],
+        ],
+    })
+
+    qdrant_rows = []
+    for opt in m["qdrant_options"]:
+        chosen = "  <- chosen" if opt["node_ram_gb"] == m["qdrant_node_ram_gb"] else ""
+        qdrant_rows.append([
+            f"{num(opt['node_ram_gb'])} GB",
+            f"{num(opt['usable_gb_per_node'], 1)} GB",
+            f"{opt['nodes']}{chosen}",
+            f"{num(opt['total_ram_gb'])} GB",
+            f"{num(opt['fill_of_allowance'] * 100, 2)}%",
+            f"{num(opt['share_of_node_ram'] * 100, 2)}%",
+        ])
+    sections.append({
+        "title": "Qdrant node choice",
+        "note": "Every row here is a what-if, not a finding, so the rows carry "
+                "no label of their own: one row is the order, the others are "
+                "what the other machine sizes would have cost. All of them are "
+                "derived from the hot vector RAM above and the two assumptions "
+                "in this note. "
+                "A node is filled to at most "
+                f"{num(QDRANT_NODE_FILL_LIMIT * 100, 0)}% of its RAM, leaving "
+                "room for the operating system, Qdrant's own metadata and shards "
+                "that come out uneven. "
+                + ("The size was forced with "
+                   f"{i.get('node_gb_source', NODE_GB_SOURCE_CLI)}."
+                   if m["qdrant_node_ram_gb_forced"] else
+                   "The chosen size is the one that buys the least total RAM; "
+                   "a tie goes to fewer machines.")
+                + (" WARNING: the chosen size is more than "
+                   f"{num(QDRANT_TIGHT_FIT_WARN_FRACTION * 100, 0)}% full within "
+                   "that allowance, so a small growth in retention adds a whole "
+                   "machine." if m["qdrant_tight_fit"] else ""),
+        "headers": ["Node RAM", "Usable per node", "Nodes needed",
+                    "Total RAM bought", "Fill of allowance",
+                    "Share of node RAM used"],
+        "rows": qdrant_rows,
+    })
+
+    pooler = ("YES - more connections than have ever been proven to work; put "
+              "PgBouncer or an equivalent connection pooler in front of "
+              "PostgreSQL"
+              if p["needs_connection_pooler"] else "no")
+    sections.append({
+        "title": "PostgreSQL",
+        "note": "Connections, not compute, are what failed on 30 Aug 2026: the "
+                "core filled the connection table, the gateway could then not "
+                "get a connection to check API keys, and it returned HTTP 401 "
+                "on valid keys.",
+        "headers": ["Item", "Value", "Label"],
+        "rows": [
+            ["Statements per second", num(p["statements_per_s"], 1), "derived"],
+            ["Workers per API server", num(p["workers_per_api_server"]),
+             "measured 30 Aug 2026 - 8 is the knee"],
+            ["Connections per worker", num(p["connections_per_worker"]),
+             (f"measured - pool {POSTGRES_POOL_SIZE} + overflow "
+              f"{POSTGRES_MAX_OVERFLOW}")],
+            ["Core connections", num(p["core_connections"]), "derived"],
+            ["Gateway connections", num(p["gateway_connections"]),
+             "assumption - 20 per API server"],
+            ["max_connections this tier needs",
+             num(p["max_connections_required"]), "derived"],
+            ["Chart default", num(p["chart_default_max_connections"]),
+             "measured - this default failed on 30 Aug 2026"],
+            ["Largest setting ever proven to work",
+             num(p["proven_max_connections"]),
+             "measured 30 Aug 2026 - cleared every error"],
+            ["Needs a connection pooler", pooler, "derived"],
+        ],
+    })
+
+    sections.append({
+        "title": "Network",
+        "note": "Every byte size behind these figures is an estimate declared as "
+                "a named constant in this program, so the numbers can be checked "
+                "by hand. Mbps means 10^6 bits per second.",
+        "headers": ["Item", "Value", "Label"],
+        "rows": [
+            ["North-south peak (clients to the service)",
+             f"{num(n['north_south_mbps'], 1)} Mbps", "estimate"],
+            ["East-west peak (between servers inside the data center)",
+             f"{num(n['east_west_mbps'], 1)} Mbps", "estimate"],
+            ["Bytes per embedding call",
+             f"{num(n['embed_bytes_per_call'])} bytes", "estimate"],
+            ["Bytes per vector search",
+             f"{num(n['vector_search_bytes_per_call'])} bytes", "estimate"],
+            ["Bytes per vector write",
+             f"{num(n['vector_write_bytes_per_call'])} bytes", "estimate"],
+            ["Headroom on a 10 GbE link (busiest direction)",
+             (f"{num(n['headroom_on_10gbe'], 1)}x"
+              if n["headroom_on_10gbe"] is not None else "no traffic"),
+             "derived from estimates - no measured number enters it"],
+        ],
+    })
+
+    sections.append({
+        "title": "Callers this capacity holds",
+        "note": "Both per-caller rates are estimates. The gap between one "
+                "request and the next has never been measured. Meter real "
+                "operations per second per API key from the first day of the "
+                "pilot. An automated client is a kind of CALLER - a program "
+                "sending requests in a loop - and has nothing to do with "
+                "agent-mode search, which is a flag on one REQUEST. Each row "
+                "below is that kind of caller on its own, sized at this run's "
+                "traffic mix.",
+        "headers": ["Kind of caller", "Sessions held", "Label"],
+        "rows": [
+            [("Human chat sessions "
+              f"({u['human_ops_per_s_low']:g}-"
+              f"{u['human_ops_per_s_high']:g} ops/s each)"),
+             (f"{num(u['human_sessions_low'], 0)} to "
+              f"{num(u['human_sessions_high'], 0)}"), "estimate"],
+            [("Automated clients in a 5-second tool loop "
+              f"({u['automated_client_ops_per_s']:g} ops/s each)"),
+             num(u["automated_client_sessions"], 0), "estimate"],
+        ],
+    })
+
+    # The agent rate takes one decimal place, matching the demand section. One
+    # decimal place is not enough to separate every pair of rates the table can
+    # hold - a mix that makes the run's own rate 2.04 puts it beside the fixed
+    # rate 2.0 and both print as "2.0" - so the run's own row says so in words.
+    sens_rows = [
+        [num(row["agent_searches_per_s"], 1)
+         + ("  <- this run" if row["is_this_run"] else ""),
+         num(row["total_ops_per_s"], 1),
+         num(row["vector_searches_per_s"], 1),
+         num(row["api_work_per_s"], 1),
+         num(row["api_servers"]),
+         (f"{num(row['llm_calls_per_s_low'], 0)} to "
+          f"{num(row['llm_calls_per_s_high'], 0)}")]
+        for row in r["sensitivity"]
+    ]
+    sections.append({
+        "title": "Sensitivity: what the agent-mode quota costs",
+        "note": "Every row here is a what-if, not a finding, so the rows carry "
+                'no label of their own: the one marked "this run" is the '
+                "traffic mix you asked about. All of them are derived from the "
+                "same "
+                "fan-out counts and the same 180/s anchor as the report above. "
+                f"Adds are held fixed at {num(r['demand']['adds_per_s'], 1)}/s and "
+                f"plain searches at {num(r['demand']['plain_searches_per_s'], 1)}/s. "
+                "Only the agent-mode rate varies. Agent-mode search is a flag "
+                "on a request, not a kind of caller. One agent-mode search "
+                f"costs about {AGENT_VECTOR_SEARCHES} plain searches, so this "
+                "one product decision moves the hardware order more than any "
+                "tuning does.",
+        "headers": ["Agent-mode searches/s", "Total ops/s", "Vector searches/s",
+                    "API work/s", "API servers", "Language-model calls/s"],
+        "rows": sens_rows,
+    })
+
+    return sections
+
+
+def render_table(headers: list, rows: list, indent: str = "  ") -> str:
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(str(cell)))
+    lines = []
+    lines.append(indent + "  ".join(h.ljust(widths[idx])
+                                    for idx, h in enumerate(headers)).rstrip())
+    lines.append(indent + "  ".join("-" * widths[idx]
+                                    for idx in range(len(headers))))
+    lines.extend(
+        indent + "  ".join(str(cell).ljust(widths[idx])
+                           for idx, cell in enumerate(row)).rstrip()
+        for row in rows)
+    return "\n".join(lines)
+
+
+def wrap(text: str, width: int = 78, indent: str = "  ") -> str:
+    words = text.split()
+    lines, current = [], ""
+    for word in words:
+        if current and len(current) + 1 + len(word) > width:
+            lines.append(indent + current)
+            current = word
+        else:
+            current = f"{current} {word}".strip()
+    if current:
+        lines.append(indent + current)
+    return "\n".join(lines)
+
+
+def population_note() -> str:
+    """The paragraph above the population tables, in the model's own numbers."""
+    spread_low = AUTOMATED_CLIENT_OPS_PER_S / HUMAN_SESSION_OPS_PER_S_HIGH
+    spread_high = AUTOMATED_CLIENT_OPS_PER_S / HUMAN_SESSION_OPS_PER_S_LOW
+    prompts_low = HUMAN_SESSION_OPS_PER_S_LOW * 3600 / OPS_PER_HUMAN_PROMPT
+    prompts_high = HUMAN_SESSION_OPS_PER_S_HIGH * 3600 / OPS_PER_HUMAN_PROMPT
+    return (
+        "There are two kinds of caller here, and both per-caller rates are "
+        "estimates. A human chat session is a person typing, assumed to make "
+        f"{HUMAN_SESSION_OPS_PER_S_LOW:g} to "
+        f"{HUMAN_SESSION_OPS_PER_S_HIGH:g} operations per second. That is about "
+        f"{prompts_low:.0f} prompts an hour at the low end and about "
+        f"{prompts_high:.0f} prompts an hour at the high end, at roughly "
+        f"{OPS_PER_HUMAN_PROMPT:g} operations per prompt. An automated client "
+        "is a program that sends requests in a loop rather than a person; in a "
+        f"5-second tool loop it is assumed to make {AUTOMATED_CLIENT_OPS_PER_S:g} "
+        f"operations per second, which is {spread_low:.0f} to "
+        f"{spread_high:.0f} times a human. An automated client is a kind of "
+        "CALLER. It is not agent-mode search, which is a flag on one REQUEST; "
+        "callers of either kind can send requests of either kind, which is why "
+        "each population below carries its own traffic mix. The gap between one "
+        "request and the next has never been measured for either caller, so "
+        "this is the largest single uncertainty in this model.")
+
+
+def tier_phrase(name, ops_per_s: float) -> str:
+    """How the report names the smallest tier that holds a rate."""
+    if name is None:
+        biggest = TIER_OPS_PER_S[TIER_ORDER[-1]]
+        return (f"above the scale tier ({num(biggest, 0)} ops/s) by "
+                f"{ops_per_s / biggest:.1f}x - no named tier holds it")
+    return f"{name} ({num(TIER_OPS_PER_S[name], 0)} ops/s design peak)"
+
+
+def population_sections(pop: dict) -> list:
+    """Every table of the population report, as (title, note, headers, rows).
+
+    Shared by the text report and the web page, so the two can never disagree.
+    """
+    human_mix = TrafficMix(**pop["human_mix"])
+    automated_mix = TrafficMix(**pop["automated_mix"])
+    blended = TrafficMix(**pop["blended_mix"])
+    sections = [{
+        "title": "Demand from this population",
+        "note": population_note(),
+        "headers": ["Kind of caller", "Count", "Rate each", "Demand", "Label"],
+        "rows": [
+            ["Human chat sessions", num(pop["humans"], 0),
+             (f"{HUMAN_SESSION_OPS_PER_S_LOW:g}-"
+              f"{HUMAN_SESSION_OPS_PER_S_HIGH:g} ops/s each"),
+             (f"{num(pop['human_ops_per_s_low'], 2)} to "
+              f"{num(pop['human_ops_per_s_high'], 2)} ops/s"),
+             "estimate - the per-caller rate has never been measured"],
+            ["Automated clients", num(pop["automated"], 0),
+             f"{AUTOMATED_CLIENT_OPS_PER_S:g} ops/s each",
+             f"{num(pop['automated_ops_per_s'], 2)} ops/s",
+             "estimate - the per-caller rate has never been measured"],
+            ["Total", num(pop["humans"] + pop["automated"], 0), "-",
+             (f"{num(pop['ops_per_s_low'], 2)} to "
+              f"{num(pop['ops_per_s_high'], 2)} ops/s"),
+             "derived from the two estimates above"],
+        ],
+    }, {
+        "title": "Traffic mix, per caller and blended",
+        "note": "Each population has its own mix, because the kind of caller "
+                "and the kind of request are correlated: automated clients may "
+                "use agent-mode search on nearly every call while people rarely "
+                "do. The blended row is the two mixes averaged, each weighted "
+                "by the operations that population demands at the busy end of "
+                "the human rate - the rate this report tells you to plan for. "
+                "The blended row, and not this program's default mix, is what "
+                "sizes the deployment below.",
+        "headers": ["Whose mix", "Per 100 operations", "Label"],
+        "rows": [
+            ["Human chat sessions", human_mix.as_words(),
+             "assumption - never measured"],
+            ["Automated clients", automated_mix.as_words(),
+             "assumption - never measured"],
+            ["Blended across the whole population", blended.as_words(),
+             "derived from the two mixes above and the demand table"],
+        ],
+    }]
+    # A population that makes no requests is not a deployment to size, so it
+    # gets no tier and no machines. Naming the pilot tier for it would be a
+    # hardware recommendation for nobody.
+    if pop["ops_per_s_high"] <= 0:
+        return sections
+
+    sections.append({
+        "title": "Smallest tier that holds this population",
+        "note": "The same headcount can need a pilot tier or a scale tier "
+                "depending on how many of the callers are automated clients "
+                "rather than people, and on how much agent-mode search each "
+                "population does.",
+        "headers": ["Case", "Demand", "Smallest tier that holds it", "Label"],
+        "rows": [
+            ["If humans are at the low rate",
+             f"{num(pop['ops_per_s_low'], 2)} ops/s",
+             tier_phrase(pop["tier_for_low"], pop["ops_per_s_low"]),
+             "derived"],
+            ["If humans are at the high rate",
+             f"{num(pop['ops_per_s_high'], 2)} ops/s",
+             tier_phrase(pop["tier_for_high"], pop["ops_per_s_high"]),
+             "derived"],
+        ],
+    })
+
+    m = pop["sizing"]["machines"]
+    embed = (f"{m['embed_gpu_cards_low']}"
+             if m["embed_gpu_cards_low"] == m["embed_gpu_cards_high"]
+             else f"{m['embed_gpu_cards_low']} to {m['embed_gpu_cards_high']}")
+    sections.append({
+        "title": "Machines this population needs",
+        "note": f"Sized at {num(pop['ops_per_s_high'], 2)} operations/s - the "
+                "high rate, which is the one to plan for - and with the "
+                "blended mix above rather than this program's default mix. "
+                "Run tier or calc for the full report behind these counts.",
+        "headers": ["Machine", "Count", "Label"],
+        "rows": [
+            ["API server (gateway + MemMachine core)", num(m["api_servers"]),
+             "derived from the 180/s anchor measured 30 Aug 2026"],
+            ["PostgreSQL server", num(m["postgres_servers"]),
+             "assumption - never benchmarked at this statement rate"],
+            [f"Qdrant server ({num(m['qdrant_node_ram_gb'])} GB RAM each)",
+             num(m["qdrant_servers"]),
+             "derived from retention and vector size"],
+            ["Embedding GPU card", embed,
+             "estimate - card rate never benchmarked"],
+            ["Agent-model GPU card", num(m["agent_gpu_cards"]),
+             "estimate - card rate never benchmarked"],
+        ],
+    })
+    return sections
+
+
+def render_report(r: dict, title: str) -> str:
+    out = []
+    out.append("=" * 80)
+    out.append(title)
+    out.append("=" * 80)
+    for section in report_sections(r):
+        out.append("")
+        out.append(section["title"])
+        out.append("-" * len(section["title"]))
+        if section["note"]:
+            out.append(wrap(section["note"]))
+            out.append("")
+        out.append(render_table(section["headers"], section["rows"]))
+    out.append("")
+    out.append("Labels: measured = from a real test, named by its date, its "
+               "configuration, or both.")
+    out.append("        derived  = computed by this program from measured "
+               "numbers.")
+    out.append("        estimate = never measured. Benchmark before ordering "
+               "hardware.")
+    out.append("        assumption = a planning choice, not a finding.")
+    out.append("        The Qdrant node choice table and the sensitivity table "
+               "show what-ifs rather")
+    out.append("        than findings, so their rows carry no label; the note "
+               "above each says")
+    out.append("        where its numbers come from.")
+    return "\n".join(out)
+
+
+# =============================================================================
+# VALIDATE - the published figures and the model's constants, as
+# "name: value" lines. It is a fixed, named list that the test suite pins, not
+# a dump of every value the model computes on the way to an answer.
+# =============================================================================
+
+
+def round_out(value):
+    """Round floats so the JSON file is stable and diffable."""
+    if isinstance(value, bool) or not isinstance(value, float):
+        return value
+    if abs(value) >= 1e12:
+        return round(value, 0)
+    return round(value, 4)
+
+
+def published_numbers(name: str, r: dict) -> list:
+    """Flat (key, value) pairs for one tier, in a fixed order."""
+    d, m, s, p, n, u, i = (r["demand"], r["machines"], r["storage"],
+                           r["postgres"], r["network"], r["users"], r["inputs"])
+    pairs = [
+        (f"{name}.ops_per_s", i["ops_per_s"]),
+        (f"{name}.mix_add", i["mix"]["add"]),
+        (f"{name}.mix_plain", i["mix"]["plain"]),
+        (f"{name}.mix_agent", i["mix"]["agent"]),
+        (f"{name}.retention_days", i["retention_days"]),
+        (f"{name}.vector_dims", i["dims"]),
+        (f"{name}.bytes_per_value", i["bytes_per_value"]),
+        # The node-size input under its own name. The size itself is
+        # qdrant_node_ram_gb below: when this flag is true that is the size
+        # that was forced, and when it is false it is the size the program
+        # chose. Exporting the raw input would put a null in the file on every
+        # ordinary run, which is harder to read than the flag.
+        (f"{name}.node_gb_forced", i["node_gb"] is not None),
+
+        (f"{name}.adds_per_s", d["adds_per_s"]),
+        (f"{name}.plain_searches_per_s", d["plain_searches_per_s"]),
+        (f"{name}.agent_searches_per_s", d["agent_searches_per_s"]),
+        (f"{name}.embeds_per_s", d["embeds_per_s"]),
+        (f"{name}.embeds_per_s_with_types_fix", d["embeds_per_s_with_types_fix"]),
+        (f"{name}.vector_searches_per_s", d["vector_searches_per_s"]),
+        (f"{name}.vector_writes_per_s", d["vector_writes_per_s"]),
+        (f"{name}.postgres_statements_per_s", d["postgres_statements_per_s"]),
+        (f"{name}.agent_llm_calls_per_s_low", d["agent_llm_calls_per_s_low"]),
+        (f"{name}.agent_llm_calls_per_s_high", d["agent_llm_calls_per_s_high"]),
+        (f"{name}.agent_llm_calls_per_s_planning",
+         d["agent_llm_calls_per_s_planning"]),
+
+        (f"{name}.api_work_per_s", m["api_work_per_s"]),
+        (f"{name}.api_usable_searches_per_server",
+         m["api_usable_searches_per_server"]),
+        (f"{name}.api_servers", m["api_servers"]),
+        (f"{name}.api_server_spec", m["api_server_spec"]),
+        (f"{name}.postgres_servers", m["postgres_servers"]),
+        (f"{name}.qdrant_servers", m["qdrant_servers"]),
+        (f"{name}.qdrant_node_ram_gb", m["qdrant_node_ram_gb"]),
+        (f"{name}.qdrant_usable_gb_per_node", m["qdrant_usable_gb_per_node"]),
+        (f"{name}.qdrant_total_ram_gb", m["qdrant_total_ram_gb"]),
+        (f"{name}.qdrant_fill_of_allowance_pct",
+         m["qdrant_fill_of_allowance"] * 100),
+        (f"{name}.qdrant_tight_fit", m["qdrant_tight_fit"]),
+        (f"{name}.embed_gpu_cards_low", m["embed_gpu_cards_low"]),
+        (f"{name}.embed_gpu_cards_high", m["embed_gpu_cards_high"]),
+        (f"{name}.embed_gpu_spare", m["embed_gpu_spare"]),
+        (f"{name}.agent_gpu_cards", m["agent_gpu_cards"]),
+        (f"{name}.agent_gpu_spare", m["agent_gpu_spare"]),
+        (f"{name}.total_cpu_servers", m["total_cpu_servers"]),
+    ]
+    pairs.extend(
+        (f"{name}.qdrant_nodes_at_{opt['node_ram_gb']}gb", opt["nodes"])
+        for opt in m["qdrant_options"])
+    pairs += [
+        (f"{name}.episodes_per_day", s["episodes_per_day"]),
+        (f"{name}.episodes_per_year", s["episodes_per_year"]),
+        (f"{name}.episodes_retained", s["episodes_retained"]),
+        (f"{name}.hot_vector_ram_gb", s["hot_vector_ram_gb"]),
+        (f"{name}.qdrant_nvme_gb", s["qdrant_nvme_gb"]),
+        (f"{name}.postgres_gb_low", s["postgres_gb_low"]),
+        (f"{name}.postgres_gb_high", s["postgres_gb_high"]),
+        (f"{name}.unbounded_year_hot_vector_ram_gb",
+         s["unbounded_year_hot_vector_ram_gb"]),
+        (f"{name}.unbounded_year_qdrant_nvme_gb",
+         s["unbounded_year_qdrant_nvme_gb"]),
+        (f"{name}.unbounded_year_postgres_gb_low",
+         s["unbounded_year_postgres_gb_low"]),
+        (f"{name}.unbounded_year_postgres_gb_high",
+         s["unbounded_year_postgres_gb_high"]),
+
+        (f"{name}.postgres_core_connections", p["core_connections"]),
+        (f"{name}.postgres_gateway_connections", p["gateway_connections"]),
+        (f"{name}.postgres_total_connections", p["total_connections"]),
+        (f"{name}.postgres_max_connections_required",
+         p["max_connections_required"]),
+        (f"{name}.postgres_exceeds_chart_default", p["exceeds_chart_default"]),
+        (f"{name}.postgres_exceeds_proven_setting", p["exceeds_proven_setting"]),
+        (f"{name}.postgres_needs_connection_pooler", p["needs_connection_pooler"]),
+
+        (f"{name}.network_north_south_mbps", n["north_south_mbps"]),
+        (f"{name}.network_east_west_mbps", n["east_west_mbps"]),
+        (f"{name}.network_busiest_link_mbps", n["busiest_link_mbps"]),
+        (f"{name}.network_embed_bytes_per_call", n["embed_bytes_per_call"]),
+        (f"{name}.network_vector_search_bytes_per_call",
+         n["vector_search_bytes_per_call"]),
+        (f"{name}.network_vector_write_bytes_per_call",
+         n["vector_write_bytes_per_call"]),
+        (f"{name}.network_llm_bytes_per_call", n["llm_bytes_per_call"]),
+        (f"{name}.network_headroom_on_10gbe", n["headroom_on_10gbe"]),
+
+        (f"{name}.human_sessions_low", u["human_sessions_low"]),
+        (f"{name}.human_sessions_high", u["human_sessions_high"]),
+        (f"{name}.automated_client_sessions", u["automated_client_sessions"]),
+    ]
+    # Numbered rows, not a key built from the agent rate. The rate is a float
+    # that the traffic mix can make fractional, so a key like "agent2" put the
+    # 2.0 row and the 2.5 row in the same place and the second silently
+    # overwrote the first. Each row now carries its own rate as a value.
+    for position, row in enumerate(r["sensitivity"], start=1):
+        stem = f"{name}.sensitivity.row{position}"
+        pairs += [
+            (f"{stem}.agent_searches_per_s", row["agent_searches_per_s"]),
+            (f"{stem}.total_ops_per_s", row["total_ops_per_s"]),
+            (f"{stem}.vector_searches_per_s", row["vector_searches_per_s"]),
+            (f"{stem}.api_work_per_s", row["api_work_per_s"]),
+            (f"{stem}.api_servers", row["api_servers"]),
+            (f"{stem}.llm_calls_per_s_low", row["llm_calls_per_s_low"]),
+            (f"{stem}.llm_calls_per_s_high", row["llm_calls_per_s_high"]),
+        ]
+    return pairs
+
+
+def constant_numbers() -> list:
+    """The model's own inputs, so they can be quoted elsewhere and checked.
+
+    Every named constant in the README's "Every input, and what it is set to"
+    table appears here, under its own name in lower case. A test reads that
+    table and fails if any of them is missing, so the two cannot drift apart.
+    """
+    return [
+        ("constants.tier_ops_per_s_pilot", TIER_OPS_PER_S["pilot"]),
+        ("constants.tier_ops_per_s_target", TIER_OPS_PER_S["target"]),
+        ("constants.tier_ops_per_s_scale", TIER_OPS_PER_S["scale"]),
+        ("constants.sensitivity_agent_rates", list(SENSITIVITY_AGENT_RATES)),
+        ("constants.api_searches_per_s_per_server",
+         API_SEARCHES_PER_S_PER_SERVER),
+        ("constants.api_utilization_ceiling", API_UTILIZATION_CEILING),
+        ("constants.api_usable_searches_per_server",
+         api_usable_searches_per_server()),
+        ("constants.api_workers_per_server", API_WORKERS_PER_SERVER),
+        ("constants.api_server_vcpu", API_SERVER_VCPU),
+        ("constants.api_server_ram_gb", API_SERVER_RAM_GB),
+        ("constants.add_embeds", ADD_EMBEDS),
+        ("constants.add_vector_writes", ADD_VECTOR_WRITES),
+        ("constants.add_postgres_statements", ADD_POSTGRES_STATEMENTS),
+        ("constants.add_llm_calls", ADD_LLM_CALLS),
+        ("constants.add_cost_in_plain_search_equivalents",
+         ADD_COST_IN_PLAIN_SEARCH_EQUIVALENTS),
+        ("constants.plain_embeds", PLAIN_EMBEDS),
+        ("constants.plain_embeds_with_types_fix", PLAIN_EMBEDS_WITH_TYPES_FIX),
+        ("constants.plain_vector_searches", PLAIN_VECTOR_SEARCHES),
+        ("constants.plain_postgres_statements", PLAIN_POSTGRES_STATEMENTS),
+        ("constants.plain_llm_calls", PLAIN_LLM_CALLS),
+        ("constants.agent_embeds", AGENT_EMBEDS),
+        ("constants.agent_vector_searches", AGENT_VECTOR_SEARCHES),
+        ("constants.agent_postgres_statements", AGENT_POSTGRES_STATEMENTS),
+        ("constants.agent_llm_calls_low", AGENT_LLM_CALLS_LOW),
+        ("constants.agent_llm_calls_high", AGENT_LLM_CALLS_HIGH),
+        ("constants.agent_llm_calls_planning", AGENT_LLM_CALLS_PLANNING),
+        ("constants.embed_card_requests_per_s_low",
+         EMBED_CARD_REQUESTS_PER_S_LOW),
+        ("constants.embed_card_requests_per_s_high",
+         EMBED_CARD_REQUESTS_PER_S_HIGH),
+        ("constants.gpu_utilization_ceiling", GPU_UTILIZATION_CEILING),
+        ("constants.embed_usable_per_card_low",
+         EMBED_CARD_REQUESTS_PER_S_LOW * GPU_UTILIZATION_CEILING),
+        ("constants.embed_usable_per_card_high",
+         EMBED_CARD_REQUESTS_PER_S_HIGH * GPU_UTILIZATION_CEILING),
+        ("constants.gpu_spare_cards", GPU_SPARE_CARDS),
+        ("constants.agent_llm_calls_per_s_per_card",
+         AGENT_LLM_CALLS_PER_S_PER_CARD),
+        ("constants.qdrant_index_overhead_factor", QDRANT_INDEX_OVERHEAD_FACTOR),
+        ("constants.qdrant_node_fill_limit", QDRANT_NODE_FILL_LIMIT),
+        ("constants.qdrant_node_ram_options_gb",
+         list(QDRANT_NODE_RAM_OPTIONS_GB)),
+        ("constants.qdrant_tight_fit_warn_fraction",
+         QDRANT_TIGHT_FIT_WARN_FRACTION),
+        ("constants.bytes_per_gb", BYTES_PER_GB),
+
+        ("constants.max_ops_per_s", MAX_OPS_PER_S),
+        ("constants.max_retention_days", MAX_RETENTION_DAYS),
+        ("constants.max_vector_dims", MAX_VECTOR_DIMS),
+        ("constants.max_bytes_per_value", MAX_BYTES_PER_VALUE),
+        ("constants.max_node_gb", MAX_NODE_GB),
+
+        ("constants.original_vector_bytes_per_value",
+         ORIGINAL_VECTOR_BYTES_PER_VALUE),
+        ("constants.qdrant_disk_payload_bytes_per_episode",
+         QDRANT_DISK_PAYLOAD_BYTES_PER_EPISODE),
+        ("constants.qdrant_disk_overhead_factor", QDRANT_DISK_OVERHEAD_FACTOR),
+        ("constants.episode_text_bytes_low", EPISODE_TEXT_BYTES_LOW),
+        ("constants.episode_text_bytes_high", EPISODE_TEXT_BYTES_HIGH),
+        ("constants.postgres_row_overhead_bytes", POSTGRES_ROW_OVERHEAD_BYTES),
+        ("constants.postgres_index_bytes_per_episode",
+         POSTGRES_INDEX_BYTES_PER_EPISODE),
+        ("constants.postgres_bloat_factor", POSTGRES_BLOAT_FACTOR),
+
+        ("constants.postgres_pool_size", POSTGRES_POOL_SIZE),
+        ("constants.postgres_max_overflow", POSTGRES_MAX_OVERFLOW),
+        ("constants.postgres_connections_per_worker",
+         POSTGRES_CONNECTIONS_PER_WORKER),
+        ("constants.gateway_connections_per_api_server",
+         GATEWAY_CONNECTIONS_PER_API_SERVER),
+        ("constants.postgres_chart_default_max_connections",
+         POSTGRES_CHART_DEFAULT_MAX_CONNECTIONS),
+        ("constants.postgres_proven_max_connections",
+         POSTGRES_PROVEN_MAX_CONNECTIONS),
+        ("constants.postgres_servers_per_tier", POSTGRES_SERVERS_PER_TIER),
+
+        ("constants.ns_add_request_bytes", NS_ADD_REQUEST_BYTES),
+        ("constants.ns_add_response_bytes", NS_ADD_RESPONSE_BYTES),
+        ("constants.ns_search_request_bytes", NS_SEARCH_REQUEST_BYTES),
+        ("constants.ns_response_bytes_per_episode",
+         NS_RESPONSE_BYTES_PER_EPISODE),
+        ("constants.ns_agent_answer_bytes", NS_AGENT_ANSWER_BYTES),
+        ("constants.plain_search_episodes_returned",
+         PLAIN_SEARCH_EPISODES_RETURNED),
+        ("constants.agent_search_episodes_returned",
+         AGENT_SEARCH_EPISODES_RETURNED),
+        ("constants.embed_request_bytes", EMBED_REQUEST_BYTES),
+        ("constants.embed_response_envelope_bytes",
+         EMBED_RESPONSE_ENVELOPE_BYTES),
+        ("constants.qdrant_search_request_envelope_bytes",
+         QDRANT_SEARCH_REQUEST_ENVELOPE_BYTES),
+        ("constants.qdrant_candidates_per_search", QDRANT_CANDIDATES_PER_SEARCH),
+        ("constants.qdrant_bytes_per_candidate", QDRANT_BYTES_PER_CANDIDATE),
+        ("constants.qdrant_upsert_envelope_bytes", QDRANT_UPSERT_ENVELOPE_BYTES),
+        ("constants.qdrant_upsert_response_bytes", QDRANT_UPSERT_RESPONSE_BYTES),
+        ("constants.postgres_bytes_per_statement", POSTGRES_BYTES_PER_STATEMENT),
+        ("constants.llm_call_request_bytes", LLM_CALL_REQUEST_BYTES),
+        ("constants.llm_call_response_bytes", LLM_CALL_RESPONSE_BYTES),
+        ("constants.network_protocol_overhead_factor",
+         NETWORK_PROTOCOL_OVERHEAD_FACTOR),
+
+        ("constants.human_session_ops_per_s_low", HUMAN_SESSION_OPS_PER_S_LOW),
+        ("constants.human_session_ops_per_s_high", HUMAN_SESSION_OPS_PER_S_HIGH),
+        ("constants.automated_client_ops_per_s", AUTOMATED_CLIENT_OPS_PER_S),
+        ("constants.ops_per_human_prompt", OPS_PER_HUMAN_PROMPT),
+
+        ("constants.server_request_timeout_s", SERVER_REQUEST_TIMEOUT_S),
+    ]
+
+
+def run_validate(mix: TrafficMix, retention_days: float, dims: int,
+                 bytes_per_value: float, node_gb=None,
+                 out_path: str = NUMBERS_FILE) -> int:
+    pairs = list(constant_numbers())
+    for name in TIER_ORDER:
+        r = size_deployment(TIER_OPS_PER_S[name], mix, retention_days, dims,
+                            bytes_per_value, node_gb, run_name=name)
+        pairs += published_numbers(name, r)
+
+    def show(value):
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, float):
+            return f"{round_out(value)}"
+        if isinstance(value, list):
+            return ", ".join(str(v) for v in value)
+        return str(value)
+
+    flat = {}
+    for key, value in pairs:
+        flat[key] = round_out(value)
+        print(f"{key}: {show(value)}")
+
+    with open(out_path, "w", encoding="utf-8") as handle:
+        json.dump(flat, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    print()
+    print(f"wrote {len(flat)} numbers to {out_path}")
+    return 0
+
+
+# =============================================================================
+# WEB SERVER
+# One HTML form at / and one JSON endpoint at /api/calc. No internet access is
+# needed: the page carries its own styling and uses no external files.
+# =============================================================================
+
+PAGE_STYLE = """
+:root { color-scheme: light; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica,
+       Arial, sans-serif; margin: 0; background: #f6f6f4; color: #16181d; }
+main { max-width: 1000px; margin: 0 auto; padding: 24px 20px 64px; }
+h1 { font-size: 22px; margin: 0 0 4px; }
+h2 { font-size: 16px; margin: 32px 0 6px; padding-bottom: 4px;
+     border-bottom: 2px solid #16181d; }
+p.lede, p.note { font-size: 13px; line-height: 1.55; color: #4a4f57;
+                 margin: 0 0 12px; }
+form { background: #fff; border: 1px solid #d8d8d2; border-radius: 8px;
+       padding: 16px; margin: 16px 0 8px; }
+.fields { display: flex; flex-wrap: wrap; gap: 14px; }
+label { display: block; font-size: 12px; font-weight: 600; margin-bottom: 4px; }
+label span { display: block; font-weight: 400; color: #6b7079; font-size: 11px; }
+input { font: inherit; font-size: 14px; padding: 6px 8px; width: 110px;
+        border: 1px solid #c5c5bd; border-radius: 5px; background: #fff; }
+button { font: inherit; font-size: 14px; font-weight: 600; margin-top: 14px;
+         padding: 8px 18px; border: 0; border-radius: 5px; background: #16181d;
+         color: #fff; cursor: pointer; }
+.tablewrap { overflow-x: auto; margin-bottom: 4px; }
+table { border-collapse: collapse; width: 100%; background: #fff;
+        font-size: 13px; border: 1px solid #d8d8d2; }
+th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid #ececE6;
+         vertical-align: top; }
+th { background: #eeeee8; font-weight: 600; }
+tr:last-child td { border-bottom: 0; }
+td.num { font-variant-numeric: tabular-nums; }
+.err { background: #fff1f0; border: 1px solid #e0b4ae; border-radius: 8px;
+       padding: 14px 16px; font-size: 14px; color: #8a2a1c; margin: 16px 0; }
+footer { margin-top: 40px; font-size: 12px; color: #6b7079; line-height: 1.6; }
+code { background: #eeeee8; padding: 1px 5px; border-radius: 4px;
+       font-size: 12px; overflow-wrap: anywhere; }
+"""
+
+SIZING_FORM_FIELDS = [
+    ("ops", "Design peak, operations/s", "worst rate sustained 5 minutes"),
+    ("add", "Adds per 100 ops", "planning assumption"),
+    ("plain", "Plain searches per 100 ops", "planning assumption"),
+    ("agent", "Agent-mode searches per 100 ops",
+     "a request flag, not a caller"),
+    ("retention_days", "Retention, days", "undecided - placeholder"),
+    ("dims", "Vector dimensions", "fix before first ingest"),
+    ("bytes_per_value", "Bytes per number", "1 means int8 quantized"),
+    ("node_gb", "RAM per vector-store machine, GB",
+     "blank or 'automatic' chooses it"),
+]
+
+# The caller population, which is a separate question from the sizing above:
+# how many callers there are and how fast each sends, rather than a design
+# peak somebody already knows. Both counts may be left blank, and then the
+# page asks nothing about a population at all.
+POPULATION_FORM_FIELDS = [
+    ("humans", "Human chat sessions", "people typing; blank for none"),
+    ("automated", "Automated clients",
+     "programs in a tool loop; blank for none"),
+    ("human_mix", "Human traffic mix", "adds/plain/agent-mode"),
+    ("automated_mix", "Automated client traffic mix",
+     "adds/plain/agent-mode"),
+]
+
+# Every box on the page, in the order it is drawn.
+FORM_FIELDS = SIZING_FORM_FIELDS + POPULATION_FORM_FIELDS
+
+# What a reader may type in the "RAM per vector-store machine" box to ask for
+# the automatic choice, as well as leaving it empty.
+NODE_GB_AUTOMATIC_WORDS = ("auto", "automatic")
+
+# What each box is called in an error message, and what belongs in it. A
+# message that says "every field must be a number" leaves the reader to hunt
+# through eight boxes, so every message below names one box and quotes what was
+# typed into it.
+FORM_FIELD_HELP = {
+    "ops": ("design peak",
+            "the operations per second you need to serve"),
+    "add": ("adds per 100 operations",
+            "how many of every 100 operations are adds"),
+    "plain": ("plain searches per 100 operations",
+              "how many of every 100 operations are plain searches"),
+    "agent": ("agent-mode searches per 100 operations",
+              "how many of every 100 operations are agent-mode searches"),
+    "retention_days": ("retention, days",
+                       "how many days an episode is kept before it is deleted"),
+    "dims": ("vector dimensions", "how many numbers one vector holds"),
+    "bytes_per_value": ("bytes per number",
+                        "how many bytes are stored for each number"),
+    "node_gb": ("RAM per vector-store machine",
+                ("the GB of RAM one machine has, or nothing at all to have "
+                 "the size chosen for you")),
+    "humans": ("human chat sessions",
+               ("how many people are typing at once, or nothing at all if "
+                "you are not sizing from a population")),
+    "automated": ("automated clients",
+                  ("how many programs are sending requests in a loop, or "
+                   "nothing at all if you are not sizing from a population")),
+    "human_mix": ("human traffic mix",
+                  ("how the human sessions' 100 operations split, as "
+                   f"adds/plain/agent-mode, such as {MIX_TRIPLE_EXAMPLE}")),
+    "automated_mix": ("automated client traffic mix",
+                      ("how the automated clients' 100 operations split, "
+                       "written the same way")),
+}
+
+# What each box holds when it is not sent at all - a bare /api/calc call, or a
+# first visit to the page. None in the node_gb box means "choose the size".
+FORM_DEFAULTS = {
+    "ops": TIER_OPS_PER_S["target"],
+    "add": DEFAULT_MIX_ADD,
+    "plain": DEFAULT_MIX_PLAIN,
+    "agent": DEFAULT_MIX_AGENT,
+    "retention_days": DEFAULT_RETENTION_DAYS,
+    "dims": DEFAULT_VECTOR_DIMS,
+    "bytes_per_value": DEFAULT_BYTES_PER_VALUE,
+    "node_gb": None,
+    # A population is an optional second question. Both counts start empty,
+    # and while they are both empty the page says nothing about a population.
+    "humans": None,
+    "automated": None,
+    "human_mix": default_mix_text(),
+    "automated_mix": default_mix_text(),
+}
+
+# The id of the error message, so that a box can point at it with
+# aria-describedby and a screen reader reads the two together.
+FORM_ERROR_ID = "form-error"
+
+
+class FieldError(SizingError):
+    """A bad input that knows which box on the form it came from."""
+
+    def __init__(self, field: str, message: str):
+        super().__init__(message)
+        self.field = field
+
+
+def html_sections(sections: list) -> list:
+    """One report section per heading and table, as HTML fragments.
+
+    The sizing report and the population report are drawn by this one
+    function, so a table can never look one way in the first and another way
+    in the second.
+    """
+    parts = []
+    for section in sections:
+        parts.append(f"<h2>{escape(section['title'])}</h2>")
+        if section["note"]:
+            parts.append(f"<p class=\"note\">{escape(section['note'])}</p>")
+        parts.append('<div class="tablewrap"><table><thead><tr>')
+        parts.extend(f"<th>{escape(head)}</th>" for head in section["headers"])
+        parts.append("</tr></thead><tbody>")
+        for row in section["rows"]:
+            parts.append("<tr>")
+            for idx, cell in enumerate(row):
+                css = ' class="num"' if idx > 0 else ""
+                parts.append(f"<td{css}>{escape(str(cell))}</td>")
+            parts.append("</tr>")
+        parts.append("</tbody></table></div>")
+    return parts
+
+
+def render_html(values: dict, result: dict | None, error: str | None,
+                bad_field: str | None = None) -> str:
+    parts = [
+        '<!doctype html><html lang="en"><head><meta charset="utf-8">',
+        '<meta name="viewport" content="width=device-width, initial-scale=1">',
+        "<title>MemMachine sizing calculator</title>",
+        f"<style>{PAGE_STYLE}</style></head><body><main>",
+        "<h1>MemMachine sizing calculator</h1>",
+        ('<p class="lede">Set the design peak, the traffic mix and the '
+         "retention period, and this page gives the machine counts, storage, "
+         "PostgreSQL connections and network peaks. Every number in the tables "
+         "of findings below is labelled measured, derived, estimate or "
+         'assumption. Two tables are different - "Qdrant node choice" and the '
+         "sensitivity table show what-ifs rather than findings, and the note "
+         "above each says where its numbers come from. The traffic mix is a "
+         "planning assumption that nobody has measured.</p>"
+         '<p class="lede">Two things here sound alike and are not. '
+         "<strong>Agent-mode search</strong> is how a request behaves: one "
+         "search that fans out into about 22. <strong>Automated clients</strong> "
+         "are callers: programs that send requests in a loop, about 0.4 "
+         "operations a second each, where a person sends 0.011 to 0.028. One "
+         "is how expensive a request is, the other is how fast a caller sends "
+         "them, and a caller of either kind can send requests of either "
+         "kind.</p>"),
+    ]
+    # The message goes above the form, carries role="alert" so a screen reader
+    # announces it, and the box it blames takes the focus - so submitting with
+    # the keyboard lands the reader on the box that has to change.
+    if error:
+        parts.append(f'<div class="err" id="{FORM_ERROR_ID}" role="alert">'
+                     f"<strong>Cannot calculate.</strong> {escape(error)}</div>")
+    parts.append('<form method="get" action="/">')
+
+    def draw_boxes(fields):
+        parts.append('<div class="fields">')
+        for key, title, hint in fields:
+            val = escape(str(values.get(key, "")))
+            flags = ""
+            if error and key == bad_field:
+                flags = (' aria-invalid="true" '
+                         f'aria-describedby="{FORM_ERROR_ID}" autofocus')
+            parts.append(
+                f'<div><label for="{key}">{escape(title)}'
+                f"<span>{escape(hint)}</span>"
+                f'</label><input id="{key}" name="{key}" value="{val}" '
+                f'type="text" inputmode="decimal"{flags}></div>')
+        parts.append("</div>")
+
+    draw_boxes(SIZING_FORM_FIELDS)
+    parts.append(
+        '<p class="note">A caller population, if you would rather start from '
+        "how many callers there are than from a rate. Leave both counts empty "
+        "and this part is skipped. An automated client is a caller: a program "
+        "that sends requests in a loop. It is not the same thing as "
+        "agent-mode search above, which is a flag on one request. Each "
+        "population carries its own mix, written as adds/plain/agent-mode.")
+    draw_boxes(POPULATION_FORM_FIELDS)
+    parts.append('<button type="submit">Calculate</button></form>')
+    if result is not None and result.get("population") is not None:
+        parts.extend(html_sections(population_sections(result["population"])))
+    if result is not None:
+        parts.extend(html_sections(report_sections(result)))
+
+    parts.append(
+        "<footer><p><strong>Labels.</strong> measured = from a real test, named "
+        "by its date, its configuration, or both. derived = computed by this "
+        "program from measured "
+        "numbers. estimate = never measured; benchmark before ordering "
+        "hardware. assumption = a planning choice, not a finding. The Qdrant "
+        "node choice table and the sensitivity table show what-ifs rather than "
+        "findings, so their rows carry no label; the note above each says "
+        "where its numbers come from.</p>"
+        "<p>The JSON below carries the same numbers without labels. Its "
+        "<code>run_name</code> field is the name of the run, not one of the "
+        "four labels above.</p>"
+        "<p>The same figures as JSON: "
+        "<code>/api/calc?ops=100&amp;add=45&amp;plain=45&amp;agent=10"
+        "&amp;retention_days=90&amp;dims=1024&amp;bytes_per_value=1</code>. "
+        "Add <code>&amp;node_gb=512</code> to force the size of a "
+        "vector-store machine; leave it out and the size is chosen "
+        "automatically.</p>"
+        "<p>To size from a caller population instead, add "
+        "<code>&amp;humans=5000&amp;automated=40</code>, and "
+        "<code>&amp;human_mix=48/50/2&amp;automated_mix=20/20/60</code> to "
+        "give each population its own traffic mix. <code>automated</code> "
+        "counts callers that are programs; <code>agent</code> above is the "
+        "agent-mode share of the requests themselves.</p>"
+        "<p>GB means 10<sup>9</sup> bytes, TB means 10<sup>12</sup> bytes and "
+        "Mbps means 10<sup>6</sup> bits per second throughout.</p></footer>")
+    parts.append("</main></body></html>")
+    return "".join(parts)
+
+
+def parse_node_gb(raw):
+    """Read the "RAM per vector-store machine" box.
+
+    Empty, or one of the words in NODE_GB_AUTOMATIC_WORDS, means the program
+    chooses the size itself, exactly as it does when --node-gb is not given.
+    This is the one box where empty is an answer rather than a blank, and the
+    hint under it says so. Anything else must be a number; size_deployment
+    then refuses it if it is not greater than zero, so a bad value becomes the
+    same reported error as any other bad field rather than a silent fall back
+    to the automatic choice.
+    """
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if text == "" or text.lower() in NODE_GB_AUTOMATIC_WORDS:
+        return None
+    return read_number(text, "node_gb")
+
+
+def format_default(value) -> str:
+    """A default as it should read in a form box.
+
+    A whole number reads as a whole number: the design peak default shows as
+    "100" and not "100.0", so the first view of the page matches every view
+    after a submit. A default that is already text - a traffic mix written as
+    45/45/10 - is shown as it stands.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return f"{float(value):g}"
+
+
+def read_number(text: str, key: str) -> float:
+    """One box's text as a number, or a FieldError that names that box."""
+    name, what = FORM_FIELD_HELP[key]
+    typed = str(text).strip()
+    if typed == "":
+        raise FieldError(key, f"the {name} box is empty - type {what}")
+    try:
+        return float(typed)
+    except (TypeError, ValueError, OverflowError):
+        if "," in typed:
+            raise FieldError(
+                key,
+                f'the {name} box says "{typed}", which is not a number - '
+                "type digits only, with no comma between the thousands"
+            ) from None
+        raise FieldError(
+            key,
+            f'the {name} box says "{typed}", which is not a number - '
+            f"type {what}") from None
+
+
+def submitted_text(query: dict, key: str):
+    """The text submitted for one box, or None when the box was not sent.
+
+    An empty box and a box that was never sent are different things. A bare
+    /api/calc call sends no boxes at all and takes every default, which is how
+    the command line behaves when a flag is left off. A form submission always
+    sends all eight boxes, so an empty one is a blank answer, and blanking the
+    design peak must not quietly become a plan for 100 operations per second.
+    """
+    sent = query.get(key)
+    if not sent:
+        return None
+    return sent[0]
+
+
+def unknown_parameter_error(query: dict):
+    """Complain about a web address this calculator cannot honour, or None.
+
+    A misspelled parameter used to be ignored in silence, so
+    /api/calc?ops=100&retention_day=1 answered confidently for the 90-day
+    default - a hardware order for a question nobody asked. A parameter sent
+    twice was quietly first-wins for the same reason.
+    """
+    for key in query:
+        if key not in FORM_DEFAULTS:
+            # "agents" is the one wrong spelling that must not be answered
+            # with "did you mean agent?", because agent is the mix share and
+            # the reader almost certainly meant the count of callers that are
+            # programs. It is named against the setting they want instead.
+            if key.lower() == "agents":
+                return RETIRED_AGENTS_SETTING_MESSAGE
+            known = ", ".join(sorted(FORM_DEFAULTS))
+            # Matched in lower case: the settings are all lower case, and the
+            # commonest miss is the right word in the wrong case. "Ops" scores
+            # 0.67 against "ops" and "OPS" scores 0, both below the cutoff, so
+            # neither used to get the one suggestion that would help.
+            near = difflib.get_close_matches(key.lower(), FORM_DEFAULTS, n=1,
+                                             cutoff=0.7)
+            suggestion = (f' Did you mean "{near[0]}"?' if near else
+                          f" The settings it accepts are: {known}.")
+            return (f'the web address has a setting called "{key}", which '
+                    f"this calculator does not know.{suggestion}")
+    for key, sent in query.items():
+        if len(sent) > 1:
+            return (f'the web address sets "{key}" {len(sent)} times. Set it '
+                    "once, so it is clear which value you meant.")
+    return None
+
+
+def population_from_form(values: dict):
+    """The caller population the form asks about, or None if it asks about none.
+
+    The two count boxes are the switch. Leave both empty and the page is only
+    a sizing calculator, exactly as it was before it could take a population;
+    fill in either one and the empty one counts as none of that kind of
+    caller. The two mix boxes are always answered, because each has a default
+    on the page, and each is read the same way as --human-mix and
+    --automated-mix on the command line.
+    """
+    humans_text = str(values.get("humans", "")).strip()
+    automated_text = str(values.get("automated", "")).strip()
+    if humans_text == "" and automated_text == "":
+        return None
+    humans = 0.0 if humans_text == "" else read_number(humans_text, "humans")
+    automated = (0.0 if automated_text == ""
+                 else read_number(automated_text, "automated"))
+    human_mix = read_mix_box(values, "human_mix")
+    automated_mix = read_mix_box(values, "automated_mix")
+    return ops_for_population(humans, automated, human_mix, automated_mix)
+
+
+def read_mix_box(values: dict, key: str) -> TrafficMix:
+    """One traffic-mix box as a mix, named by its own label when it is wrong."""
+    name, what = FORM_FIELD_HELP[key]
+    text = str(values.get(key, "")).strip()
+    if text == "":
+        raise FieldError(key, f"the {name} box is empty - type {what}")
+    try:
+        return parse_mix_text(text, f"the {name} box")
+    except SizingError as exc:
+        raise FieldError(key, str(exc)) from None
+
+
+def result_from_query(query: dict) -> tuple:
+    """Return (values_for_the_form, result, error, the_box_the_error_blames).
+
+    result is None when there is an error, and error is None when there is a
+    result. The fourth item names the box to mark invalid on the page, and is
+    None when the fault is not one box's alone - a traffic mix that does not
+    add up to 100, for instance.
+    """
+    values = {}
+    for key, default in FORM_DEFAULTS.items():
+        raw = submitted_text(query, key)
+        values[key] = format_default(default) if raw is None else raw
+    # No box on the page is at fault for a bad web address, so nothing is
+    # marked invalid: the fourth item stays None.
+    bad_address = unknown_parameter_error(query)
+    if bad_address is not None:
+        return values, None, bad_address, None
+    try:
+        ops = read_number(values["ops"], "ops")
+        mix = TrafficMix(read_number(values["add"], "add"),
+                         read_number(values["plain"], "plain"),
+                         read_number(values["agent"], "agent"))
+        retention = read_number(values["retention_days"], "retention_days")
+        dims = read_number(values["dims"], "dims")
+        bpv = read_number(values["bytes_per_value"], "bytes_per_value")
+        node_gb = parse_node_gb(values["node_gb"])
+        result = size_deployment(ops, mix, retention, dims, bpv, node_gb,
+                                 node_gb_source=NODE_GB_SOURCE_WEB,
+                                 run_name="web")
+        result["population"] = population_from_form(values)
+    except FieldError as exc:
+        return values, None, str(exc), exc.field
+    except (SizingError, ValueError, OverflowError, ArithmeticError) as exc:
+        return values, None, str(exc), None
+    return values, result, None, None
+
+
+class SizingHandler(BaseHTTPRequestHandler):
+    server_version = "MemMachineSizing/1.0"
+
+    # socketserver applies this to the connection with settimeout(), so a
+    # client that opens a connection and then sends nothing is dropped instead
+    # of holding a thread and a file descriptor for as long as it likes.
+    # BaseHTTPRequestHandler already treats the timeout as "close and stop".
+    timeout = SERVER_REQUEST_TIMEOUT_S
+
+    def do_GET(self):
+        # Belt and braces: a caller must always get an HTTP response, never a
+        # dropped connection, whatever a future change to the model raises.
+        try:
+            self._handle_get()
+        except (BrokenPipeError, ConnectionResetError):
+            # The reader closed the tab or hit stop. That is ordinary, not an
+            # internal error, and there is no longer a socket to answer on.
+            pass
+        except Exception as exc:
+            sys.stderr.write(f"unhandled error serving {self.path}: {exc}\n")
+            try:
+                self._send(500, "text/plain; charset=utf-8",
+                           b"internal error while sizing this request\n")
+            except OSError:
+                pass
+
+    def _handle_get(self):
+        parsed = urlparse(self.path)
+        # keep_blank_values matters: without it "?ops=" would arrive looking
+        # exactly like a request that never mentioned ops at all, and an empty
+        # box on the form would silently take the default.
+        query = parse_qs(parsed.query, keep_blank_values=True)
+        if parsed.path in ("/", "/index.html"):
+            values, result, error, bad_field = result_from_query(query)
+            body = render_html(values, result, error, bad_field).encode("utf-8")
+            self._send(200 if error is None else 400, "text/html; charset=utf-8",
+                       body)
+        elif parsed.path == "/favicon.ico":
+            # Every browser asks for a tab icon on every page load. Answering
+            # 404 puts an error in the console of an otherwise clean page, so
+            # say plainly that there is no icon and nothing went wrong.
+            self._send_no_content()
+        elif parsed.path == "/api/calc":
+            _, result, error, _bad_field = result_from_query(query)
+            if error is not None:
+                payload = json.dumps({"error": error}, indent=2).encode("utf-8")
+                self._send(400, "application/json; charset=utf-8", payload)
+            else:
+                payload = json.dumps(result, indent=2, default=str).encode("utf-8")
+                self._send(200, "application/json; charset=utf-8", payload)
+        elif parsed.path == "/healthz":
+            self._send(200, "text/plain; charset=utf-8", b"ok\n")
+        else:
+            self._send(404, "text/plain; charset=utf-8",
+                       b"not found - try / or /api/calc\n")
+
+    def _send_no_content(self) -> None:
+        """204 No Content: a real answer with nothing in it, and no error."""
+        self.send_response(204)
+        self.end_headers()
+
+    def _send(self, status: int, content_type: str, body: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        # fmt % args is http.server's own calling convention for this hook.
+        sys.stderr.write(f"{self.address_string()} - {fmt % args}\n")
+
+
+def checked_port(port: int) -> int:
+    """Refuse a port the operating system cannot bind, by name."""
+    if not 0 < port < 65536:
+        raise SizingError(f"port {port} is not between 1 and 65535")
+    return port
+
+
+def run_server(host: str, port: int) -> int:
+    httpd = ThreadingHTTPServer((host, port), SizingHandler)
+    print(f"sizing calculator on http://{host}:{port}/  "
+          f"(JSON at http://{host}:{port}/api/calc)  press Ctrl-C to stop")
+    print("this is a local development server: no authentication, no rate "
+          "limiting, not for an address the public can reach")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopped")
+    finally:
+        httpd.server_close()
+    return 0
+
+
+# =============================================================================
+# COMMAND LINE
+# =============================================================================
+
+
+def render_users_report(pop: dict) -> str:
+    out = []
+    title = "Caller population to required capacity"
+    out.append("=" * 80)
+    out.append(title)
+    out.append("=" * 80)
+    for section in population_sections(pop):
+        out.append("")
+        out.append(section["title"])
+        out.append("-" * len(section["title"]))
+        if section["note"]:
+            out.append(wrap(section["note"]))
+            out.append("")
+        out.append(render_table(section["headers"], section["rows"]))
+    out.append("")
+    if pop["ops_per_s_high"] <= 0:
+        out.append(wrap(
+            "This population makes no requests at all, so there is nothing to "
+            "size and no tier to name. Count the callers who will actually be "
+            "using it and ask again."))
+        return "\n".join(out)
+    recommended = pop["tier_for_high"] or "none - above the scale tier"
+    out.append(f"  Plan for the high rate: {recommended}")
+    out.append("")
+    out.append(wrap(
+        "The same population of callers can demand a pilot tier or a scale "
+        "tier depending on how many of them are automated clients rather than "
+        "people, and on how much agent-mode search each population does. Meter "
+        "real operations per second per API key from the first day of the "
+        "pilot and re-check this answer against the metered figure."))
+    return "\n".join(out)
+
+
+def render_tier_headline(r: dict) -> str:
+    m = r["machines"]
+    embed = (f"{m['embed_gpu_cards_low']}"
+             if m["embed_gpu_cards_low"] == m["embed_gpu_cards_high"]
+             else f"{m['embed_gpu_cards_low']} to {m['embed_gpu_cards_high']}")
+    return wrap(
+        f"In words: {m['api_servers']} API server(s), {m['postgres_servers']} "
+        f"PostgreSQL server(s) and {m['qdrant_servers']} Qdrant server(s) of "
+        f"{num(m['qdrant_node_ram_gb'])} GB RAM each, plus {embed} embedding GPU "
+        f"card(s) and {m['agent_gpu_cards']} agent-model GPU card(s), both "
+        "counts including one spare.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="memmachine_sizing.py",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=(
+            "MemMachine deployment sizing calculator. Turns a design peak in\n"
+            "operations per second into machine counts, storage, PostgreSQL\n"
+            "connections and network peaks. Read the module docstring for the\n"
+            "full list of inputs and where each one came from."),
+        epilog=(
+            "Examples:\n"
+            "  memmachine_sizing.py tier target\n"
+            "  memmachine_sizing.py calc --ops 250 --agent 4 --plain 51 --json\n"
+            "  memmachine_sizing.py users --humans 5000 --automated 40\n"
+            "  memmachine_sizing.py users --humans 5000 --automated 200 "
+            "--human-mix 48/50/2 --automated-mix 20/20/60\n"
+            "  memmachine_sizing.py validate --out sizing-numbers.json\n"
+            "  memmachine_sizing.py serve --port 8899\n"))
+    subs = parser.add_subparsers(dest="command", metavar="<subcommand>")
+
+    def add_mix_options(sub, include_shape=True):
+        sub.add_argument("--add", type=float, default=DEFAULT_MIX_ADD,
+                         help="adds per 100 operations (default: %(default)s; "
+                              "planning assumption, never measured)")
+        sub.add_argument("--plain", type=float, default=DEFAULT_MIX_PLAIN,
+                         help="plain searches per 100 operations "
+                              "(default: %(default)s)")
+        sub.add_argument("--agent", type=float, default=DEFAULT_MIX_AGENT,
+                         help="agent-mode searches per 100 operations "
+                              "(default: %(default)s; a request flag, not a "
+                              "kind of caller, and the biggest single lever "
+                              "on the hardware order)")
+        # Refused by name in main. Hidden, because it is not a flag any more:
+        # without it, --agents here would only ever be an unrecognized
+        # argument, and the reader would never be told that the flag they
+        # want is --automated on the users subcommand.
+        sub.add_argument("--agents", dest="retired_agents", nargs="?",
+                         const="", default=None, help=argparse.SUPPRESS)
+        if include_shape:
+            sub.add_argument("--retention-days", type=float,
+                             default=DEFAULT_RETENTION_DAYS,
+                             help="days an episode is kept before deletion "
+                                  "(default: %(default)s; a placeholder, "
+                                  "retention is undecided)")
+            sub.add_argument("--dims", type=int, default=DEFAULT_VECTOR_DIMS,
+                             help="numbers per vector (default: %(default)s)")
+            sub.add_argument("--bytes-per-value", type=float,
+                             default=DEFAULT_BYTES_PER_VALUE,
+                             help="bytes stored per number (default: "
+                                  "%(default)s, meaning int8 quantized)")
+            sub.add_argument("--node-gb", type=float, default=None,
+                             help="RAM per vector-store machine in GB "
+                                  "(default: chosen automatically; pass 256, "
+                                  "512 or 768 to force a shape)")
+
+    tier = subs.add_parser(
+        "tier", help="full report for one tier",
+        description="Print the full sizing report for one named tier as an "
+                    "aligned text table, including the agent-mode sensitivity "
+                    "table.")
+    tier.add_argument("name", choices=TIER_ORDER,
+                      help="pilot (20 ops/s), target (100 ops/s) or scale "
+                           "(1,000 ops/s)")
+    add_mix_options(tier)
+    tier.add_argument("--json", action="store_true",
+                      help="print the raw result as JSON instead of a table")
+
+    calc = subs.add_parser(
+        "calc", help="full report for any operations-per-second rate",
+        description="Size an arbitrary point: any design peak, any traffic mix, "
+                    "any retention period and any vector shape.")
+    calc.add_argument("--ops", type=float, required=True,
+                      help="design peak in operations per second")
+    add_mix_options(calc)
+    calc.add_argument("--json", action="store_true",
+                      help="print the raw result as JSON instead of a table")
+
+    users = subs.add_parser(
+        "users", help="convert a caller population into required capacity",
+        description="Convert a population of human chat sessions and "
+                    "automated clients into the operations per second they "
+                    "demand, blend their two traffic mixes, name the smallest "
+                    "tier that holds them and size the machines that mix "
+                    "needs. An automated client is a caller - a program "
+                    "sending requests in a loop. It is not agent-mode search, "
+                    "which is a flag on one request.")
+    users.add_argument("--humans", type=float, required=True,
+                       help="concurrent human chat sessions - people typing")
+    users.add_argument("--automated", type=float, default=0.0,
+                       help="concurrent automated clients: programs sending "
+                            "requests in a 5-second tool loop "
+                            "(default: %(default)s)")
+    users.add_argument("--human-mix", default=None,
+                       help="traffic mix of the human chat sessions, three "
+                            "numbers as adds/plain/agent-mode, such as "
+                            f"{MIX_TRIPLE_EXAMPLE} or 45,45,10 "
+                            f"(default: {default_mix_text()})")
+    users.add_argument("--automated-mix", default=None,
+                       help="traffic mix of the automated clients, written "
+                            "the same way "
+                            f"(default: {default_mix_text()})")
+    # Refused by name in main. See the note in add_mix_options.
+    users.add_argument("--agents", dest="retired_agents", nargs="?",
+                       const="", default=None, help=argparse.SUPPRESS)
+
+    validate = subs.add_parser(
+        "validate", help="print the published figures for all three tiers, "
+                          "and the model constants behind them",
+        description="Print the figures this program publishes for the pilot, "
+                    "target and scale tiers, together with every named "
+                    "constant the model is built from, as 'name: value' lines, "
+                    f"and write them to {NUMBERS_FILE} in the current "
+                    "directory so any figures quoted elsewhere can be checked "
+                    "against this program mechanically. It is a fixed, named "
+                    "list, not a dump of the model's intermediate working.")
+    add_mix_options(validate)
+    validate.add_argument("--out", default=NUMBERS_FILE,
+                          help="where to write the JSON file "
+                               "(default: %(default)s)")
+
+    serve = subs.add_parser(
+        "serve", help="run the web form and the JSON endpoint",
+        description="Serve an HTML form at / and a JSON endpoint at /api/calc. "
+                    "The page is self-contained and needs no internet access. "
+                    "Binds to localhost unless told otherwise. This is a local "
+                    "development server for one person at a desk, not a "
+                    "service: it has no authentication and no rate limiting, "
+                    "so do not put it on an address the public can reach.")
+    serve.add_argument("--host", default="127.0.0.1",
+                       help="address to bind (default: %(default)s)")
+    serve.add_argument("--port", type=int, default=8000,
+                       help="port to bind (default: %(default)s)")
+
+    return parser
+
+
+def refuse_the_retired_agents_flag(args) -> None:
+    """Refuse --agents by name, on every subcommand that could take it.
+
+    It used to mean "how many callers are programs", one letter from --agent,
+    which is the agent-mode share of the traffic mix. Left as an unrecognized
+    argument it would be refused without ever naming the flag the reader
+    wants, and on a parser that has --agent there is a real risk of it being
+    read as the mix share instead.
+    """
+    if getattr(args, "retired_agents", None) is not None:
+        raise SizingError(RETIRED_AGENTS_FLAG_MESSAGE)
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not args.command:
+        parser.print_help()
+        return 0
+
+    try:
+        # --agents used to mean "how many callers are programs", one letter
+        # from --agent, which is the agent-mode share of the traffic mix.
+        # It is refused by name on every subcommand that took it or that
+        # takes --agent, so it can never be read as the mix share.
+        refuse_the_retired_agents_flag(args)
+
+        if args.command == "tier":
+            mix = TrafficMix(args.add, args.plain, args.agent)
+            result = size_deployment(TIER_OPS_PER_S[args.name], mix,
+                                     args.retention_days, args.dims,
+                                     args.bytes_per_value, args.node_gb,
+                                     run_name=args.name)
+            if args.json:
+                print(json.dumps(result, indent=2, default=str))
+            else:
+                title = (f"{args.name.upper()} TIER - design peak "
+                         f"{as_given(TIER_OPS_PER_S[args.name])} operations/s")
+                print(render_report(result, title))
+                print()
+                print(render_tier_headline(result))
+            return 0
+
+        if args.command == "calc":
+            mix = TrafficMix(args.add, args.plain, args.agent)
+            result = size_deployment(args.ops, mix, args.retention_days,
+                                     args.dims, args.bytes_per_value,
+                                     args.node_gb, run_name="custom")
+            if args.json:
+                print(json.dumps(result, indent=2, default=str))
+            else:
+                print(render_report(
+                    result,
+                    f"DESIGN PEAK {as_given(args.ops)} operations/s"))
+                print()
+                print(render_tier_headline(result))
+            return 0
+
+        if args.command == "users":
+            human_mix = (parse_mix_text(args.human_mix, "--human-mix")
+                         if args.human_mix is not None else TrafficMix())
+            automated_mix = (
+                parse_mix_text(args.automated_mix, "--automated-mix")
+                if args.automated_mix is not None else TrafficMix())
+            print(render_users_report(ops_for_population(
+                args.humans, args.automated, human_mix, automated_mix)))
+            return 0
+
+        if args.command == "validate":
+            mix = TrafficMix(args.add, args.plain, args.agent)
+            mix.validate()
+            return run_validate(mix, args.retention_days, args.dims,
+                                args.bytes_per_value, args.node_gb, args.out)
+
+        if args.command == "serve":
+            return run_server(args.host, checked_port(args.port))
+
+    except SizingError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sizing/test_memmachine_sizing.py
+++ b/tools/sizing/test_memmachine_sizing.py
@@ -1,0 +1,4001 @@
+#!/usr/bin/env python3
+"""Tests for memmachine_sizing.py, the MemMachine sizing calculator.
+
+These tests are written from the agreed sizing model, NOT from what the
+program happens to do. Every expected number below is worked out by hand from
+the model and written as a literal, so that a test failure means the program
+and the model disagree.
+
+The model, restated so the tests can be audited without another document:
+
+  Tiers (design peak, the worst rate held for five minutes):
+      pilot 20 ops/s, target 100 ops/s, scale 1000 ops/s. A design peak must be
+      greater than zero: zero operations per second is not a deployment to
+      size, so it is refused rather than sized.
+
+  Traffic mix (a planning assumption, never measured): per 100 operations,
+      45 adds, 45 plain searches, 10 agent-mode searches. Adjustable.
+
+  Fan-out per request (read from the code on 30 August 2026):
+      add           1 embed,   1 vector write,   2 PostgreSQL statements, 0 LLM
+      plain search  2 embeds,  1 vector search,  2 PostgreSQL statements, 0 LLM
+      agent search 22 embeds, 22 vector searches, 44 PostgreSQL statements,
+                   1 to 2 LLM calls (plan on 1.5)
+      A plain search drops to 1 embed once every request sends
+      types: ["episodic"].
+
+  API servers: work = vector searches/s + adds/s (one add counted as one
+      plain-search-equivalent). Anchor 180 plain searches/s per 16-vCPU server
+      at 8 workers, measured 30 August 2026. Ceiling 0.60, so 108 usable/s per
+      server, and servers = ceil(work / 108).
+
+  Embedding GPU cards: demand = embeds/s WITHOUT the types fix. A card does
+      300 to 500 requests/s (estimate). Ceiling 0.60, so 180 to 300 usable/s.
+      cards = ceil(demand / usable) + 1 spare.
+
+  Agent-model GPU cards: 15 LLM calls/s per 8B-class card (estimate),
+      + 1 spare, sized on the 1.5-calls planning figure.
+
+  Qdrant: episodes = adds/s x 86400 x retention days.
+      hot RAM bytes = episodes x dims x bytes per value x 1.5.
+      dims 1024 and 1 byte per value by default. GB means 10^9 bytes.
+      Node RAM options 256 / 512 / 768 GB, each filled to at most 70%. The
+      size is chosen automatically unless it is forced - with --node-gb, or
+      with the "RAM per vector-store machine" box on the web form - and a
+      forced size must be greater than zero. The report names whichever of the
+      two forced it.
+
+  Machine counts always round up, and any work at all costs at least one
+      machine: a positive design peak never comes back as nothing to buy.
+
+  Values are never quietly changed. Dimensions must be a whole number - 1024.7
+      is refused, not cut down to 1024. Every input that scales the arithmetic
+      has an upper bound far above any deployment, so a number too large is
+      refused by name instead of overflowing to infinity and being reported as
+      "inf", a value nobody typed. The bounds change no machine count.
+
+  On the web form, an empty box is a blank answer and not a request for the
+      default: the page says which box is blank. A parameter left out of the
+      URL altogether is different and still takes the default, which is how
+      the command line treats a flag that is left off. The "RAM per
+      vector-store machine" box is the one exception, because empty there
+      already means "choose the size for me".
+
+  PostgreSQL: connections = api servers x 8 workers x 15 connections
+      + 20 gateway connections per API server. Compare with the chart default
+      of 100 and with the 600 that cleared every error on 30 August 2026.
+
+  Network: from named per-call byte-size estimates, reported in Mbps.
+
+  Callers: two kinds, and they are told apart from the two kinds of request.
+      A human chat session is a person typing, 0.011 to 0.028 ops/s. An
+      automated client is a program sending requests in a loop, 0.4 ops/s in a
+      5-second tool loop. Both estimates. Neither is agent-mode search, which
+      is a flag on one request and the third share of the traffic mix. Each
+      population carries its own mix, and the `users` subcommand blends the
+      two, weighted by the operations each population demands at the busy end
+      of the human rate, and sizes the deployment from the blended mix.
+"""
+
+from __future__ import annotations
+
+import ast
+import http.server
+import io
+import json
+import math
+import os
+import re
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.request
+from typing import ClassVar
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MODULE_PATH = os.path.join(HERE, "memmachine_sizing.py")
+# The tests run the calculator as a command with whatever interpreter is
+# running them, so there is no virtual environment to set up and nothing to
+# install: the calculator uses the standard library only.
+PYTHON = sys.executable
+
+sys.path.insert(0, HERE)
+
+import memmachine_sizing as ps  # noqa: E402
+
+# =============================================================================
+# The model's own numbers, written out by hand.
+# =============================================================================
+
+USABLE_SEARCHES_PER_SERVER = 108.0          # 180 x 0.60
+EMBED_USABLE_LOW = 180.0                    # 300 x 0.60, pessimistic card
+EMBED_USABLE_HIGH = 300.0                   # 500 x 0.60, optimistic card
+LLM_CALLS_PER_CARD = 15.0
+SPARE_CARDS = 1
+SECONDS_PER_DAY = 86400
+INDEX_OVERHEAD = 1.5
+NODE_FILL = 0.70
+GB = 1_000_000_000
+
+# Per tier, worked out by hand from the mix 45 / 45 / 10.
+#   pilot  20 ops/s ->   9 adds,   9 plain,   2 agent
+#   target 100      ->  45 adds,  45 plain,  10 agent
+#   scale  1000     -> 450 adds, 450 plain, 100 agent
+TIER_EXPECTATIONS = {
+    "pilot": {
+        "ops": 20.0,
+        "adds": 9.0, "plain": 9.0, "agent": 2.0,
+        # embeds = 9x1 + 9x2 + 2x22
+        "embeds": 71.0,
+        # with the types fix = 9x1 + 9x1 + 2x22
+        "embeds_with_fix": 62.0,
+        # vector searches = 9x1 + 2x22
+        "vector_searches": 53.0,
+        "vector_writes": 9.0,
+        # PostgreSQL = 9x2 + 9x2 + 2x44
+        "pg_statements": 124.0,
+        "llm_low": 2.0, "llm_high": 4.0, "llm_planning": 3.0,
+        # work = 53 + 9 = 62 -> ceil(62/108) = 1
+        "api_work": 62.0, "api_servers": 1,
+        # ceil(71/300)=1 (+1 spare); ceil(71/180)=1 (+1 spare)
+        "embed_cards_low": 2, "embed_cards_high": 2,
+        # ceil(3/15)=1 (+1 spare)
+        "agent_cards": 2,
+        # 1 server x 8 workers x 15 = 120, plus 1 x 20 gateway
+        "pg_core_connections": 120, "pg_gateway_connections": 20,
+        "pg_total_connections": 140,
+        # 9 x 86400 x 90
+        "episodes": 69_984_000.0,
+        # 69,984,000 x 1024 x 1 x 1.5
+        "hot_ram_bytes": 107_495_424_000.0,
+        # 107.495 GB fits one 256 GB node (179.2 GB usable); 256 GB is the
+        # least total RAM of the three options.
+        "qdrant_nodes": 1, "qdrant_node_ram_gb": 256,
+    },
+    "target": {
+        "ops": 100.0,
+        "adds": 45.0, "plain": 45.0, "agent": 10.0,
+        "embeds": 355.0,            # 45 + 90 + 220
+        "embeds_with_fix": 310.0,   # 45 + 45 + 220
+        "vector_searches": 265.0,   # 45 + 220
+        "vector_writes": 45.0,
+        "pg_statements": 620.0,     # 90 + 90 + 440
+        "llm_low": 10.0, "llm_high": 20.0, "llm_planning": 15.0,
+        # work = 265 + 45 = 310 -> ceil(310/108) = 3
+        "api_work": 310.0, "api_servers": 3,
+        # ceil(355/300)=2 (+1); ceil(355/180)=2 (+1)
+        "embed_cards_low": 3, "embed_cards_high": 3,
+        # ceil(15/15)=1 (+1)
+        "agent_cards": 2,
+        "pg_core_connections": 360, "pg_gateway_connections": 60,
+        "pg_total_connections": 420,
+        "episodes": 349_920_000.0,
+        "hot_ram_bytes": 537_477_120_000.0,
+        # 537.477 GB against 537.6 GB usable on one 768 GB node. The 256 GB
+        # option needs 3 nodes and also buys 768 GB, so the tie goes to the
+        # single machine.
+        "qdrant_nodes": 1, "qdrant_node_ram_gb": 768,
+    },
+    "scale": {
+        "ops": 1000.0,
+        "adds": 450.0, "plain": 450.0, "agent": 100.0,
+        "embeds": 3550.0,           # 450 + 900 + 2200
+        "embeds_with_fix": 3100.0,  # 450 + 450 + 2200
+        "vector_searches": 2650.0,  # 450 + 2200
+        "vector_writes": 450.0,
+        "pg_statements": 6200.0,    # 900 + 900 + 4400
+        "llm_low": 100.0, "llm_high": 200.0, "llm_planning": 150.0,
+        # work = 2650 + 450 = 3100 -> ceil(3100/108) = 29
+        "api_work": 3100.0, "api_servers": 29,
+        # ceil(3550/300)=12 (+1); ceil(3550/180)=20 (+1)
+        "embed_cards_low": 13, "embed_cards_high": 21,
+        # ceil(150/15)=10 (+1)
+        "agent_cards": 11,
+        "pg_core_connections": 3480, "pg_gateway_connections": 580,
+        "pg_total_connections": 4060,
+        "episodes": 3_499_200_000.0,
+        "hot_ram_bytes": 5_374_771_200_000.0,
+        # 5,374.77 GB. All three node sizes buy 7,680 GB in total
+        # (30 x 256, 15 x 512, 10 x 768), so the tie goes to the fewest
+        # machines.
+        "qdrant_nodes": 10, "qdrant_node_ram_gb": 768,
+    },
+}
+
+
+def free_port() -> int:
+    """Ask the operating system for a port that is free right now."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def run_cli(*args, timeout=120):
+    """Run the calculator as a command and return the finished process."""
+    return subprocess.run([PYTHON, MODULE_PATH, *args],
+                          capture_output=True, text=True, timeout=timeout)
+
+
+def report_section(r: dict, title_starts_with: str) -> dict:
+    """One section of the printed report, by the start of its title."""
+    for section in ps.report_sections(r):
+        if section["title"].startswith(title_starts_with):
+            return section
+    raise AssertionError(f"the report has no {title_starts_with} section")
+
+
+def sensitivity_rate_cells(r: dict) -> list:
+    """The first column of the printed sensitivity table."""
+    return [row[0] for row in report_section(r, "Sensitivity")["rows"]]
+
+
+class ModelBaseTest(unittest.TestCase):
+
+    def size(self, ops, **kwargs):
+        return ps.size_deployment(ops, **kwargs)
+
+    # Named the way unittest names its own assertion helpers, so it
+    # reads beside assertEqual rather than against it.
+    def assertClose(self, actual, expected, msg=None, places=6):  # noqa: N802
+        if expected == 0:
+            self.assertAlmostEqual(actual, 0.0, places=places, msg=msg)
+        else:
+            self.assertAlmostEqual(actual / expected, 1.0, places=places,
+                                   msg=f"{msg}: expected {expected!r}, "
+                                       f"got {actual!r}")
+
+
+# =============================================================================
+# 1. Fan-out arithmetic at all three tiers
+# =============================================================================
+
+
+class TestFanOutAtEveryTier(ModelBaseTest):
+    """One request of each kind makes a known number of internal calls."""
+
+    def test_fan_out_constants_match_the_code_reading(self):
+        self.assertEqual(ps.ADD_EMBEDS, 1)
+        self.assertEqual(ps.ADD_VECTOR_WRITES, 1)
+        self.assertEqual(ps.ADD_POSTGRES_STATEMENTS, 2)
+        self.assertEqual(ps.ADD_LLM_CALLS, 0)
+        self.assertEqual(ps.PLAIN_EMBEDS, 2)
+        self.assertEqual(ps.PLAIN_EMBEDS_WITH_TYPES_FIX, 1)
+        self.assertEqual(ps.PLAIN_VECTOR_SEARCHES, 1)
+        self.assertEqual(ps.PLAIN_POSTGRES_STATEMENTS, 2)
+        self.assertEqual(ps.PLAIN_LLM_CALLS, 0)
+        self.assertEqual(ps.AGENT_EMBEDS, 22)
+        self.assertEqual(ps.AGENT_VECTOR_SEARCHES, 22)
+        self.assertEqual(ps.AGENT_POSTGRES_STATEMENTS, 44)
+        self.assertEqual(ps.AGENT_LLM_CALLS_LOW, 1.0)
+        self.assertEqual(ps.AGENT_LLM_CALLS_HIGH, 2.0)
+        self.assertEqual(ps.AGENT_LLM_CALLS_PLANNING, 1.5)
+
+    def test_tier_design_peaks(self):
+        self.assertEqual(ps.TIER_OPS_PER_S["pilot"], 20.0)
+        self.assertEqual(ps.TIER_OPS_PER_S["target"], 100.0)
+        self.assertEqual(ps.TIER_OPS_PER_S["scale"], 1000.0)
+
+    def test_default_mix_is_45_45_10(self):
+        mix = ps.TrafficMix()
+        self.assertEqual((mix.add, mix.plain, mix.agent), (45.0, 45.0, 10.0))
+
+    def test_request_rates_by_type(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                d = self.size(want["ops"])["demand"]
+                self.assertClose(d["adds_per_s"], want["adds"], "adds/s")
+                self.assertClose(d["plain_searches_per_s"], want["plain"],
+                                 "plain searches/s")
+                self.assertClose(d["agent_searches_per_s"], want["agent"],
+                                 "agent searches/s")
+
+    def test_embedding_demand_today_and_with_the_types_fix(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                d = self.size(want["ops"])["demand"]
+                self.assertClose(d["embeds_per_s"], want["embeds"], "embeds/s")
+                self.assertClose(d["embeds_per_s_with_types_fix"],
+                                 want["embeds_with_fix"],
+                                 "embeds/s with the types fix")
+                self.assertLess(d["embeds_per_s_with_types_fix"],
+                                d["embeds_per_s"],
+                                "the types fix must lower the embedding demand")
+
+    def test_vector_store_demand(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                d = self.size(want["ops"])["demand"]
+                self.assertClose(d["vector_searches_per_s"],
+                                 want["vector_searches"], "vector searches/s")
+                self.assertClose(d["vector_writes_per_s"],
+                                 want["vector_writes"], "vector writes/s")
+
+    def test_postgres_statement_demand(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                d = self.size(want["ops"])["demand"]
+                self.assertClose(d["postgres_statements_per_s"],
+                                 want["pg_statements"],
+                                 "PostgreSQL statements/s")
+
+    def test_language_model_call_demand(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                d = self.size(want["ops"])["demand"]
+                self.assertClose(d["agent_llm_calls_per_s_low"],
+                                 want["llm_low"], "LLM calls/s low")
+                self.assertClose(d["agent_llm_calls_per_s_high"],
+                                 want["llm_high"], "LLM calls/s high")
+                self.assertClose(d["agent_llm_calls_per_s_planning"],
+                                 want["llm_planning"],
+                                 "LLM calls/s planning figure")
+
+    def test_only_agent_mode_searches_call_a_language_model(self):
+        mix = ps.TrafficMix(add=50.0, plain=50.0, agent=0.0)
+        d = self.size(100.0, mix=mix)["demand"]
+        self.assertEqual(d["agent_llm_calls_per_s_low"], 0.0)
+        self.assertEqual(d["agent_llm_calls_per_s_high"], 0.0)
+        self.assertEqual(d["agent_llm_calls_per_s_planning"], 0.0)
+
+
+# =============================================================================
+# 2. API server counts, including the rounding boundary
+# =============================================================================
+
+
+class TestApiServers(ModelBaseTest):
+
+    def test_anchor_and_ceiling(self):
+        self.assertEqual(ps.API_SEARCHES_PER_S_PER_SERVER, 180.0)
+        self.assertEqual(ps.API_UTILIZATION_CEILING, 0.60)
+        self.assertEqual(ps.API_WORKERS_PER_SERVER, 8)
+        self.assertClose(ps.api_usable_searches_per_server(),
+                         USABLE_SEARCHES_PER_SERVER, "usable searches/s")
+
+    def test_work_is_vector_searches_plus_adds(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                r = self.size(want["ops"])
+                self.assertClose(r["machines"]["api_work_per_s"],
+                                 want["api_work"], "API work/s")
+                self.assertEqual(r["machines"]["api_servers"],
+                                 want["api_servers"])
+
+    def test_server_count_at_every_tier(self):
+        self.assertEqual(self.size(20.0)["machines"]["api_servers"], 1)
+        self.assertEqual(self.size(100.0)["machines"]["api_servers"], 3)
+        self.assertEqual(self.size(1000.0)["machines"]["api_servers"], 29)
+
+    def test_exactly_one_server_of_work(self):
+        """108 work/s is exactly one server, not two."""
+        self.assertEqual(ps.api_servers_for_work(108.0), 1)
+
+    def test_just_above_one_server_of_work(self):
+        """Anything above 108 work/s needs a second server."""
+        self.assertEqual(ps.api_servers_for_work(108.0001), 2)
+        self.assertEqual(ps.api_servers_for_work(108.5), 2)
+        self.assertEqual(ps.api_servers_for_work(109.0), 2)
+
+    def test_exact_multiples_do_not_round_up(self):
+        self.assertEqual(ps.api_servers_for_work(216.0), 2)
+        self.assertEqual(ps.api_servers_for_work(324.0), 3)
+        self.assertEqual(ps.api_servers_for_work(1080.0), 10)
+
+    def test_just_above_exact_multiples(self):
+        self.assertEqual(ps.api_servers_for_work(216.5), 3)
+        self.assertEqual(ps.api_servers_for_work(324.5), 4)
+
+    def test_just_below_a_boundary(self):
+        self.assertEqual(ps.api_servers_for_work(107.999), 1)
+        self.assertEqual(ps.api_servers_for_work(215.999), 2)
+
+    def test_no_work_needs_no_server(self):
+        self.assertEqual(ps.api_servers_for_work(0.0), 0)
+
+    def test_a_sliver_of_work_still_needs_one_whole_server(self):
+        self.assertEqual(ps.api_servers_for_work(0.5), 1)
+        self.assertEqual(ps.api_servers_for_work(1.0), 1)
+
+    def test_server_count_is_a_whole_number(self):
+        for ops in (1.0, 7.5, 20.0, 100.0, 333.0, 1000.0):
+            with self.subTest(ops=ops):
+                servers = self.size(ops)["machines"]["api_servers"]
+                self.assertIsInstance(servers, int)
+
+
+# =============================================================================
+# 3. Embedding GPU cards
+# =============================================================================
+
+
+class TestEmbeddingGpuCards(ModelBaseTest):
+
+    def test_card_rate_constants(self):
+        self.assertEqual(ps.EMBED_CARD_REQUESTS_PER_S_LOW, 300.0)
+        self.assertEqual(ps.EMBED_CARD_REQUESTS_PER_S_HIGH, 500.0)
+        self.assertEqual(ps.GPU_UTILIZATION_CEILING, 0.60)
+        self.assertEqual(ps.GPU_SPARE_CARDS, 1)
+
+    def test_usable_requests_per_card(self):
+        m = self.size(100.0)["machines"]
+        self.assertClose(m["embed_usable_per_card_low"], EMBED_USABLE_LOW,
+                         "usable per card at the pessimistic rate")
+        self.assertClose(m["embed_usable_per_card_high"], EMBED_USABLE_HIGH,
+                         "usable per card at the optimistic rate")
+
+    def test_card_counts_at_every_tier(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                m = self.size(want["ops"])["machines"]
+                self.assertEqual(m["embed_gpu_cards_low"],
+                                 want["embed_cards_low"],
+                                 "cards if a card really does 500/s")
+                self.assertEqual(m["embed_gpu_cards_high"],
+                                 want["embed_cards_high"],
+                                 "cards if a card only does 300/s")
+
+    def test_every_card_count_includes_one_spare(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                r = self.size(want["ops"])
+                embeds = r["demand"]["embeds_per_s"]
+                bare_low = math.ceil(embeds / EMBED_USABLE_HIGH)
+                bare_high = math.ceil(embeds / EMBED_USABLE_LOW)
+                self.assertEqual(r["machines"]["embed_gpu_cards_low"],
+                                 bare_low + SPARE_CARDS)
+                self.assertEqual(r["machines"]["embed_gpu_cards_high"],
+                                 bare_high + SPARE_CARDS)
+                self.assertEqual(r["machines"]["embed_gpu_spare"], SPARE_CARDS)
+
+    def test_sized_on_the_demand_without_the_types_fix(self):
+        """The conservative figure is the one that sets the order."""
+        # A mix of plain searches only makes the two embedding figures differ
+        # by a factor of two, so the choice is unmistakable.
+        mix = ps.TrafficMix(add=0.0, plain=100.0, agent=0.0)
+        r = self.size(100.0, mix=mix)
+        self.assertClose(r["demand"]["embeds_per_s"], 200.0, "embeds/s today")
+        self.assertClose(r["demand"]["embeds_per_s_with_types_fix"], 100.0,
+                         "embeds/s with the types fix")
+        # 200/300 -> 1 card, +1 spare = 2.  200/180 -> 2 cards, +1 spare = 3.
+        self.assertEqual(r["machines"]["embed_gpu_cards_low"], 2)
+        self.assertEqual(r["machines"]["embed_gpu_cards_high"], 3)
+
+    def test_low_count_is_never_above_the_high_count(self):
+        for ops in (1.0, 20.0, 100.0, 500.0, 1000.0, 5000.0):
+            with self.subTest(ops=ops):
+                m = self.size(ops)["machines"]
+                self.assertLessEqual(m["embed_gpu_cards_low"],
+                                     m["embed_gpu_cards_high"])
+
+    def test_no_embedding_traffic_needs_no_card(self):
+        """No embedding demand means no card, and so no spare card either.
+
+        A design peak of zero operations per second is refused (see
+        TestBadInputInTheLibrary), so this asks the card arithmetic directly
+        instead of sizing a deployment that carries no traffic.
+        """
+        for rate in (ps.EMBED_CARD_REQUESTS_PER_S_LOW,
+                     ps.EMBED_CARD_REQUESTS_PER_S_HIGH):
+            with self.subTest(card_rate=rate):
+                self.assertEqual(ps.embed_gpu_cards_for_demand(0.0, rate), 0)
+        # A sliver of demand still buys a whole card plus the spare.
+        self.assertEqual(
+            ps.embed_gpu_cards_for_demand(0.5,
+                                          ps.EMBED_CARD_REQUESTS_PER_S_LOW),
+            1 + SPARE_CARDS)
+
+
+# =============================================================================
+# 4. Agent-model GPU cards
+# =============================================================================
+
+
+class TestAgentModelGpuCards(ModelBaseTest):
+
+    def test_planning_rate_per_card(self):
+        self.assertEqual(ps.AGENT_LLM_CALLS_PER_S_PER_CARD, LLM_CALLS_PER_CARD)
+
+    def test_card_counts_at_every_tier(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                m = self.size(want["ops"])["machines"]
+                self.assertEqual(m["agent_gpu_cards"], want["agent_cards"])
+
+    def test_count_includes_one_spare(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                r = self.size(want["ops"])
+                planning = r["demand"]["agent_llm_calls_per_s_planning"]
+                bare = math.ceil(planning / LLM_CALLS_PER_CARD)
+                self.assertEqual(r["machines"]["agent_gpu_cards"],
+                                 bare + SPARE_CARDS)
+                self.assertEqual(r["machines"]["agent_gpu_spare"], SPARE_CARDS)
+
+    def test_sized_on_the_midpoint_of_one_to_two_calls(self):
+        # 100 ops/s with 30 agent-mode searches per 100 ops -> 30 agent
+        # searches/s -> 45 planning calls/s -> ceil(45/15) = 3, +1 spare = 4.
+        mix = ps.TrafficMix(add=35.0, plain=35.0, agent=30.0)
+        r = self.size(100.0, mix=mix)
+        self.assertClose(r["demand"]["agent_llm_calls_per_s_planning"], 45.0,
+                         "planning LLM calls/s")
+        self.assertEqual(r["machines"]["agent_gpu_cards"], 4)
+
+    def test_no_agent_traffic_needs_no_card(self):
+        mix = ps.TrafficMix(add=50.0, plain=50.0, agent=0.0)
+        m = self.size(100.0, mix=mix)["machines"]
+        self.assertEqual(m["agent_gpu_cards"], 0)
+        self.assertEqual(m["agent_gpu_spare"], 0)
+
+
+# =============================================================================
+# 5. Qdrant episodes, bytes and node counts at 70% fill
+# =============================================================================
+
+
+class TestQdrantStorage(ModelBaseTest):
+
+    def test_storage_constants(self):
+        self.assertEqual(ps.DEFAULT_VECTOR_DIMS, 1024)
+        self.assertEqual(ps.DEFAULT_BYTES_PER_VALUE, 1)
+        self.assertEqual(ps.QDRANT_INDEX_OVERHEAD_FACTOR, INDEX_OVERHEAD)
+        self.assertEqual(ps.QDRANT_NODE_FILL_LIMIT, NODE_FILL)
+        self.assertEqual(tuple(ps.QDRANT_NODE_RAM_OPTIONS_GB), (256, 512, 768))
+        self.assertEqual(ps.SECONDS_PER_DAY, SECONDS_PER_DAY)
+        self.assertEqual(ps.BYTES_PER_GB, GB, "GB must mean 10^9 bytes")
+        self.assertEqual(ps.DEFAULT_RETENTION_DAYS, 90)
+
+    def test_episode_counts_at_every_tier(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                s = self.size(want["ops"])["storage"]
+                self.assertClose(s["episodes_retained"], want["episodes"],
+                                 "episodes retained")
+
+    def test_hot_vector_ram_bytes_at_every_tier(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                s = self.size(want["ops"])["storage"]
+                self.assertClose(s["hot_vector_ram_bytes"],
+                                 want["hot_ram_bytes"], "hot vector RAM bytes")
+                self.assertClose(s["hot_vector_ram_gb"],
+                                 want["hot_ram_bytes"] / GB,
+                                 "hot vector RAM in GB")
+
+    def test_node_counts_at_every_tier(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                m = self.size(want["ops"])["machines"]
+                self.assertEqual(m["qdrant_servers"], want["qdrant_nodes"])
+                self.assertEqual(m["qdrant_node_ram_gb"],
+                                 want["qdrant_node_ram_gb"])
+
+    def test_every_node_size_is_offered(self):
+        m = self.size(100.0)["machines"]
+        sizes = [o["node_ram_gb"] for o in m["qdrant_options"]]
+        self.assertEqual(sizes, [256, 512, 768])
+
+    def test_usable_ram_per_node_is_70_percent(self):
+        m = self.size(100.0)["machines"]
+        for opt in m["qdrant_options"]:
+            with self.subTest(node_ram_gb=opt["node_ram_gb"]):
+                self.assertClose(opt["usable_gb_per_node"],
+                                 opt["node_ram_gb"] * NODE_FILL,
+                                 "usable GB per node")
+
+    def test_node_counts_for_each_size_at_the_scale_tier(self):
+        # 5,374.7712 GB against 179.2 / 358.4 / 537.6 GB usable per node.
+        m = self.size(1000.0)["machines"]
+        by_size = {o["node_ram_gb"]: o["nodes"] for o in m["qdrant_options"]}
+        self.assertEqual(by_size[256], 30)
+        self.assertEqual(by_size[512], 15)
+        self.assertEqual(by_size[768], 10)
+
+    def test_no_node_is_asked_to_hold_more_than_70_percent(self):
+        for ops in (20.0, 100.0, 250.0, 1000.0, 4000.0):
+            with self.subTest(ops=ops):
+                r = self.size(ops)
+                m = r["machines"]
+                hot = r["storage"]["hot_vector_ram_bytes"]
+                bought = m["qdrant_servers"] * m["qdrant_node_ram_gb"] * GB
+                self.assertLessEqual(hot, bought * NODE_FILL + 1.0,
+                                     "the plan fills a node past 70% of its "
+                                     "RAM, which leaves no headroom")
+
+    def test_data_exactly_filling_one_node(self):
+        """179.2 GB is exactly one 256 GB node's 70% allowance."""
+        exact = 256 * GB * NODE_FILL
+        plan = ps.qdrant_node_plan(exact)
+        by_size = {o["node_ram_gb"]: o["nodes"] for o in plan["options"]}
+        self.assertEqual(by_size[256], 1, "exactly one node's worth is one node")
+        self.assertEqual(by_size[512], 1)
+        self.assertEqual(by_size[768], 1)
+        self.assertEqual(plan["nodes"], 1)
+        self.assertEqual(plan["node_ram_gb"], 256)
+        self.assertClose(plan["fill_of_allowance"], 1.0, "fill of allowance")
+
+    def test_data_exactly_filling_several_nodes(self):
+        exact = 3 * 256 * GB * NODE_FILL          # 537.6 GB
+        plan = ps.qdrant_node_plan(exact)
+        by_size = {o["node_ram_gb"]: o["nodes"] for o in plan["options"]}
+        self.assertEqual(by_size[256], 3)
+        self.assertEqual(by_size[512], 2)         # 537.6 / 358.4 = 1.5
+        self.assertEqual(by_size[768], 1)         # 537.6 / 537.6 = 1.0
+
+    def test_a_byte_over_a_node_adds_a_node(self):
+        just_over = 256 * GB * NODE_FILL * 1.000001
+        plan = ps.qdrant_node_plan(just_over)
+        by_size = {o["node_ram_gb"]: o["nodes"] for o in plan["options"]}
+        self.assertEqual(by_size[256], 2)
+
+    def test_no_data_and_no_work_needs_no_node(self):
+        plan = ps.qdrant_node_plan(0.0)
+        self.assertEqual(plan["nodes"], 0)
+
+    def test_no_data_but_some_work_still_needs_one_node(self):
+        """Bytes are not the only reason to own a machine."""
+        plan = ps.qdrant_node_plan(0.0, least_nodes=1)
+        self.assertEqual(plan["nodes"], 1)
+        self.assertTrue(all(o["nodes"] >= 1 for o in plan["options"]),
+                        "every size in the comparison keeps the floor")
+        # The cheapest way to own one machine is the smallest one offered.
+        self.assertEqual(plan["node_ram_gb"], 256)
+
+    def test_the_floor_never_shrinks_a_count_the_bytes_earned(self):
+        exact = 3 * 256 * GB * NODE_FILL
+        with_floor = ps.qdrant_node_plan(exact, node_gb=256, least_nodes=1)
+        self.assertEqual(with_floor["nodes"], 3)
+
+    def test_the_chosen_size_buys_the_least_total_ram(self):
+        for ops in (20.0, 100.0, 400.0, 1000.0):
+            with self.subTest(ops=ops):
+                m = self.size(ops)["machines"]
+                usable = [o for o in m["qdrant_options"] if o["nodes"] > 0]
+                least = min(o["total_ram_gb"] for o in usable)
+                self.assertEqual(m["qdrant_total_ram_gb"], least)
+
+    def test_a_tie_on_total_ram_goes_to_fewer_machines(self):
+        for ops in (100.0, 1000.0):
+            with self.subTest(ops=ops):
+                m = self.size(ops)["machines"]
+                tied = [o for o in m["qdrant_options"]
+                        if o["nodes"] > 0
+                        and o["total_ram_gb"] == m["qdrant_total_ram_gb"]]
+                fewest = min(o["nodes"] for o in tied)
+                self.assertEqual(m["qdrant_servers"], fewest)
+
+    def test_dimensions_and_bytes_per_value_scale_the_ram(self):
+        base = self.size(100.0)["storage"]["hot_vector_ram_bytes"]
+        wider = self.size(100.0, dims=2048)["storage"]["hot_vector_ram_bytes"]
+        fatter = self.size(100.0,
+                           bytes_per_value=4)["storage"]["hot_vector_ram_bytes"]
+        self.assertClose(wider, base * 2, "doubling the dimensions")
+        self.assertClose(fatter, base * 4, "four bytes per number")
+
+    def test_retention_scales_the_episode_count(self):
+        thirty = self.size(100.0, retention_days=30)["storage"]
+        ninety = self.size(100.0, retention_days=90)["storage"]
+        self.assertClose(ninety["episodes_retained"],
+                         thirty["episodes_retained"] * 3, "three times as long")
+
+
+# =============================================================================
+# 6. Forcing the vector-store machine size with --node-gb
+# =============================================================================
+
+
+class TestForcedNodeSize(ModelBaseTest):
+    """--node-gb overrides the automatic choice of vector-store machine.
+
+    At the target tier, 100 operations per second with the default mix, the
+    hot vector RAM is 45 x 86,400 x 90 x 1,024 x 1 x 1.5 = 537,477,120,000
+    bytes. Filled to 70%:
+        256 GB machine ->  179.2 GB usable -> 3 machines, 768 GB bought
+        512 GB machine ->  358.4 GB usable -> 2 machines, 1,024 GB bought
+        768 GB machine ->  537.6 GB usable -> 1 machine,  768 GB bought
+    so the automatic choice is one 768 GB machine (the tie on total RAM goes
+    to fewer machines), and forcing 512 GB must give two 512 GB machines.
+    """
+
+    TARGET_HOT_RAM_BYTES = 45.0 * SECONDS_PER_DAY * 90 * 1024 * 1 * INDEX_OVERHEAD
+
+    def test_the_hand_worked_hot_ram_at_the_target_tier(self):
+        s = self.size(100.0)["storage"]
+        self.assertClose(s["hot_vector_ram_bytes"], self.TARGET_HOT_RAM_BYTES,
+                         "target tier hot vector RAM")
+
+    def test_the_default_is_the_automatic_choice(self):
+        m = self.size(100.0)["machines"]
+        self.assertEqual(m["qdrant_node_ram_gb"], 768)
+        self.assertEqual(m["qdrant_servers"], 1)
+        self.assertFalse(m["qdrant_node_ram_gb_forced"])
+
+    def test_no_forced_size_leaves_the_input_empty(self):
+        self.assertIsNone(self.size(100.0)["inputs"]["node_gb"])
+
+    def test_forcing_512_gb_gives_two_512_gb_machines(self):
+        m = self.size(100.0, node_gb=512)["machines"]
+        self.assertEqual(m["qdrant_node_ram_gb"], 512)
+        self.assertEqual(m["qdrant_servers"], 2)
+        self.assertEqual(m["qdrant_total_ram_gb"], 1024)
+        self.assertTrue(m["qdrant_node_ram_gb_forced"])
+
+    def test_forcing_256_gb_gives_three_256_gb_machines(self):
+        m = self.size(100.0, node_gb=256)["machines"]
+        self.assertEqual(m["qdrant_node_ram_gb"], 256)
+        self.assertEqual(m["qdrant_servers"], 3)
+        self.assertEqual(m["qdrant_total_ram_gb"], 768)
+
+    def test_forcing_768_gb_matches_the_automatic_choice(self):
+        forced = self.size(100.0, node_gb=768)["machines"]
+        auto = self.size(100.0)["machines"]
+        self.assertEqual(forced["qdrant_servers"], auto["qdrant_servers"])
+        self.assertEqual(forced["qdrant_node_ram_gb"],
+                         auto["qdrant_node_ram_gb"])
+
+    def test_a_forced_size_is_reported_back_in_the_inputs(self):
+        self.assertEqual(self.size(100.0, node_gb=512)["inputs"]["node_gb"], 512)
+
+    def test_a_whole_number_of_gb_stays_a_whole_number(self):
+        node_gb = self.size(100.0, node_gb=512.0)["inputs"]["node_gb"]
+        self.assertIsInstance(node_gb, int)
+        self.assertEqual(node_gb, 512)
+
+    def test_a_forced_size_that_is_not_one_of_the_three_is_still_offered(self):
+        m = self.size(100.0, node_gb=1024)["machines"]
+        self.assertEqual(m["qdrant_node_ram_gb"], 1024)
+        self.assertEqual(m["qdrant_servers"], 1)
+        self.assertEqual([o["node_ram_gb"] for o in m["qdrant_options"]],
+                         [256, 512, 768, 1024])
+
+    def test_a_forced_size_never_holds_more_than_70_percent(self):
+        for node_gb in (256, 512, 768, 1024):
+            with self.subTest(node_gb=node_gb):
+                r = self.size(100.0, node_gb=node_gb)
+                m, s = r["machines"], r["storage"]
+                per_node = s["hot_vector_ram_bytes"] / m["qdrant_servers"]
+                self.assertLessEqual(per_node,
+                                     node_gb * GB * NODE_FILL + 1e-6)
+
+    def test_a_forced_size_changes_nothing_but_the_vector_store(self):
+        auto = self.size(100.0)
+        forced = self.size(100.0, node_gb=256)
+        self.assertEqual(forced["machines"]["api_servers"],
+                         auto["machines"]["api_servers"])
+        self.assertEqual(forced["demand"], auto["demand"])
+        self.assertClose(forced["storage"]["hot_vector_ram_bytes"],
+                         auto["storage"]["hot_vector_ram_bytes"], "hot RAM")
+
+    def test_a_smaller_forced_size_never_needs_fewer_machines(self):
+        counts = [self.size(100.0, node_gb=size)["machines"]["qdrant_servers"]
+                  for size in (256, 512, 768)]
+        self.assertEqual(counts, sorted(counts, reverse=True))
+
+    def test_zero_is_refused(self):
+        with self.assertRaises(ps.SizingError):
+            self.size(100.0, node_gb=0)
+
+    def test_a_negative_size_is_refused(self):
+        with self.assertRaises(ps.SizingError):
+            self.size(100.0, node_gb=-256)
+
+    def test_a_size_that_is_not_a_number_is_refused(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(node_gb=bad):
+                with self.assertRaises(ps.SizingError):
+                    self.size(100.0, node_gb=bad)
+
+    def test_the_report_states_the_forced_size(self):
+        r = self.size(100.0, node_gb=512)
+        text = ps.render_report(r, "FORCED")
+        self.assertIn("RAM per vector-store machine", text)
+        self.assertIn("512 GB, forced", text)
+
+    def test_the_report_states_the_automatic_choice(self):
+        text = ps.render_report(self.size(100.0), "AUTOMATIC")
+        self.assertIn("chosen automatically", text)
+
+    def test_an_empty_box_means_the_automatic_choice(self):
+        for raw in (None, "", "   ", "auto", "automatic", "AUTOMATIC"):
+            with self.subTest(raw=raw):
+                self.assertIsNone(ps.parse_node_gb(raw))
+
+    def test_a_number_in_the_box_is_read_as_gb(self):
+        self.assertEqual(ps.parse_node_gb("512"), 512.0)
+        self.assertEqual(ps.parse_node_gb(" 768 "), 768.0)
+
+    def test_text_in_the_box_is_not_silently_ignored(self):
+        for raw in ("big", "512gb", "five hundred"):
+            with self.subTest(raw=raw):
+                with self.assertRaises(ValueError):
+                    ps.parse_node_gb(raw)
+
+
+class TestForcedNodeSizeOnTheCommandLine(unittest.TestCase):
+    """--node-gb is offered by tier, calc and validate, and only by those."""
+
+    def test_calc_forces_two_512_gb_machines_at_100_ops(self):
+        proc = run_cli("calc", "--ops", "100", "--node-gb", "512", "--json")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        m = json.loads(proc.stdout)["machines"]
+        self.assertEqual(m["qdrant_node_ram_gb"], 512)
+        self.assertEqual(m["qdrant_servers"], 2)
+
+    def test_tier_forces_two_512_gb_machines_at_the_target_tier(self):
+        proc = run_cli("tier", "target", "--node-gb", "512", "--json")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        m = json.loads(proc.stdout)["machines"]
+        self.assertEqual(m["qdrant_node_ram_gb"], 512)
+        self.assertEqual(m["qdrant_servers"], 2)
+
+    def test_tier_without_the_flag_keeps_the_automatic_choice(self):
+        proc = run_cli("tier", "target", "--json")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        m = json.loads(proc.stdout)["machines"]
+        self.assertEqual(m["qdrant_node_ram_gb"], 768)
+        self.assertEqual(m["qdrant_servers"], 1)
+
+    def test_validate_carries_the_forced_size_into_every_tier(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "numbers.json")
+            proc = run_cli("validate", "--node-gb", "512", "--out", out)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            with open(out, encoding="utf-8") as handle:
+                numbers = json.load(handle)
+            self.assertEqual(numbers["target.qdrant_node_ram_gb"], 512)
+            self.assertEqual(numbers["target.qdrant_servers"], 2)
+            for tier in ("pilot", "target", "scale"):
+                with self.subTest(tier=tier):
+                    self.assertEqual(numbers[f"{tier}.qdrant_node_ram_gb"], 512)
+
+    def test_the_text_report_names_the_forced_size(self):
+        proc = run_cli("calc", "--ops", "100", "--node-gb", "512")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("512 GB, forced", proc.stdout)
+
+    def test_zero_exits_2_with_a_message(self):
+        for command in (("calc", "--ops", "100", "--node-gb", "0"),
+                        ("tier", "target", "--node-gb", "0"),
+                        ("validate", "--node-gb", "0")):
+            with self.subTest(command=command[0]):
+                proc = run_cli(*command)
+                self.assertEqual(proc.returncode, 2, proc.stdout)
+                self.assertNotIn("Traceback", proc.stderr)
+                self.assertIn("greater than zero", proc.stderr)
+
+    def test_a_negative_size_exits_2_with_a_message(self):
+        for command in (("calc", "--ops", "100", "--node-gb=-256"),
+                        ("tier", "target", "--node-gb=-256"),
+                        ("validate", "--node-gb=-256")):
+            with self.subTest(command=command[0]):
+                proc = run_cli(*command)
+                self.assertEqual(proc.returncode, 2, proc.stdout)
+                self.assertNotIn("Traceback", proc.stderr)
+                self.assertIn("greater than zero", proc.stderr)
+
+    def test_a_size_that_is_not_a_number_exits_non_zero_with_a_message(self):
+        proc = run_cli("calc", "--ops", "100", "--node-gb", "big")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertNotIn("Traceback", proc.stderr)
+        self.assertTrue(proc.stderr.strip())
+
+    def test_the_help_text_says_what_the_default_is(self):
+        for command in ("tier", "calc", "validate"):
+            with self.subTest(command=command):
+                proc = run_cli(command, "--help")
+                self.assertEqual(proc.returncode, 0, proc.stderr)
+                # argparse wraps help text, so compare on a single line.
+                text = " ".join(proc.stdout.split())
+                self.assertIn("--node-gb", text)
+                self.assertIn("RAM per vector-store machine in GB (default: "
+                              "chosen automatically; pass 256, 512 or 768 to "
+                              "force a shape)", text)
+
+    def test_the_subcommands_without_a_vector_store_do_not_offer_it(self):
+        for command in ("users", "serve"):
+            with self.subTest(command=command):
+                proc = run_cli(command, "--help")
+                self.assertEqual(proc.returncode, 0, proc.stderr)
+                self.assertNotIn("--node-gb", proc.stdout)
+
+
+# =============================================================================
+# 7. Storage growth figures
+# =============================================================================
+
+
+class TestStorageGrowth(ModelBaseTest):
+
+    def test_episodes_per_day_and_per_year(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                s = self.size(want["ops"])["storage"]
+                self.assertClose(s["episodes_per_day"],
+                                 want["adds"] * SECONDS_PER_DAY,
+                                 "episodes per day")
+                self.assertClose(s["episodes_per_year"],
+                                 want["adds"] * SECONDS_PER_DAY * 365,
+                                 "episodes per year")
+
+    def test_target_tier_episodes_per_day_and_year(self):
+        s = self.size(100.0)["storage"]
+        self.assertClose(s["episodes_per_day"], 3_888_000.0, "episodes per day")
+        self.assertClose(s["episodes_per_year"], 1_419_120_000.0,
+                         "episodes per year")
+
+    def test_qdrant_disk_at_the_target_tier(self):
+        # 349,920,000 episodes x (1024 x 4 + 256) bytes x 1.3
+        s = self.size(100.0)["storage"]
+        self.assertClose(s["qdrant_nvme_bytes"], 1_979_707_392_000.0,
+                         "Qdrant NVMe bytes")
+        self.assertClose(s["qdrant_nvme_gb"], 1_979.707392, "Qdrant NVMe GB")
+
+    def test_postgres_disk_range_at_the_target_tier(self):
+        # low  : 349,920,000 x (800 + 400 + 300) x 1.4
+        # high : 349,920,000 x (2400 + 400 + 300) x 1.4
+        s = self.size(100.0)["storage"]
+        self.assertClose(s["postgres_bytes_low"], 734_832_000_000.0,
+                         "PostgreSQL bytes, low case")
+        self.assertClose(s["postgres_bytes_high"], 1_518_652_800_000.0,
+                         "PostgreSQL bytes, high case")
+        self.assertLess(s["postgres_bytes_low"], s["postgres_bytes_high"])
+
+    def test_one_year_with_nothing_deleted(self):
+        """The 90-day figure scaled up by 365/90."""
+        s = self.size(100.0)["storage"]
+        factor = 365.0 / 90.0
+        self.assertClose(s["unbounded_year_hot_vector_ram_bytes"],
+                         s["hot_vector_ram_bytes"] * factor,
+                         "one year of hot vector RAM")
+        self.assertClose(s["unbounded_year_qdrant_nvme_bytes"],
+                         s["qdrant_nvme_bytes"] * factor,
+                         "one year of Qdrant NVMe")
+        self.assertClose(s["unbounded_year_postgres_bytes_low"],
+                         s["postgres_bytes_low"] * factor,
+                         "one year of PostgreSQL, low case")
+        self.assertClose(s["unbounded_year_postgres_bytes_high"],
+                         s["postgres_bytes_high"] * factor,
+                         "one year of PostgreSQL, high case")
+
+    def test_one_year_hot_ram_matches_a_year_of_episodes(self):
+        s = self.size(100.0)["storage"]
+        # 45 adds/s x 86400 x 365 x 1024 x 1 x 1.5
+        self.assertClose(s["unbounded_year_hot_vector_ram_bytes"],
+                         2_179_768_320_000.0, "one year of hot vector RAM")
+
+    def test_one_year_figures_ignore_the_retention_setting(self):
+        """A year of adds is a year of adds, whatever retention is set to.
+
+        These figures used to be worked out by scaling the retained figures by
+        365 / retention_days, so at retention 0 the report printed
+        1,419,120,000 episodes a year and 0.00 GB to hold them.
+        """
+        keys = ("unbounded_year_hot_vector_ram_bytes",
+                "unbounded_year_qdrant_nvme_bytes",
+                "unbounded_year_postgres_bytes_low",
+                "unbounded_year_postgres_bytes_high")
+        reference = self.size(100.0, retention_days=90)["storage"]
+        for days in (0, 1, 7, 90, 365, 3650):
+            s = self.size(100.0, retention_days=days)["storage"]
+            for key in keys:
+                with self.subTest(retention_days=days, figure=key):
+                    self.assertClose(s[key], reference[key], key)
+
+    def test_one_year_hot_ram_at_retention_zero(self):
+        """The number the plan quotes to argue that retention is required."""
+        s = self.size(100.0, retention_days=0)["storage"]
+        self.assertClose(s["unbounded_year_hot_vector_ram_bytes"],
+                         2_179_768_320_000.0, "one year of hot vector RAM")
+        self.assertEqual(s["hot_vector_ram_bytes"], 0.0)
+
+    def test_gb_means_ten_to_the_ninth_bytes(self):
+        s = self.size(100.0)["storage"]
+        self.assertClose(s["hot_vector_ram_gb"],
+                         s["hot_vector_ram_bytes"] / 1_000_000_000,
+                         "GB conversion")
+
+
+# =============================================================================
+# 7. PostgreSQL connections
+# =============================================================================
+
+
+class TestPostgresConnections(ModelBaseTest):
+
+    def test_connection_constants(self):
+        self.assertEqual(ps.POSTGRES_POOL_SIZE, 5)
+        self.assertEqual(ps.POSTGRES_MAX_OVERFLOW, 10)
+        self.assertEqual(ps.POSTGRES_CONNECTIONS_PER_WORKER, 15)
+        self.assertEqual(ps.GATEWAY_CONNECTIONS_PER_API_SERVER, 20)
+        self.assertEqual(ps.POSTGRES_CHART_DEFAULT_MAX_CONNECTIONS, 100)
+        self.assertEqual(ps.POSTGRES_PROVEN_MAX_CONNECTIONS, 600)
+
+    def test_connection_totals_at_every_tier(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                p = self.size(want["ops"])["postgres"]
+                self.assertEqual(p["core_connections"],
+                                 want["pg_core_connections"])
+                self.assertEqual(p["gateway_connections"],
+                                 want["pg_gateway_connections"])
+                self.assertEqual(p["total_connections"],
+                                 want["pg_total_connections"])
+                self.assertEqual(p["max_connections_required"],
+                                 want["pg_total_connections"])
+
+    def test_the_formula_holds_for_any_server_count(self):
+        for ops in (20.0, 100.0, 400.0, 1000.0):
+            with self.subTest(ops=ops):
+                r = self.size(ops)
+                servers = r["machines"]["api_servers"]
+                p = r["postgres"]
+                self.assertEqual(p["core_connections"], servers * 8 * 15)
+                self.assertEqual(p["gateway_connections"], servers * 20)
+                self.assertEqual(p["total_connections"], servers * 140)
+
+    def test_every_tier_exceeds_the_chart_default_of_100(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                p = self.size(want["ops"])["postgres"]
+                self.assertGreater(p["total_connections"], 100)
+                self.assertTrue(p["exceeds_chart_default"])
+
+    def test_pilot_and_target_fit_inside_the_proven_600(self):
+        for name in ("pilot", "target"):
+            with self.subTest(tier=name):
+                p = self.size(TIER_EXPECTATIONS[name]["ops"])["postgres"]
+                self.assertLessEqual(p["total_connections"], 600)
+                self.assertFalse(p["exceeds_proven_setting"])
+                self.assertFalse(p["needs_connection_pooler"])
+
+    def test_scale_tier_needs_more_than_has_ever_been_proven(self):
+        p = self.size(1000.0)["postgres"]
+        self.assertEqual(p["total_connections"], 4060)
+        self.assertGreater(p["total_connections"], 600)
+        self.assertTrue(p["exceeds_proven_setting"])
+        self.assertTrue(p["needs_connection_pooler"])
+
+    def test_statement_rate_is_carried_through(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                r = self.size(want["ops"])
+                self.assertClose(r["postgres"]["statements_per_s"],
+                                 want["pg_statements"], "statements/s")
+                self.assertEqual(r["postgres"]["statements_per_s"],
+                                 r["demand"]["postgres_statements_per_s"])
+
+    def test_one_postgres_server_per_tier(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                r = self.size(want["ops"])
+                self.assertEqual(r["postgres"]["servers"], 1)
+                self.assertEqual(r["machines"]["postgres_servers"], 1)
+
+
+# =============================================================================
+# 8. Network
+# =============================================================================
+
+
+class TestNetwork(ModelBaseTest):
+
+    def test_per_call_byte_sizes_are_built_from_named_constants(self):
+        n = self.size(100.0)["network"]
+        self.assertEqual(n["embed_bytes_per_call"],
+                         ps.EMBED_REQUEST_BYTES
+                         + 1024 * ps.ORIGINAL_VECTOR_BYTES_PER_VALUE
+                         + ps.EMBED_RESPONSE_ENVELOPE_BYTES)
+        self.assertEqual(n["embed_bytes_per_call"], 5296)
+        self.assertEqual(n["vector_search_bytes_per_call"], 14396)
+        self.assertEqual(n["vector_write_bytes_per_call"], 4796)
+        self.assertEqual(n["llm_bytes_per_call"], 10000)
+
+    def test_north_south_peak_at_the_target_tier(self):
+        # 45 x (1200 + 300) + 45 x (600 + 10 x 900)
+        #   + 10 x (600 + 2000 + 20 x 900) = 705,500 bytes/s, x 1.2 framing.
+        n = self.size(100.0)["network"]
+        self.assertClose(n["north_south_bytes_per_s"], 846_600.0,
+                         "north-south bytes/s")
+        self.assertClose(n["north_south_mbps"], 6.7728, "north-south Mbps")
+
+    def test_east_west_peak_at_the_target_tier(self):
+        # 355 x 5296 + 265 x 14396 + 45 x 4796 + 620 x 1800 + 15 x 10000
+        #   = 7,176,840 bytes/s, x 1.2 framing.
+        n = self.size(100.0)["network"]
+        self.assertClose(n["east_west_bytes_per_s"], 8_612_208.0,
+                         "east-west bytes/s")
+        self.assertClose(n["east_west_mbps"], 68.897664, "east-west Mbps")
+
+    def test_mbps_means_ten_to_the_sixth_bits_per_second(self):
+        n = self.size(100.0)["network"]
+        self.assertClose(n["north_south_mbps"],
+                         n["north_south_bytes_per_s"] * 8 / 1_000_000,
+                         "Mbps conversion")
+        self.assertClose(n["east_west_mbps"],
+                         n["east_west_bytes_per_s"] * 8 / 1_000_000,
+                         "Mbps conversion")
+
+    def test_traffic_grows_with_the_operation_rate(self):
+        one = self.size(100.0)["network"]
+        ten = self.size(1000.0)["network"]
+        self.assertClose(ten["east_west_mbps"], one["east_west_mbps"] * 10,
+                         "ten times the operations")
+        self.assertClose(ten["north_south_mbps"], one["north_south_mbps"] * 10,
+                         "ten times the operations")
+
+    def test_east_west_is_the_busier_direction(self):
+        n = self.size(100.0)["network"]
+        self.assertGreater(n["east_west_mbps"], n["north_south_mbps"])
+        self.assertClose(n["busiest_link_mbps"], n["east_west_mbps"],
+                         "busiest link")
+
+    def test_the_old_70_mbps_claim_is_reproducible_now(self):
+        """The figure must come out of the program's own declared inputs."""
+        n = self.size(100.0)["network"]
+        by_hand = ((355 * 5296 + 265 * 14396 + 45 * 4796
+                    + 620 * 1800 + 15 * 10000) * 1.2 * 8 / 1_000_000)
+        self.assertClose(n["east_west_mbps"], by_hand, "east-west Mbps by hand")
+
+
+# =============================================================================
+# 9. Users, in both directions
+# =============================================================================
+
+
+class TestUserConversion(ModelBaseTest):
+
+    def test_per_session_rate_constants(self):
+        self.assertEqual(ps.HUMAN_SESSION_OPS_PER_S_LOW, 0.011)
+        self.assertEqual(ps.HUMAN_SESSION_OPS_PER_S_HIGH, 0.028)
+        self.assertEqual(ps.AUTOMATED_CLIENT_OPS_PER_S, 0.4)
+
+    def test_capacity_to_sessions_at_the_target_tier(self):
+        u = self.size(100.0)["users"]
+        # Busier sessions mean fewer of them fit.
+        self.assertClose(u["human_sessions_low"], 100.0 / 0.028,
+                         "human sessions at the busy end")
+        self.assertClose(u["human_sessions_high"], 100.0 / 0.011,
+                         "human sessions at the quiet end")
+        self.assertClose(u["automated_client_sessions"], 250.0,
+                         "automated clients")
+
+    def test_capacity_to_sessions_at_every_tier(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                u = self.size(want["ops"])["users"]
+                self.assertClose(u["human_sessions_low"], want["ops"] / 0.028,
+                                 "human sessions, busy end")
+                self.assertClose(u["human_sessions_high"], want["ops"] / 0.011,
+                                 "human sessions, quiet end")
+                self.assertClose(u["automated_client_sessions"],
+                                 want["ops"] / 0.4, "automated clients")
+                self.assertLess(u["human_sessions_low"], u["human_sessions_high"])
+
+    def test_no_capacity_is_not_a_deployment_to_convert(self):
+        """A design peak of zero holds no sessions because it is refused.
+
+        Zero operations per second is not a capacity to divide into sessions,
+        so the program rejects it rather than reporting zero sessions. An empty
+        population converts the other way round quite happily: no users demand
+        no operations.
+        """
+        with self.assertRaises(ps.SizingError):
+            ps.size_deployment(0.0)
+        pop = ps.ops_for_population(humans=0, automated=0)
+        self.assertEqual(pop["ops_per_s_low"], 0.0)
+        self.assertEqual(pop["ops_per_s_high"], 0.0)
+
+    def test_sessions_to_capacity(self):
+        pop = ps.ops_for_population(humans=5000, automated=40)
+        # 5000 x 0.011 + 40 x 0.4 = 55 + 16 = 71
+        # 5000 x 0.028 + 40 x 0.4 = 140 + 16 = 156
+        self.assertClose(pop["ops_per_s_low"], 71.0, "ops/s, quiet humans")
+        self.assertClose(pop["ops_per_s_high"], 156.0, "ops/s, busy humans")
+
+    def test_the_two_directions_agree(self):
+        """Converting one way and back must return the starting number."""
+        for humans in (100, 5000, 250000):
+            with self.subTest(humans=humans):
+                pop = ps.ops_for_population(humans=humans, automated=0)
+                back = self.size(pop["ops_per_s_high"])["users"]
+                self.assertClose(back["human_sessions_low"], float(humans),
+                                 "round trip through the busy rate")
+
+    def test_a_population_of_automated_clients_only(self):
+        pop = ps.ops_for_population(humans=0, automated=250)
+        self.assertClose(pop["ops_per_s_low"], 100.0, "ops/s")
+        self.assertClose(pop["ops_per_s_high"], 100.0, "ops/s")
+
+    def test_smallest_tier_that_holds_a_population(self):
+        pop = ps.ops_for_population(humans=5000, automated=40)
+        self.assertEqual(pop["tier_for_low"], "target")   # 71 ops/s
+        self.assertEqual(pop["tier_for_high"], "scale")   # 156 ops/s
+
+    def test_tier_boundaries(self):
+        self.assertEqual(ps.smallest_tier_holding(0.0), "pilot")
+        self.assertEqual(ps.smallest_tier_holding(20.0), "pilot")
+        self.assertEqual(ps.smallest_tier_holding(20.001), "target")
+        self.assertEqual(ps.smallest_tier_holding(100.0), "target")
+        self.assertEqual(ps.smallest_tier_holding(100.001), "scale")
+        self.assertEqual(ps.smallest_tier_holding(1000.0), "scale")
+
+    def test_above_the_scale_tier_no_tier_holds_it(self):
+        self.assertIsNone(ps.smallest_tier_holding(1000.001))
+        pop = ps.ops_for_population(humans=0, automated=100000)
+        self.assertIsNone(pop["tier_for_high"])
+
+    def test_an_automated_client_is_worth_many_humans(self):
+        self.assertGreater(ps.AUTOMATED_CLIENT_OPS_PER_S
+                           / ps.HUMAN_SESSION_OPS_PER_S_HIGH, 10.0)
+
+
+# =============================================================================
+# 10. A traffic mix that is not 45 / 45 / 10
+# =============================================================================
+
+
+class TestCustomTrafficMix(ModelBaseTest):
+
+    def test_an_agent_heavy_mix(self):
+        """20 adds, 20 plain searches, 60 agent-mode searches per 100 ops."""
+        mix = ps.TrafficMix(add=20.0, plain=20.0, agent=60.0)
+        r = self.size(100.0, mix=mix)
+        d, m = r["demand"], r["machines"]
+        self.assertClose(d["adds_per_s"], 20.0, "adds/s")
+        self.assertClose(d["plain_searches_per_s"], 20.0, "plain searches/s")
+        self.assertClose(d["agent_searches_per_s"], 60.0, "agent searches/s")
+        # embeds = 20 + 40 + 1320
+        self.assertClose(d["embeds_per_s"], 1380.0, "embeds/s")
+        # vector searches = 20 + 1320
+        self.assertClose(d["vector_searches_per_s"], 1340.0,
+                         "vector searches/s")
+        # PostgreSQL = 40 + 40 + 2640
+        self.assertClose(d["postgres_statements_per_s"], 2720.0,
+                         "PostgreSQL statements/s")
+        # work = 1340 + 20 = 1360 -> ceil(1360/108) = 13
+        self.assertClose(m["api_work_per_s"], 1360.0, "API work/s")
+        self.assertEqual(m["api_servers"], 13)
+        # planning LLM calls = 60 x 1.5 = 90 -> ceil(90/15) = 6, +1 spare
+        self.assertEqual(m["agent_gpu_cards"], 7)
+
+    def test_a_search_only_mix(self):
+        """No adds at all, so no storage grows.
+
+        The searches still have to run on a machine, so the order is one
+        vector-store machine even though the stored bytes come to nothing.
+        """
+        mix = ps.TrafficMix(add=0.0, plain=90.0, agent=10.0)
+        r = self.size(100.0, mix=mix)
+        self.assertEqual(r["demand"]["adds_per_s"], 0.0)
+        self.assertEqual(r["demand"]["vector_writes_per_s"], 0.0)
+        self.assertEqual(r["storage"]["episodes_retained"], 0.0)
+        self.assertEqual(r["storage"]["hot_vector_ram_bytes"], 0.0)
+        self.assertEqual(r["machines"]["qdrant_servers"], 1)
+        # vector searches = 90 + 220 = 310 = the work, ceil(310/108) = 3
+        self.assertClose(r["machines"]["api_work_per_s"], 310.0, "API work/s")
+        self.assertEqual(r["machines"]["api_servers"], 3)
+
+    def test_an_add_only_mix(self):
+        mix = ps.TrafficMix(add=100.0, plain=0.0, agent=0.0)
+        r = self.size(100.0, mix=mix)
+        d = r["demand"]
+        self.assertClose(d["embeds_per_s"], 100.0, "embeds/s")
+        self.assertEqual(d["vector_searches_per_s"], 0.0)
+        self.assertClose(d["vector_writes_per_s"], 100.0, "vector writes/s")
+        self.assertClose(d["postgres_statements_per_s"], 200.0, "statements/s")
+        # work = 0 searches + 100 adds -> ceil(100/108) = 1
+        self.assertClose(r["machines"]["api_work_per_s"], 100.0, "API work/s")
+        self.assertEqual(r["machines"]["api_servers"], 1)
+        self.assertEqual(r["machines"]["agent_gpu_cards"], 0)
+
+    def test_the_agent_share_dominates_the_hardware_order(self):
+        """One agent-mode search costs about 22 plain searches."""
+        even = self.size(100.0, mix=ps.TrafficMix(45.0, 55.0, 0.0))
+        with_agents = self.size(100.0, mix=ps.TrafficMix(45.0, 45.0, 10.0))
+        self.assertGreater(with_agents["machines"]["api_servers"],
+                           even["machines"]["api_servers"])
+
+    def test_fractional_mix_shares(self):
+        mix = ps.TrafficMix(add=33.5, plain=64.0, agent=2.5)
+        r = self.size(200.0, mix=mix)
+        d = r["demand"]
+        self.assertClose(d["adds_per_s"], 67.0, "adds/s")
+        self.assertClose(d["plain_searches_per_s"], 128.0, "plain searches/s")
+        self.assertClose(d["agent_searches_per_s"], 5.0, "agent searches/s")
+
+    def test_the_mix_is_reported_back_in_the_inputs(self):
+        mix = ps.TrafficMix(add=20.0, plain=20.0, agent=60.0)
+        r = self.size(100.0, mix=mix)
+        self.assertEqual(r["inputs"]["mix"],
+                         {"add": 20.0, "plain": 20.0, "agent": 60.0})
+
+
+# =============================================================================
+# 11. Bad input: a clean message and a non-zero exit, never a traceback
+# =============================================================================
+
+
+class TestBadInputInTheLibrary(ModelBaseTest):
+
+    def test_mix_that_sums_to_less_than_100(self):
+        mix = ps.TrafficMix(add=45.0, plain=45.0, agent=5.0)
+        with self.assertRaises(ps.SizingError) as caught:
+            ps.size_deployment(100.0, mix)
+        self.assertIn("100", str(caught.exception))
+
+    def test_mix_that_sums_to_more_than_100(self):
+        mix = ps.TrafficMix(add=50.0, plain=50.0, agent=50.0)
+        with self.assertRaises(ps.SizingError):
+            ps.size_deployment(100.0, mix)
+
+    def test_negative_mix_share(self):
+        mix = ps.TrafficMix(add=110.0, plain=-5.0, agent=-5.0)
+        with self.assertRaises(ps.SizingError) as caught:
+            ps.size_deployment(100.0, mix)
+        self.assertIn("negative", str(caught.exception))
+
+    def test_negative_operations_per_second(self):
+        with self.assertRaises(ps.SizingError):
+            ps.size_deployment(-1.0)
+
+    def test_zero_operations_per_second_is_rejected(self):
+        """A design peak of zero operations is not a deployment to size."""
+        with self.assertRaises(ps.SizingError):
+            ps.size_deployment(0.0)
+
+    def test_negative_retention(self):
+        with self.assertRaises(ps.SizingError):
+            ps.size_deployment(100.0, retention_days=-1)
+
+    def test_zero_or_negative_dimensions(self):
+        with self.assertRaises(ps.SizingError):
+            ps.size_deployment(100.0, dims=0)
+        with self.assertRaises(ps.SizingError):
+            ps.size_deployment(100.0, dims=-1024)
+
+    def test_zero_or_negative_bytes_per_value(self):
+        with self.assertRaises(ps.SizingError):
+            ps.size_deployment(100.0, bytes_per_value=0)
+        with self.assertRaises(ps.SizingError):
+            ps.size_deployment(100.0, bytes_per_value=-1)
+
+    def test_negative_user_counts(self):
+        with self.assertRaises(ps.SizingError):
+            ps.ops_for_population(humans=-1, automated=0)
+        with self.assertRaises(ps.SizingError):
+            ps.ops_for_population(humans=0, automated=-1)
+
+    def test_not_a_number_and_infinity_are_refused(self):
+        """NaN passes every < and > test, so it needs its own check.
+
+        Without one it slips past validation and crashes deep in the rounding
+        arithmetic with a Python traceback.
+        """
+        for kwargs in ({"retention_days": float("nan")},
+                       {"retention_days": float("inf")},
+                       {"dims": float("nan")},
+                       {"bytes_per_value": float("nan")},
+                       {"bytes_per_value": float("inf")}):
+            with self.subTest(**kwargs):
+                with self.assertRaises(ps.SizingError):
+                    ps.size_deployment(100.0, **kwargs)
+        for ops in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(ops=ops):
+                with self.assertRaises(ps.SizingError):
+                    ps.size_deployment(ops)
+
+    def test_a_traffic_mix_share_that_is_not_a_number(self):
+        """NaN + 45 + 10 is NaN, and NaN never differs from 100 by more than
+        the tolerance, so the sum check alone lets it through."""
+        for mix in (ps.TrafficMix(float("nan"), 45.0, 10.0),
+                    ps.TrafficMix(45.0, float("nan"), 10.0),
+                    ps.TrafficMix(45.0, 45.0, float("inf"))):
+            with self.subTest(mix=mix):
+                with self.assertRaises(ps.SizingError):
+                    ps.size_deployment(100.0, mix)
+
+    def test_caller_counts_that_are_not_numbers(self):
+        for humans, automated in ((float("nan"), 0), (0, float("nan")),
+                                  (float("inf"), 0)):
+            with self.subTest(humans=humans, automated=automated):
+                with self.assertRaises(ps.SizingError):
+                    ps.ops_for_population(humans=humans,
+                                          automated=automated)
+
+    def test_ceil_up_refuses_a_quantity_that_is_not_finite(self):
+        for value in (float("nan"), float("inf")):
+            with self.subTest(value=value):
+                with self.assertRaises(ps.SizingError):
+                    ps.ceil_up(value, 108.0)
+
+    def test_sizing_error_is_a_value_error(self):
+        self.assertTrue(issubclass(ps.SizingError, ValueError))
+
+
+class TestBadInputOnTheCommandLine(unittest.TestCase):
+    """Every bad input must exit non-zero with a message, not a traceback."""
+
+    # Named the way unittest names its own assertion helpers, so it
+    # reads beside assertEqual rather than against it.
+    def assertCleanFailure(self, proc):  # noqa: N802
+        self.assertNotEqual(proc.returncode, 0,
+                            "bad input must exit non-zero")
+        self.assertNotIn("Traceback", proc.stderr,
+                         "bad input printed a Python traceback")
+        self.assertNotIn("Traceback", proc.stdout,
+                         "bad input printed a Python traceback")
+        self.assertTrue(proc.stderr.strip() or proc.stdout.strip(),
+                        "bad input printed no message at all")
+
+    def test_mix_below_100(self):
+        proc = run_cli("calc", "--ops", "100", "--add", "45", "--plain", "45",
+                       "--agent", "5")
+        self.assertCleanFailure(proc)
+        self.assertIn("100", proc.stderr + proc.stdout)
+
+    def test_mix_above_100(self):
+        proc = run_cli("calc", "--ops", "100", "--add", "50", "--plain", "50",
+                       "--agent", "50")
+        self.assertCleanFailure(proc)
+
+    def test_negative_mix_share(self):
+        proc = run_cli("calc", "--ops", "100", "--add", "110", "--plain", "-5",
+                       "--agent", "-5")
+        self.assertCleanFailure(proc)
+
+    def test_negative_ops(self):
+        proc = run_cli("calc", "--ops", "-100")
+        self.assertCleanFailure(proc)
+
+    def test_zero_ops(self):
+        proc = run_cli("calc", "--ops", "0")
+        self.assertCleanFailure(proc)
+
+    def test_negative_retention(self):
+        proc = run_cli("calc", "--ops", "100", "--retention-days", "-30")
+        self.assertCleanFailure(proc)
+
+    def test_zero_dimensions(self):
+        proc = run_cli("calc", "--ops", "100", "--dims", "0")
+        self.assertCleanFailure(proc)
+
+    def test_negative_user_count(self):
+        proc = run_cli("users", "--humans", "-10")
+        self.assertCleanFailure(proc)
+
+    def test_bad_tier_name(self):
+        proc = run_cli("tier", "enormous")
+        self.assertCleanFailure(proc)
+
+    def test_non_numeric_ops(self):
+        proc = run_cli("calc", "--ops", "lots")
+        self.assertCleanFailure(proc)
+
+    def test_operations_per_second_that_is_not_a_number(self):
+        for value in ("nan", "inf", "-inf"):
+            with self.subTest(ops=value):
+                proc = run_cli("calc", "--ops", value)
+                self.assertCleanFailure(proc)
+                self.assertEqual(proc.returncode, 2)
+
+    def test_an_operations_rate_so_large_it_overflows(self):
+        """1e300 is finite, but far past the largest peak this will size.
+
+        It used to pass the finite check and overflow to infinity part-way
+        through the byte arithmetic, and the reader was told about "inf" - a
+        value they never typed. It is refused by name now.
+        """
+        proc = run_cli("calc", "--ops", "1e300")
+        self.assertCleanFailure(proc)
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("the design peak is 1e+300", proc.stderr + proc.stdout)
+        self.assertNotIn("inf", proc.stderr + proc.stdout)
+
+    def test_retention_that_is_not_a_number(self):
+        for value in ("inf", "nan"):
+            with self.subTest(retention=value):
+                proc = run_cli("calc", "--ops", "100", "--retention-days", value)
+                self.assertCleanFailure(proc)
+                self.assertEqual(proc.returncode, 2)
+
+    def test_bytes_per_value_that_is_not_a_number(self):
+        proc = run_cli("calc", "--ops", "100", "--bytes-per-value", "nan")
+        self.assertCleanFailure(proc)
+        self.assertEqual(proc.returncode, 2)
+
+    def test_a_traffic_mix_share_that_is_not_a_number(self):
+        proc = run_cli("calc", "--ops", "100", "--add", "nan", "--plain", "45",
+                       "--agent", "10")
+        self.assertCleanFailure(proc)
+        self.assertEqual(proc.returncode, 2)
+
+    def test_a_user_count_that_is_not_a_number(self):
+        """It used to exit 0 and print a report full of the word nan."""
+        proc = run_cli("users", "--humans", "nan")
+        self.assertCleanFailure(proc)
+        self.assertEqual(proc.returncode, 2)
+        self.assertNotIn("nan ops/s", proc.stdout)
+
+    def test_bad_mix_on_the_validate_subcommand(self):
+        proc = run_cli("validate", "--add", "45", "--plain", "45",
+                       "--agent", "5")
+        self.assertCleanFailure(proc)
+
+    def test_bad_port_on_the_serve_subcommand(self):
+        proc = run_cli("serve", "--port", "0")
+        self.assertCleanFailure(proc)
+
+
+# =============================================================================
+# 12. The shape of the JSON result
+# =============================================================================
+
+
+class TestResultShape(ModelBaseTest):
+
+    TOP_LEVEL = ("run_name", "inputs", "demand", "machines", "storage",
+                 "postgres", "network", "users", "sensitivity")
+
+    def test_top_level_keys(self):
+        r = self.size(100.0)
+        for key in self.TOP_LEVEL:
+            with self.subTest(key=key):
+                self.assertIn(key, r)
+
+    def test_inputs_block(self):
+        r = self.size(100.0, retention_days=30, dims=768, bytes_per_value=2)
+        self.assertEqual(r["inputs"]["ops_per_s"], 100.0)
+        self.assertEqual(r["inputs"]["retention_days"], 30)
+        self.assertEqual(r["inputs"]["dims"], 768)
+        self.assertEqual(r["inputs"]["bytes_per_value"], 2)
+        self.assertEqual(set(r["inputs"]["mix"]), {"add", "plain", "agent"})
+
+    def test_demand_keys(self):
+        d = self.size(100.0)["demand"]
+        for key in ("adds_per_s", "plain_searches_per_s", "agent_searches_per_s",
+                    "embeds_per_s", "embeds_per_s_with_types_fix",
+                    "vector_searches_per_s", "vector_writes_per_s",
+                    "postgres_statements_per_s", "agent_llm_calls_per_s_low",
+                    "agent_llm_calls_per_s_high",
+                    "agent_llm_calls_per_s_planning"):
+            with self.subTest(key=key):
+                self.assertIn(key, d)
+
+    def test_machines_keys(self):
+        m = self.size(100.0)["machines"]
+        for key in ("api_servers", "api_work_per_s",
+                    "api_usable_searches_per_server", "postgres_servers",
+                    "qdrant_servers", "qdrant_node_ram_gb",
+                    "qdrant_usable_gb_per_node", "qdrant_total_ram_gb",
+                    "qdrant_options", "embed_gpu_cards_low",
+                    "embed_gpu_cards_high", "agent_gpu_cards",
+                    "total_cpu_servers"):
+            with self.subTest(key=key):
+                self.assertIn(key, m)
+
+    def test_machine_counts_are_whole_numbers(self):
+        m = self.size(100.0)["machines"]
+        for key in ("api_servers", "postgres_servers", "qdrant_servers",
+                    "embed_gpu_cards_low", "embed_gpu_cards_high",
+                    "agent_gpu_cards", "total_cpu_servers"):
+            with self.subTest(key=key):
+                self.assertIsInstance(m[key], int)
+
+    def test_total_ordinary_servers_adds_up(self):
+        m = self.size(100.0)["machines"]
+        self.assertEqual(m["total_cpu_servers"],
+                         m["api_servers"] + m["postgres_servers"]
+                         + m["qdrant_servers"])
+
+    def test_sensitivity_table_rows(self):
+        r = self.size(100.0)
+        rates = [row["agent_searches_per_s"] for row in r["sensitivity"]]
+        self.assertEqual(rates, [0.0, 2.0, 10.0, 25.0])
+        for row in r["sensitivity"]:
+            with self.subTest(rate=row["agent_searches_per_s"]):
+                for key in ("total_ops_per_s", "vector_searches_per_s",
+                            "api_work_per_s", "api_servers",
+                            "llm_calls_per_s_low", "llm_calls_per_s_high"):
+                    self.assertIn(key, row)
+
+    def test_sensitivity_holds_adds_and_plain_searches_fixed(self):
+        r = self.size(100.0)
+        for row in r["sensitivity"]:
+            rate = row["agent_searches_per_s"]
+            with self.subTest(rate=rate):
+                # adds 45 and plain searches 45 stay put; only agents vary.
+                self.assertClose(row["total_ops_per_s"], 90.0 + rate,
+                                 "total ops/s")
+                self.assertClose(row["vector_searches_per_s"], 45.0 + 22 * rate,
+                                 "vector searches/s")
+                self.assertClose(row["api_work_per_s"], 90.0 + 22 * rate,
+                                 "API work/s")
+                self.assertEqual(row["api_servers"],
+                                 math.ceil((90.0 + 22 * rate) / 108.0))
+
+    def test_sensitivity_matches_the_headline_at_the_real_agent_rate(self):
+        """At every tier, not only where the tier rate happens to be in the
+        fixed list. The scale tier's own rate is 100 agent-mode searches/s,
+        which the fixed rates 0/2/10/25 do not cover."""
+        for ops in (20.0, 100.0, 1000.0):
+            with self.subTest(ops=ops):
+                r = self.size(ops)
+                want = r["demand"]["agent_searches_per_s"]
+                rows = [x for x in r["sensitivity"]
+                        if abs(x["agent_searches_per_s"] - want) <= 1e-9]
+                self.assertEqual(len(rows), 1,
+                                 "the tier's own agent-mode rate must appear "
+                                 "exactly once in the sensitivity table")
+                self.assertEqual(rows[0]["api_servers"],
+                                 r["machines"]["api_servers"])
+
+    def test_sensitivity_rows_are_in_ascending_order(self):
+        for ops in (20.0, 100.0, 1000.0):
+            with self.subTest(ops=ops):
+                rates = [x["agent_searches_per_s"]
+                         for x in self.size(ops)["sensitivity"]]
+                self.assertEqual(rates, sorted(rates))
+                self.assertEqual(len(rates), len(set(rates)))
+
+    def test_sensitivity_always_keeps_the_four_fixed_rates(self):
+        rates = [x["agent_searches_per_s"] for x in self.size(1000.0)["sensitivity"]]
+        for fixed in ps.SENSITIVITY_AGENT_RATES:
+            self.assertIn(fixed, rates)
+
+    def test_the_whole_result_is_json_serialisable(self):
+        r = self.size(100.0)
+        text = json.dumps(r)
+        back = json.loads(text)
+        self.assertEqual(back["machines"]["api_servers"],
+                         r["machines"]["api_servers"])
+        self.assertEqual(set(back), set(r))
+
+    def test_the_json_carries_no_infinity_or_not_a_number(self):
+        """Every number must survive a strict parser.
+
+        Python writes a floating-point infinity as the bare token Infinity,
+        which jq, JavaScript's JSON.parse and most other parsers reject. The
+        default json.loads accepts it, so this test refuses it explicitly.
+        """
+        def refuse(token):
+            raise AssertionError(f"the JSON contains the bare token {token}, "
+                                 "which is not valid JSON")
+
+        for ops in (0.5, 20.0, 100.0, 1000.0):
+            with self.subTest(ops=ops):
+                text = json.dumps(self.size(ops))
+                json.loads(text, parse_constant=refuse)
+                for token in ("Infinity", "NaN"):
+                    self.assertNotIn(token, text)
+
+    def test_the_run_name_is_carried_through(self):
+        """run_name names the run - it is not one of the four provenance
+        labels, and the README says so."""
+        self.assertEqual(self.size(100.0, run_name="target")["run_name"],
+                         "target")
+        self.assertEqual(self.size(100.0)["run_name"], "custom")
+        self.assertNotIn("label", self.size(100.0),
+                         "no key called label, so nothing invites a reader to "
+                         "mistake the run name for a provenance label")
+
+
+# =============================================================================
+# 13. Every command-line subcommand, run as a real command
+# =============================================================================
+
+
+class TestCommandLine(unittest.TestCase):
+
+    def test_the_interpreter_exists(self):
+        self.assertTrue(os.path.exists(PYTHON),
+                        f"{PYTHON} is the interpreter the tests must use")
+
+    def test_no_arguments_prints_help(self):
+        proc = run_cli()
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("tier", proc.stdout)
+        self.assertIn("calc", proc.stdout)
+
+    def test_help_flag(self):
+        proc = run_cli("--help")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("memmachine_sizing.py", proc.stdout)
+
+    def test_tier_subcommand_for_each_tier(self):
+        for name in ("pilot", "target", "scale"):
+            with self.subTest(tier=name):
+                proc = run_cli("tier", name)
+                self.assertEqual(proc.returncode, 0, proc.stderr)
+                self.assertIn(name.upper(), proc.stdout)
+                self.assertIn("API server", proc.stdout)
+                self.assertIn("PostgreSQL", proc.stdout)
+                self.assertIn("Qdrant", proc.stdout)
+                self.assertNotIn("Traceback", proc.stderr)
+
+    def test_tier_json_matches_the_library(self):
+        for name in ("pilot", "target", "scale"):
+            with self.subTest(tier=name):
+                proc = run_cli("tier", name, "--json")
+                self.assertEqual(proc.returncode, 0, proc.stderr)
+                got = json.loads(proc.stdout)
+                want = ps.size_deployment(ps.TIER_OPS_PER_S[name],
+                                          run_name=name)
+                self.assertEqual(got["machines"]["api_servers"],
+                                 want["machines"]["api_servers"])
+                self.assertEqual(got["demand"], want["demand"])
+                self.assertEqual(got["run_name"], name)
+
+    def test_tier_report_states_the_expected_server_count(self):
+        proc = run_cli("tier", "target")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("3 API server(s)", proc.stdout)
+
+    def test_calc_subcommand(self):
+        proc = run_cli("calc", "--ops", "250")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("250", proc.stdout)
+
+    def test_calc_json_matches_the_library(self):
+        proc = run_cli("calc", "--ops", "250", "--add", "20", "--plain", "20",
+                       "--agent", "60", "--json")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        got = json.loads(proc.stdout)
+        want = ps.size_deployment(250.0, ps.TrafficMix(20.0, 20.0, 60.0))
+        self.assertEqual(got["demand"], want["demand"])
+        self.assertEqual(got["machines"]["api_servers"],
+                         want["machines"]["api_servers"])
+
+    def test_calc_honours_retention_dims_and_bytes_per_value(self):
+        proc = run_cli("calc", "--ops", "100", "--retention-days", "30",
+                       "--dims", "768", "--bytes-per-value", "2", "--json")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        got = json.loads(proc.stdout)
+        self.assertEqual(got["inputs"]["retention_days"], 30)
+        self.assertEqual(got["inputs"]["dims"], 768)
+        self.assertEqual(got["inputs"]["bytes_per_value"], 2)
+        want = ps.size_deployment(100.0, retention_days=30, dims=768,
+                                  bytes_per_value=2)
+        self.assertAlmostEqual(got["storage"]["hot_vector_ram_bytes"],
+                               want["storage"]["hot_vector_ram_bytes"])
+
+    def test_users_subcommand(self):
+        proc = run_cli("users", "--humans", "5000", "--automated", "40")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("5,000", proc.stdout)
+        self.assertIn("scale", proc.stdout)
+        self.assertNotIn("Traceback", proc.stderr)
+
+    def test_users_subcommand_with_no_automated_clients(self):
+        proc = run_cli("users", "--humans", "100")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("pilot", proc.stdout)
+
+    def test_validate_subcommand_writes_a_json_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "numbers.json")
+            proc = run_cli("validate", "--out", out)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertTrue(os.path.exists(out))
+            with open(out, encoding="utf-8") as handle:
+                numbers = json.load(handle)
+            self.assertGreater(len(numbers), 50)
+            self.assertEqual(numbers["target.api_servers"], 3)
+            self.assertEqual(numbers["pilot.api_servers"], 1)
+            self.assertEqual(numbers["scale.api_servers"], 29)
+            self.assertEqual(numbers["target.postgres_total_connections"], 420)
+            self.assertEqual(numbers["scale.postgres_total_connections"], 4060)
+            self.assertEqual(
+                numbers["constants.api_searches_per_s_per_server"], 180.0)
+            self.assertEqual(
+                numbers["constants.api_usable_searches_per_server"], 108.0)
+
+    def test_validate_prints_label_value_lines(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "numbers.json")
+            proc = run_cli("validate", "--out", out)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("target.api_servers: 3", proc.stdout)
+            self.assertIn("target.embeds_per_s: 355", proc.stdout)
+
+    def test_validate_covers_all_three_tiers(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "numbers.json")
+            proc = run_cli("validate", "--out", out)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            with open(out, encoding="utf-8") as handle:
+                numbers = json.load(handle)
+            for name, want in TIER_EXPECTATIONS.items():
+                with self.subTest(tier=name):
+                    self.assertEqual(numbers[f"{name}.api_servers"],
+                                     want["api_servers"])
+                    self.assertEqual(numbers[f"{name}.qdrant_servers"],
+                                     want["qdrant_nodes"])
+                    self.assertEqual(numbers[f"{name}.agent_gpu_cards"],
+                                     want["agent_cards"])
+                    self.assertEqual(numbers[f"{name}.embed_gpu_cards_low"],
+                                     want["embed_cards_low"])
+                    self.assertEqual(numbers[f"{name}.embed_gpu_cards_high"],
+                                     want["embed_cards_high"])
+
+    def test_validate_honours_a_custom_mix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "numbers.json")
+            proc = run_cli("validate", "--add", "20", "--plain", "20",
+                           "--agent", "60", "--out", out)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            with open(out, encoding="utf-8") as handle:
+                numbers = json.load(handle)
+            self.assertEqual(numbers["target.mix_agent"], 60.0)
+            self.assertEqual(numbers["target.api_servers"], 13)
+
+    def test_serve_subcommand_help(self):
+        proc = run_cli("serve", "--help")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("--port", proc.stdout)
+
+    def test_every_subcommand_is_reachable(self):
+        proc = run_cli("--help")
+        for name in ("tier", "calc", "users", "validate", "serve"):
+            with self.subTest(subcommand=name):
+                self.assertIn(name, proc.stdout)
+
+
+# =============================================================================
+# 14. The web server
+# =============================================================================
+
+
+class TestWebServer(unittest.TestCase):
+    """Start the server on a free port, ask it questions, then stop it."""
+
+    proc = None
+    base = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.port = free_port()
+        cls.base = f"http://127.0.0.1:{cls.port}"
+        cls.proc = subprocess.Popen(
+            [PYTHON, MODULE_PATH, "serve", "--host", "127.0.0.1",
+             "--port", str(cls.port)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        deadline = time.monotonic() + 30.0
+        last = None
+        while time.monotonic() < deadline:
+            if cls.proc.poll() is not None:
+                out, err = cls.proc.communicate()
+                raise AssertionError(
+                    f"the server exited straight away\nstdout: {out}\n"
+                    f"stderr: {err}")
+            try:
+                with urllib.request.urlopen(f"{cls.base}/healthz", timeout=2):
+                    return
+            except Exception as exc:      # not up yet
+                last = exc
+                time.sleep(0.1)
+        cls.tearDownClass()
+        raise AssertionError(f"the server never answered: {last}")
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.proc is not None and cls.proc.poll() is None:
+            cls.proc.terminate()
+            try:
+                cls.proc.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                cls.proc.kill()
+                cls.proc.communicate(timeout=10)
+        cls.proc = None
+
+    def fetch(self, path):
+        """Return (status, content type, body text), even for an error status."""
+        try:
+            with urllib.request.urlopen(self.base + path, timeout=10) as resp:
+                return (resp.status, resp.headers.get("Content-Type"),
+                        resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as err:
+            return (err.code, err.headers.get("Content-Type"),
+                    err.read().decode("utf-8"))
+
+    def test_home_page_status_and_content_type(self):
+        status, ctype, body = self.fetch("/")
+        self.assertEqual(status, 200)
+        self.assertEqual(ctype, "text/html; charset=utf-8")
+        self.assertIn("<!doctype html>", body.lower())
+        self.assertIn("MemMachine sizing calculator", body)
+
+    def test_home_page_carries_the_form(self):
+        _, _, body = self.fetch("/")
+        for field in ("ops", "add", "plain", "agent", "retention_days", "dims",
+                      "bytes_per_value", "node_gb", "humans", "automated",
+                      "human_mix", "automated_mix"):
+            with self.subTest(field=field):
+                self.assertIn(f'name="{field}"', body)
+
+    def test_home_page_shows_the_default_target_tier_answer(self):
+        _, _, body = self.fetch("/")
+        self.assertIn("Machines", body)
+        self.assertIn("PostgreSQL", body)
+
+    def test_home_page_with_explicit_settings(self):
+        status, ctype, body = self.fetch(
+            "/?ops=1000&add=45&plain=45&agent=10&retention_days=90"
+            "&dims=1024&bytes_per_value=1")
+        self.assertEqual(status, 200)
+        self.assertEqual(ctype, "text/html; charset=utf-8")
+        self.assertIn("29", body, "the scale tier needs 29 API servers")
+
+    def test_json_endpoint_status_and_content_type(self):
+        status, ctype, _ = self.fetch(
+            "/api/calc?ops=100&add=45&plain=45&agent=10&retention_days=90"
+            "&dims=1024&bytes_per_value=1")
+        self.assertEqual(status, 200)
+        self.assertEqual(ctype, "application/json; charset=utf-8")
+
+    def test_json_endpoint_numbers_match_the_library(self):
+        _, _, body = self.fetch(
+            "/api/calc?ops=100&add=45&plain=45&agent=10&retention_days=90"
+            "&dims=1024&bytes_per_value=1")
+        got = json.loads(body)
+        want = ps.size_deployment(100.0, ps.TrafficMix(45.0, 45.0, 10.0),
+                                  retention_days=90.0, dims=1024,
+                                  bytes_per_value=1.0)
+        self.assertEqual(got["demand"], want["demand"])
+        self.assertEqual(got["storage"], want["storage"])
+        self.assertEqual(got["postgres"], want["postgres"])
+        self.assertEqual(got["network"], want["network"])
+        self.assertEqual(got["users"], want["users"])
+        self.assertEqual(got["machines"]["api_servers"],
+                         want["machines"]["api_servers"])
+        self.assertEqual(got["machines"]["qdrant_servers"],
+                         want["machines"]["qdrant_servers"])
+
+    def test_json_endpoint_matches_the_hand_worked_target_tier(self):
+        _, _, body = self.fetch("/api/calc?ops=100")
+        got = json.loads(body)
+        want = TIER_EXPECTATIONS["target"]
+        self.assertEqual(got["machines"]["api_servers"], want["api_servers"])
+        self.assertEqual(got["machines"]["agent_gpu_cards"],
+                         want["agent_cards"])
+        self.assertEqual(got["postgres"]["total_connections"],
+                         want["pg_total_connections"])
+        self.assertAlmostEqual(got["demand"]["embeds_per_s"], want["embeds"])
+
+    def test_json_endpoint_with_a_custom_mix(self):
+        _, _, body = self.fetch("/api/calc?ops=100&add=20&plain=20&agent=60")
+        got = json.loads(body)
+        self.assertAlmostEqual(got["demand"]["agent_searches_per_s"], 60.0)
+        self.assertEqual(got["machines"]["api_servers"], 13)
+
+    def test_json_endpoint_defaults_to_the_target_tier(self):
+        _, _, body = self.fetch("/api/calc")
+        got = json.loads(body)
+        self.assertAlmostEqual(got["inputs"]["ops_per_s"], 100.0)
+        self.assertEqual(got["machines"]["api_servers"], 3)
+
+    def test_json_endpoint_rejects_a_mix_that_does_not_sum_to_100(self):
+        status, ctype, body = self.fetch(
+            "/api/calc?ops=100&add=45&plain=45&agent=5")
+        self.assertEqual(status, 400)
+        self.assertEqual(ctype, "application/json; charset=utf-8")
+        payload = json.loads(body)
+        self.assertIn("error", payload)
+        self.assertNotIn("Traceback", body)
+
+    def test_json_endpoint_rejects_a_negative_operation_rate(self):
+        status, _, body = self.fetch("/api/calc?ops=-5")
+        self.assertEqual(status, 400)
+        self.assertIn("error", json.loads(body))
+
+    def test_json_endpoint_rejects_text_where_a_number_belongs(self):
+        status, _, body = self.fetch("/api/calc?ops=lots")
+        self.assertEqual(status, 400)
+        self.assertIn("error", json.loads(body))
+
+    NON_FINITE_QUERIES = (
+        "/api/calc?ops=nan",
+        "/api/calc?ops=inf",
+        "/api/calc?ops=1e300",
+        "/api/calc?ops=100&retention_days=inf",
+        "/api/calc?ops=100&retention_days=nan",
+        "/api/calc?ops=100&bytes_per_value=nan",
+        "/api/calc?ops=100&dims=nan",
+        "/api/calc?ops=100&dims=1e400",
+        "/api/calc?ops=100&add=nan&plain=45&agent=10",
+    )
+
+    def test_json_endpoint_answers_every_non_finite_query(self):
+        """Each of these used to close the connection with no HTTP response."""
+        for path in self.NON_FINITE_QUERIES:
+            with self.subTest(path=path):
+                status, ctype, body = self.fetch(path)
+                self.assertEqual(status, 400,
+                                 "a bad query must get an HTTP 400, not a "
+                                 "dropped connection")
+                self.assertEqual(ctype, "application/json; charset=utf-8")
+                self.assertIn("error", json.loads(body))
+                self.assertNotIn("Traceback", body)
+
+    def test_home_page_answers_every_non_finite_query(self):
+        for path in self.NON_FINITE_QUERIES:
+            page = path.replace("/api/calc?", "/?")
+            with self.subTest(path=page):
+                status, ctype, body = self.fetch(page)
+                self.assertEqual(status, 400)
+                self.assertEqual(ctype, "text/html; charset=utf-8")
+                self.assertIn("Cannot calculate", body)
+                self.assertNotIn("Traceback", body)
+
+    def test_the_server_is_still_running_after_a_non_finite_query(self):
+        for path in self.NON_FINITE_QUERIES:
+            self.fetch(path)
+        status, _, _ = self.fetch("/healthz")
+        self.assertEqual(status, 200)
+
+    def test_home_page_reports_a_bad_mix_in_the_page(self):
+        status, ctype, body = self.fetch("/?ops=100&add=45&plain=45&agent=5")
+        self.assertEqual(status, 400)
+        self.assertEqual(ctype, "text/html; charset=utf-8")
+        self.assertIn("Cannot calculate", body)
+        self.assertNotIn("Traceback", body)
+
+    # Every flag that changes what is sized, on any subcommand, against the
+    # box that sets the same thing on the form. Nothing may be reachable by
+    # flag but not by the form.
+    FLAGS_AND_BOXES: ClassVar[tuple] = (
+        ("--ops", "ops"), ("--add", "add"), ("--plain", "plain"),
+        ("--agent", "agent"), ("--retention-days", "retention_days"),
+        ("--dims", "dims"), ("--bytes-per-value", "bytes_per_value"),
+        ("--node-gb", "node_gb"),
+        # The users subcommand. --automated counts callers that are programs;
+        # --agent above is the agent-mode share of the requests.
+        ("--humans", "humans"), ("--automated", "automated"),
+        ("--human-mix", "human_mix"), ("--automated-mix", "automated_mix"),
+    )
+
+    def test_the_form_offers_every_model_input_the_command_line_offers(self):
+        """No input may be reachable by flag but not by the form."""
+        _, _, body = self.fetch("/")
+        for _, key in self.FLAGS_AND_BOXES:
+            with self.subTest(field=key):
+                self.assertIn(f'name="{key}"', body)
+
+    def test_every_flag_in_that_pairing_is_a_flag_the_command_line_takes(self):
+        """The other direction: the pairing must not invent a flag.
+
+        A box paired with a flag nobody can type would let the form and the
+        command line drift apart while this test still passed.
+        """
+        helps = {name: run_cli(name, "--help").stdout
+                 for name in ("tier", "calc", "users")}
+        for flag, key in self.FLAGS_AND_BOXES:
+            with self.subTest(flag=flag):
+                self.assertTrue(
+                    any(flag in text for text in helps.values()),
+                    f"{flag} is paired with the {key} box but no subcommand "
+                    f"offers it")
+
+    def test_the_node_size_box_is_labelled_in_plain_english(self):
+        _, _, body = self.fetch("/")
+        self.assertIn("RAM per vector-store machine, GB", body)
+
+    def test_the_node_size_box_starts_empty(self):
+        _, _, body = self.fetch("/")
+        self.assertIn('name="node_gb" value=""', body)
+
+    def test_json_endpoint_forces_two_512_gb_machines(self):
+        status, _, body = self.fetch("/api/calc?ops=100&node_gb=512")
+        self.assertEqual(status, 200, body)
+        m = json.loads(body)["machines"]
+        self.assertEqual(m["qdrant_node_ram_gb"], 512)
+        self.assertEqual(m["qdrant_servers"], 2)
+        self.assertTrue(m["qdrant_node_ram_gb_forced"])
+
+    def test_json_endpoint_accepts_the_other_offered_sizes(self):
+        for node_gb, nodes in ((256, 3), (512, 2), (768, 1)):
+            with self.subTest(node_gb=node_gb):
+                status, _, body = self.fetch(
+                    f"/api/calc?ops=100&node_gb={node_gb}")
+                self.assertEqual(status, 200, body)
+                m = json.loads(body)["machines"]
+                self.assertEqual(m["qdrant_node_ram_gb"], node_gb)
+                self.assertEqual(m["qdrant_servers"], nodes)
+
+    def test_json_endpoint_accepts_a_size_that_is_not_one_of_the_three(self):
+        status, _, body = self.fetch("/api/calc?ops=100&node_gb=1024")
+        self.assertEqual(status, 200, body)
+        m = json.loads(body)["machines"]
+        self.assertEqual(m["qdrant_node_ram_gb"], 1024)
+        self.assertEqual(m["qdrant_servers"], 1)
+
+    def test_an_empty_node_size_box_keeps_the_automatic_choice(self):
+        for query in ("/api/calc?ops=100",
+                      "/api/calc?ops=100&node_gb=",
+                      "/api/calc?ops=100&node_gb=automatic",
+                      "/api/calc?ops=100&node_gb=auto"):
+            with self.subTest(query=query):
+                status, _, body = self.fetch(query)
+                self.assertEqual(status, 200, body)
+                m = json.loads(body)["machines"]
+                self.assertEqual(m["qdrant_node_ram_gb"], 768)
+                self.assertEqual(m["qdrant_servers"], 1)
+                self.assertFalse(m["qdrant_node_ram_gb_forced"])
+
+    def test_json_endpoint_rejects_a_node_size_of_zero(self):
+        status, ctype, body = self.fetch("/api/calc?ops=100&node_gb=0")
+        self.assertEqual(status, 400)
+        self.assertIn("application/json", ctype)
+        self.assertIn("greater than zero", json.loads(body)["error"])
+
+    def test_json_endpoint_rejects_a_negative_node_size(self):
+        status, _, body = self.fetch("/api/calc?ops=100&node_gb=-256")
+        self.assertEqual(status, 400)
+        self.assertIn("greater than zero", json.loads(body)["error"])
+
+    def test_json_endpoint_rejects_text_in_the_node_size_box(self):
+        for value in ("big", "512gb", "five hundred"):
+            with self.subTest(value=value):
+                status, ctype, body = self.fetch(
+                    f"/api/calc?ops=100&node_gb={value.replace(' ', '%20')}")
+                self.assertEqual(status, 400)
+                self.assertIn("application/json", ctype)
+                self.assertIn("error", json.loads(body))
+                self.assertNotIn("Traceback", body)
+
+    def test_json_endpoint_rejects_a_node_size_that_is_not_finite(self):
+        for value in ("nan", "inf", "-inf"):
+            with self.subTest(value=value):
+                status, _, body = self.fetch(
+                    f"/api/calc?ops=100&node_gb={value}")
+                self.assertEqual(status, 400)
+                self.assertIn("error", json.loads(body))
+
+    def test_the_page_shows_the_forced_node_size(self):
+        status, _, body = self.fetch("/?ops=100&node_gb=512")
+        self.assertEqual(status, 200)
+        self.assertIn("512 GB, forced", body)
+        self.assertIn('name="node_gb" value="512"', body)
+
+    def test_the_page_reports_a_bad_node_size_in_the_page(self):
+        status, ctype, body = self.fetch("/?ops=100&node_gb=0")
+        self.assertEqual(status, 400)
+        self.assertIn("text/html", ctype)
+        self.assertIn("Cannot calculate", body)
+        self.assertIn("greater than zero", body)
+        self.assertNotIn("Traceback", body)
+
+    def test_the_server_is_still_running_after_a_bad_node_size(self):
+        self.fetch("/api/calc?ops=100&node_gb=0")
+        self.fetch("/api/calc?ops=100&node_gb=big")
+        status, _, _ = self.fetch("/healthz")
+        self.assertEqual(status, 200)
+
+    def test_health_endpoint(self):
+        status, ctype, body = self.fetch("/healthz")
+        self.assertEqual(status, 200)
+        self.assertEqual(ctype, "text/plain; charset=utf-8")
+        self.assertEqual(body.strip(), "ok")
+
+    def test_unknown_path_is_a_404(self):
+        status, _, body = self.fetch("/nowhere")
+        self.assertEqual(status, 404)
+        self.assertIn("not found", body)
+
+    def test_the_page_needs_no_outside_files(self):
+        """No <script src>, no <link href> - the page must stand alone."""
+        _, _, body = self.fetch("/")
+        self.assertNotIn("<script", body.lower())
+        self.assertNotIn("<link", body.lower())
+        self.assertNotIn("http://", body.replace("http://127.0.0.1", ""))
+
+    def test_the_server_is_still_running_after_a_bad_request(self):
+        self.fetch("/api/calc?ops=lots")
+        status, _, _ = self.fetch("/healthz")
+        self.assertEqual(status, 200)
+
+    # -- an empty box is a blank answer, not a request for the default -------
+    #
+    # The command line refuses to run calc without --ops. The form used to
+    # invent 100 operations per second for a box the reader had cleared, and
+    # print a full hardware plan for it with no message at all.
+
+    FULL_FORM = ("ops=100&add=45&plain=45&agent=10&retention_days=90"
+                 "&dims=1024&bytes_per_value=1&node_gb=")
+
+    def submit(self, **changes):
+        """Submit the form as a browser does: all eight boxes, some changed."""
+        boxes = dict(pair.split("=", 1)
+                     for pair in self.FULL_FORM.split("&"))
+        boxes.update(changes)
+        return "&".join(f"{k}={v}" for k, v in boxes.items())
+
+    def test_an_empty_design_peak_box_is_reported_and_not_defaulted(self):
+        status, ctype, body = self.fetch("/?" + self.submit(ops=""))
+        self.assertEqual(status, 400,
+                         "a blank required box must not return a report")
+        self.assertIn("text/html", ctype)
+        self.assertIn("design peak box is empty", body)
+        self.assertNotIn("Total ordinary servers", body,
+                         "no hardware plan may be printed for a blank box")
+        self.assertIn('name="ops" value=""', body,
+                      "the box must stay blank, not be refilled with 100")
+
+    def test_an_empty_design_peak_box_is_reported_by_the_json_endpoint(self):
+        status, _, body = self.fetch("/api/calc?ops=&add=45")
+        self.assertEqual(status, 400)
+        self.assertIn("design peak box is empty", json.loads(body)["error"])
+
+    def test_every_box_that_must_be_answered_is_named_when_left_blank(self):
+        wanted = {
+            "ops": "design peak box is empty",
+            "add": "adds per 100 operations box is empty",
+            "plain": "plain searches per 100 operations box is empty",
+            "agent": "agent-mode searches per 100 operations box is empty",
+            "retention_days": "retention, days box is empty",
+            "dims": "vector dimensions box is empty",
+            "bytes_per_value": "bytes per number box is empty",
+        }
+        for field, message in wanted.items():
+            with self.subTest(field=field):
+                status, _, body = self.fetch("/?" + self.submit(**{field: ""}))
+                self.assertEqual(status, 400)
+                self.assertIn(message, body)
+
+    def test_a_box_holding_only_spaces_counts_as_blank(self):
+        status, _, body = self.fetch("/?" + self.submit(ops="%20%20%20"))
+        self.assertEqual(status, 400)
+        self.assertIn("design peak box is empty", body)
+
+    def test_a_parameter_left_out_altogether_still_takes_the_default(self):
+        """The deliberate difference: an absent parameter is not a blank box.
+
+        A bare /api/calc call names no parameters at all, and must keep
+        working exactly as the command line does when a flag is left off.
+        """
+        status, _, body = self.fetch("/api/calc?ops=100")
+        self.assertEqual(status, 200)
+        got = json.loads(body)
+        self.assertEqual(got["inputs"]["retention_days"],
+                         ps.DEFAULT_RETENTION_DAYS)
+        self.assertEqual(got["inputs"]["dims"], ps.DEFAULT_VECTOR_DIMS)
+        self.assertAlmostEqual(got["inputs"]["mix"]["add"], ps.DEFAULT_MIX_ADD)
+
+    def test_an_empty_node_size_box_still_means_the_automatic_choice(self):
+        """The one box where empty is itself an answer."""
+        status, _, body = self.fetch("/?" + self.submit(node_gb=""))
+        self.assertEqual(status, 200)
+        self.assertIn("chosen automatically", body)
+
+    # -- the boxes read the same on the first view as on every later view ----
+
+    def test_the_first_view_shows_whole_number_defaults_without_a_zero(self):
+        _, _, body = self.fetch("/")
+        for field, shown in (("ops", "100"), ("add", "45"), ("plain", "45"),
+                             ("agent", "10"), ("retention_days", "90"),
+                             ("dims", "1024"), ("bytes_per_value", "1")):
+            with self.subTest(field=field):
+                self.assertIn(f'name="{field}" value="{shown}"', body)
+        self.assertNotIn('value="100.0"', body)
+        self.assertNotIn('value="45.0"', body)
+
+    def test_the_boxes_read_the_same_before_and_after_a_submit(self):
+        _, _, first = self.fetch("/")
+        _, _, later = self.fetch("/?" + self.submit())
+        for field in ("ops", "add", "plain", "agent", "retention_days",
+                      "dims", "bytes_per_value", "node_gb"):
+            with self.subTest(field=field):
+                self.assertEqual(self.box_value(first, field),
+                                 self.box_value(later, field))
+
+    @staticmethod
+    def box_value(body, field):
+        mark = f'name="{field}" value="'
+        start = body.index(mark) + len(mark)
+        return body[start:body.index('"', start)]
+
+    # -- a bad number names its own box --------------------------------------
+
+    def test_a_bad_number_names_the_box_and_quotes_what_was_typed(self):
+        status, _, body = self.fetch("/?" + self.submit(ops="abc"))
+        self.assertEqual(status, 400)
+        self.assertIn("design peak box says", body)
+        self.assertIn("abc", body)
+        self.assertNotIn("every field must be a number", body)
+
+    def test_each_box_names_itself_rather_than_all_eight(self):
+        for field, name in (("dims", "vector dimensions box says"),
+                            ("bytes_per_value", "bytes per number box says"),
+                            ("node_gb",
+                             "RAM per vector-store machine box says")):
+            with self.subTest(field=field):
+                status, _, body = self.fetch(
+                    "/?" + self.submit(**{field: "lots"}))
+                self.assertEqual(status, 400)
+                self.assertIn(name, body)
+
+    def test_a_thousands_comma_gets_advice_of_its_own(self):
+        status, _, body = self.fetch("/api/calc?ops=1,000")
+        self.assertEqual(status, 400)
+        message = json.loads(body)["error"]
+        self.assertIn("design peak box says", message)
+        self.assertIn("1,000", message)
+        self.assertIn("comma", message)
+
+    # -- the message is announced, and points at the box that caused it ------
+
+    def test_the_error_box_is_announced_to_a_screen_reader(self):
+        _, _, body = self.fetch("/?" + self.submit(ops="abc"))
+        self.assertIn('class="err"', body)
+        self.assertIn('role="alert"', body)
+        self.assertIn(f'id="{ps.FORM_ERROR_ID}"', body)
+
+    def test_the_offending_box_is_marked_invalid_and_takes_the_focus(self):
+        _, _, body = self.fetch("/?" + self.submit(ops="abc"))
+        start = body.index('id="ops"')
+        box = body[start:body.index(">", start)]
+        self.assertIn('aria-invalid="true"', box)
+        self.assertIn(f'aria-describedby="{ps.FORM_ERROR_ID}"', box)
+        self.assertIn("autofocus", box)
+        other = body[body.index('id="dims"'):]
+        other = other[:other.index(">")]
+        self.assertNotIn("aria-invalid", other,
+                         "only the box at fault may be marked invalid")
+
+    def test_the_message_comes_before_the_form_in_the_page(self):
+        _, _, body = self.fetch("/?" + self.submit(ops="abc"))
+        self.assertLess(body.index('class="err"'), body.index("<form"),
+                        "a reader must meet the message before the boxes")
+
+    def test_a_good_answer_marks_no_box_invalid(self):
+        _, _, body = self.fetch("/?" + self.submit())
+        self.assertNotIn("aria-invalid", body)
+        self.assertNotIn("autofocus", body)
+
+    # -- a clean page load leaves nothing in the browser console -------------
+
+    def test_the_favicon_request_is_answered_with_no_content(self):
+        """Every browser asks for a tab icon; a 404 is a console error."""
+        status, _, body = self.fetch("/favicon.ico")
+        self.assertEqual(status, 204)
+        self.assertEqual(body, "")
+
+    # -- a wide table scrolls inside itself, not by dragging the page --------
+
+    def test_every_table_sits_inside_a_scrolling_container(self):
+        _, _, body = self.fetch("/")
+        self.assertEqual(body.count("<table>"),
+                         body.count('<div class="tablewrap"><table>'),
+                         "a table outside a scrolling box drags the whole "
+                         "page sideways on a narrow screen")
+        self.assertIn(".tablewrap { overflow-x: auto;", body)
+
+    def test_a_long_example_url_is_allowed_to_break(self):
+        _, _, body = self.fetch("/")
+        style = body[body.index("<style>"):body.index("</style>")]
+        code_rule = style[style.index("code {"):]
+        self.assertIn("overflow-wrap: anywhere", code_rule)
+
+    # -- the page never names a command-line flag the reader did not type ----
+
+    def test_the_page_names_the_box_that_forced_the_node_size(self):
+        _, _, body = self.fetch("/?" + self.submit(node_gb="512"))
+        self.assertIn("The size was forced with the RAM per vector-store "
+                      "machine box.", body)
+        self.assertNotIn("--node-gb", body)
+
+    def test_the_inputs_row_does_not_claim_an_automatic_choice(self):
+        _, _, body = self.fetch("/?" + self.submit(node_gb="512"))
+        self.assertIn("512 GB, forced", body)
+        self.assertIn("assumption - set by hand", body)
+        self.assertNotIn("the automatic choice buys the least total RAM", body)
+
+    # -- values the reader typed are never quietly changed -------------------
+
+    def test_a_fractional_dimension_is_refused_rather_than_cut_down(self):
+        status, _, body = self.fetch("/?" + self.submit(dims="1024.7"))
+        self.assertEqual(status, 400)
+        self.assertIn("vector dimensions is 1024.7", body)
+        self.assertIn("whole number", body)
+
+    def test_a_design_peak_too_large_to_size_is_refused_by_name(self):
+        status, _, body = self.fetch("/api/calc?ops=1e307")
+        self.assertEqual(status, 400)
+        message = json.loads(body)["error"]
+        self.assertIn("the design peak is 1e+307", message)
+        self.assertIn("1,000,000,000", message)
+        self.assertNotIn("inf", message,
+                         "the reader typed 1e307, not infinity")
+
+    def test_a_tiny_design_peak_still_orders_a_whole_machine(self):
+        _, _, body = self.fetch("/api/calc?ops=1e-9")
+        got = json.loads(body)
+        self.assertEqual(got["machines"]["api_servers"], 1)
+        self.assertEqual(got["machines"]["qdrant_servers"], 1)
+
+
+# =============================================================================
+# 15. The module uses nothing outside the standard library
+# =============================================================================
+
+
+class TestStandardLibraryOnly(unittest.TestCase):
+
+    def top_level_imports(self):
+        with open(MODULE_PATH, encoding="utf-8") as handle:
+            tree = ast.parse(handle.read(), filename=MODULE_PATH)
+        names = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    names.add(alias.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:          # a relative import, so a local package
+                    names.add("<relative import>")
+                elif node.module:
+                    names.add(node.module.split(".")[0])
+        return names
+
+    def test_every_import_is_in_the_standard_library(self):
+        allowed = set(sys.stdlib_module_names) | {"__future__"}
+        outside = sorted(name for name in self.top_level_imports()
+                         if name not in allowed)
+        self.assertEqual(outside, [],
+                         f"the calculator imports something outside the "
+                         f"standard library: {outside}")
+
+    def test_no_relative_imports(self):
+        self.assertNotIn("<relative import>", self.top_level_imports(),
+                         "the calculator must be a single self-contained file")
+
+    def test_the_module_imports_with_no_third_party_packages_installed(self):
+        """Import it in a fresh interpreter with site-packages switched off."""
+        proc = subprocess.run(
+            [PYTHON, "-S", "-c",
+             (f"import sys; sys.path.insert(0, {HERE!r}); "
+              "import memmachine_sizing; "
+              "print(memmachine_sizing.API_SEARCHES_PER_S_PER_SERVER)")],
+            capture_output=True, text=True, timeout=60)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "180.0")
+
+    def test_the_imports_it_actually_uses(self):
+        expected = {"__future__", "argparse", "difflib", "json", "math",
+                    "sys", "dataclasses", "html", "http", "urllib"}
+        self.assertEqual(self.top_level_imports(), expected)
+
+
+# =============================================================================
+# 16. Cross-checks that tie the whole model together
+# =============================================================================
+
+
+class TestModelConsistency(ModelBaseTest):
+
+    def test_ten_times_the_traffic_is_ten_times_the_demand(self):
+        one = self.size(100.0)["demand"]
+        ten = self.size(1000.0)["demand"]
+        for key in ("adds_per_s", "plain_searches_per_s", "embeds_per_s",
+                    "vector_searches_per_s", "postgres_statements_per_s"):
+            with self.subTest(key=key):
+                self.assertClose(ten[key], one[key] * 10, key)
+
+    def test_machine_counts_never_shrink_as_traffic_grows(self):
+        previous = None
+        for ops in (1.0, 20.0, 50.0, 100.0, 300.0, 1000.0, 3000.0):
+            m = self.size(ops)["machines"]
+            if previous is not None:
+                self.assertGreaterEqual(m["api_servers"],
+                                        previous["api_servers"])
+                self.assertGreaterEqual(m["embed_gpu_cards_high"],
+                                        previous["embed_gpu_cards_high"])
+                self.assertGreaterEqual(m["qdrant_servers"],
+                                        previous["qdrant_servers"])
+            previous = m
+
+    def test_the_reranker_adds_no_gpu(self):
+        """rrf-hybrid runs on the API server's own CPU; its cost is in the 180/s
+        anchor already, so nothing in the model prices a reranker card."""
+        source = open(MODULE_PATH, encoding="utf-8").read().lower()
+        self.assertIn("rrf-hybrid", source,
+                      "the reranker must be named, so a reader knows which one "
+                      "the 180/s anchor was measured with")
+        m = self.size(100.0)["machines"]
+        gpu_keys = [k for k in m if "gpu" in k]
+        self.assertEqual(sorted(gpu_keys),
+                         ["agent_gpu_cards", "agent_gpu_spare",
+                          "embed_gpu_cards_high", "embed_gpu_cards_low",
+                          "embed_gpu_spare"],
+                         "the only GPU roles are embedding and the agent model")
+
+    def test_the_report_renders_for_every_tier(self):
+        for name in ("pilot", "target", "scale"):
+            with self.subTest(tier=name):
+                r = self.size(ps.TIER_OPS_PER_S[name], run_name=name)
+                text = ps.render_report(r, name.upper())
+                self.assertIn("Demand per second", text)
+                self.assertIn("Machines", text)
+                self.assertIn("Sensitivity", text)
+
+    # The two tables of what-ifs carry no per-row label column, because each
+    # of their rows is an alternative rather than a published figure. The
+    # README and the note above each table both say so.
+    WHAT_IF_SECTIONS = ("Qdrant node choice",
+                        "Sensitivity: what the agent-mode quota costs")
+
+    def test_every_row_of_every_report_section_carries_a_label(self):
+        """measured, derived, estimate or assumption on EVERY row, not just
+        the first row of each section, and at every tier - the scale tier has
+        an extra sensitivity row and a different vector-store choice."""
+        wanted = ("measured", "derived", "estimate", "assumption")
+        checked = 0
+        for ops in (20.0, 100.0, 1000.0):
+            for section in ps.report_sections(self.size(ops)):
+                if section["title"] in self.WHAT_IF_SECTIONS:
+                    continue
+                for index, row in enumerate(section["rows"]):
+                    with self.subTest(ops=ops, section=section["title"],
+                                      row=index):
+                        last = str(row[-1]).lower()
+                        self.assertTrue(
+                            any(word in last for word in wanted),
+                            f"row label {last!r} is not one of "
+                            f"measured / derived / estimate / assumption")
+                        checked += 1
+        self.assertGreater(checked, 40,
+                           "every row of every labelled section must be "
+                           "inspected, not one row per section")
+
+    def test_the_two_what_if_tables_say_in_their_note_where_their_numbers_come_from(self):
+        """They are the only sections with no label column, so the README's
+        claim about labels holds only if each explains itself in its note."""
+        seen = []
+        for section in ps.report_sections(self.size(100.0)):
+            if section["title"] not in self.WHAT_IF_SECTIONS:
+                continue
+            seen.append(section["title"])
+            with self.subTest(section=section["title"]):
+                self.assertNotIn("Label", section["headers"])
+                self.assertIn("what-if", section["note"])
+                self.assertIn("derived", section["note"])
+        self.assertEqual(sorted(seen), sorted(self.WHAT_IF_SECTIONS))
+
+    def test_the_report_footer_names_the_two_tables_that_carry_no_label(self):
+        text = ps.render_report(self.size(100.0), "TARGET")
+        self.assertIn("assumption = a planning choice, not a finding.", text)
+        self.assertIn("carry no label", text)
+        self.assertIn("Qdrant node choice table and the sensitivity table",
+                      text)
+
+    def test_no_network_row_is_labelled_plainly_derived(self):
+        """Nothing measured enters the network figures.
+
+        Every input to them is one of the per-call byte-size estimates, so a
+        bare "derived" label there would claim a measurement that does not
+        exist.
+        """
+        r = self.size(100.0)
+        for section in ps.report_sections(r):
+            if section["title"] != "Network":
+                continue
+            for row in section["rows"]:
+                with self.subTest(row=row[0]):
+                    self.assertNotEqual(row[-1].strip().lower(), "derived")
+
+
+# =============================================================================
+# 17. Values the reader gave are never quietly changed, and no positive
+#     workload comes back as no machines at all
+# =============================================================================
+
+
+class TestWorkAlwaysCostsAMachine(ModelBaseTest):
+    """A positive workload has to run somewhere.
+
+    ceil_up used to subtract a flat 1e-9 to absorb floating-point dust, which
+    is dust next to three machines but is larger than the whole answer for a
+    very small workload: any work below about 1.08e-7 searches per second came
+    back as zero machines. The dust allowance is a fraction of the answer now.
+    """
+
+    def test_a_workload_far_below_one_machine_still_needs_one(self):
+        for work in (1e-12, 1e-9, 1e-7, 1e-3, 0.5):
+            with self.subTest(work=work):
+                self.assertEqual(ps.api_servers_for_work(work), 1)
+
+    def test_no_work_still_needs_no_machine(self):
+        self.assertEqual(ps.api_servers_for_work(0.0), 0)
+        self.assertEqual(ps.ceil_up(0.0, 108.0), 0)
+        self.assertEqual(ps.ceil_up(-5.0, 108.0), 0)
+
+    def test_exact_multiples_still_do_not_round_up(self):
+        """The reason the dust allowance exists at all."""
+        self.assertEqual(ps.ceil_up(324.0, 108.0), 3)
+        self.assertEqual(ps.ceil_up(108.0, 108.0), 1)
+        self.assertEqual(ps.ceil_up(0.1 + 0.2, 0.1), 3)
+
+    def test_a_hair_above_a_multiple_still_rounds_up(self):
+        self.assertEqual(ps.ceil_up(324.1, 108.0), 4)
+
+    def test_a_tiny_design_peak_orders_a_real_deployment(self):
+        r = self.size(1e-9)
+        self.assertEqual(r["machines"]["api_servers"], 1)
+        self.assertEqual(r["machines"]["qdrant_servers"], 1)
+        self.assertGreaterEqual(r["machines"]["qdrant_total_ram_gb"], 1)
+        self.assertGreaterEqual(r["machines"]["embed_gpu_cards_low"],
+                                1 + SPARE_CARDS)
+
+    def test_a_deployment_that_searches_vectors_owns_somewhere_to_search(self):
+        """Stored bytes are not the only reason to own a vector-store machine.
+
+        A search-only mix stores nothing, and so does a retention of zero days,
+        which the report itself calls a placeholder. Both used to order zero
+        vector-store machines beside hundreds of vector searches a second.
+        """
+        cases = {
+            "search only": {"mix": ps.TrafficMix(0.0, 90.0, 10.0)},
+            "retention zero": {"retention_days": 0},
+            "search only and retention zero": {
+                "mix": ps.TrafficMix(0.0, 90.0, 10.0), "retention_days": 0},
+            "adds only": {"mix": ps.TrafficMix(100.0, 0.0, 0.0),
+                          "retention_days": 0},
+        }
+        for label, kwargs in cases.items():
+            with self.subTest(case=label):
+                r = self.size(100.0, **kwargs)
+                d, m = r["demand"], r["machines"]
+                self.assertGreater(d["vector_searches_per_s"]
+                                   + d["vector_writes_per_s"], 0.0)
+                self.assertGreaterEqual(m["qdrant_servers"], 1)
+                self.assertGreaterEqual(m["total_cpu_servers"],
+                                        m["api_servers"]
+                                        + m["postgres_servers"] + 1)
+
+    def test_the_written_order_never_names_zero_vector_store_machines(self):
+        headline = ps.render_tier_headline(self.size(100.0, retention_days=0))
+        self.assertIn("1 Qdrant server(s)", headline)
+
+
+class TestVectorDimensionsMustBeWhole(ModelBaseTest):
+    """A vector cannot hold part of a number.
+
+    The report itself warns that the dimension count must be fixed before the
+    first episode is ingested, so cutting 1024.7 down to 1024 without saying so
+    is exactly the kind of change worth refusing.
+    """
+
+    def test_a_fraction_of_a_dimension_is_refused(self):
+        with self.assertRaises(ps.SizingError) as caught:
+            self.size(100.0, dims=1024.7)
+        message = str(caught.exception)
+        self.assertIn("1024.7", message)
+        self.assertIn("whole number", message)
+
+    def test_a_whole_number_written_as_a_float_is_accepted(self):
+        r = self.size(100.0, dims=1024.0)
+        self.assertEqual(r["inputs"]["dims"], 1024)
+        self.assertIsInstance(r["inputs"]["dims"], int)
+
+    def test_a_fraction_is_not_sized_as_the_whole_number_below_it(self):
+        with self.assertRaises(ps.SizingError):
+            self.size(100.0, dims=1024.7)
+
+    def test_the_message_for_a_negative_dimension_is_unchanged(self):
+        with self.assertRaises(ps.SizingError) as caught:
+            self.size(100.0, dims=-8)
+        self.assertIn("vector dimensions is -8", str(caught.exception))
+
+
+class TestSanityBounds(ModelBaseTest):
+    """A number far larger than any deployment is refused by name.
+
+    1e307 is a finite number, so it passed the finite check at the front of
+    size_deployment and only overflowed to infinity later, deep in the byte
+    arithmetic - and came back as a complaint about "inf", a value the reader
+    never typed. The bounds change no machine count; they only decide what is
+    refused, and they say what the limit is.
+    """
+
+    def test_the_bounds_are_far_above_the_largest_tier(self):
+        self.assertGreater(ps.MAX_OPS_PER_S, ps.TIER_OPS_PER_S["scale"] * 1000)
+        self.assertGreater(ps.MAX_VECTOR_DIMS, ps.DEFAULT_VECTOR_DIMS * 100)
+        self.assertGreater(ps.MAX_RETENTION_DAYS,
+                           ps.DEFAULT_RETENTION_DAYS * 100)
+
+    def test_a_design_peak_above_the_bound_is_refused(self):
+        for ops in (ps.MAX_OPS_PER_S * 1.001, 1e12, 1e307):
+            with self.subTest(ops=ops):
+                with self.assertRaises(ps.SizingError) as caught:
+                    self.size(ops)
+                message = str(caught.exception)
+                self.assertIn("the design peak is", message)
+                self.assertIn("1,000,000,000 operations/s", message)
+                self.assertNotIn("inf", message)
+
+    def test_a_design_peak_at_the_bound_is_still_sized(self):
+        r = self.size(ps.MAX_OPS_PER_S)
+        self.assertGreater(r["machines"]["api_servers"], 0)
+        self.assertTrue(math.isfinite(r["storage"]["hot_vector_ram_bytes"]))
+
+    # One above each bound, and the limit each one prints.
+    JUST_OVER_EACH_BOUND: ClassVar[tuple] = (
+        ("ops_per_s", ps.MAX_OPS_PER_S + 1, "the design peak is",
+         "1,000,000,000"),
+        ("retention_days", ps.MAX_RETENTION_DAYS + 1, "retention is",
+         "36,500"),
+        ("dims", ps.MAX_VECTOR_DIMS + 1, "vector dimensions is",
+         "1,000,000"),
+        ("bytes_per_value", ps.MAX_BYTES_PER_VALUE + 1,
+         "bytes per number is", "64"),
+        ("node_gb", ps.MAX_NODE_GB + 1, "RAM per vector-store machine is",
+         "1,000,000"),
+    )
+
+    def refusal(self, field, value):
+        if field == "ops_per_s":
+            args, kwargs = (value,), {}
+        else:
+            args, kwargs = (100.0,), {field: value}
+        with self.assertRaises(ps.SizingError) as caught:
+            self.size(*args, **kwargs)
+        return str(caught.exception)
+
+    def test_every_bounded_input_is_refused_by_name(self):
+        for field, value, opening, _limit in self.JUST_OVER_EACH_BOUND:
+            with self.subTest(field=field):
+                message = self.refusal(field, value)
+                self.assertTrue(message.startswith(opening),
+                                f"{message!r} must name the field it is about")
+                self.assertIn("larger than this calculator will size", message)
+
+    def test_the_refused_value_reads_as_larger_than_the_limit(self):
+        """The message used to print the value with :g, which rounded it to
+        look exactly like the limit it was being compared against: "the design
+        peak is 1e+09 ... the most it accepts is 1,000,000,000"."""
+        for field, value, _opening, limit in self.JUST_OVER_EACH_BOUND:
+            with self.subTest(field=field):
+                message = self.refusal(field, value)
+                before, _, after = message.partition(
+                    "larger than this calculator will size")
+                self.assertIn(limit, after, "the limit is named")
+                self.assertNotIn(limit, before,
+                                 f"the rejected value reads as {limit}, which "
+                                 "is the limit it is said to exceed")
+                self.assertIn(ps.as_given(value), before,
+                              "the rejected value is quoted as it was given")
+
+    def test_each_bound_is_itself_still_accepted(self):
+        for field, value in (("retention_days", ps.MAX_RETENTION_DAYS),
+                             ("dims", ps.MAX_VECTOR_DIMS),
+                             ("bytes_per_value", ps.MAX_BYTES_PER_VALUE),
+                             ("node_gb", ps.MAX_NODE_GB)):
+            with self.subTest(field=field):
+                r = self.size(100.0, **{field: value})
+                self.assertTrue(
+                    math.isfinite(r["storage"]["hot_vector_ram_bytes"]))
+
+    def test_the_bounds_move_no_machine_count(self):
+        """Every tier is sized exactly as it was before the bounds existed."""
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                r = self.size(ps.TIER_OPS_PER_S[name])
+                self.assertEqual(r["machines"]["api_servers"],
+                                 want["api_servers"])
+
+
+class TestTheReportNamesWhatForcedTheNodeSize(ModelBaseTest):
+    """The reader of a web page never typed a command-line flag."""
+
+    @staticmethod
+    def qdrant_note(r):
+        for section in ps.report_sections(r):
+            if section["title"] == "Qdrant node choice":
+                return section["note"]
+        raise AssertionError("the report lost its Qdrant node choice section")
+
+    def test_the_command_line_report_names_the_flag(self):
+        note = self.qdrant_note(self.size(100.0, node_gb=512))
+        self.assertIn("The size was forced with --node-gb.", note)
+
+    def test_the_web_report_names_the_box(self):
+        r = self.size(100.0, node_gb=512,
+                      node_gb_source=ps.NODE_GB_SOURCE_WEB)
+        note = self.qdrant_note(r)
+        self.assertIn("The size was forced with the RAM per vector-store "
+                      "machine box.", note)
+        self.assertNotIn("--node-gb", ps.render_report(r, "FORCED"),
+                         "a web reader never typed a command-line flag")
+
+    def test_the_automatic_choice_names_neither(self):
+        note = self.qdrant_note(self.size(100.0))
+        self.assertIn("buys the least total RAM", note)
+        self.assertNotIn("The size was forced", note)
+
+    def test_a_forced_size_is_not_labelled_an_automatic_choice(self):
+        rows = self.node_row(self.size(100.0, node_gb=512))
+        self.assertEqual(rows[1], "512 GB, forced")
+        self.assertEqual(rows[2], "assumption - set by hand")
+
+    def test_an_automatic_size_keeps_the_label_that_describes_it(self):
+        rows = self.node_row(self.size(100.0))
+        self.assertEqual(rows[1], "chosen automatically")
+        self.assertIn("automatic choice buys the least total RAM", rows[2])
+
+    @staticmethod
+    def node_row(r):
+        for section in ps.report_sections(r):
+            if section["title"] != "Inputs":
+                continue
+            for row in section["rows"]:
+                if row[0] == "RAM per vector-store machine":
+                    return row
+        raise AssertionError("the Inputs table lost its node-size row")
+
+
+class TestReadingOneFormBox(unittest.TestCase):
+    """read_number names the box, so a reader is not left to hunt."""
+
+    def test_a_blank_box_is_named(self):
+        with self.assertRaises(ps.FieldError) as caught:
+            ps.read_number("", "ops")
+        self.assertEqual(caught.exception.field, "ops")
+        self.assertIn("design peak box is empty", str(caught.exception))
+
+    def test_text_is_quoted_back_with_the_box_that_holds_it(self):
+        with self.assertRaises(ps.FieldError) as caught:
+            ps.read_number("lots", "dims")
+        self.assertEqual(caught.exception.field, "dims")
+        self.assertIn('vector dimensions box says "lots"',
+                      str(caught.exception))
+
+    def test_a_thousands_comma_is_called_out_on_its_own(self):
+        with self.assertRaises(ps.FieldError) as caught:
+            ps.read_number("1,000", "ops")
+        self.assertIn("comma", str(caught.exception))
+
+    def test_a_good_number_is_read(self):
+        self.assertEqual(ps.read_number(" 512 ", "node_gb"), 512.0)
+
+    def test_a_field_error_is_still_an_ordinary_bad_input(self):
+        self.assertIsInstance(ps.FieldError("ops", "x"), ps.SizingError)
+        self.assertIsInstance(ps.FieldError("ops", "x"), ValueError)
+
+    def test_every_box_on_the_form_has_a_name_and_a_what_to_type(self):
+        for key, _, _ in ps.FORM_FIELDS:
+            with self.subTest(box=key):
+                self.assertIn(key, ps.FORM_FIELD_HELP)
+                name, what = ps.FORM_FIELD_HELP[key]
+                self.assertTrue(name and what)
+        self.assertEqual(set(ps.FORM_DEFAULTS),
+                         {key for key, _, _ in ps.FORM_FIELDS})
+
+    def test_a_whole_number_default_reads_as_a_whole_number(self):
+        self.assertEqual(ps.format_default(100.0), "100")
+        self.assertEqual(ps.format_default(45.0), "45")
+        self.assertEqual(ps.format_default(90), "90")
+        self.assertEqual(ps.format_default(None), "")
+
+    def test_a_box_that_was_never_sent_is_told_apart_from_an_empty_one(self):
+        self.assertIsNone(ps.submitted_text({}, "ops"))
+        self.assertEqual(ps.submitted_text({"ops": [""]}, "ops"), "")
+        self.assertEqual(ps.submitted_text({"ops": ["100"]}, "ops"), "100")
+
+
+class TestResultFromQuery(unittest.TestCase):
+    """The form's answer, without going through a socket."""
+
+    FULL: ClassVar[dict] = {
+        "ops": ["100"], "add": ["45"], "plain": ["45"], "agent": ["10"],
+        "retention_days": ["90"], "dims": ["1024"],
+        "bytes_per_value": ["1"], "node_gb": [""]}
+
+    def test_a_full_submission_is_sized(self):
+        values, result, error, bad = ps.result_from_query(dict(self.FULL))
+        self.assertIsNone(error)
+        self.assertIsNone(bad)
+        self.assertEqual(result["machines"]["api_servers"], 3)
+        self.assertEqual(values["ops"], "100")
+
+    def test_a_blank_box_is_an_error_that_names_itself(self):
+        query = dict(self.FULL, ops=[""])
+        values, result, error, bad = ps.result_from_query(query)
+        self.assertIsNone(result)
+        self.assertEqual(bad, "ops")
+        self.assertIn("design peak box is empty", error)
+        self.assertEqual(values["ops"], "",
+                         "the box must stay as the reader left it")
+
+    def test_an_absent_box_takes_the_default(self):
+        values, result, error, _bad = ps.result_from_query({"ops": ["100"]})
+        self.assertIsNone(error)
+        self.assertEqual(values["dims"], "1024")
+        self.assertEqual(result["inputs"]["dims"], ps.DEFAULT_VECTOR_DIMS)
+
+    def test_no_box_at_all_gives_the_target_tier(self):
+        values, result, error, _ = ps.result_from_query({})
+        self.assertIsNone(error)
+        self.assertEqual(values["ops"], "100")
+        self.assertEqual(result["inputs"]["ops_per_s"],
+                         ps.TIER_OPS_PER_S["target"])
+
+    def test_a_blank_node_size_box_is_the_automatic_choice(self):
+        _, result, error, _ = ps.result_from_query(dict(self.FULL))
+        self.assertIsNone(error)
+        self.assertFalse(result["machines"]["qdrant_node_ram_gb_forced"])
+
+    def test_a_fault_that_belongs_to_no_single_box_blames_none(self):
+        query = dict(self.FULL, add=["50"], plain=["50"], agent=["10"])
+        _, result, error, bad = ps.result_from_query(query)
+        self.assertIsNone(result)
+        self.assertIsNone(bad, "the mix is three boxes together, not one")
+        self.assertIn("must add up to 100", error)
+
+    def test_the_web_result_says_the_box_forced_the_node_size(self):
+        query = dict(self.FULL, node_gb=["512"])
+        _, result, _, _ = ps.result_from_query(query)
+        self.assertEqual(result["inputs"]["node_gb_source"],
+                         ps.NODE_GB_SOURCE_WEB)
+
+    def test_the_first_box_at_fault_is_the_one_reported(self):
+        query = dict(self.FULL, ops=[""], dims=[""])
+        _, _, error, bad = ps.result_from_query(query)
+        self.assertEqual(bad, "ops")
+        self.assertIn("design peak", error)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+
+
+# =============================================================================
+# 22. What `validate` exports, and the README's claim about it
+# =============================================================================
+
+
+class TestTheExportedNumbers(unittest.TestCase):
+    """`validate` promises a fixed, named list of keys. These tests pin it."""
+
+    # Every key one tier writes, apart from the sensitivity rows, which are
+    # checked separately because how many there are depends on the mix.
+    PINNED_TIER_KEYS: ClassVar[list] = [
+        "adds_per_s", "agent_gpu_cards", "agent_gpu_spare",
+        "agent_llm_calls_per_s_high", "agent_llm_calls_per_s_low",
+        "agent_llm_calls_per_s_planning", "agent_searches_per_s",
+        "api_server_spec", "api_servers", "automated_client_sessions",
+        "api_usable_searches_per_server", "api_work_per_s",
+        "bytes_per_value", "embed_gpu_cards_high", "embed_gpu_cards_low",
+        "embed_gpu_spare", "embeds_per_s", "embeds_per_s_with_types_fix",
+        "episodes_per_day", "episodes_per_year", "episodes_retained",
+        "hot_vector_ram_gb", "human_sessions_high", "human_sessions_low",
+        "mix_add", "mix_agent", "mix_plain", "network_busiest_link_mbps",
+        "network_east_west_mbps", "network_embed_bytes_per_call",
+        "network_headroom_on_10gbe", "network_llm_bytes_per_call",
+        "network_north_south_mbps", "network_vector_search_bytes_per_call",
+        "network_vector_write_bytes_per_call", "node_gb_forced", "ops_per_s",
+        "plain_searches_per_s", "postgres_core_connections",
+        "postgres_exceeds_chart_default", "postgres_exceeds_proven_setting",
+        "postgres_gateway_connections", "postgres_gb_high", "postgres_gb_low",
+        "postgres_max_connections_required",
+        "postgres_needs_connection_pooler", "postgres_servers",
+        "postgres_statements_per_s", "postgres_total_connections",
+        "qdrant_fill_of_allowance_pct", "qdrant_node_ram_gb",
+        "qdrant_nodes_at_256gb", "qdrant_nodes_at_512gb",
+        "qdrant_nodes_at_768gb", "qdrant_nvme_gb", "qdrant_servers",
+        "qdrant_tight_fit", "qdrant_total_ram_gb", "qdrant_usable_gb_per_node",
+        "retention_days", "total_cpu_servers",
+        "unbounded_year_hot_vector_ram_gb", "unbounded_year_postgres_gb_high",
+        "unbounded_year_postgres_gb_low", "unbounded_year_qdrant_nvme_gb",
+        "vector_dims", "vector_searches_per_s", "vector_writes_per_s",
+    ]
+
+    SENSITIVITY_ROW_FIELDS: ClassVar[list] = [
+        "agent_searches_per_s", "api_servers", "api_work_per_s",
+        "llm_calls_per_s_high", "llm_calls_per_s_low", "total_ops_per_s",
+        "vector_searches_per_s",
+    ]
+
+    def exported(self, name="target", **kwargs):
+        r = ps.size_deployment(ps.TIER_OPS_PER_S[name], run_name=name, **kwargs)
+        return dict(ps.published_numbers(name, r)), r
+
+    def test_the_exported_key_list_is_pinned_so_none_can_quietly_disappear(self):
+        """The README promises a fixed, named list. A key that is dropped or
+        renamed must fail here rather than vanish from the published file."""
+        pairs, r = self.exported()
+        got = sorted(k.split(".", 1)[1] for k in pairs
+                     if not k.startswith("target.sensitivity."))
+        self.assertEqual(got, sorted(self.PINNED_TIER_KEYS))
+        rows = len(r["sensitivity"])
+        for position in range(1, rows + 1):
+            with self.subTest(row=position):
+                fields = sorted(
+                    k.rsplit(".", 1)[1] for k in pairs
+                    if k.startswith(f"target.sensitivity.row{position}."))
+                self.assertEqual(fields, sorted(self.SENSITIVITY_ROW_FIELDS))
+        self.assertNotIn(f"target.sensitivity.row{rows + 1}.api_servers", pairs)
+
+    def test_every_constant_the_readme_names_is_exported(self):
+        """The README's input table calls itself the whole model, and the
+        `validate` section promises every constant in it. This test reads the
+        README, so the two cannot drift apart."""
+        named = set()
+        with open(os.path.join(HERE, "README.md"), encoding="utf-8") as handle:
+            for line in handle:
+                if not line.startswith("|"):
+                    continue
+                for quoted in re.findall(r"`([^`]+)`", line):
+                    if re.fullmatch(r"[A-Z][A-Z0-9_]{2,}", quoted):
+                        named.add(quoted)
+        self.assertGreater(len(named), 60,
+                           "the README input table must still be readable as a "
+                           "table of named constants")
+        keys = {key for key, _ in ps.constant_numbers()}
+        for constant in sorted(named):
+            with self.subTest(constant=constant):
+                stem = "constants." + constant.lower()
+                self.assertTrue(
+                    stem in keys or any(k.startswith(stem + "_")
+                                        for k in keys),
+                    f"{constant} is in the README's input table but "
+                    f"`validate` never writes it")
+
+    def test_every_exported_constant_is_a_real_constant_of_the_model(self):
+        """The other direction: no key naming something the program does not
+        actually define."""
+        for key, value in ps.constant_numbers():
+            with self.subTest(key=key):
+                self.assertTrue(key.startswith("constants."))
+                self.assertIsNotNone(value)
+
+    def test_the_per_call_network_sizes_the_report_prints_are_exported(self):
+        """The Network table prints these four and the busiest link, so the
+        file has to be able to back the report."""
+        pairs, r = self.exported()
+        n = r["network"]
+        self.assertEqual(pairs["target.network_embed_bytes_per_call"],
+                         n["embed_bytes_per_call"])
+        self.assertEqual(pairs["target.network_vector_search_bytes_per_call"],
+                         n["vector_search_bytes_per_call"])
+        self.assertEqual(pairs["target.network_vector_write_bytes_per_call"],
+                         n["vector_write_bytes_per_call"])
+        self.assertEqual(pairs["target.network_llm_bytes_per_call"],
+                         n["llm_bytes_per_call"])
+        self.assertEqual(pairs["target.network_busiest_link_mbps"],
+                         n["busiest_link_mbps"])
+
+    def test_the_node_size_input_is_exported_under_its_own_name(self):
+        """Two runs that ordered the same machines for different reasons must
+        not look identical in the file."""
+        automatic, _ = self.exported()
+        forced, _ = self.exported(node_gb=768)
+        self.assertFalse(automatic["target.node_gb_forced"])
+        self.assertTrue(forced["target.node_gb_forced"])
+        self.assertEqual(forced["target.qdrant_node_ram_gb"], 768)
+
+
+class TestFractionalSensitivityRates(unittest.TestCase):
+    """A mix can put a fractional agent rate in the sensitivity table. Keys
+    built by truncating the rate put 2.0 and 2.5 in the same place and the
+    second silently overwrote the first."""
+
+    # 47.5 adds, 50 plain, 2.5 agent-mode per 100 operations, at 100 ops/s.
+    # The tier's own agent rate is 2.5/s, so the table shows 0, 2, 2.5, 10, 25.
+    MIX = ps.TrafficMix(47.5, 50.0, 2.5)
+    EXPECTED_RATES: ClassVar[list] = [0.0, 2.0, 2.5, 10.0, 25.0]
+
+    def result(self):
+        return ps.size_deployment(100.0, self.MIX, run_name="target")
+
+    def test_a_fractional_mix_exports_every_sensitivity_row(self):
+        r = self.result()
+        self.assertEqual([row["agent_searches_per_s"] for row in r["sensitivity"]],
+                         self.EXPECTED_RATES)
+        pairs = dict(ps.published_numbers("target", r))
+        exported = [pairs[f"target.sensitivity.row{i}.agent_searches_per_s"]
+                    for i in range(1, len(self.EXPECTED_RATES) + 1)]
+        self.assertEqual(exported, self.EXPECTED_RATES,
+                         "all five rows must survive the export")
+        # The 2.0 row and the 2.5 row are different sizings, and the file has
+        # to keep them apart: 89.0 vector searches against 100.0.
+        self.assertEqual(pairs["target.sensitivity.row2.vector_searches_per_s"],
+                         r["sensitivity"][1]["vector_searches_per_s"])
+        self.assertEqual(pairs["target.sensitivity.row3.vector_searches_per_s"],
+                         r["sensitivity"][2]["vector_searches_per_s"])
+        self.assertNotEqual(
+            pairs["target.sensitivity.row2.vector_searches_per_s"],
+            pairs["target.sensitivity.row3.vector_searches_per_s"])
+
+    def test_the_sensitivity_table_prints_a_fractional_rate_as_itself(self):
+        """Rounding the rate to a whole number printed two rows both labelled
+        "2", which is two different answers under one heading."""
+        printed = sensitivity_rate_cells(self.result())
+        self.assertEqual(printed, ["0.0", "2.0", "2.5  <- this run",
+                                   "10.0", "25.0"])
+        self.assertEqual(len(set(printed)), len(printed),
+                         "no two rows may print the same rate")
+
+    def test_validate_writes_every_row_of_a_fractional_mix_to_the_file(self):
+        with tempfile.TemporaryDirectory() as folder:
+            out = os.path.join(folder, "numbers.json")
+            proc = run_cli("validate", "--add", "47.5", "--plain", "50",
+                           "--agent", "2.5", "--out", out)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            with open(out, encoding="utf-8") as handle:
+                written = json.load(handle)
+        rates = [written[f"target.sensitivity.row{i}.agent_searches_per_s"]
+                 for i in range(1, 6)]
+        self.assertEqual(rates, self.EXPECTED_RATES)
+        # The pilot tier's own agent rate is 0.5/s. Truncating it printed the
+        # key pilot.sensitivity.agent0 twice, with two different values.
+        keys = [k for k in written if k.startswith("pilot.sensitivity.")]
+        self.assertEqual(len(keys), len(set(keys)))
+        self.assertEqual(written["pilot.sensitivity.row1.agent_searches_per_s"],
+                         0.0)
+        self.assertEqual(written["pilot.sensitivity.row2.agent_searches_per_s"],
+                         0.5)
+
+
+# =============================================================================
+# 23. A web address the calculator cannot honour
+# =============================================================================
+
+
+class TestUnknownQueryParameters(unittest.TestCase):
+    """A misspelled setting used to be ignored in silence, so the endpoint
+    answered a question the reader had not asked."""
+
+    def test_a_misspelled_setting_is_refused_and_a_correction_offered(self):
+        query = {"ops": ["100"], "retention_day": ["1"]}
+        values, result, error, bad = ps.result_from_query(query)
+        self.assertIsNone(result)
+        self.assertIn("retention_day", error)
+        self.assertIn("retention_days", error, "it must suggest the spelling")
+        self.assertIsNone(bad, "no box on the form is at fault")
+        self.assertEqual(values["ops"], "100",
+                         "the boxes keep what was sent, so the page can be "
+                         "redrawn with them")
+
+    def test_a_setting_in_the_wrong_case_is_named_against_its_spelling(self):
+        """The commonest miss is the right word in the wrong case, and it used
+        to get no suggestion at all: "Ops" scores 0.67 against "ops" and "OPS"
+        scores 0, both below the cutoff, so both got the full list instead."""
+        for typed in ("OPS", "Ops", "Retention_Days", "NODE_GB"):
+            with self.subTest(typed=typed):
+                _, result, error, _ = ps.result_from_query({typed: ["100"]})
+                self.assertIsNone(result)
+                self.assertIn(typed, error)
+                self.assertIn(f'Did you mean "{typed.lower()}"?', error)
+
+    def test_a_setting_with_no_near_spelling_lists_the_ones_that_work(self):
+        _, result, error, _ = ps.result_from_query({"nonsense": ["zzz"]})
+        self.assertIsNone(result)
+        self.assertIn("nonsense", error)
+        for known in ("ops", "retention_days", "node_gb"):
+            self.assertIn(known, error)
+
+    def test_a_setting_given_twice_is_refused_rather_than_first_wins(self):
+        _, result, error, bad = ps.result_from_query(
+            {"ops": ["100", "999999"]})
+        self.assertIsNone(result)
+        self.assertIn("ops", error)
+        self.assertIn("2 times", error)
+        self.assertIsNone(bad)
+
+    def test_a_web_address_the_calculator_knows_is_still_accepted(self):
+        _, result, error, _ = ps.result_from_query(
+            {"ops": ["100"], "node_gb": ["512"]})
+        self.assertIsNone(error)
+        self.assertEqual(result["machines"]["qdrant_node_ram_gb"], 512)
+
+
+# =============================================================================
+# 24. The web server is a local development server
+# =============================================================================
+
+
+class TestTheServerDoesNotHoldStalledConnections(unittest.TestCase):
+    """A client that connects and sends partial headers used to hold one
+    thread and one file descriptor for as long as it liked."""
+
+    def test_the_shipped_handler_sets_a_read_timeout(self):
+        self.assertIsInstance(ps.SERVER_REQUEST_TIMEOUT_S, (int, float))
+        self.assertGreater(ps.SERVER_REQUEST_TIMEOUT_S, 0)
+        self.assertLessEqual(ps.SERVER_REQUEST_TIMEOUT_S, 60,
+                             "long enough to be useless is the same as none")
+        self.assertEqual(ps.SizingHandler.timeout, ps.SERVER_REQUEST_TIMEOUT_S,
+                         "socketserver applies this attribute to the socket")
+
+    def test_a_client_that_sends_partial_headers_is_dropped(self):
+        """Run the real handler with a short timeout so the test is quick; the
+        mechanism under test is the class attribute, not the number."""
+
+        class QuickHandler(ps.SizingHandler):
+            timeout = 0.5
+
+            def log_message(self, fmt, *args):
+                pass
+
+        httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), QuickHandler)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            sock = socket.create_connection(httpd.server_address, timeout=10)
+            with sock:
+                sock.sendall(b"GET /healthz HTTP/1.1\r\nHost: x\r\n")
+                sock.settimeout(10)
+                started = time.monotonic()
+                # The server drops the connection, so the read ends in end-of
+                # -file rather than blocking until the test's own timeout.
+                data = sock.recv(4096)
+                waited = time.monotonic() - started
+            self.assertEqual(data, b"",
+                             "a half-sent request must be dropped, not served")
+            self.assertLess(waited, 8.0,
+                            "the connection has to be dropped on the handler's "
+                            "own timeout, not held open")
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+            thread.join(timeout=10)
+
+
+class TestTheServerStaysQuietWhenAClientHangsUp(unittest.TestCase):
+    """A reader closing the tab is ordinary. It used to be logged as an
+    internal error, and the 500 was then written to the same dead socket."""
+
+    def handler_whose_work_raises(self, exc):
+        handler = ps.SizingHandler.__new__(ps.SizingHandler)
+        handler.path = "/api/calc?ops=100"
+        sent = []
+
+        def raiser():
+            raise exc
+
+        # Reaching into the handler is the point: do_GET's job is to decide
+        # what happens when the work it delegates to raises.
+        handler._handle_get = raiser                      # noqa: SLF001
+        handler._send = lambda *args: sent.append(args)   # noqa: SLF001
+        return handler, sent
+
+    def run_do_get(self, exc):
+        handler, sent = self.handler_whose_work_raises(exc)
+        noise = io.StringIO()
+        real_stderr, sys.stderr = sys.stderr, noise
+        try:
+            handler.do_GET()
+        finally:
+            sys.stderr = real_stderr
+        return sent, noise.getvalue()
+
+    def test_a_broken_pipe_is_not_reported_as_an_internal_error(self):
+        for exc in (BrokenPipeError(32, "Broken pipe"),
+                    ConnectionResetError(104, "Connection reset by peer")):
+            with self.subTest(exc=type(exc).__name__):
+                sent, noise = self.run_do_get(exc)
+                self.assertEqual(noise, "")
+                self.assertEqual(sent, [],
+                                 "there is no socket left to answer on")
+
+    def test_a_real_fault_is_still_reported_and_answered_with_a_500(self):
+        sent, noise = self.run_do_get(RuntimeError("the model exploded"))
+        self.assertIn("the model exploded", noise)
+        self.assertEqual([args[0] for args in sent], [500])
+
+
+class TestTheServeHelpSaysItIsForLocalUse(unittest.TestCase):
+
+    def test_serve_help_warns_that_this_is_a_development_server(self):
+        proc = run_cli("serve", "--help")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        text = proc.stdout.lower()
+        self.assertIn("local development server", text)
+        self.assertIn("authentication", text)
+
+    def test_the_readme_warns_that_this_is_a_development_server(self):
+        with open(os.path.join(HERE, "README.md"), encoding="utf-8") as handle:
+            text = handle.read()
+        self.assertIn("local development server, not a service", text)
+        self.assertIn("SERVER_REQUEST_TIMEOUT_S", text)
+
+
+# =============================================================================
+# 25. The README's own examples, worked out by hand
+# =============================================================================
+
+
+class TestTheReadmeExamples(unittest.TestCase):
+
+    def test_the_readme_calc_example_sizes_its_own_mix(self):
+        """README: `calc --ops 250 --agent 4 --plain 51`. By hand, at 250
+        ops/s with 45 adds / 51 plain / 4 agent-mode per 100 operations:
+          adds           = 250 x 0.45 = 112.5/s
+          plain searches = 250 x 0.51 = 127.5/s
+          agent searches = 250 x 0.04 =  10.0/s
+          vector searches = 127.5 x 1 + 10 x 22 = 347.5/s
+          API work        = 347.5 + 112.5 = 460.0/s
+          API servers     = ceil(460 / 108) = 5
+        """
+        proc = run_cli("calc", "--ops", "250", "--agent", "4", "--plain", "51",
+                       "--json")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        got = json.loads(proc.stdout)
+        self.assertEqual(got["demand"]["adds_per_s"], 112.5)
+        self.assertEqual(got["demand"]["plain_searches_per_s"], 127.5)
+        self.assertEqual(got["demand"]["agent_searches_per_s"], 10.0)
+        self.assertEqual(got["demand"]["vector_searches_per_s"], 347.5)
+        self.assertEqual(got["machines"]["api_work_per_s"], 460.0)
+        self.assertEqual(got["machines"]["api_servers"], 5)
+
+    def test_the_readme_calc_example_renders_as_a_report(self):
+        proc = run_cli("calc", "--ops", "250", "--agent", "4", "--plain", "51")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("5 API server(s)", proc.stdout)
+        self.assertIn("45 adds, 51 plain searches, 4 agent-mode searches",
+                      proc.stdout)
+
+
+class TestTheUsersReportCarriesLabels(unittest.TestCase):
+    """The `users` table was the third table with no label column, and its
+    provenance lived only in the prose above it."""
+
+    def test_the_users_table_has_a_label_column_on_every_row(self):
+        proc = run_cli("users", "--humans", "5000", "--automated", "40")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        lines = proc.stdout.splitlines()
+        header = next(line for line in lines if "Kind of caller" in line)
+        self.assertTrue(header.rstrip().endswith("Label"), header)
+        for kind in ("Human chat sessions", "Automated clients", "Total"):
+            row = next(line for line in lines
+                       if line.strip().startswith(kind))
+            with self.subTest(kind=kind):
+                self.assertTrue(
+                    any(word in row for word in ("estimate", "derived")),
+                    f"{kind} row carries no label: {row!r}")
+
+
+class TestVectorDimensionsAreQuotedFaithfully(unittest.TestCase):
+    """The refusal used to format the value with :g, so a dimension count of
+    1024.0000000001 was reported as "vector dimensions is 1024, but it must be
+    a whole number" - naming the value as the very thing it required."""
+
+    def test_a_dimension_just_off_a_whole_number_is_quoted_as_typed(self):
+        with self.assertRaises(ps.SizingError) as caught:
+            ps.size_deployment(100.0, dims=1024.0000000001)
+        message = str(caught.exception)
+        self.assertIn("1024.0000000001", message)
+        self.assertIn("whole number", message)
+
+
+class TestTheWebPageDoesNotOverclaimItsLabels(unittest.TestCase):
+    """The page used to say "Every number is labelled", which two of its own
+    tables contradict."""
+
+    def page(self, query=None):
+        _, result, error, bad = ps.result_from_query(query or {})
+        self.assertIsNone(error)
+        return ps.render_html({}, result, None, bad)
+
+    def test_the_page_names_the_two_tables_that_carry_no_label(self):
+        html = self.page()
+        self.assertIn("Qdrant node choice", html)
+        self.assertIn("what-ifs rather than findings", html)
+        self.assertNotIn("Every number is labelled", html)
+
+    def test_the_page_says_the_json_carries_no_labels(self):
+        html = self.page()
+        self.assertIn("without labels", html)
+        self.assertIn("run_name", html)
+
+
+# =============================================================================
+# 26. One name per input, and inputs echoed exactly as they were given
+# =============================================================================
+
+
+class TestEveryMessageCallsAnInputByTheSameName(ModelBaseTest):
+    """One box, one name.
+
+    The bound check and the older zero check used to call the same box two
+    different things: "bytes per number is 65 bytes" when it was too large and
+    "bytes per value is 0" when it was zero, next to a form that labels it
+    "Bytes per number".
+    """
+
+    # The name each input answers to, and a too-small and a too-large value
+    # for it. Each name is the label on the web form, less the units.
+    INPUTS: ClassVar[tuple] = (
+        ("the design peak", "ops_per_s", 0, ps.MAX_OPS_PER_S + 1),
+        ("retention", "retention_days", -1, ps.MAX_RETENTION_DAYS + 1),
+        ("vector dimensions", "dims", -8, ps.MAX_VECTOR_DIMS + 1),
+        ("bytes per number", "bytes_per_value", 0, ps.MAX_BYTES_PER_VALUE + 1),
+        ("RAM per vector-store machine", "node_gb", 0, ps.MAX_NODE_GB + 1),
+    )
+
+    def refusal(self, field, value):
+        if field == "ops_per_s":
+            args, kwargs = (value,), {}
+        else:
+            args, kwargs = (100.0,), {field: value}
+        with self.assertRaises(ps.SizingError) as caught:
+            self.size(*args, **kwargs)
+        return str(caught.exception)
+
+    def test_both_refusals_of_one_input_open_with_the_same_name(self):
+        for name, field, too_small, too_large in self.INPUTS:
+            for value in (too_small, too_large):
+                with self.subTest(field=field, value=value):
+                    message = self.refusal(field, value)
+                    self.assertTrue(
+                        message.startswith(name + " is"),
+                        f"{message!r} should open with {name!r}")
+
+    def test_every_name_is_the_label_on_the_form(self):
+        """A message that names a box the page does not have helps nobody."""
+        labels = {key: title for key, title, _hint in ps.FORM_FIELDS}
+        for name, field, _small, _large in self.INPUTS:
+            key = "ops" if field == "ops_per_s" else field
+            with self.subTest(field=field):
+                label = labels[key].split(",")[0].lower()
+                self.assertIn(label, name.lower())
+
+
+class TestTheReportEchoesItsInputsExactly(ModelBaseTest):
+    """A reader has to be able to reproduce the answer from the inputs printed
+    above it. The Inputs table used to round them to whole numbers, so half a
+    byte per number read as "0" above a table sized for half a byte."""
+
+    def inputs_table(self, r):
+        return {row[0]: row[1]
+                for row in report_section(r, "Inputs")["rows"]}
+
+    def test_a_fractional_input_is_printed_as_itself(self):
+        r = self.size(100.0, retention_days=0.5, bytes_per_value=0.5)
+        rows = self.inputs_table(r)
+        self.assertEqual(rows["Retention"], "0.5 days")
+        self.assertEqual(rows["Bytes stored per number"], "0.5")
+        self.assertIn("0.5 days of retention",
+                      report_section(r, "Storage")["note"])
+        self.assertIn("0.5 byte(s) per number",
+                      report_section(r, "Storage")["note"])
+
+    def test_a_fractional_traffic_mix_is_printed_as_itself(self):
+        r = self.size(100.0, mix=ps.TrafficMix(45.4, 44.6, 10.0))
+        row = self.inputs_table(r)["Traffic mix per 100 operations"]
+        self.assertEqual(row, "45.4 adds, 44.6 plain searches, "
+                              "10 agent-mode searches")
+        # The demand table one section below is worked out from these.
+        self.assertClose(r["demand"]["adds_per_s"], 45.4, "adds/s")
+
+    def test_a_whole_number_keeps_its_thousands_separator(self):
+        rows = self.inputs_table(self.size(1000.0))
+        self.assertEqual(rows["Design peak"], "1,000 operations/s")
+        self.assertEqual(rows["Vector dimensions"], "1,024")
+
+    def test_a_design_peak_below_half_an_operation_still_prints(self):
+        """0.0000001 ops/s used to head the whole report as "0.0
+        operations/s", a rate the program refuses when it is typed."""
+        rows = self.inputs_table(self.size(1e-7))
+        self.assertEqual(rows["Design peak"], "1e-07 operations/s")
+
+    def test_the_command_line_titles_the_report_with_the_rate_it_sized(self):
+        done = run_cli("calc", "--ops", "0.5")
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertIn("DESIGN PEAK 0.5 operations/s", done.stdout)
+
+
+class TestAsGiven(unittest.TestCase):
+    """The one formatter both the report and the refusals use."""
+
+    def test_whole_numbers_lose_their_point_zero(self):
+        self.assertEqual(ps.as_given(100.0), "100")
+        self.assertEqual(ps.as_given(1000.0), "1,000")
+        self.assertEqual(ps.as_given(64), "64")
+
+    def test_a_fraction_keeps_every_digit(self):
+        self.assertEqual(ps.as_given(0.5), "0.5")
+        self.assertEqual(ps.as_given(1024.0000000001), "1024.0000000001")
+
+    def test_a_number_too_large_to_count_exactly_stays_short(self):
+        """1e307 as 309 digits is not what anybody typed either."""
+        self.assertEqual(ps.as_given(1e307), "1e+307")
+
+    def test_it_never_rounds_one_number_into_another(self):
+        self.assertNotEqual(ps.as_given(ps.MAX_OPS_PER_S + 1),
+                            ps.as_given(ps.MAX_OPS_PER_S))
+
+
+# =============================================================================
+# 27. The report says only what the model knows
+# =============================================================================
+
+
+class TestHeadroomIsMeasuredOnTheBusiestLink(ModelBaseTest):
+    """The row is labelled "busiest direction". It used to be computed from
+    the east-west figure whatever the north-south figure came to, and the real
+    maximum was computed and then never used."""
+
+    def test_headroom_matches_the_busiest_of_the_two_directions(self):
+        for ops in (20.0, 100.0, 1000.0):
+            with self.subTest(ops=ops):
+                n = self.size(ops)["network"]
+                self.assertClose(n["headroom_on_10gbe"],
+                                 10000.0 / n["busiest_link_mbps"], "headroom")
+
+    def test_headroom_would_follow_a_busier_north_south_link(self):
+        """The label has to stay true if the byte sizes ever change."""
+        original = ps.NS_ADD_RESPONSE_BYTES
+        ps.NS_ADD_RESPONSE_BYTES = original * 10_000
+        try:
+            n = self.size(100.0)["network"]
+            self.assertGreater(n["north_south_mbps"], n["east_west_mbps"])
+            self.assertClose(n["headroom_on_10gbe"],
+                             10000.0 / n["north_south_mbps"], "headroom")
+        finally:
+            ps.NS_ADD_RESPONSE_BYTES = original
+
+
+class TestTheMachinesTableStatesNoSpecItDoesNotHave(ModelBaseTest):
+    """API_SERVER_VCPU and API_SERVER_RAM_GB describe the machine the API
+    benchmark ran on. The PostgreSQL and Qdrant rows used to borrow them, so
+    the report stated a spec for two machines nobody has sized."""
+
+    def spec(self, machine):
+        rows = report_section(self.size(100.0), "Machines")["rows"]
+        return next(row[2] for row in rows if row[0].startswith(machine))
+
+    def test_the_api_row_keeps_its_measured_machine_class(self):
+        spec = self.spec("API server")
+        self.assertIn(f"{ps.API_SERVER_VCPU} vCPU", spec)
+        self.assertIn(f"{ps.API_SERVER_RAM_GB} GB", spec)
+
+    def test_the_other_two_rows_claim_no_vcpu(self):
+        for machine in ("PostgreSQL server", "Qdrant server"):
+            with self.subTest(machine=machine):
+                spec = self.spec(machine)
+                self.assertNotIn("vCPU,", spec)
+                self.assertIn("undecided", spec)
+
+    def test_the_qdrant_row_keeps_the_ram_the_model_did_choose(self):
+        r = self.size(100.0)
+        rows = report_section(r, "Machines")["rows"]
+        spec = next(row[2] for row in rows if row[0].startswith("Qdrant"))
+        self.assertIn(f"{r['machines']['qdrant_node_ram_gb']} GB RAM", spec)
+
+
+class TestTheSensitivityTableSaysWhichRowIsThisRun(ModelBaseTest):
+    """One decimal place is not enough to keep every pair of rates apart: a
+    mix whose own agent rate is 2.04 sits beside the fixed rate 2.0 and both
+    print as "2.0". The table used to leave the reader to guess which of the
+    two rows was the traffic mix they had asked about."""
+
+    def test_a_rate_that_collides_with_a_fixed_rate_is_still_marked(self):
+        r = self.size(20.4)
+        self.assertClose(r["demand"]["agent_searches_per_s"], 2.04, "agents/s")
+        cells = sensitivity_rate_cells(r)
+        self.assertEqual(cells, ["0.0", "2.0", "2.0  <- this run",
+                                 "10.0", "25.0"])
+
+    def test_exactly_one_row_is_marked_at_every_tier(self):
+        for ops in (20.0, 100.0, 1000.0, 20.4):
+            with self.subTest(ops=ops):
+                r = self.size(ops)
+                marked = [row for row in r["sensitivity"] if row["is_this_run"]]
+                self.assertEqual(len(marked), 1)
+                self.assertEqual(marked[0]["api_servers"],
+                                 r["machines"]["api_servers"])
+                self.assertEqual(
+                    sum("<- this run" in cell
+                        for cell in sensitivity_rate_cells(r)), 1)
+
+    def test_the_note_points_at_the_mark_rather_than_at_nothing(self):
+        note = report_section(self.size(20.4), "Sensitivity")["note"]
+        self.assertIn("this run", note)
+
+
+class TestAPopulationOfNobodyGetsNoTier(unittest.TestCase):
+    """`users --humans 0 --automated 0` used to answer "Plan for the high rate:
+    pilot" - a hardware recommendation for a population that makes no
+    requests. The sizing direction refuses a design peak of zero by name."""
+
+    def test_the_report_names_no_tier_for_an_empty_population(self):
+        text = ps.render_users_report(ps.ops_for_population(0, 0))
+        self.assertIn("makes no requests", text)
+        self.assertNotIn("Plan for the high rate", text)
+        self.assertNotIn("fits the pilot tier", text)
+
+    def test_one_user_is_still_a_population_to_size(self):
+        text = ps.render_users_report(ps.ops_for_population(1, 0))
+        self.assertIn("Plan for the high rate", text)
+
+    def test_the_command_still_prints_the_demand_it_worked_out(self):
+        done = run_cli("users", "--humans", "0", "--automated", "0")
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertIn("0.00 ops/s", done.stdout)
+        self.assertIn("nothing to size", done.stdout)
+
+
+# =============================================================================
+# 28. Two things that sound alike and are not: agent-mode search is a property
+#     of a REQUEST, an automated client is a property of a CALLER
+# =============================================================================
+
+
+class TestTheOldAgentsFlagIsRefusedByName(unittest.TestCase):
+    """`--agents` meant the count of callers that are programs. It was one
+    letter from `--agent`, the agent-mode share of the traffic mix, and the
+    two mean completely different things. Accepting it quietly, or letting
+    argparse read it as the mix share, would size the wrong deployment."""
+
+    def test_the_old_flag_is_refused_and_names_the_new_one(self):
+        proc = run_cli("users", "--humans", "5000", "--agents", "40")
+        self.assertEqual(proc.returncode, 2, proc.stdout)
+        message = proc.stderr + proc.stdout
+        self.assertIn("--agents is no longer a flag", message)
+        self.assertIn("--automated", message)
+        self.assertNotIn("Traceback", message)
+
+    def test_the_refusal_explains_the_difference_in_one_sentence(self):
+        proc = run_cli("users", "--humans", "5000", "--agents", "40")
+        message = proc.stderr + proc.stdout
+        self.assertIn("CALLER", message)
+        self.assertIn("REQUEST", message)
+
+    def test_the_old_flag_never_becomes_a_report(self):
+        """It used to be the flag that answered. It must answer nothing now."""
+        proc = run_cli("users", "--humans", "5000", "--agents", "40")
+        self.assertNotIn("Plan for the high rate", proc.stdout)
+        self.assertNotIn("ops/s", proc.stdout)
+
+    def test_the_old_flag_is_refused_where_the_mix_share_lives_too(self):
+        """On tier, calc and validate, `--agents` sits beside `--agent`.
+
+        Left undeclared it would be an unrecognized argument, which never
+        names the flag the reader wants; declared, there is a real risk of it
+        being read as the mix share. It is refused by name on all three.
+        """
+        for args in (("tier", "target", "--agents", "40"),
+                     ("calc", "--ops", "100", "--agents", "40"),
+                     ("validate", "--agents", "40")):
+            with self.subTest(args=args):
+                proc = run_cli(*args)
+                self.assertEqual(proc.returncode, 2, proc.stdout)
+                self.assertIn("--agents is no longer a flag",
+                              proc.stderr + proc.stdout)
+
+    def test_the_old_flag_is_never_read_as_the_agent_mode_mix_share(self):
+        """`calc --ops 100 --agents 60` must not size 60 agent-mode searches."""
+        proc = run_cli("calc", "--ops", "100", "--agents", "60", "--json")
+        self.assertEqual(proc.returncode, 2, proc.stdout)
+        self.assertNotIn("agent_searches_per_s", proc.stdout)
+
+    def test_the_new_flag_gives_what_the_old_one_used_to_give(self):
+        """`--automated 40` must reproduce the old `--agents 40` figures.
+
+        5000 x 0.011 + 40 x 0.4 = 55 + 16 = 71 ops/s
+        5000 x 0.028 + 40 x 0.4 = 140 + 16 = 156 ops/s
+        """
+        proc = run_cli("users", "--humans", "5000", "--automated", "40")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("71.00 to 156.00 ops/s", proc.stdout)
+        pop = ps.ops_for_population(humans=5000, automated=40)
+        self.assertEqual(pop["ops_per_s_low"], 71.0)
+        self.assertEqual(pop["ops_per_s_high"], 156.0)
+
+    def test_the_web_address_setting_agents_is_answered_the_same_way(self):
+        """"agents" must not be answered with "did you mean agent?".
+
+        `agent` is the mix share. A reader who typed `agents` wants
+        `automated`, the count of callers that are programs.
+        """
+        _, result, error, bad = ps.result_from_query({"ops": ["100"],
+                                                      "agents": ["40"]})
+        self.assertIsNone(result)
+        self.assertIsNone(bad)
+        self.assertIn('"automated"', error)
+        self.assertNotIn('Did you mean "agent"?', error)
+
+
+class TestEachPopulationCarriesItsOwnTrafficMix(unittest.TestCase):
+    """The model used to force one mix on every caller, so it could not say
+    "5,000 people who rarely use multi-hop search, plus 75 automated clients
+    that use it constantly" - even though the kind of caller and the kind of
+    request go together in practice."""
+
+    # Worked out by hand. 2,500 human chat sessions at the busy rate:
+    #   2,500 x 0.028 = 70.0 ops/s, mixed 90 adds / 9 plain / 1 agent-mode.
+    # 75 automated clients:
+    #   75 x 0.4 = 30.0 ops/s, mixed 10 adds / 20 plain / 70 agent-mode.
+    # Total 100.0 ops/s, so each share is the two shares weighted 70 and 30:
+    #   adds  = (70 x 90 + 30 x 10) / 100 = (6,300 +   300) / 100 = 66.0
+    #   plain = (70 x  9 + 30 x 20) / 100 = (  630 +   600) / 100 = 12.3
+    #   agent = (70 x  1 + 30 x 70) / 100 = (   70 + 2,100) / 100 = 21.7
+    #   and 66.0 + 12.3 + 21.7 = 100.0
+    HUMANS = 2500
+    AUTOMATED = 75
+    HUMAN_MIX = ps.TrafficMix(90.0, 9.0, 1.0)
+    AUTOMATED_MIX = ps.TrafficMix(10.0, 20.0, 70.0)
+    BLENDED: ClassVar[dict] = {"add": 66.0, "plain": 12.3, "agent": 21.7}
+
+    def population(self):
+        return ps.ops_for_population(self.HUMANS, self.AUTOMATED,
+                                     self.HUMAN_MIX, self.AUTOMATED_MIX)
+
+    def test_each_population_demands_its_own_operations_per_second(self):
+        pop = self.population()
+        self.assertAlmostEqual(pop["human_ops_per_s_low"], 27.5)
+        self.assertAlmostEqual(pop["human_ops_per_s_high"], 70.0)
+        self.assertAlmostEqual(pop["automated_ops_per_s"], 30.0)
+        self.assertAlmostEqual(pop["ops_per_s_low"], 57.5)
+        self.assertAlmostEqual(pop["ops_per_s_high"], 100.0)
+
+    def test_the_blended_mix_matches_the_hand_worked_arithmetic(self):
+        blended = self.population()["blended_mix"]
+        for share, want in self.BLENDED.items():
+            with self.subTest(share=share):
+                self.assertAlmostEqual(blended[share], want, places=9)
+
+    def test_the_blended_mix_still_adds_up_to_100(self):
+        blended = self.population()["blended_mix"]
+        self.assertAlmostEqual(sum(blended.values()), 100.0)
+        ps.TrafficMix(**blended).validate()
+
+    def test_two_identical_mixes_blend_to_themselves(self):
+        """The default mixes must leave every existing answer where it was."""
+        pop = ps.ops_for_population(5000, 40)
+        self.assertEqual(pop["blended_mix"],
+                         {"add": 45.0, "plain": 45.0, "agent": 10.0})
+
+    def test_a_population_of_only_one_kind_takes_that_kind_of_mix(self):
+        only_automated = ps.ops_for_population(
+            0, 100, self.HUMAN_MIX, self.AUTOMATED_MIX)
+        self.assertEqual(only_automated["blended_mix"],
+                         self.AUTOMATED_MIX.as_dict())
+        only_humans = ps.ops_for_population(
+            100, 0, self.HUMAN_MIX, self.AUTOMATED_MIX)
+        self.assertEqual(only_humans["blended_mix"], self.HUMAN_MIX.as_dict())
+
+    def test_a_mix_that_does_not_add_up_to_100_is_refused(self):
+        with self.assertRaises(ps.SizingError):
+            ps.ops_for_population(100, 100, ps.TrafficMix(45.0, 45.0, 5.0))
+
+
+class TestTheBlendedMixSizesTheDeployment(unittest.TestCase):
+    """Reporting a blended mix and then sizing on the global default would be
+    a hardware order for traffic nobody described."""
+
+    # The population above: 100.0 ops/s blended to 66 adds / 12.3 plain /
+    # 21.7 agent-mode. By hand, at 100 ops/s:
+    #   adds            = 66.0/s
+    #   plain searches  = 12.3/s
+    #   agent searches  = 21.7/s
+    #   vector searches = 12.3 x 1 + 21.7 x 22 = 12.3 + 477.4 = 489.7/s
+    #   API work        = 489.7 + 66.0 = 555.7/s
+    #   API servers     = ceil(555.7 / 108) = ceil(5.145) = 6
+    # The same 100 ops/s at the default 45/45/10 mix needs only 3.
+    WANT_API_SERVERS = 6
+    WANT_AT_THE_DEFAULT_MIX = 3
+
+    def population(self):
+        return ps.ops_for_population(2500, 75, ps.TrafficMix(90.0, 9.0, 1.0),
+                                     ps.TrafficMix(10.0, 20.0, 70.0))
+
+    def test_the_machines_are_sized_from_the_blended_mix(self):
+        sizing = self.population()["sizing"]
+        self.assertEqual(sizing["inputs"]["mix"],
+                         {"add": 66.0, "plain": 12.3, "agent": 21.7})
+        self.assertAlmostEqual(sizing["demand"]["vector_searches_per_s"], 489.7)
+        self.assertAlmostEqual(sizing["machines"]["api_work_per_s"], 555.7)
+        self.assertEqual(sizing["machines"]["api_servers"],
+                         self.WANT_API_SERVERS)
+
+    def test_the_default_mix_would_have_ordered_fewer_machines(self):
+        """The two mixes must not be interchangeable, or the test above proves
+        nothing."""
+        at_default = ps.size_deployment(100.0)
+        self.assertEqual(at_default["machines"]["api_servers"],
+                         self.WANT_AT_THE_DEFAULT_MIX)
+        self.assertGreater(self.WANT_API_SERVERS, self.WANT_AT_THE_DEFAULT_MIX)
+
+    def test_the_report_prints_the_blended_mix_and_the_machines_it_bought(self):
+        text = ps.render_users_report(self.population())
+        self.assertIn("Blended across the whole population", text)
+        self.assertIn("66 adds, 12.3 plain searches, 21.7 agent-mode searches",
+                      text)
+        self.assertIn("Machines this population needs", text)
+        self.assertIn(str(self.WANT_API_SERVERS), text)
+
+    def test_the_command_line_prints_the_same_blended_mix(self):
+        proc = run_cli("users", "--humans", "2500", "--automated", "75",
+                       "--human-mix", "90/9/1", "--automated-mix", "10/20/70")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("66 adds, 12.3 plain searches, 21.7 agent-mode searches",
+                      proc.stdout)
+
+    def test_an_empty_population_is_still_not_a_deployment_to_size(self):
+        pop = ps.ops_for_population(0, 0)
+        self.assertIsNone(pop["sizing"])
+
+
+class TestAMixWrittenAsThreeNumbers(unittest.TestCase):
+    """`--human-mix 45/45/10` and `--human-mix 45,45,10` are the same mix."""
+
+    def test_both_separators_are_read_the_same_way(self):
+        for text in ("45/45/10", "45,45,10", " 45 / 45 / 10 "):
+            with self.subTest(text=text):
+                self.assertEqual(ps.parse_mix_text(text, "--human-mix"),
+                                 ps.TrafficMix(45.0, 45.0, 10.0))
+
+    def test_the_default_is_the_models_own_default_mix(self):
+        self.assertEqual(ps.parse_mix_text(ps.default_mix_text(), "x"),
+                         ps.TrafficMix())
+        self.assertEqual(ps.default_mix_text(), "45/45/10")
+
+    def test_too_few_or_too_many_numbers_are_refused_by_name(self):
+        for text in ("45/45", "45/45/10/0", "45"):
+            with self.subTest(text=text):
+                with self.assertRaises(ps.SizingError) as caught:
+                    ps.parse_mix_text(text, "--human-mix")
+                self.assertIn("--human-mix", str(caught.exception))
+                self.assertIn("adds/plain/agent-mode", str(caught.exception))
+
+    def test_text_where_a_number_belongs_is_quoted_back(self):
+        with self.assertRaises(ps.SizingError) as caught:
+            ps.parse_mix_text("45/lots/10", "--automated-mix")
+        self.assertIn('"lots"', str(caught.exception))
+
+    def test_a_mix_that_does_not_add_up_is_refused(self):
+        with self.assertRaises(ps.SizingError) as caught:
+            ps.parse_mix_text("45/45/5", "--human-mix")
+        self.assertIn("must add up to 100", str(caught.exception))
+
+    def test_the_command_line_refuses_a_bad_mix_without_a_traceback(self):
+        for flag, value in (("--human-mix", "45/45"),
+                            ("--automated-mix", "45/45/5"),
+                            ("--human-mix", "lots")):
+            with self.subTest(flag=flag, value=value):
+                proc = run_cli("users", "--humans", "10", flag, value)
+                self.assertEqual(proc.returncode, 2, proc.stdout)
+                self.assertNotIn("Traceback", proc.stderr)
+                self.assertIn(flag, proc.stderr + proc.stdout)
+
+
+class TestTheFormTakesACallerPopulationToo(unittest.TestCase):
+    """Whatever `users` takes as a flag, the form has to take as a box."""
+
+    def test_both_counts_empty_asks_nothing_about_a_population(self):
+        _, result, error, _ = ps.result_from_query({"ops": ["100"]})
+        self.assertIsNone(error)
+        self.assertIsNone(result["population"],
+                          "an unasked question must not be answered")
+
+    def test_a_population_typed_into_the_boxes_is_answered(self):
+        _, result, error, _ = ps.result_from_query({
+            "ops": ["100"], "humans": ["2500"], "automated": ["75"],
+            "human_mix": ["90/9/1"], "automated_mix": ["10,20,70"]})
+        self.assertIsNone(error)
+        pop = result["population"]
+        self.assertEqual(pop["blended_mix"],
+                         {"add": 66.0, "plain": 12.3, "agent": 21.7})
+        self.assertEqual(pop["sizing"]["machines"]["api_servers"], 6)
+
+    def test_one_count_left_empty_means_none_of_that_kind_of_caller(self):
+        _, result, error, _ = ps.result_from_query({"humans": ["2500"],
+                                                    "automated": [""]})
+        self.assertIsNone(error)
+        self.assertEqual(result["population"]["automated"], 0.0)
+
+    def test_the_mix_boxes_start_at_the_models_default_mix(self):
+        values, _, _, _ = ps.result_from_query({})
+        self.assertEqual(values["human_mix"], "45/45/10")
+        self.assertEqual(values["automated_mix"], "45/45/10")
+
+    def test_a_bad_mix_box_names_itself_rather_than_all_twelve(self):
+        _, result, error, bad = ps.result_from_query({"humans": ["10"],
+                                                      "human_mix": ["45/45"]})
+        self.assertIsNone(result)
+        self.assertEqual(bad, "human_mix")
+        self.assertIn("human traffic mix box", error)
+
+    def test_an_empty_mix_box_is_a_blank_answer(self):
+        _, result, error, bad = ps.result_from_query({"humans": ["10"],
+                                                      "human_mix": [""]})
+        self.assertIsNone(result)
+        self.assertEqual(bad, "human_mix")
+        self.assertIn("box is empty", error)
+
+    def test_the_page_draws_the_population_tables(self):
+        values, result, _, _ = ps.result_from_query({"humans": ["2500"],
+                                                     "automated": ["75"]})
+        html = ps.render_html(values, result, None, None)
+        self.assertIn("Demand from this population", html)
+        self.assertIn("Blended across the whole population", html)
+        self.assertIn("Automated clients", html)
+
+    def test_the_page_says_nothing_about_a_population_when_none_was_asked(self):
+        values, result, _, _ = ps.result_from_query({})
+        html = ps.render_html(values, result, None, None)
+        self.assertNotIn("Demand from this population", html)
+
+    def test_the_population_boxes_are_labelled_for_a_caller_not_a_request(self):
+        values, result, _, _ = ps.result_from_query({})
+        html = ps.render_html(values, result, None, None)
+        self.assertIn("Automated clients", html)
+        self.assertIn("Human chat sessions", html)
+        self.assertNotIn("Software agents", html)
+
+
+class TestNeitherConceptIsCalledByTheOthersName(unittest.TestCase):
+    """The rename is only worth having if the old word is gone everywhere a
+    caller is meant, and the product's own word is kept where a request is."""
+
+    def source(self, name):
+        with open(os.path.join(HERE, name), encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_no_caller_anywhere_is_still_called_a_software_agent(self):
+        for name in ("memmachine_sizing.py", "README.md"):
+            with self.subTest(name=name):
+                text = self.source(name).lower()
+                self.assertNotIn("software agent", text)
+
+    def test_the_request_flag_keeps_the_products_own_name(self):
+        """agent_mode is the real field on a MemMachine search. Renaming it
+        here would misrepresent the API."""
+        proc = run_cli("calc", "--help")
+        self.assertIn("--agent", proc.stdout)
+        self.assertIn("agent-mode searches per 100 operations", proc.stdout)
+
+    def test_the_report_says_the_agent_mode_share_is_a_request_flag(self):
+        row = next(r for r in report_section(ps.size_deployment(100.0),
+                                             "Inputs")["rows"]
+                   if r[0].startswith("Traffic mix"))
+        self.assertIn("request flag, not a kind of caller", row[-1])
+
+    def test_the_readme_explains_the_two_concepts_near_the_top(self):
+        text = self.source("README.md")
+        passage = text[:text.index("## What it does not do")]
+        self.assertIn("Agent-mode search is a property of a request", passage)
+        self.assertIn("An automated client is a property of a caller", passage)
+        self.assertIn("size the deployment wrongly", passage)
+
+    def test_the_module_docstring_explains_them_too(self):
+        self.assertIn("Agent-mode search is a property of a REQUEST",
+                      ps.__doc__)
+        self.assertIn("An automated client is a property of a CALLER",
+                      ps.__doc__)
+
+    def test_the_web_page_explains_them_too(self):
+        _, result, _, _ = ps.result_from_query({})
+        html = ps.render_html({}, result, None, None)
+        self.assertIn("Agent-mode search", html)
+        self.assertIn("Automated clients", html)
+        self.assertIn("how fast a caller sends", html)
+
+    def test_the_exported_numbers_name_the_caller_rate_after_the_caller(self):
+        keys = {key for key, _ in ps.constant_numbers()}
+        self.assertIn("constants.automated_client_ops_per_s", keys)
+        self.assertNotIn("constants.agent_session_ops_per_s", keys)
+
+
+class TestTheDefaultAnswersDidNotMove(unittest.TestCase):
+    """No machine count may change because of the rename. These are the same
+    hand-worked figures as the tier tests above, pinned again here so that a
+    change made for the sake of wording cannot quietly move an order."""
+
+    def test_every_tier_orders_what_it_ordered_before(self):
+        for name, want in TIER_EXPECTATIONS.items():
+            with self.subTest(tier=name):
+                m = ps.size_deployment(ps.TIER_OPS_PER_S[name])["machines"]
+                self.assertEqual(m["api_servers"], want["api_servers"])
+                self.assertEqual(m["qdrant_servers"], want["qdrant_nodes"])
+                self.assertEqual(m["agent_gpu_cards"], want["agent_cards"])
+                self.assertEqual(m["total_cpu_servers"],
+                                 want["api_servers"] + 1 + want["qdrant_nodes"])
+
+    def test_calc_at_100_ops_a_second_is_the_target_tier(self):
+        proc = run_cli("calc", "--ops", "100")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("3 API server(s)", proc.stdout)


### PR DESCRIPTION
## What this is

A sizing calculator for MemMachine deployments, under `tools/sizing/`. Give it a design peak in
operations per second and it returns the hardware a deployment needs: API servers, vector-store
machines and their memory size, a PostgreSQL server, embedding and agent-model GPU cards, hot vector
memory and disk for a chosen retention period, the `max_connections` PostgreSQL will need, the
network peaks, and how many callers that capacity holds.

## Why it exists

Capacity questions about MemMachine were being answered in prose, and prose cannot be re-run. When
someone asks "what if we keep episodes for a year instead of ninety days", or "what if a tenth of
searches use agent mode instead of one in a hundred", the honest answer is a different hardware
order, not a paragraph. This puts the model in one file so the answer can be recomputed instead of
re-argued, and so every assumption behind it is visible.

Three properties matter more than the arithmetic:

- **Every number is labelled** measured, derived, estimate or assumption. A reader can see at a
  glance which figures rest on a benchmark and which rest on a guess that has never been tested.
- **Every input is a knob**, on the command line and on the web form, so nobody has to edit code to
  ask a different question.
- **It states what it does not know.** The embedding-card rate has never been benchmarked. The
  traffic mix is a planning assumption nobody has measured. The tool says so where it uses them,
  rather than presenting a confident total.

## Usage

It needs no dependencies — Python standard library only.

```
cd tools/sizing
uv run --no-project python memmachine_sizing.py --help
```

| Subcommand | What it does |
|---|---|
| `tier pilot\|target\|scale` | the full report for one of three built-in design peaks (20, 100, 1,000 ops/s) |
| `calc --ops N` | the same report for any design peak |
| `users --humans N --automated M` | converts a caller population into the capacity it demands |
| `validate` | prints every published figure for all three tiers and writes them as JSON |
| `serve` | a local web form and a JSON endpoint offering the same inputs |

Re-price an order against a different traffic mix:

```
uv run --no-project python memmachine_sizing.py tier target --agent 2 --plain 53
```

Size for a mixed population, where each kind of caller sends a different mix:

```
uv run --no-project python memmachine_sizing.py users --humans 2500 --automated 75 \
  --human-mix 90/9/1 --automated-mix 10/20/70
```

## Two things that sound alike and are not

The README leads with this, because confusing them sizes a deployment wrongly.

**Agent-mode search is a property of a request** — the `agent_mode` flag on a MemMachine search.
A search sent with it fans out into a multi-hop retrieval of roughly 22 embedding calls, 22 vector
searches, 44 database reads and one or two language-model calls. It is the third share of the
traffic mix, set with `--agent`. It is a **cost** multiplier: how expensive one request is.

**An automated client is a property of a caller** — a program sending requests in a loop rather than
a person typing. One in a five-second tool loop is assumed to send about 0.4 operations per second,
where a human chat session sends 0.011 to 0.028. It is a population count on `users`, set with
`--automated`. It is a **rate** multiplier: how fast requests arrive.

They are independent, so each population carries its own traffic mix and the calculator blends them.

## Where the numbers come from

The one measured anchor is 180 searches per second per 16-vCPU AMD EPYC server at 8 worker
processes, from a benchmark on 30 August 2026 with a real OpenAI embedder, a 12,000-episode corpus
and the rrf-hybrid reranker enabled — so the reranker's cost is already inside every derived server
count. Everything else is derived from it, estimated, or an assumption, and the README lists all of
them with their defaults.

## What it deliberately does not do

It does not price high-availability additions — a second copy of every vector, a PostgreSQL standby
or a second gateway are a separate decision, and it says so rather than guessing.

## Testing

382 tests, standard-library `unittest`, run with `uv run --no-project python -m unittest` from
`tools/sizing`. They cover the arithmetic at exact machine boundaries, every command-line
subcommand, the web form driven end to end, and rejection of bad input on every path. `ruff check
tools/sizing` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiqwYpXVGDet5NiHjdU7Ng
