### PR TITLE
ci(docker): publish images that can actually use the Qdrant backend

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -112,9 +112,13 @@ jobs:
           file: ./Dockerfile
           push: true
           # FIXED: Explicitly disable GPU here to ensure 'latest' is the CPU version
+          # qdrant-client is an optional extra. An image built without it starts
+          # cleanly and then raises ModuleNotFoundError on every request that
+          # uses the event backend, so the published image has to carry it.
           build-args: |
             GPU=false
             SCM_VERSION=${{ steps.scm.outputs.version }}
+            EXTRAS=--extra qdrant
           tags: ${{ steps.meta-cpu.outputs.tags }}
           labels: ${{ steps.meta-cpu.outputs.labels }}
           platforms: linux/amd64,linux/arm64
@@ -207,9 +211,11 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          # EXTRAS carries qdrant-client; see the CPU build for why.
           build-args: |
             GPU=true
             SCM_VERSION=${{ steps.scm.outputs.version }}
+            EXTRAS=--extra qdrant
           tags: ${{ steps.meta-gpu.outputs.tags }}
           labels: ${{ steps.meta-gpu.outputs.labels }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## What

Both the CPU and GPU publish jobs now pass `EXTRAS=--extra qdrant` to the Docker build.

## Why

`qdrant-client` is an optional extra (`packages/server/pyproject.toml:67`). #1532 gave the Dockerfile an `EXTRAS` build arg so a build *can* include it, but `docker-image.yml` never passed one — so a published image does not contain the package. The core starts cleanly and then raises `ModuleNotFoundError` on the first request that uses the event backend, which makes the Qdrant vector store unusable from a published image regardless of configuration.

Unconditional rather than a dispatch input, so a published image can serve either backend and no one has to remember a flag at build time.

## Verified

- `uv.lock` already carries `qdrant-client` under `marker = "extra == 'qdrant'"`, so `uv sync --frozen --extra qdrant` resolves without relocking — otherwise `--frozen` would fail the build.
- Parsed the workflow with PyYAML: `build-args` is exactly `['GPU=…', 'SCM_VERSION=…', 'EXTRAS=--extra qdrant']` for both jobs. The rationale is a YAML comment **above** the key, not inside the `|` block scalar, where it would have reached Docker as a literal build arg.
- The GPU sync line becomes `--extra gpu --extra qdrant`.

## Not verified

**No image was built or published from this branch.** The workflow is tag-triggered and was not dispatched, so the resulting image has not been run against a Qdrant deployment.

Also note: a `workflow_dispatch` run passes `inputs.tag` to `metadata-action`'s `semver` patterns, so the input needs to be a parseable version — a bare branch name yields no tags and pushes nothing. Unchanged by this PR, but relevant to anyone dispatching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nr9kacmpFVTTfkZRw6esxP