### PR TITLE
Improve embedding fidelity (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/embedder/test_openai_embedder.py
+++ b/packages/server/server_tests/memmachine_server/common/embedder/test_openai_embedder.py
@@ -166,6 +166,6 @@ async def test_embed_oversized_input_with_no_max_input_length():
 
     assert len(result) == 1
     assert len(result[0]) == 256
-    # The text must have been split: balanced chunks of 80,000 chars at limit
-    # 75,000 produce two chunks of 40,000 each, each in its own cluster.
+    # The text must have been split: greedy chunks of 80,000 chars at limit
+    # 75,000 produce chunks of 75,000 and 5,000, each in its own cluster.
     assert mock_client.embeddings.create.call_count >= 2

--- a/packages/server/src/memmachine_server/common/embedder/amazon_bedrock_embedder.py
+++ b/packages/server/src/memmachine_server/common/embedder/amazon_bedrock_embedder.py
@@ -16,7 +16,7 @@ from memmachine_server.common.data_types import (
     ExternalServiceAPIError,
     SimilarityMetric,
 )
-from memmachine_server.common.utils import chunk_text_balanced, unflatten_like
+from memmachine_server.common.utils import chunk_text, unflatten_like
 
 from .embedder import Embedder
 
@@ -135,8 +135,12 @@ class AmazonBedrockEmbedder(Embedder):
 
         inputs = [input_text or "." for input_text in inputs]
 
+        # Greedy max-size chunks measured more faithful to the whole-text
+        # embedding than balanced chunks when combined with the
+        # length-weighted average below: most characters get the largest
+        # available context window.
         inputs_chunks = [
-            chunk_text_balanced(input_text, self._max_input_length)
+            chunk_text(input_text, self._max_input_length)
             if self._max_input_length is not None
             else [input_text]
             for input_text in inputs
@@ -203,10 +207,21 @@ class AmazonBedrockEmbedder(Embedder):
             inputs_chunks,
         )
 
-        # Average chunk embeddings to get input embeddings.
+        # Average chunk embeddings to get input embeddings, weighting each
+        # chunk by its length: under mean pooling the whole-text embedding is
+        # approximately a length-weighted average of its chunks' embeddings,
+        # and greedy chunking makes chunk lengths uneven.
         return [
-            np.mean(chunk_embeddings, axis=0).astype(float).tolist()
-            for chunk_embeddings in inputs_chunk_embeddings
+            np.average(
+                chunk_embeddings,
+                axis=0,
+                weights=[max(len(chunk), 1) for chunk in input_chunks],
+            )
+            .astype(float)
+            .tolist()
+            for input_chunks, chunk_embeddings in zip(
+                inputs_chunks, inputs_chunk_embeddings, strict=True
+            )
         ]
 
     @property

--- a/packages/server/src/memmachine_server/common/embedder/openai_embedder.py
+++ b/packages/server/src/memmachine_server/common/embedder/openai_embedder.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import re
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -16,7 +15,7 @@ from memmachine_server.common.data_types import (
 )
 from memmachine_server.common.metrics_factory import MetricsFactory, OperationTracker
 from memmachine_server.common.utils import (
-    chunk_text_balanced,
+    chunk_text,
     cluster_texts,
     unflatten_like,
 )
@@ -74,17 +73,6 @@ class OpenAIEmbedder(Embedder):
     max_num_inputs_per_request = 2048
     max_total_input_length_per_request = (
         75000  # Assume at most 4 tokens per Unicode code point.
-    )
-
-    # Tokens that cause 500 errors on text-embedding-3-small.
-    _SPECIAL_TOKEN_PATTERN = re.compile(
-        r"<\|endoftext\|>"
-        r"|<\|im_start\|>"
-        r"|<\|im_end\|>"
-        r"|<\|fim_prefix\|>"
-        r"|<\|fim_middle\|>"
-        r"|<\|fim_suffix\|>"
-        r"|<\|endofprompt\|>"
     )
 
     def __init__(self, params: OpenAIEmbedderParams) -> None:
@@ -149,17 +137,18 @@ class OpenAIEmbedder(Embedder):
         if max_attempts <= 0:
             raise ValueError("max_attempts must be a positive integer")
 
-        inputs = [
-            OpenAIEmbedder._SPECIAL_TOKEN_PATTERN.sub("", input_text) or "."
-            for input_text in inputs
-        ]
+        # The OpenAI API rejects empty inputs,
+        # and averaging over zero chunks is undefined.
+        inputs = [input_text or "." for input_text in inputs]
 
         effective_max = (
             self._max_input_length or self.max_total_input_length_per_request
         )
-        inputs_chunks = [
-            chunk_text_balanced(input_text, effective_max) for input_text in inputs
-        ]
+        # Greedy max-size chunks measured more faithful to the whole-text
+        # embedding than balanced chunks when combined with the
+        # length-weighted average below: most characters get the largest
+        # available context window.
+        inputs_chunks = [chunk_text(input_text, effective_max) for input_text in inputs]
 
         chunks = [chunk for input_chunks in inputs_chunks for chunk in input_chunks]
         chunk_clusters = cluster_texts(
@@ -203,10 +192,21 @@ class OpenAIEmbedder(Embedder):
             inputs_chunks,
         )
 
-        # Average chunk embeddings to get input embeddings.
+        # Average chunk embeddings to get input embeddings, weighting each
+        # chunk by its length: under mean pooling the whole-text embedding is
+        # approximately a length-weighted average of its chunks' embeddings,
+        # and greedy chunking makes chunk lengths uneven.
         return [
-            np.mean(chunk_embeddings, axis=0).astype(float).tolist()
-            for chunk_embeddings in inputs_chunk_embeddings
+            np.average(
+                chunk_embeddings,
+                axis=0,
+                weights=[max(len(chunk), 1) for chunk in input_chunks],
+            )
+            .astype(float)
+            .tolist()
+            for input_chunks, chunk_embeddings in zip(
+                inputs_chunks, inputs_chunk_embeddings, strict=True
+            )
         ]
 
     async def _embed_chunk_cluster(

--- a/packages/server/src/memmachine_server/common/embedder/sentence_transformer_embedder.py
+++ b/packages/server/src/memmachine_server/common/embedder/sentence_transformer_embedder.py
@@ -14,7 +14,7 @@ from memmachine_server.common.data_types import (
     ExternalServiceAPIError,
     SimilarityMetric,
 )
-from memmachine_server.common.utils import chunk_text_balanced, unflatten_like
+from memmachine_server.common.utils import chunk_text, unflatten_like
 
 from .embedder import Embedder
 
@@ -102,8 +102,12 @@ class SentenceTransformerEmbedder(Embedder):
         if max_attempts <= 0:
             raise ValueError("max_attempts must be a positive integer")
 
+        # Greedy max-size chunks measured more faithful to the whole-text
+        # embedding than balanced chunks when combined with the
+        # length-weighted average below: most characters get the largest
+        # available context window.
         inputs_chunks = [
-            chunk_text_balanced(input_text, self._max_input_length)
+            chunk_text(input_text, self._max_input_length)
             if self._max_input_length is not None and input_text
             else [input_text]
             for input_text in inputs
@@ -153,10 +157,21 @@ class SentenceTransformerEmbedder(Embedder):
             inputs_chunks,
         )
 
-        # Average chunk embeddings to get input embeddings.
+        # Average chunk embeddings to get input embeddings, weighting each
+        # chunk by its length: under mean pooling the whole-text embedding is
+        # approximately a length-weighted average of its chunks' embeddings,
+        # and greedy chunking makes chunk lengths uneven.
         return [
-            np.mean(chunk_embeddings, axis=0).astype(float).tolist()
-            for chunk_embeddings in inputs_chunk_embeddings
+            np.average(
+                chunk_embeddings,
+                axis=0,
+                weights=[max(len(chunk), 1) for chunk in input_chunks],
+            )
+            .astype(float)
+            .tolist()
+            for input_chunks, chunk_embeddings in zip(
+                inputs_chunks, inputs_chunk_embeddings, strict=True
+            )
         ]
 
     @property


### PR DESCRIPTION
Copy of #1449 onto `speedkick`. Cherry-picked cleanly; no conflicts and no changes were needed. Targeted suite `server_tests/memmachine_server/common/embedder` passes (5 passed).

### Purpose of the change

Chunk-merged embeddings (texts longer than the model input limit are split, embedded per chunk, and averaged) reproduce the whole-text embedding more faithfully with **greedy max-size chunks and a length-weighted average** than with the current balanced chunks and unweighted mean. Measured on three encoders; numbers below.

OpenAI servers no longer error when special tokens are given to text-embedding-3-small, so the special-token sanitizer is removed (probe script and results attached as a PR comment below).

### Description

- Use greedy max-size chunks (`chunk_text`) instead of balanced chunks (`chunk_text_balanced`) in the OpenAI, SentenceTransformer, and Amazon Bedrock embedders.
- Merge chunk embeddings with a length-weighted `np.average` instead of unweighted `np.mean`.
- Remove special token processing.

### Measurements

Method: 10 hand-written texts in distinct registers (fiction, technical docs, chat transcript, news, legal, academic, recipe, business memo, product review, encyclopedia), each short enough to embed whole — the whole-text embedding is the observable ground truth. Each text is chunked at limits 800 / 1600 / 3200 chars under each policy, chunks embedded, merged, and compared to the whole-text vector by cosine similarity. Single-chunk cells excluded; 28 cells per configuration per model. Probe script and raw per-cell results are attached as PR comments below (deliberately not committed to the branch).

**This PR's configuration (greedy + length-weighted) vs current behavior (balanced + unweighted), paired over the same 28 cells:**

| Encoder | Current mean cos | PR mean cos | Paired Δ | Cell wins | t (df=27) |
|---|---|---|---|---|---|
| embeddinggemma-300m (local) | 0.9578 | 0.9644 | +0.0066 | 24/28 | 4.8 |
| text-embedding-3-small | 0.9338 | 0.9394 | +0.0055 | 18/28 | 2.3 |
| text-embedding-3-large | 0.9237 | 0.9340 | +0.0103 | 20/28 | 3.3 |

**Full split × weighting grid (mean cosine to whole-text embedding, higher = more faithful):**

| Configuration | gemma-300m | 3-small | 3-large |
|---|---|---|---|
| greedy + length-weighted (**this PR**) | **0.9644** | **0.9394** | **0.9340** |
| balanced + weighted | 0.9578 | 0.9338 | 0.9237 |
| balanced + unweighted (current) | 0.9578 | 0.9338 | 0.9237 |
| greedy + unweighted | 0.9356 | 0.9217 | 0.9161 |

Two structural checks that this is signal, not noise:

- Greedy *requires* the weighting: greedy+unweighted ranks last on all three encoders. The two changes in this PR are a package.
- Balanced is indifferent to weighting (its two rows agree to ~5 decimals on every encoder), as expected for equal-size chunks — a built-in sanity check on the harness.

Mechanism: to the extent an encoder mean-pools token states, the whole-text vector is approximately a length-weighted average over the text, which a merge approximates best when weights match chunk lengths and most characters sit in maximal-context chunks. The result holds on the OpenAI models even though their pooling is undocumented.

Caveat: per-cell variance is wider on the OpenAI models than on gemma (worst cell −0.019, best +0.048), so this is a consistent aggregate win rather than a uniform per-text one.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Unit Test
- [x] Integration Test
- [ ] End-to-end Test
- [x] Test Script (please provide)
- [x] Manual verification (list step-by-step instructions)

**Test Results:** Fidelity tables above; probe scripts and raw results attached as PR comments below; embedder unit tests pass (`server_tests/memmachine_server/common/embedder/`).

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected



---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKmF9xNph9QH3ozNw3ZnJL
