### PR TITLE
fix(vector-store): create payload indexes even when the collection exists

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -1,5 +1,6 @@
 """Tests for QdrantVectorStore."""
 
+import asyncio
 import math
 from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import MagicMock
@@ -7,7 +8,7 @@ from uuid import UUID, uuid4
 
 import pytest
 import pytest_asyncio
-from qdrant_client import AsyncQdrantClient
+from qdrant_client import AsyncQdrantClient, models
 
 from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
@@ -26,6 +27,7 @@ from memmachine_server.common.vector_store.data_types import (
     VectorStoreCollectionConfigMismatchError,
 )
 from memmachine_server.common.vector_store.qdrant_vector_store import (
+    _PAYLOAD_PARTITION_KEY,
     QdrantVectorStore,
     QdrantVectorStoreCollection,
     QdrantVectorStoreParams,
@@ -1253,3 +1255,126 @@ class TestDistributedSharding:
         await store.delete_collection(namespace=ns, name=name)
         # Second delete should not raise.
         await store.delete_collection(namespace=ns, name=name)
+
+
+@pytest.mark.integration
+class TestCollectionLifecycleAcrossWorkers:
+    """Collection creation has to survive more than one creator.
+
+    The store serialises creation with an asyncio.Lock keyed on the client
+    object, which serialises callers inside one process and nothing else. Run
+    the server with MEMMACHINE_WORKERS above 1 and each worker gets its own
+    client, its own lock, and no mutual exclusion - so two workers can decide to
+    create the same collection at the same moment.
+
+    These need a real server: payload indexes have no effect in local-mode
+    Qdrant, so the thing under test is invisible there.
+    """
+
+    @staticmethod
+    def _config() -> VectorStoreCollectionConfig:
+        return VectorStoreCollectionConfig(
+            vector_dimensions=VECTOR_DIM,
+            similarity_metric=SimilarityMetric.COSINE,
+            indexed_properties_schema={"name": str},
+        )
+
+    @pytest.mark.asyncio
+    async def test_indexes_are_created_when_the_collection_already_exists(
+        self, qdrant_client
+    ):
+        """A collection that exists without its indexes must still get them.
+
+        _create_native_collection creates the collection and its payload indexes
+        in one try block and swallows "already exists" for the whole block. So a
+        second creator - another worker, or a retry after one died between the
+        two calls - takes the exception path and never creates an index. Its
+        docstring claims it creates both idempotently; this pins that claim.
+
+        The partition key is declared is_tenant. Verified against Qdrant 1.19:
+        filtering stays correct without the index - a filtered query on an
+        unindexed collection returns only the matching tenant's points - so what
+        is lost is the multitenant storage layout and query speed, not
+        isolation.
+        """
+        namespace, name = "raced_ns", "raced_name"
+        config = self._config()
+        native = QdrantVectorStore._build_native_collection_name(namespace, config)
+
+        # Stand in for a creator that got as far as the collection and no further.
+        await qdrant_client.create_collection(
+            collection_name=native,
+            vectors_config=models.VectorParams(
+                size=VECTOR_DIM, distance=models.Distance.COSINE
+            ),
+        )
+
+        store = QdrantVectorStore(QdrantVectorStoreParams(client=qdrant_client))
+        await store.startup()
+        try:
+            await store.open_or_create_collection(
+                namespace=namespace, name=name, config=config
+            )
+            info = await qdrant_client.get_collection(native)
+            indexed = set(info.payload_schema or {})
+            assert _PAYLOAD_PARTITION_KEY in indexed, (
+                "the tenant partition index is missing: a collection that already "
+                "existed never had its payload indexes created, so tenant "
+                f"filtering is unindexed. present: {sorted(indexed)}"
+            )
+            assert "name" in indexed, (
+                f"declared property index absent. present: {sorted(indexed)}"
+            )
+        finally:
+            await store.delete_collection(namespace=namespace, name=name)
+
+    @pytest.mark.asyncio
+    async def test_two_workers_creating_at_once_both_succeed_and_index(
+        self, qdrant_container
+    ):
+        """Two clients, no shared lock - the multi-worker shape, in one process.
+
+        The lock is keyed on the client object, so two stores holding separate
+        clients are exactly two workers as far as mutual exclusion goes. Both
+        calls must return a usable handle, and the collection they agree on must
+        end up indexed.
+        """
+        client_a = qdrant_container.get_async_client()
+        client_b = qdrant_container.get_async_client()
+        namespace, name = "race_two_ns", "race_two_name"
+        config = self._config()
+        native = QdrantVectorStore._build_native_collection_name(namespace, config)
+
+        store_a = QdrantVectorStore(QdrantVectorStoreParams(client=client_a))
+        store_b = QdrantVectorStore(QdrantVectorStoreParams(client=client_b))
+        await store_a.startup()
+        await store_b.startup()
+
+        assert (
+            store_a._client_name_locks is not store_b._client_name_locks
+        ), "separate clients must not share a lock, or this does not test anything"
+
+        try:
+            results = await asyncio.gather(
+                store_a.open_or_create_collection(
+                    namespace=namespace, name=name, config=config
+                ),
+                store_b.open_or_create_collection(
+                    namespace=namespace, name=name, config=config
+                ),
+                return_exceptions=True,
+            )
+            failures = [r for r in results if isinstance(r, BaseException)]
+            assert not failures, f"a concurrent creator raised: {failures!r}"
+
+            info = await client_a.get_collection(native)
+            indexed = set(info.payload_schema or {})
+            assert _PAYLOAD_PARTITION_KEY in indexed, (
+                "two workers raced and the tenant partition index was lost: the "
+                "loser skips index creation entirely. present: "
+                f"{sorted(indexed)}"
+            )
+        finally:
+            await store_a.delete_collection(namespace=namespace, name=name)
+            await client_a.close()
+            await client_b.close()

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -742,6 +742,12 @@ class QdrantVectorStore(VectorStore):
         distance = QdrantVectorStore._SIMILARITY_METRIC_TO_QDRANT_DISTANCE[
             config.similarity_metric
         ]
+        # The collection and its indexes are created under separate guards. Sharing
+        # one meant a collection that already existed - a second worker, or a retry
+        # after a crash between the two calls - raised on create_collection, took
+        # the already-exists path, and left the collection with no payload indexes
+        # at all. The lock above is keyed on the client object, so it serialises
+        # callers within a process and not across uvicorn workers.
         try:
             await self._client.create_collection(
                 collection_name=native_collection_name,
@@ -756,27 +762,34 @@ class QdrantVectorStore(VectorStore):
                     models.ShardingMethod.CUSTOM if self._is_distributed else None
                 ),
             )
-            await self._client.create_payload_index(
-                collection_name=native_collection_name,
-                field_name=_PAYLOAD_PARTITION_KEY,
-                field_schema=models.KeywordIndexParams(
+        except (UnexpectedResponse, grpc.aio.AioRpcError, ValueError) as e:
+            if not QdrantVectorStore._is_already_exists_error(e):
+                raise
+
+        indexes: list[tuple[str, Any]] = [
+            (
+                _PAYLOAD_PARTITION_KEY,
+                models.KeywordIndexParams(
                     type=models.KeywordIndexType.KEYWORD,
                     is_tenant=True,
                 ),
             )
-            for prop_name, prop_type in config.indexed_properties_schema.items():
-                index_type = QdrantVectorStore._PROPERTY_TYPE_TO_INDEX_TYPE.get(
-                    prop_type
+        ]
+        for prop_name, prop_type in config.indexed_properties_schema.items():
+            index_type = QdrantVectorStore._PROPERTY_TYPE_TO_INDEX_TYPE.get(prop_type)
+            if index_type is not None:
+                indexes.append((prop_name, index_type))
+
+        for field_name, field_schema in indexes:
+            try:
+                await self._client.create_payload_index(
+                    collection_name=native_collection_name,
+                    field_name=field_name,
+                    field_schema=field_schema,
                 )
-                if index_type is not None:
-                    await self._client.create_payload_index(
-                        collection_name=native_collection_name,
-                        field_name=prop_name,
-                        field_schema=index_type,
-                    )
-        except (UnexpectedResponse, grpc.aio.AioRpcError, ValueError) as e:
-            if not QdrantVectorStore._is_already_exists_error(e):
-                raise
+            except (UnexpectedResponse, grpc.aio.AioRpcError, ValueError) as e:
+                if not QdrantVectorStore._is_already_exists_error(e):
+                    raise
 
     async def _ensure_shard_key(
         self, native_collection_name: str, shard_key: str


### PR DESCRIPTION
## The defect

`_create_native_collection` wrapped `create_collection` **and every
`create_payload_index`** in one `try`, then swallowed "already exists" for the whole
block. A collection that already existed therefore raised on the first call, took the
already-exists path, and was left with **no payload indexes at all** — despite the
docstring promising both were created idempotently.

Two creators are easy to arrive at. The guarding lock is keyed on the
`AsyncQdrantClient` object:

```python
_name_locks: ClassVar[WeakKeyDictionary[AsyncQdrantClient, defaultdict[tuple[str, str], asyncio.Lock]]]
```

so it serialises callers inside one process and nothing across them. With
`MEMMACHINE_WORKERS` above 1 each worker has its own client and its own lock. A crash
between the two calls leaves the same state.

## The change

The collection and the indexes now sit under separate guards, and each index is created
individually and tolerant of already-exists.

## Evidence

Against Qdrant 1.19 in testcontainers.

**Before** — `test_indexes_are_created_when_the_collection_already_exists` fails, and not
with one index missing:

```
AssertionError: the tenant partition index is missing: a collection that already
existed never had its payload indexes created ... present: []
assert 'sys-partition_key' in set()
```

`payload_schema` is empty — none of the twelve.

**After** — both new tests pass, along with the rest of the suite: **293 unit, 142
integration**. ruff and ruff format clean.

## Scope, checked rather than assumed

A filtered query on an unindexed collection returns only the matching tenant's points, so
what a missing `sys-partition_key` index costs is the **multitenant storage layout and
query speed, not isolation**. I verified this directly rather than reasoning from
`is_tenant=True`.

Only the already-exists path reproduces. Two clients creating *simultaneously* both
succeed, which the second test pins.

## What a reviewer needs to know

These tests are marked `integration` and need a real server — local-mode Qdrant ignores
payload indexes, so the defect is invisible there. **CI will not exercise them**, since
`addopts = ["-m", "not integration"]`. To run them:

```
pytest packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py \
  -m integration -k TestCollectionLifecycleAcrossWorkers
```

Docker required; the fixture starts its own Qdrant.

## Not affected

The mm-tb6 benchmark collection was checked and holds all twelve payload indexes
including `sys-partition_key`, covering every point — no measurement ran against an
unindexed collection.
