### PR TITLE
fix: Bedrock reranker credential chain fallback and eval script compatibility with LTM backend split

### DIFF
--- a/evaluation/utils/agent_utils.py
+++ b/evaluation/utils/agent_utils.py
@@ -18,8 +18,8 @@ from memmachine_server.episodic_memory.episodic_memory import (
     EpisodicMemoryParams,
 )
 from memmachine_server.episodic_memory.long_term_memory import (
+    DeclarativeBackendParams,
     LongTermMemory,
-    LongTermMemoryParams,
 )
 from memmachine_server.retrieval_agent.agents import (
     ChainOfQueryAgent,
@@ -475,7 +475,8 @@ async def init_memmachine_params(
     normalized_session_id = session_id or "evaluation_session"
 
     long_term_memory = LongTermMemory(
-        LongTermMemoryParams(
+        DeclarativeBackendParams(
+            backend="declarative",
             session_id=normalized_session_id,
             vector_graph_store=vector_graph_store,
             embedder=embedder,

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_reranker_conf.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_reranker_conf.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 import yaml
 from pydantic import SecretStr, ValidationError
@@ -136,6 +134,40 @@ def test_valid_amazon_bedrock_reranker_conf(amazon_bedrock_reranker_conf):
     assert conf.model_id == "amazon.rerank-v1:0"
 
 
+def test_valid_amazon_bedrock_reranker_conf_without_explicit_credentials(
+    monkeypatch,
+):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
+
+    conf = AmazonBedrockRerankerConf(
+        region="us-west-2",
+        model_id="amazon.rerank-v1:0",
+    )
+
+    assert conf.region == "us-west-2"
+    assert conf.aws_access_key_id is None
+    assert conf.aws_secret_access_key is None
+    assert conf.aws_session_token is None
+    assert conf.model_id == "amazon.rerank-v1:0"
+
+
+def test_valid_amazon_bedrock_reranker_conf_uses_env_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "env-key-id")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "env-secret-key")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "env-session-token")
+
+    conf = AmazonBedrockRerankerConf(
+        region="us-west-2",
+        model_id="amazon.rerank-v1:0",
+    )
+
+    assert conf.aws_access_key_id == SecretStr("env-key-id")
+    assert conf.aws_secret_access_key == SecretStr("env-secret-key")
+    assert conf.aws_session_token == SecretStr("env-session-token")
+
+
 def test_valid_cohere_reranker_conf(cohere_reranker_conf):
     conf = CohereRerankerConf(**cohere_reranker_conf["config"])
     assert conf.cohere_key == SecretStr("test-cohere-key")
@@ -193,19 +225,6 @@ def test_serialize_deserialize_reranker_conf(full_reranker_input):
     serialized = conf.to_yaml()
     conf_cp = RerankersConf.parse(yaml.safe_load(serialized))
     assert conf == conf_cp
-
-
-def test_missing_required_field_in_bedrock_reranker():
-    config: dict[str, Any] = {
-        "region": "us-west-2",
-        "aws_access_key_id": "key-id",
-        # Missing aws_secret_access_key
-        "model_id": "amazon.rerank-v1:0",
-    }
-    with pytest.raises(ValidationError) as exc_info:
-        AmazonBedrockRerankerConf(**config)
-    assert "missing" in str(exc_info.value)
-    assert "aws_secret_access_key" in str(exc_info.value)
 
 
 def test_invalid_cohere_base_url():

--- a/packages/server/src/memmachine_server/common/configuration/reranker_conf.py
+++ b/packages/server/src/memmachine_server/common/configuration/reranker_conf.py
@@ -7,6 +7,7 @@ import yaml
 from pydantic import BaseModel, Field, PrivateAttr, SecretStr, field_validator
 
 from memmachine_server.common.configuration.mixin_confs import (
+    AWSCredentialsMixin,
     MetricsFactoryIdMixin,
     YamlSerializableMixin,
 )
@@ -28,25 +29,13 @@ class BM25RerankerConf(YamlSerializableMixin):
     )
 
 
-class AmazonBedrockRerankerConf(MetricsFactoryIdMixin, YamlSerializableMixin):
+class AmazonBedrockRerankerConf(MetricsFactoryIdMixin, YamlSerializableMixin, AWSCredentialsMixin):
     """Parameters for AmazonBedrockReranker."""
 
     model_id: str = Field(..., description="The Bedrock model ID to use for reranking")
     region: str = Field(
         ...,
         description="The AWS region of the Bedrock service",
-    )
-    aws_access_key_id: SecretStr | None = Field(
-        ...,
-        description="AWS access key ID for authentication.",
-    )
-    aws_secret_access_key: SecretStr | None = Field(
-        ...,
-        description="AWS secret access key for authentication.",
-    )
-    aws_session_token: SecretStr | None = Field(
-        default=None,
-        description="AWS session token for authentication.",
     )
     additional_model_request_fields: dict = Field(
         default_factory=dict,

--- a/packages/server/src/memmachine_server/common/resource_manager/reranker_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/reranker_manager.py
@@ -220,13 +220,21 @@ class RerankerManager(BaseResourceManager[Reranker]):
                 return None
             return secret.get_secret_value()
 
-        client = boto3.client(
-            "bedrock-agent-runtime",
-            region_name=conf.region,
-            aws_access_key_id=_get_secret_value(conf.aws_access_key_id),
-            aws_secret_access_key=_get_secret_value(conf.aws_secret_access_key),
-            aws_session_token=_get_secret_value(conf.aws_session_token),
-        )
+        # Only pass explicit credentials if they are set; otherwise let boto3
+        # use the default credential chain (~/.aws/credentials, config, SSO, etc.)
+        boto3_kwargs: dict[str, str | None] = {
+            "region_name": conf.region,
+        }
+        access_key = _get_secret_value(conf.aws_access_key_id)
+        secret_key = _get_secret_value(conf.aws_secret_access_key)
+        session_token = _get_secret_value(conf.aws_session_token)
+        if access_key and secret_key:
+            boto3_kwargs["aws_access_key_id"] = access_key
+            boto3_kwargs["aws_secret_access_key"] = secret_key
+            if session_token:
+                boto3_kwargs["aws_session_token"] = session_token
+
+        client = boto3.client("bedrock-agent-runtime", **boto3_kwargs)
         params = AmazonBedrockRerankerParams(
             client=client,
             region=conf.region,


### PR DESCRIPTION
### Purpose of the change

Fix two issues that prevent MemMachine evaluation benchmarks from running out of the box:
1. the Bedrock reranker requires explicit AWS credentials in the config YAML, blocking SSO/profile/login-based auth
2. the eval helper uses the old `LongTermMemoryParams` class which was replaced by a backend-discriminated union in #1395.

### Description

**Bedrock credential chain fix** (`reranker_conf.py` + `reranker_manager.py`):

`AmazonBedrockRerankerConf` previously defined its own `aws_access_key_id` and `aws_secret_access_key` fields as **required** (`Field(...)`), meaning any config using the Bedrock reranker had to include explicit credentials — SSO, AWS CLI login, and profile-based auth couldn't work. This PR replaces the hand-rolled fields with `AWSCredentialsMixin` (which defaults to `None` with env-var fallback) and updates `RerankerManager._build_amazon_bedrock_reranker` to only pass credentials to `boto3.client()` when they're actually set. When omitted, boto3 falls through to its default credential chain (`~/.aws/credentials`, `~/.aws/config`, SSO, instance metadata).

**Eval script fix** (`agent_utils.py`):

PR #1395 ("Wire EventMemory as backend for LongTermMemory") changed `LongTermMemoryParams` from a single concrete class to a `Discriminator`-based union of `DeclarativeBackendParams | EventBackendParams`. The evaluation helper `init_memmachine_params` still used the old `LongTermMemoryParams`, which no longer accepts the fields directly. This PR updates it to use `DeclarativeBackendParams(backend="declarative", ...)`.

**Tests** (`test_reranker_conf.py`):

- Added `test_valid_amazon_bedrock_reranker_conf_without_explicit_credentials` — verifies the config accepts no AWS credentials when env vars are unset
- Added `test_valid_amazon_bedrock_reranker_conf_uses_env_credentials` — verifies env-var resolution populates credentials correctly
- Removed `test_missing_required_field_in_bedrock_reranker` — this tested the old required-field behavior which no longer applies

### Fixes/Closes

None

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g., code style improvements, linting)
- [ ] Documentation update
- [ ] Project Maintenance (updates to build scripts, CI, etc., that do not affect the main project)
- [ ] Security (improves security without changing functionality)

### How Has This Been Tested?

- [x] Unit Test
- [x] Test Script

**Lint (all changed files):**
```bash
uv run ruff check evaluation/utils/agent_utils.py \
  packages/server/src/memmachine_server/common/configuration/reranker_conf.py \
  packages/server/server_tests/memmachine_server/common/configuration/test_reranker_conf.py \
  packages/server/server_tests/memmachine_server/common/resource_manager/test_reranker_manager.py
```

**Unit tests (config + manager):**
```bash
uv run pytest \
  packages/server/server_tests/memmachine_server/common/configuration/test_reranker_conf.py \
  packages/server/server_tests/memmachine_server/common/resource_manager/test_reranker_manager.py
```

**End-to-end eval (LoCoMo benchmark, retrieval_agent mode):**

Tested the "no keys in config" path using a personal AWS account via boto3's default credential chain. The Bedrock reranker (`amazon.rerank-v1:0`, `us-west-2`) resolved credentials automatically and completed successfully — no `AccessDeniedException`, no `ValidationError`. All 10 conversation groups processed with the retrieval agent routing queries through `MemMachineAgent`, `SplitQueryAgent`, and `ChainOfQueryAgent` as expected.

```bash
./run_test.sh locomo exp1 search retrieval_agent
```

---