### PR TITLE
Register SQLite per-connection state at engine creation for the vector stores (fixes #1568)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
@@ -709,7 +709,11 @@ def _sqlite_vector_store_only_conf(**vs_overrides) -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_sqlite_vector_store_creates_store_and_engine():
-    """async_get_sqlite_vector_store builds an engine, store, and starts it up."""
+    """async_get_sqlite_vector_store builds an engine, store, and starts it up.
+
+    Foreign-key enforcement is registered on the engine at creation, before
+    the store exists, so no connection can be pooled without it.
+    """
     conf = _sqlite_vector_store_only_conf(
         sqlite_vector_store_confs={
             "vs1": SQLiteVectorStoreConf(
@@ -723,6 +727,7 @@ async def test_sqlite_vector_store_creates_store_and_engine():
 
     mock_engine = MagicMock(spec=AsyncEngine)
     mock_engine.dispose = AsyncMock()
+    ordered_calls = MagicMock()
 
     with (
         patch(
@@ -730,12 +735,19 @@ async def test_sqlite_vector_store_creates_store_and_engine():
             return_value=mock_engine,
         ) as mock_create,
         patch(
+            "memmachine_server.common.resource_manager.database_manager.enable_sqlite_foreign_keys",
+        ) as mock_enable_foreign_keys,
+        patch(
             "memmachine_server.common.vector_store.sqlite_vector_store.SQLiteVectorStoreParams",
         ) as mock_params_cls,
         patch(
             "memmachine_server.common.vector_store.sqlite_vector_store.SQLiteVectorStore",
         ) as mock_store_cls,
     ):
+        ordered_calls.attach_mock(
+            mock_enable_foreign_keys, "enable_sqlite_foreign_keys"
+        )
+        ordered_calls.attach_mock(mock_store_cls, "SQLiteVectorStore")
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
@@ -745,6 +757,12 @@ async def test_sqlite_vector_store_creates_store_and_engine():
     mock_create.assert_called_once()
     create_args = mock_create.call_args
     assert create_args.args[0] == "sqlite+aiosqlite:///vs.db"
+
+    mock_enable_foreign_keys.assert_called_once_with(mock_engine)
+    call_names = [name for name, _args, _kwargs in ordered_calls.mock_calls]
+    assert call_names.index("enable_sqlite_foreign_keys") < call_names.index(
+        "SQLiteVectorStore"
+    )
 
     params_kwargs = mock_params_cls.call_args.kwargs
     assert params_kwargs["sqlalchemy_engine"] is mock_engine
@@ -880,13 +898,18 @@ async def test_sqlite_vector_store_unknown_name_raises():
 
 @pytest.mark.asyncio
 async def test_sqlite_vec_vector_store_creates_store_and_engine():
-    """async_get_sqlite_vec_vector_store builds an engine, store, and starts it up."""
+    """async_get_sqlite_vec_vector_store builds an engine, store, and starts it up.
+
+    The sqlite-vec loader is registered on the engine at creation, before
+    the store exists, so no connection can be pooled without the extension.
+    """
     conf = _sqlite_vector_store_only_conf(
         sqlite_vec_vector_store_confs={"vec1": SQLiteVecVectorStoreConf(path="vec.db")}
     )
 
     mock_engine = MagicMock(spec=AsyncEngine)
     mock_engine.dispose = AsyncMock()
+    ordered_calls = MagicMock()
 
     with (
         patch(
@@ -894,12 +917,17 @@ async def test_sqlite_vec_vector_store_creates_store_and_engine():
             return_value=mock_engine,
         ) as mock_create,
         patch(
+            "memmachine_server.common.vector_store.sqlite_vec_vector_store.load_sqlite_vec_extension",
+        ) as mock_load_extension,
+        patch(
             "memmachine_server.common.vector_store.sqlite_vec_vector_store.SQLiteVecVectorStoreParams",
         ) as mock_params_cls,
         patch(
             "memmachine_server.common.vector_store.sqlite_vec_vector_store.SQLiteVecVectorStore",
         ) as mock_store_cls,
     ):
+        ordered_calls.attach_mock(mock_load_extension, "load_sqlite_vec_extension")
+        ordered_calls.attach_mock(mock_store_cls, "SQLiteVecVectorStore")
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
@@ -908,6 +936,12 @@ async def test_sqlite_vec_vector_store_creates_store_and_engine():
     assert store is mock_store_cls.return_value
     create_args = mock_create.call_args
     assert create_args.args[0] == "sqlite+aiosqlite:///vec.db"
+
+    mock_load_extension.assert_called_once_with(mock_engine)
+    call_names = [name for name, _args, _kwargs in ordered_calls.mock_calls]
+    assert call_names.index("load_sqlite_vec_extension") < call_names.index(
+        "SQLiteVecVectorStore"
+    )
 
     params_kwargs = mock_params_cls.call_args.kwargs
     assert params_kwargs["engine"] is mock_engine
@@ -949,6 +983,9 @@ async def test_get_vector_store_dispatches_to_sqlite_backends():
         patch(
             "memmachine_server.common.vector_store.sqlite_vector_store.SQLiteVectorStore",
         ) as mock_vs_cls,
+        patch(
+            "memmachine_server.common.vector_store.sqlite_vec_vector_store.load_sqlite_vec_extension",
+        ),
         patch(
             "memmachine_server.common.vector_store.sqlite_vec_vector_store.SQLiteVecVectorStoreParams",
         ),

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from memmachine_server.common.data_types import SimilarityMetric
@@ -27,6 +28,7 @@ from memmachine_server.common.vector_store.sqlite_vec_vector_store import (
     SQLiteVecVectorStore,
     SQLiteVecVectorStoreCollection,
     SQLiteVecVectorStoreParams,
+    load_sqlite_vec_extension,
 )
 
 pytestmark = pytest.mark.skipif(
@@ -61,6 +63,7 @@ def _make_record(
 async def store(tmp_path):
     db_path = tmp_path / "test.db"
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    load_sqlite_vec_extension(engine)
     params = SQLiteVecVectorStoreParams(engine=engine)
     vector_store = SQLiteVecVectorStore(params)
     await vector_store.startup()
@@ -1011,3 +1014,58 @@ class TestFilterEdgeCases:
         assert r1.uuid in uuids
         assert r3.uuid in uuids
         assert r2.uuid not in uuids
+
+
+# ── Engine per-connection state ──
+
+
+@pytest.mark.asyncio
+async def test_startup_refuses_engine_without_sqlite_vec(tmp_path):
+    """vec statements need the extension loaded from engine creation.
+
+    A listener added by the store would miss connections the caller's
+    engine pooled earlier and would race a live pool's event dispatch, so
+    the store verifies and refuses loudly instead.
+    """
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'bare.db'}")
+    store = SQLiteVecVectorStore(SQLiteVecVectorStoreParams(engine=engine))
+    try:
+        with pytest.raises(RuntimeError, match="sqlite-vec"):
+            await store.startup()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_extension_covers_connection_pooled_before_store_exists(tmp_path):
+    """A connection pooled before the store is built still serves vec.
+
+    Creation-time registration is what covers it: a store-side listener
+    left this connection without the extension, so creating a collection
+    failed with "no such module: vec0".
+    """
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'test.db'}")
+    load_sqlite_vec_extension(engine)
+    async with engine.connect() as connection:
+        await connection.execute(text("SELECT 1"))
+
+    store = SQLiteVecVectorStore(SQLiteVecVectorStoreParams(engine=engine))
+    await store.startup()
+    try:
+        coll = await store.open_or_create_collection(
+            namespace=NAMESPACE,
+            name=NAME,
+            config=VectorStoreCollectionConfig(
+                vector_dimensions=VECTOR_DIM,
+                similarity_metric=SimilarityMetric.COSINE,
+            ),
+        )
+        vector = _normalize([1.0, 0.0, 0.0])
+        record = _make_record(vector=vector)
+        await coll.upsert(records=[record])
+
+        results = await coll.query(query_vectors=[vector], limit=10)
+        assert [m.record.uuid for m in results[0].matches] == [record.uuid]
+    finally:
+        await store.shutdown()
+        await engine.dispose()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import func, select, update
+from sqlalchemy import func, select, text, update
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from memmachine_server.common.data_types import SimilarityMetric
@@ -16,6 +16,9 @@ from memmachine_server.common.filter.filter_parser import (
     In,
     Not,
     Or,
+)
+from memmachine_server.common.resource_manager.database_manager import (
+    enable_sqlite_foreign_keys,
 )
 from memmachine_server.common.vector_store.data_types import (
     Record,
@@ -62,6 +65,7 @@ def _make_record(
 async def store(tmp_path):
     db_path = tmp_path / "test.db"
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    enable_sqlite_foreign_keys(engine)
     params = SQLiteVectorStoreParams(
         sqlalchemy_engine=engine,
         vector_search_engine_factory=lambda ndim, metric: USearchVectorSearchEngine(
@@ -1090,6 +1094,7 @@ CONFIG = VectorStoreCollectionConfig(
 async def _fresh_store(db_path, tmp_path, *, save_threshold=1000):
     """Create a new SQLiteVectorStore against the same DB file."""
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    enable_sqlite_foreign_keys(engine)
     params = SQLiteVectorStoreParams(
         sqlalchemy_engine=engine,
         vector_search_engine_factory=_engine_factory,
@@ -1483,3 +1488,63 @@ class TestIndexFileDurability:
 
         await store2.shutdown()
         await engine2.dispose()
+
+
+# ── Engine per-connection state ──
+
+
+@pytest.mark.asyncio
+async def test_startup_refuses_engine_without_foreign_key_enforcement(tmp_path):
+    """Cascade deletes need PRAGMA foreign_keys=ON from engine creation.
+
+    A listener added by the store would miss connections the caller's
+    engine pooled earlier and would race a live pool's event dispatch, so
+    the store verifies and refuses loudly instead.
+    """
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'bare.db'}")
+    store = SQLiteVectorStore(
+        SQLiteVectorStoreParams(
+            sqlalchemy_engine=engine,
+            vector_search_engine_factory=_engine_factory,
+        )
+    )
+    try:
+        with pytest.raises(RuntimeError, match="foreign keys"):
+            await store.startup()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cascade_covers_connection_pooled_before_store_exists(tmp_path):
+    """A connection pooled before the store is built still cascades.
+
+    Creation-time registration is what covers it: a store-side listener
+    left this connection with foreign keys off, so deleting a collection
+    orphaned its pending-operation rows without any error.
+    """
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'test.db'}")
+    enable_sqlite_foreign_keys(engine)
+    async with engine.connect() as connection:
+        await connection.execute(text("SELECT 1"))
+
+    store = SQLiteVectorStore(
+        SQLiteVectorStoreParams(
+            sqlalchemy_engine=engine,
+            vector_search_engine_factory=_engine_factory,
+            index_directory=str(tmp_path / "indexes"),
+        )
+    )
+    await store.startup()
+    try:
+        coll = await store.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
+        assert await _pending_operation_count(engine) == 1
+
+        await store.delete_collection(namespace=NAMESPACE, name=NAME)
+        assert await _pending_operation_count(engine) == 0
+    finally:
+        await store.shutdown()
+        await engine.dispose()

--- a/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
@@ -7,8 +7,10 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Self
 
 from neo4j import AsyncDriver, AsyncGraphDatabase
-from sqlalchemy import text
+from sqlalchemy import event, text
+from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.pool import ConnectionPoolEntry
 
 from memmachine_server.common.configuration.database_conf import (
     DatabasesConf,
@@ -43,6 +45,28 @@ if TYPE_CHECKING:
     from qdrant_client import AsyncQdrantClient
 
 logger = logging.getLogger(__name__)
+
+
+def enable_sqlite_foreign_keys(engine: AsyncEngine) -> None:
+    """Enforce foreign keys on every connection of a SQLite engine.
+
+    SQLite defaults foreign_keys to OFF, per connection. Registering the
+    pragma at engine creation, before any connection is pooled, is the
+    only placement that covers every connection: a listener added later
+    misses already-pooled connections, and mutating a live pool's
+    listeners races its event dispatch. No-op for other dialects.
+    """
+    if engine.dialect.name != "sqlite":
+        return
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(
+        dbapi_connection: DBAPIConnection,
+        _connection_record: ConnectionPoolEntry,
+    ) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
 
 
 class DatabaseManager:
@@ -765,6 +789,7 @@ class DatabaseManager:
             )
 
             engine = create_async_engine(f"sqlite+aiosqlite:///{conf.path}")
+            enable_sqlite_foreign_keys(engine)
             self.vector_store_sql_engines[name] = engine
 
             try:
@@ -806,9 +831,11 @@ class DatabaseManager:
             from memmachine_server.common.vector_store.sqlite_vec_vector_store import (
                 SQLiteVecVectorStore,
                 SQLiteVecVectorStoreParams,
+                load_sqlite_vec_extension,
             )
 
             engine = create_async_engine(f"sqlite+aiosqlite:///{conf.path}")
+            load_sqlite_vec_extension(engine)
             self.vector_store_sql_engines[name] = engine
 
             try:

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -424,6 +424,32 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
             )
 
 
+def load_sqlite_vec_extension(engine: AsyncEngine) -> None:
+    """Load the sqlite-vec extension on every connection of a SQLite engine.
+
+    Loadable extensions are per-connection state. Registering the loader
+    at engine creation, before any connection is pooled, is the only
+    placement that covers every connection: a listener added later
+    misses already-pooled connections, which then serve vec queries
+    without the extension, and mutating a live pool's listeners races
+    its event dispatch.
+    """
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _load_sqlite_vec(
+        dbapi_connection: DBAPIConnection,
+        _connection_record: ConnectionPoolEntry,
+    ) -> None:
+        async def _load_extension(
+            aio_connection: aiosqlite.Connection,
+        ) -> None:
+            await aio_connection.enable_load_extension(True)
+            await aio_connection.load_extension(sqlite_vec.loadable_path())
+            await aio_connection.enable_load_extension(False)
+
+        dbapi_connection.run_async(_load_extension)
+
+
 class SQLiteVecVectorStoreParams(BaseModel):
     """
     Parameters for constructing a SQLiteVecVectorStore.
@@ -471,23 +497,32 @@ class SQLiteVecVectorStore(VectorStore):
         self._create_session = async_sessionmaker(self._engine, expire_on_commit=False)
         self._sa_metadata = MetaData()
 
-        @event.listens_for(self._engine.sync_engine, "connect")
-        def _load_sqlite_vec(
-            dbapi_connection: DBAPIConnection,
-            _connection_record: ConnectionPoolEntry,
-        ) -> None:
-            async def _load_extension(
-                aio_connection: aiosqlite.Connection,
-            ) -> None:
-                await aio_connection.enable_load_extension(True)
-                await aio_connection.load_extension(sqlite_vec.loadable_path())
-                await aio_connection.enable_load_extension(False)
-
-            dbapi_connection.run_async(_load_extension)
-
     @override
     async def startup(self) -> None:
         async with self._engine.begin() as connection:
+            # The sqlite-vec extension is per-connection state and must be
+            # loaded at ENGINE creation: a listener added by this store
+            # would miss connections the caller's engine pooled earlier --
+            # which then fail every vec statement -- and registering
+            # listeners on a live pool races its event dispatch. The store
+            # therefore verifies rather than mutates. Probing the function
+            # list keeps the check a scalar; calling vec_version() would
+            # need its failure told apart from other OperationalErrors.
+            loaded = (
+                await connection.execute(
+                    text(
+                        "SELECT count(*) FROM pragma_function_list "
+                        "WHERE name = 'vec_version'"
+                    )
+                )
+            ).scalar()
+            if not loaded:
+                raise RuntimeError(
+                    "SQLite engine does not load the sqlite-vec extension, so "
+                    "every vec statement would fail. Register the loader at "
+                    "engine creation (load_sqlite_vec_extension) before "
+                    "constructing the store."
+                )
             await connection.run_sync(BaseSQLiteVecVectorStore.metadata.create_all)
 
     @override

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -31,6 +31,7 @@ from sqlalchemy import (
     event,
     func,
     select,
+    text,
     update,
 )
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
@@ -688,7 +689,10 @@ class SQLiteVectorStore(VectorStore):
             str(self._sqlalchemy_engine.url).replace("aiosqlite", "pysqlite")
         )
 
-        @event.listens_for(self._sqlalchemy_engine.sync_engine, "connect")
+        # Registered only on the sync engine created just above, before it
+        # pools anything. The caller's async engine must have had the same
+        # pragma registered at its own creation; startup() verifies that
+        # instead of registering late (see enable_sqlite_foreign_keys).
         @event.listens_for(self._sync_sqlalchemy_engine, "connect")
         def _enable_sqlite_foreign_keys(
             dbapi_connection: DBAPIConnection,
@@ -715,6 +719,22 @@ class SQLiteVectorStore(VectorStore):
             self._index_directory.mkdir(parents=True, exist_ok=True)
 
         async with self._sqlalchemy_engine.begin() as connection:
+            # Foreign-key enforcement is per-connection state on SQLite
+            # and must be registered at ENGINE creation: a listener added
+            # by this store would miss connections the caller's engine
+            # pooled earlier -- silently disabling the pending-operation
+            # cascade on exactly those connections -- and registering
+            # listeners on a live pool races its event dispatch. The
+            # store therefore verifies rather than mutates.
+            enforced = (await connection.execute(text("PRAGMA foreign_keys"))).scalar()
+            if not enforced:
+                raise RuntimeError(
+                    "SQLite engine does not enforce foreign keys, so deleting "
+                    "a collection would silently orphan its pending-operation "
+                    "rows. Register PRAGMA foreign_keys=ON at engine creation "
+                    "(enable_sqlite_foreign_keys) before constructing the "
+                    "store."
+                )
             await connection.run_sync(BaseSQLiteVectorStore.metadata.create_all)
 
         await self._replay_pending_operations()


### PR DESCRIPTION
### Purpose of the change

Fix #1568. `SQLiteVectorStore` and `SQLiteVecVectorStore` registered SQLite per-connection state (`PRAGMA foreign_keys=ON`; the sqlite-vec extension loader) through a `connect` listener in their own `__init__`, on the engine supplied through their params. This is the structural fault #1545 fixed for the segment store, fixed here with the same convention.

### Description

The two faults, as #1568 lays them out:

1. A `connect` listener fires only for connections opened after it is registered. Anything the engine pooled earlier serves the store with foreign keys off -- a cascade delete silently orphans pending-operation rows, nothing errors -- or without the extension, so every vec statement fails with `no such module: vec0`.
2. Registering listeners on an engine already serving traffic races SQLAlchemy's event dispatch (`RuntimeError: deque mutated during iteration`; the issue reports it reproduced in #1545's concurrency tests).

Both are latent on the production path today, since the `DatabaseManager` creates each engine immediately before constructing its store, but the params API accepts any engine.

What changed:

- `database_manager.py`: `enable_sqlite_foreign_keys(engine)` is added -- verbatim the helper from #1545, at the same location -- and applied to the `SQLiteVectorStore` engine at creation; `load_sqlite_vec_extension(engine)` is applied to the `SQLiteVecVectorStore` engine at creation. The shared relational engine (`async_get_sql_engine`) is left to #1545.
- `sqlite_vector_store.py`: the listener on the caller-supplied async engine is dropped. The listener on the sync engine the store creates itself two lines above stays, since nothing can have been pooled on it yet. `startup()` checks `PRAGMA foreign_keys` and refuses an unenforced engine with a directive naming the helper.
- `sqlite_vec_vector_store.py`: the loader moves out of `__init__` into the module-level `load_sqlite_vec_extension`, next to the store that needs it. `startup()` probes `pragma_function_list` for `vec_version` and refuses with a directive. The probe keeps the check a scalar; calling `vec_version()` would need its failure told apart from other `OperationalError`s.
- Tests: engine fixtures register the helpers at creation (as #1545's `sqlalchemy_sqlite_engine` fixture does). Per store: a refusal test and a pooled-before-construction test. The manager tests assert each helper is applied to the engine before the store is constructed.

### Testing

Fail-before on untouched `main`. Each script pools one connection (`SELECT 1`) before constructing the store, then exercises it:

```
register_at_creation=False: pending rows before delete=1, orphaned after=1, PRAGMA foreign_keys=0
register_at_creation=False: create_collection FAILED: OperationalError: (sqlite3.OperationalError) no such module: vec0
```

The same scripts on this branch, registering at engine creation:

```
register_at_creation=True: pending rows before delete=1, orphaned after=0, PRAGMA foreign_keys=1
register_at_creation=True: create_collection OK
```

Without registration each store now refuses at `startup()`:

```
RuntimeError: SQLite engine does not enforce foreign keys, so deleting a collection would silently orphan its pending-operation rows. Register PRAGMA foreign_keys=ON at engine creation (enable_sqlite_foreign_keys) before constructing the store.
RuntimeError: SQLite engine does not load the sqlite-vec extension, so every vec statement would fail. Register the loader at engine creation (load_sqlite_vec_extension) before constructing the store.
```

- `uv run --frozen --all-extras pytest packages/server/server_tests` (default lane, integration excluded): 1873 passed, 3 skipped, 0 failed
- `ruff check` and `ruff format --check`: clean
- `ty check --project packages/server`: 17 diagnostics, the same 17 as `main` (pre-existing nebulagraph and OpenAI stub imports; none on touched lines)

### Compatibility

- Out-of-tree callers constructing either store on their own engine must register the matching helper at engine creation; `startup()` now fails loudly with the directive otherwise. In-tree construction goes through the `DatabaseManager`, which does this. No config or schema change.
- Relation to #1545: `enable_sqlite_foreign_keys` is byte-identical in both PRs at the same location, and `git merge-tree` of the two branches is conflict-free, so they can merge in either order.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (a store now refuses an engine without its per-connection state at `startup()`; only out-of-tree callers constructing stores on their own engines are affected)

### Fixes/Closes

Fixes #1568

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JdJHiDWgrwNEYfARF8Yvic
