### PR TITLE
feat(config): default to no short-term or semantic memory, and infer the backend

### DIFF
--- a/deployments/helm/templates/memmachine-configmaps.yaml
+++ b/deployments/helm/templates/memmachine-configmaps.yaml
@@ -32,11 +32,17 @@ data:
         embedder: default_embedder
         reranker: my_reranker_id
         vector_graph_store: db_neo4j
+      # Stated rather than inherited: the default is now off, and this chart
+      # configures short-term memory, so leaving it unset would ship a chart
+      # whose llm_model and message_capacity were never used.
+      short_term_memory_enabled: true
       short_term_memory:
         llm_model: default_model
         message_capacity: 500
 
     semantic_memory:
+      # Likewise: this chart configures semantic memory, so it must now say so.
+      enabled: true
       llm_model: default_model
       embedding_model: default_embedder
       database: db_postgres

--- a/evaluation/episodic_memory/locomo_config.yaml
+++ b/evaluation/episodic_memory/locomo_config.yaml
@@ -6,6 +6,10 @@ episode_store:
   database: db_sqlite
 
 episodic_memory:
+  # Stated rather than inherited: short-term memory used to be on by default and
+  # this evaluation ran with it. The default is now off, so leaving it unset here
+  # would quietly change what this measures.
+  short_term_memory_enabled: true
   long_term_memory:
     embedder: my_embedder_id
     reranker: my_reranker_id

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_configuration.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_configuration.py
@@ -267,6 +267,134 @@ def test_old_param_data_without_backend_loads_as_declarative():
     assert conf.long_term_memory.vector_graph_store == "my_storage_id"
 
 
+def test_short_term_memory_is_off_unless_asked_for():
+    """A config that configures short-term memory does not thereby enable it.
+
+    The merge used to read True whenever a short_term_memory section existed,
+    which meant the field default never applied to any real config. Configuring
+    the block and enabling it are now separate statements.
+    """
+    partial = EpisodicMemoryConfPartial.model_validate(
+        {
+            "session_key": "s",
+            "short_term_memory": _ltm_minimal_short_term_block(),
+            "long_term_memory": {
+                "session_id": "s",
+                "embedder": "e",
+                "reranker": "r",
+                "vector_graph_store": "g",
+            },
+        }
+    )
+    conf = partial.merge(EpisodicMemoryConfPartial())
+    assert conf.short_term_memory_enabled is False
+
+
+def test_short_term_memory_honours_an_explicit_true():
+    partial = EpisodicMemoryConfPartial.model_validate(
+        {
+            "session_key": "s",
+            "short_term_memory": _ltm_minimal_short_term_block(),
+            "short_term_memory_enabled": True,
+            "long_term_memory": {
+                "session_id": "s",
+                "embedder": "e",
+                "reranker": "r",
+                "vector_graph_store": "g",
+            },
+        }
+    )
+    conf = partial.merge(EpisodicMemoryConfPartial())
+    assert conf.short_term_memory_enabled is True
+
+
+def test_semantic_memory_is_off_by_default():
+    """Off even when fully configured, which is the only case the default decides.
+
+    An incomplete config is already forced off by _auto_disable_when_incomplete,
+    so asserting against a bare instance would pass whatever the default is.
+    Every required field is supplied here so that nothing but the default is
+    left to determine the answer.
+    """
+    from memmachine_server.common.configuration import SemanticMemoryConf
+
+    conf = SemanticMemoryConf(
+        config_database="db",
+        database="db",
+        llm_model="my_llm",
+        embedding_model="my_embedder",
+    )
+    assert conf.enabled is False
+
+
+def test_semantic_memory_honours_an_explicit_true():
+    from memmachine_server.common.configuration import SemanticMemoryConf
+
+    conf = SemanticMemoryConf(
+        enabled=True,
+        config_database="db",
+        database="db",
+        llm_model="my_llm",
+        embedding_model="my_embedder",
+    )
+    assert conf.enabled is True
+
+
+def test_backend_inferred_as_event_from_a_vector_store():
+    """Naming an event-only field is an unambiguous request for event memory.
+
+    The two backends share no field names, so a config pointing at a
+    `vector_store` cannot mean the declarative backend - it has no such field.
+    This is what makes event memory reachable without a `backend` key while
+    leaving pre-discriminator configs, which name a `vector_graph_store`, alone.
+    """
+    partial = LongTermMemoryConfPartial.model_validate(
+        {
+            "session_id": "s",
+            "embedder": "e",
+            "vector_store": "my_qdrant",
+            "segment_store": "my_sql",
+        }
+    )
+    merged = partial.merge(LongTermMemoryConfPartial())
+    assert merged.backend == "event"
+
+
+def test_backend_inferred_as_declarative_from_a_vector_graph_store():
+    partial = LongTermMemoryConfPartial.model_validate(
+        {
+            "session_id": "s",
+            "embedder": "e",
+            "reranker": "r",
+            "vector_graph_store": "my_neo4j",
+        }
+    )
+    merged = partial.merge(LongTermMemoryConfPartial())
+    assert merged.backend == "declarative"
+
+
+def test_explicit_backend_beats_inference():
+    """An explicit discriminator is a decision; inference is only a fallback."""
+    partial = LongTermMemoryConfPartial.model_validate(
+        {
+            "session_id": "s",
+            "embedder": "e",
+            "reranker": "r",
+            "backend": "declarative",
+            "vector_graph_store": "n",
+        }
+    )
+    assert partial.merge(LongTermMemoryConfPartial()).backend == "declarative"
+
+
+def test_backend_falls_back_to_declarative_when_no_store_is_named():
+    """Nothing to infer from, so the legacy reading stands."""
+    partial = LongTermMemoryConfPartial.model_validate(
+        {"session_id": "s", "embedder": "e", "reranker": "r", "vector_graph_store": "g"}
+    )
+    assert partial.merge(LongTermMemoryConfPartial()).backend == "declarative"
+
+
 def test_episodic_memory_conf_with_explicit_event_backend_loads_as_event():
     data = {
         "session_key": "s",

--- a/packages/server/src/memmachine_server/common/configuration/__init__.py
+++ b/packages/server/src/memmachine_server/common/configuration/__init__.py
@@ -100,8 +100,8 @@ class SemanticMemoryConf(YamlSerializableMixin):
     """Configuration for semantic memory defaults."""
 
     enabled: bool = Field(
-        default=True,
-        description="Whether semantic memory is enabled. "
+        default=False,
+        description="Whether semantic memory is enabled. Off by default. "
         "Auto-disabled when required backend, llm_model, or embedding_model fields are empty.",
     )
     database: str | None = Field(

--- a/packages/server/src/memmachine_server/common/configuration/episodic_config.py
+++ b/packages/server/src/memmachine_server/common/configuration/episodic_config.py
@@ -316,19 +316,46 @@ class LongTermMemoryConfPartial(BaseModel):
         description="ID of the Reranker instance for reranking search results",
     )
 
+    @staticmethod
+    def _infer_backend(
+        primary: "LongTermMemoryConfPartial",
+        fallback: "LongTermMemoryConfPartial",
+    ) -> Literal["declarative", "event"]:
+        """Guess the backend from which side's fields a config filled in.
+
+        The two backends share no field names, so naming one of them is an
+        unambiguous statement of intent - a config pointing at a `vector_store`
+        cannot mean the declarative backend, which has no such field. Inferring
+        rather than defaulting is what lets event memory be reachable without a
+        `backend` key while leaving every pre-discriminator config alone: those
+        name a `vector_graph_store`, and resolve as they always did.
+
+        Declarative wins a config that somehow names both, since that is the
+        legacy reading and the safer one to be wrong about: it points at the
+        store the data is already in.
+        """
+        for side in (primary, fallback):
+            if side.vector_graph_store is not None:
+                return "declarative"
+            if side.vector_store is not None or side.segment_store is not None:
+                return "event"
+        return "declarative"
+
     def merge(self, other: Self) -> LongTermMemoryConf:
         """Merge with another partial into a complete long-term config.
 
         Resolution rule for the backend discriminator:
         - if either side sets `backend` explicitly, that value wins (primary first).
-        - if neither side sets `backend`, default to `declarative` (the legacy
-          shape, for backwards compatibility with pre-discriminator configs).
-          Callers that want event-memory should set `backend="event"`
-          explicitly at creation time (e.g. wizard, project-creation API).
+        - otherwise infer it from which backend's fields are present: the two
+          share no field names, so a config that names a `vector_store` wants
+          event memory and one that names a `vector_graph_store` wants
+          declarative, whether or not it knows the discriminator exists.
+        - if neither side names a store, fall back to `declarative`, the legacy
+          shape, so that pre-discriminator configs keep resolving as they did.
         """
         backend = self.backend if self.backend is not None else other.backend
         if backend is None:
-            backend = "declarative"
+            backend = LongTermMemoryConfPartial._infer_backend(self, other)
 
         if backend == "declarative":
             return merge_partial_configs(self, other, DeclarativeLongTermMemoryConf)
@@ -376,8 +403,12 @@ class EpisodicMemoryConf(MetricsFactoryIdMixin, YamlSerializableMixin):
         description="Whether the long-term memory is enabled",
     )
     short_term_memory_enabled: bool = Field(
-        default=True,
-        description="Whether the short-term memory is enabled",
+        default=False,
+        description=(
+            "Whether the short-term memory is enabled. Off by default: each save "
+            "costs an LLM round trip, and a deployment that only wants retrieval "
+            "should not pay for it without asking."
+        ),
     )
     enabled: bool = Field(
         default=True,
@@ -452,8 +483,13 @@ class EpisodicMemoryConfPartial(YamlSerializableMixin):
             long_term_memory_enabled=True
             if merged.long_term_memory_enabled is None and ltm_merged is not None
             else merged.long_term_memory_enabled,
-            short_term_memory_enabled=True
-            if merged.short_term_memory_enabled is None and stm_merged is not None
-            else merged.short_term_memory_enabled,
+            # Off unless asked for. This previously read True whenever a
+            # short_term_memory section existed, which meant the field default
+            # above never applied to any real config.
+            short_term_memory_enabled=(
+                merged.short_term_memory_enabled
+                if merged.short_term_memory_enabled is not None
+                else False
+            ),
             enabled=True if merged.enabled is None else merged.enabled,
         )


### PR DESCRIPTION
A deployment that runs the server **on its own** — hand-written config, no chart,
no Kubernetes — gets whatever the code defaults are. Those defaults assumed a
full installation: short-term memory on, semantic memory on, long-term memory on
Neo4j. A lab wanting MemMachine for retrieval alone had to turn two things off
and switch a third before it matched what it wanted.

## Short-term memory: off unless asked for

Two changes were needed, not one. The field default was `True`, but the merge
also read `True` whenever a `short_term_memory` section existed at all:

```python
short_term_memory_enabled=True if merged.short_term_memory_enabled is None
                               and stm_merged is not None else ...
```

so the field default never applied to any real config. Configuring the block and
enabling it are now separate statements.

## Semantic memory: off by default

With a caveat worth stating: `_auto_disable_when_incomplete` already forced it
off whenever `llm_model`, `embedding_model` or the storage fields were missing.
The old default of `True` therefore only took effect for a deployment that had
wired all of them up — which is also why the first version of the test for this
was vacuous (see Verification).

## Long-term backend: inferred, not defaulted

The two backends share no field names, so naming one is an unambiguous
statement of intent — a config pointing at a `vector_store` cannot mean the
declarative backend, which has no such field.

| the config names | resolves to |
|---|---|
| `vector_store` / `segment_store` | **event** (Qdrant) |
| `vector_graph_store` | declarative (Neo4j) |
| neither, or `backend:` set explicitly | unchanged |

### What this deliberately does not do

**The discriminator is untouched.** Flipping `None -> declarative` would repoint
every pre-discriminator config at Qdrant, against data sitting in Neo4j. Those
configs name a `vector_graph_store`, so inference resolves them exactly as
before, and `test_old_param_data_without_backend_loads_as_declarative` passes
unchanged.

**Defaulting to event when nothing is named would not work either** — such a
config has no store ids, so the event backend cannot start. Defaulting there
just moves the failure.

## Configs that relied on the old defaults

Both now state what they want, so this change does not quietly alter them:

- `evaluation/episodic_memory/locomo_config.yaml` ran with short-term memory on
- `deployments/helm` configures both memories, and would otherwise have shipped
  an `llm_model` and `message_capacity` that were never used

## Verification

**1964 tests pass**, ruff and format clean.

Seven new tests cover the changed behaviour, and **each was run against the old
code to confirm it fails there** — which caught one that did not. Asserting the
semantic default on a bare `SemanticMemoryConf` passes whatever the default is,
because the auto-disable fires first. That test now supplies every required
field so that nothing but the default decides the answer.

## Who this affects

Anyone whose config **omits** these settings — the standalone case this is for.

Deployments using the platform chart are unaffected: it writes `backend: event`,
`short_term_memory_enabled` and `semantic_memory.enabled` explicitly, and an
explicit setting always beats a default.

This is a **behaviour change on upgrade** for standalone users who relied on the
old defaults, which is the main thing to weigh. Worth noting for semantic memory
in particular: turning it back on later hands the whole accumulated backlog to
`process_set_ids` in one call.
