### PR TITLE
ci(docker): stop the GPU build silently overwriting the CPU image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,6 +12,12 @@ on:
         description: "The git tag to build (e.g., v0.1.1)"
         required: true
         type: string
+      variant:
+        description: "Which image to build"
+        required: false
+        default: both
+        type: choice
+        options: [both, cpu, gpu]
 
 env:
   # Docker image name to publish
@@ -31,6 +37,7 @@ jobs:
     name: Build and Push CPU Image
     # Use the latest Ubuntu runner
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch' || inputs.variant != 'gpu'
     steps:
       # Step 0: Free Disk Space (Manual)
       - name: Free Disk Space (Manual)
@@ -88,7 +95,10 @@ jobs:
             latest=false
           tags: |
             # For Manual (workflow_dispatch) runs
-            type=semver,pattern=v{{version}}-cpu,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            # semver drops the pattern for a pre-release input, so v0.3.9-post1
+            # yields the bare 0.3.9-post1 for *both* jobs and the GPU build
+            # silently overwrites the CPU one. raw always carries the suffix.
+            type=raw,value=${{ inputs.tag }}-cpu,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=semver,pattern=latest-cpu,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && !contains(inputs.tag, '-') }}
             type=semver,pattern=latest,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && !contains(inputs.tag, '-') }}
 
@@ -135,6 +145,13 @@ jobs:
     needs: build-cpu
     # Use the latest Ubuntu runner
     runs-on: ubuntu-latest
+    # always() is needed because a deliberately skipped CPU build would
+    # otherwise skip this job with it; the result check still stops a *failed*
+    # CPU build from letting the GPU one through.
+    if: >-
+      always()
+      && (needs.build-cpu.result == 'success' || needs.build-cpu.result == 'skipped')
+      && (github.event_name != 'workflow_dispatch' || inputs.variant != 'cpu')
     steps:
       # Step 0: Free Disk Space (Manual)
       - name: Free Disk Space (Manual)
@@ -190,7 +207,8 @@ jobs:
             latest=false
           tags: |
             # For Manual (workflow_dispatch) runs
-            type=semver,pattern=v{{version}}-gpu,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            # See the CPU build: raw keeps the two jobs on distinct tags.
+            type=raw,value=${{ inputs.tag }}-gpu,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=semver,pattern=latest-gpu,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && !contains(inputs.tag, '-') }}
 
             # For Release events


### PR DESCRIPTION
## The bug

Dispatching this workflow with a **pre-release** tag publishes one image, not two.

`metadata-action`'s `semver` type drops its `pattern` when the parsed version has a pre-release component. So `v0.3.9-post1` produced the bare tag `0.3.9-post1` for **both** jobs instead of `v0.3.9-post1-cpu` / `-gpu`. The CPU build pushed first, the GPU build overwrote it twenty minutes later, and nothing reported an error — the tag simply ended up holding a 2.9 GB GPU image under a name meant for CPU.

Observed on [run 33439754567](https://github.com/MemMachine/MemMachine/actions/runs/33439754567), where both jobs logged `tags: memmachine/memmachine:0.3.9-post1` and pushed distinct manifests to it:

```
CPU  21:12  pushing manifest ... @sha256:2c7f5328…
GPU  21:36  pushing manifest ... @sha256:99206749…
```

This has never been hit before because every release so far used a plain `vX.Y.Z`, for which the pattern applies normally. **It is not specific to this branch** — the rules are character-identical on `main`, so the same dispatch there would collide the same way.

## The fix

**1. The dispatch version tag is now `type=raw`** with the variant appended, which cannot lose the suffix:

| input | before | after |
|---|---|---|
| `v0.3.9` | `v0.3.9-cpu` / `v0.3.9-gpu` | unchanged |
| `v0.3.9-post1` | `0.3.9-post1` for **both** | `v0.3.9-post1-cpu` / `v0.3.9-post1-gpu` |

For a release input `raw` reproduces exactly what `semver` did, so the existing release flow is unaffected.

**2. A `variant` input** (`both` \| `cpu` \| `gpu`, default `both`) so a caller can skip the 26-minute GPU build. `build-gpu` needs `always()` for this, because a deliberately skipped CPU job would otherwise skip it too; the `needs.build-cpu.result` check still stops a *failed* CPU build from letting the GPU one through.

The `latest` rules are untouched and stay guarded by `!contains(inputs.tag, '-')`, so a pre-release still cannot move `latest` / `latest-cpu` / `latest-gpu`.

## Verified

Evaluated both rule sets over both input shapes; no tag overlaps between the jobs:

```
input v0.3.9         build-cpu -> [v0.3.9-cpu]           build-gpu -> [v0.3.9-gpu]
input v0.3.9-post1   build-cpu -> [v0.3.9-post1-cpu]     build-gpu -> [v0.3.9-post1-gpu]
```

## Not verified

**No build was dispatched from this branch.** The tag sets above were derived by evaluating the rules, not by running the workflow. Worth one dispatch with `variant: cpu` before relying on it.

## Note for anyone pinning

After this, rebuilding the tag `v0.3.9-post1` publishes `v0.3.9-post1-cpu` rather than `0.3.9-post1`. The existing `0.3.9-post1` image is left as it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nr9kacmpFVTTfkZRw6esxP