### PR TITLE
fix: drop the duplicate _cleanup_semantic_history that shadows the guarded one

### DIFF
--- a/packages/server/src/memmachine_server/main/memmachine.py
+++ b/packages/server/src/memmachine_server/main/memmachine.py
@@ -1165,19 +1165,6 @@ class MemMachine:
         tasks.append(semantic_service.delete_history(episode_ids))
         await asyncio.gather(*tasks)
 
-    async def _cleanup_semantic_history(self, episode_ids: list[str]) -> None:
-        """Delete semantic history entries for the given episode IDs.
-
-        Args:
-            episode_ids: IDs of episodes whose semantic history should be removed.
-
-        Returns:
-            None.
-
-        """
-        semantic_service = await self._resources.get_semantic_service()
-        await semantic_service.delete_history(episode_ids)
-
     async def delete_features(
         self,
         feature_ids: list[FeatureIdT],


### PR DESCRIPTION
## Problem

`MemMachine` defines `_cleanup_semantic_history` **twice**, both added by #1151:

| line | body | wired to |
|---|---|---|
| 565 | catches `ResourceNotReadyError` from `get_semantic_service()`, logs, returns | the batched delete loop in `delete_session` (`_delete_episode_store`, line 383) |
| 1168 | no guard — `get_semantic_service()` propagates | nothing; it has no callers of its own |

Python keeps the **later** definition, so the guarded one at 565 is dead code and line 383 silently gets the unguarded implementation.

That matters because the caller is a deletion loop:

```python
while True:
    episode_ids = await episode_store.get_episode_ids(...)
    if not episode_ids:
        break
    await self._cleanup_semantic_history(episode_ids)
    await episode_store.delete_episodes(episode_ids)   # <-- never reached
```

If the semantic service is not ready, `ResourceNotReadyError` escapes the loop **before** `delete_episodes()` runs, so `delete_session` aborts with **zero episodes deleted** — the exact outcome the guard at 565 was written to prevent (`"Semantic service not ready during history cleanup; skipping cleanup for episode IDs %s"`).

`ruff check` does not report this — `F811` is selected in `pyproject.toml` but does not fire on this pair, so lint gave no signal.

## Change

Remove the unguarded duplicate (−13 lines). No other file changes; the surviving definition also carries the more precise `list[EpisodeIdT]` annotation.

## Verification

No services needed. Both definitions are lifted verbatim out of the file with `ast` (by line range, so the real source is exercised, not a hand copy), bound into a class **in the same order Python binds them**, and the `_delete_episode_store` loop is replayed against a `_resources` stub whose `get_semantic_service()` raises `ResourceNotReadyError`:

```
before (main) : defs_in_class=2  bound_impl=UNGUARDED session delete -> ABORTED with ResourceNotReadyError; episodes deleted = []
after  (patch): defs_in_class=1  bound_impl=guarded   session delete -> completed; episodes deleted = ['ep1', 'ep2']
```

`ruff format --check` is clean, and `ruff check` reports exactly the same findings before and after the patch (no new violations).

If you would rather keep the simpler unguarded body and delete the guarded one instead, say so and I will flip the patch — but then `delete_session` loses the error handling #1151 added for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
