### PR TITLE
Publish vector index files atomically (but not durably) (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -2,7 +2,6 @@
 
 import math
 from datetime import UTC, datetime, timedelta, timezone
-from pathlib import Path
 from uuid import UUID, uuid4
 
 import pytest
@@ -31,9 +30,6 @@ from memmachine_server.common.vector_store.sqlite_vector_store import (
     SQLiteVectorStoreParams,
     _CollectionRow,
     _PendingOperationRow,
-)
-from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
-    published_index_path,
 )
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
@@ -1343,16 +1339,6 @@ async def _get_index_saved(engine, namespace, name) -> bool | None:
         ).scalar_one_or_none()
 
 
-def _delete_file(path: str) -> None:
-    """Remove a file from under a running store."""
-    Path(path).unlink()
-
-
-def _overwrite_file(path: str, contents: bytes) -> None:
-    """Replace a file's contents from under a running store."""
-    Path(path).write_bytes(contents)
-
-
 class TestIndexFileDurability:
     """Once the index has been saved, the file is part of the durable contract."""
 
@@ -1418,14 +1404,11 @@ class TestIndexFileDurability:
         await store1.shutdown()
         await engine1.dispose()
 
-        # Operator deletes the published index out from under us, leaving the
-        # generation record that names it.
+        # Operator deletes the index file out from under us.
         index_dir = tmp_path / "indexes"
-        bases = {p.with_suffix("") for p in index_dir.glob("*.idx.[01]")}
-        assert len(bases) == 1
-        published = published_index_path(str(next(iter(bases))))
-        assert published is not None
-        _delete_file(published)
+        idx_files = list(index_dir.glob("*.idx"))
+        assert len(idx_files) == 1
+        idx_files[0].unlink()
 
         # Restart: open_collection must surface the failure, not return an
         # engine silently rebuilt empty.
@@ -1453,46 +1436,15 @@ class TestIndexFileDurability:
         await engine1.dispose()
 
         index_dir = tmp_path / "indexes"
-        bases = {p.with_suffix("") for p in index_dir.glob("*.idx.[01]")}
-        assert len(bases) == 1
-        published = published_index_path(str(next(iter(bases))))
-        assert published is not None
-        _overwrite_file(published, b"not a valid index file")
+        idx_files = list(index_dir.glob("*.idx"))
+        assert len(idx_files) == 1
+        idx_files[0].write_bytes(b"not a valid index file")
 
         store2, engine2 = await _fresh_store(db_path, tmp_path)
         with pytest.raises(IndexLoadError) as exc_info:
             await store2.open_collection(namespace=NAMESPACE, name=NAME)
         assert exc_info.value.namespace == NAMESPACE
         assert exc_info.value.name == NAME
-        assert exc_info.value.__cause__ is not None
-
-        await store2.shutdown()
-        await engine2.dispose()
-
-    @pytest.mark.asyncio
-    async def test_nothing_published_when_saved_raises(self, tmp_path):
-        """A saved collection whose engine publishes nothing is a fault."""
-        db_path = tmp_path / "test.db"
-        store1, engine1 = await _fresh_store(db_path, tmp_path)
-
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
-        await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
-        await store1.shutdown()
-        await engine1.dispose()
-
-        # Both generation records lost: the slots may still hold indexes, but
-        # nothing names one, and an unnamed index is not a publication.
-        index_dir = tmp_path / "indexes"
-        records = list(index_dir.glob("*.gen"))
-        assert records
-        for record in records:
-            _delete_file(str(record))
-
-        store2, engine2 = await _fresh_store(db_path, tmp_path)
-        with pytest.raises(IndexLoadError) as exc_info:
-            await store2.open_collection(namespace=NAMESPACE, name=NAME)
         assert exc_info.value.__cause__ is not None
 
         await store2.shutdown()
@@ -1528,6 +1480,57 @@ class TestIndexFileDurability:
             query_vectors=[_normalize([1.0, 0.0, 0.0])], limit=10
         )
         assert len(results[0].matches) == 2
+
+        await store2.shutdown()
+        await engine2.dispose()
+
+    @pytest.mark.asyncio
+    async def test_a_reverted_publication_costs_search_not_records(self, tmp_path):
+        """A publication lost to power failure leaves records unsearchable.
+
+        The swap is atomic, not durable, so a power failure can revert the last
+        publication after the trim behind it has committed. Restoring the
+        previous index bytes reconstructs exactly that state, deterministically
+        rather than by pulling a plug, and pins the direction it fails in: the
+        record survives and still resolves by uuid, it simply cannot be found
+        by search until it is upserted again.
+        """
+        db_path = tmp_path / "test.db"
+        store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=1)
+
+        coll = await store1.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        r1 = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
+        await coll.upsert(records=[r1])
+
+        index_dir = tmp_path / "indexes"
+        idx_files = list(index_dir.glob("*.idx"))
+        assert len(idx_files) == 1
+        published_without_r2 = idx_files[0].read_bytes()
+
+        # Publishes an index holding both, then trims r2's only other copy.
+        r2 = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+        await coll.upsert(records=[r2])
+        assert await _pending_operation_count(engine1) == 0
+
+        await store1.shutdown()
+        await engine1.dispose()
+
+        # Power failure: the publication that held r2 never reached the disk.
+        idx_files[0].write_bytes(published_without_r2)
+
+        store2, engine2 = await _fresh_store(db_path, tmp_path)
+        coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        assert coll2 is not None
+
+        # The record is still a record.
+        fetched = await coll2.get(record_uuids=[r2.uuid])
+        assert [record.uuid for record in fetched] == [r2.uuid]
+
+        # The index just cannot find it any more.
+        results = await coll2.query(query_vectors=[r2.vector], limit=10)
+        assert [match.record.uuid for match in results[0].matches] == [r1.uuid]
 
         await store2.shutdown()
         await engine2.dispose()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -2,6 +2,7 @@
 
 import math
 from datetime import UTC, datetime, timedelta, timezone
+from pathlib import Path
 from uuid import UUID, uuid4
 
 import pytest
@@ -30,6 +31,9 @@ from memmachine_server.common.vector_store.sqlite_vector_store import (
     SQLiteVectorStoreParams,
     _CollectionRow,
     _PendingOperationRow,
+)
+from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
+    published_index_path,
 )
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
@@ -1339,6 +1343,16 @@ async def _get_index_saved(engine, namespace, name) -> bool | None:
         ).scalar_one_or_none()
 
 
+def _delete_file(path: str) -> None:
+    """Remove a file from under a running store."""
+    Path(path).unlink()
+
+
+def _overwrite_file(path: str, contents: bytes) -> None:
+    """Replace a file's contents from under a running store."""
+    Path(path).write_bytes(contents)
+
+
 class TestIndexFileDurability:
     """Once the index has been saved, the file is part of the durable contract."""
 
@@ -1404,11 +1418,14 @@ class TestIndexFileDurability:
         await store1.shutdown()
         await engine1.dispose()
 
-        # Operator deletes the index file out from under us.
+        # Operator deletes the published index out from under us, leaving the
+        # generation record that names it.
         index_dir = tmp_path / "indexes"
-        idx_files = list(index_dir.glob("*.idx"))
-        assert len(idx_files) == 1
-        idx_files[0].unlink()
+        bases = {p.with_suffix("") for p in index_dir.glob("*.idx.[01]")}
+        assert len(bases) == 1
+        published = published_index_path(str(next(iter(bases))))
+        assert published is not None
+        _delete_file(published)
 
         # Restart: open_collection must surface the failure, not return an
         # engine silently rebuilt empty.
@@ -1436,15 +1453,46 @@ class TestIndexFileDurability:
         await engine1.dispose()
 
         index_dir = tmp_path / "indexes"
-        idx_files = list(index_dir.glob("*.idx"))
-        assert len(idx_files) == 1
-        idx_files[0].write_bytes(b"not a valid index file")
+        bases = {p.with_suffix("") for p in index_dir.glob("*.idx.[01]")}
+        assert len(bases) == 1
+        published = published_index_path(str(next(iter(bases))))
+        assert published is not None
+        _overwrite_file(published, b"not a valid index file")
 
         store2, engine2 = await _fresh_store(db_path, tmp_path)
         with pytest.raises(IndexLoadError) as exc_info:
             await store2.open_collection(namespace=NAMESPACE, name=NAME)
         assert exc_info.value.namespace == NAMESPACE
         assert exc_info.value.name == NAME
+        assert exc_info.value.__cause__ is not None
+
+        await store2.shutdown()
+        await engine2.dispose()
+
+    @pytest.mark.asyncio
+    async def test_nothing_published_when_saved_raises(self, tmp_path):
+        """A saved collection whose engine publishes nothing is a fault."""
+        db_path = tmp_path / "test.db"
+        store1, engine1 = await _fresh_store(db_path, tmp_path)
+
+        coll = await store1.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
+        await store1.shutdown()
+        await engine1.dispose()
+
+        # Both generation records lost: the slots may still hold indexes, but
+        # nothing names one, and an unnamed index is not a publication.
+        index_dir = tmp_path / "indexes"
+        records = list(index_dir.glob("*.gen"))
+        assert records
+        for record in records:
+            _delete_file(str(record))
+
+        store2, engine2 = await _fresh_store(db_path, tmp_path)
+        with pytest.raises(IndexLoadError) as exc_info:
+            await store2.open_collection(namespace=NAMESPACE, name=NAME)
         assert exc_info.value.__cause__ is not None
 
         await store2.shutdown()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
@@ -362,6 +362,42 @@ class TestPersistence:
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=3)
         assert {m.key for m in result.matches} == {1, 3}
 
+    @pytest.mark.asyncio
+    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
+        engine = HnswlibVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine.add({1: _normalize([1, 0, 0])})
+
+        path = tmp_path / "test.hnswlib"
+        await engine.save(str(path))
+
+        assert path.exists()
+        assert not (tmp_path / "test.hnswlib.tmp").exists()
+
+    @pytest.mark.asyncio
+    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+        engine = HnswlibVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
+
+        path = tmp_path / "test.hnswlib"
+        await engine.save(str(path))
+
+        # A temp file left behind by a previously interrupted save.
+        stale_temp = tmp_path / "test.hnswlib.tmp"
+        stale_temp.write_text("STALE")
+
+        engine2 = HnswlibVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine2.load(str(path))
+
+        assert not stale_temp.exists()
+        result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
+        assert {m.key for m in result.matches} == {1, 2}
+
 
 # -- allow_replace_deleted=True (slot reclamation) --
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
@@ -21,9 +21,6 @@ from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.vector_store.vector_search_engine.hnswlib_engine import (
     HnswlibVectorSearchEngine,
 )
-from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
-    published_index_path,
-)
 
 NDIM = 3
 
@@ -366,47 +363,38 @@ class TestPersistence:
         assert {m.key for m in result.matches} == {1, 3}
 
     @pytest.mark.asyncio
-    async def test_save_publishes_under_the_base_path(self, tmp_path: Path):
+    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
         engine = HnswlibVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
         await engine.add({1: _normalize([1, 0, 0])})
 
-        base = tmp_path / "test.hnswlib"
-        await engine.save(str(base))
+        path = tmp_path / "test.hnswlib"
+        await engine.save(str(path))
 
-        # The base path is a name, not a file: the engine owns what sits under
-        # it, and something is published there.
-        assert not base.exists()
-        assert published_index_path(str(base)) is not None
+        assert path.exists()
+        assert not (tmp_path / "test.hnswlib.tmp").exists()
 
     @pytest.mark.asyncio
-    async def test_load_without_a_published_index_raises(self, tmp_path: Path):
+    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
         engine = HnswlibVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
+        await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
-        with pytest.raises(OSError, match="No published index"):
-            await engine.load(str(tmp_path / "test.hnswlib"))
+        path = tmp_path / "test.hnswlib"
+        await engine.save(str(path))
 
-    @pytest.mark.asyncio
-    async def test_load_sees_the_latest_checkpoint(self, tmp_path: Path):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
-        base = tmp_path / "test.hnswlib"
-
-        await engine.add({1: _normalize([1, 0, 0])})
-        await engine.save(str(base))
-        # A second checkpoint lands in the other slot; the load must follow it.
-        await engine.add({2: _normalize([0, 1, 0])})
-        await engine.save(str(base))
+        # A temp file left behind by a previously interrupted save.
+        stale_temp = tmp_path / "test.hnswlib.tmp"
+        stale_temp.write_text("STALE")
 
         engine2 = HnswlibVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
-        await engine2.load(str(base))
+        await engine2.load(str(path))
 
+        assert not stale_temp.exists()
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
@@ -21,6 +21,9 @@ from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.vector_store.vector_search_engine.hnswlib_engine import (
     HnswlibVectorSearchEngine,
 )
+from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
+    published_index_path,
+)
 
 NDIM = 3
 
@@ -363,38 +366,47 @@ class TestPersistence:
         assert {m.key for m in result.matches} == {1, 3}
 
     @pytest.mark.asyncio
-    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
+    async def test_save_publishes_under_the_base_path(self, tmp_path: Path):
         engine = HnswlibVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
         await engine.add({1: _normalize([1, 0, 0])})
 
-        path = tmp_path / "test.hnswlib"
-        await engine.save(str(path))
+        base = tmp_path / "test.hnswlib"
+        await engine.save(str(base))
 
-        assert path.exists()
-        assert not (tmp_path / "test.hnswlib.tmp").exists()
+        # The base path is a name, not a file: the engine owns what sits under
+        # it, and something is published there.
+        assert not base.exists()
+        assert published_index_path(str(base)) is not None
 
     @pytest.mark.asyncio
-    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+    async def test_load_without_a_published_index_raises(self, tmp_path: Path):
         engine = HnswlibVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
-        await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
-        path = tmp_path / "test.hnswlib"
-        await engine.save(str(path))
+        with pytest.raises(OSError, match="No published index"):
+            await engine.load(str(tmp_path / "test.hnswlib"))
 
-        # A temp file left behind by a previously interrupted save.
-        stale_temp = tmp_path / "test.hnswlib.tmp"
-        stale_temp.write_text("STALE")
+    @pytest.mark.asyncio
+    async def test_load_sees_the_latest_checkpoint(self, tmp_path: Path):
+        engine = HnswlibVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        base = tmp_path / "test.hnswlib"
+
+        await engine.add({1: _normalize([1, 0, 0])})
+        await engine.save(str(base))
+        # A second checkpoint lands in the other slot; the load must follow it.
+        await engine.add({2: _normalize([0, 1, 0])})
+        await engine.save(str(base))
 
         engine2 = HnswlibVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
-        await engine2.load(str(path))
+        await engine2.load(str(base))
 
-        assert not stale_temp.exists()
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -1,0 +1,97 @@
+"""Tests for the shared atomic index persistence helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
+    atomic_index_write,
+    clear_stale_index_temp,
+)
+
+
+class TestAtomicIndexWrite:
+    def test_swaps_temp_into_place_on_success(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        path.write_text("OLD")
+
+        with atomic_index_write(str(path)) as temp:
+            Path(temp).write_text("NEW")
+            # Until the context exits, the target still holds the old contents.
+            assert path.read_text() == "OLD"
+
+        assert path.read_text() == "NEW"
+        assert not (tmp_path / "index.idx.tmp").exists()
+
+    def test_creates_target_when_missing(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+
+        with atomic_index_write(str(path)) as temp:
+            Path(temp).write_text("NEW")
+
+        assert path.read_text() == "NEW"
+
+    def test_preserves_existing_index_on_failure(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        path.write_text("GOOD")
+
+        def write_then_fail() -> None:
+            with atomic_index_write(str(path)) as temp:
+                Path(temp).write_text("PARTIAL")
+                raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            write_then_fail()
+
+        # The existing index is untouched and the temp file is cleaned up.
+        assert path.read_text() == "GOOD"
+        assert not (tmp_path / "index.idx.tmp").exists()
+
+    def test_does_not_create_target_on_failure(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+
+        def write_then_fail() -> None:
+            with atomic_index_write(str(path)) as temp:
+                Path(temp).write_text("PARTIAL")
+                raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            write_then_fail()
+
+        assert not path.exists()
+        assert not (tmp_path / "index.idx.tmp").exists()
+
+    def test_clears_stale_temp_before_writing(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        # A temp file left by a previously interrupted save.
+        (tmp_path / "index.idx.tmp").write_text("STALE")
+
+        with atomic_index_write(str(path)) as temp:
+            assert not Path(temp).exists()
+            Path(temp).write_text("NEW")
+
+        assert path.read_text() == "NEW"
+
+
+class TestClearStaleIndexTemp:
+    def test_removes_leftover_temp(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        temp = tmp_path / "index.idx.tmp"
+        temp.write_text("STALE")
+
+        clear_stale_index_temp(str(path))
+
+        assert not temp.exists()
+
+    def test_no_temp_is_noop(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        # Must not raise when there is nothing to clear.
+        clear_stale_index_temp(str(path))
+
+    def test_leaves_index_file_untouched(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        path.write_text("GOOD")
+
+        clear_stale_index_temp(str(path))
+
+        assert path.read_text() == "GOOD"

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -1,275 +1,97 @@
-"""
-Tests for crash-safe index publication.
+"""Tests for the shared atomic index persistence helpers."""
 
-The anomaly tests walk the crash points in the publish sequence by constructing
-the on-disk state each one would leave — stricter than killing a process, since
-every state is produced deterministically. The one property construction cannot
-observe is the *ordering* itself: a generation record written before its index
-would satisfy every state-based test here, so
-`test_a_failed_index_write_publishes_nothing` pins it separately.
-"""
-
-import errno
-import os
-import stat
-import struct
-import sys
 from pathlib import Path
 
 import pytest
 
-from memmachine_server.common.vector_store.vector_search_engine import (
-    index_persistence,
-)
 from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
-    index_artifact_paths,
-    publish_index,
-    published_index_path,
+    atomic_index_write,
+    clear_stale_index_temp,
 )
 
-_MASK = 0xFFFFFFFFFFFFFFFF
 
+class TestAtomicIndexWrite:
+    def test_swaps_temp_into_place_on_success(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        path.write_text("OLD")
 
-def _write_index(base: str, contents: str) -> str:
-    """Publish `contents` as the next index generation, returning its slot."""
-    with publish_index(base) as slot:
-        Path(slot).write_text(contents)
-    return slot
+        with atomic_index_write(str(path)) as temp:
+            Path(temp).write_text("NEW")
+            # Until the context exits, the target still holds the old contents.
+            assert path.read_text() == "OLD"
 
+        assert path.read_text() == "NEW"
+        assert not (tmp_path / "index.idx.tmp").exists()
 
-def _record(base: str, slot: int) -> Path:
-    return Path(f"{base}.{slot}.gen")
+    def test_creates_target_when_missing(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
 
+        with atomic_index_write(str(path)) as temp:
+            Path(temp).write_text("NEW")
 
-def _slot(base: str, slot: int) -> Path:
-    return Path(f"{base}.{slot}")
+        assert path.read_text() == "NEW"
 
+    def test_preserves_existing_index_on_failure(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        path.write_text("GOOD")
 
-def _generation(base: str, slot: int) -> int | None:
-    """The generation stored in a record, ignoring the complement check."""
-    data = _record(base, slot).read_bytes()
-    if len(data) != 16:
-        return None
-    return struct.unpack("<QQ", data)[0]
-
-
-class TestPublish:
-    def test_nothing_is_published_before_the_first_save(self, tmp_path: Path):
-        assert published_index_path(str(tmp_path / "index.idx")) is None
-
-    def test_publishes_and_reads_back(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-
-        _write_index(base, "FIRST")
-
-        published = published_index_path(base)
-        assert published is not None
-        assert Path(published).read_text() == "FIRST"
-
-    def test_alternates_slots_across_checkpoints(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-
-        first = _write_index(base, "FIRST")
-        second = _write_index(base, "SECOND")
-        third = _write_index(base, "THIRD")
-
-        assert first != second
-        assert third == first
-        published = published_index_path(base)
-        assert published is not None
-        assert Path(published).read_text() == "THIRD"
-
-    def test_empties_the_retired_slot(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-
-        retired = _write_index(base, "FIRST")
-        _write_index(base, "SECOND")
-
-        # The spare costs no disk at rest, and its record no longer publishes.
-        assert Path(retired).stat().st_size == 0
-        retired_slot = int(retired[-1])
-        assert _record(base, retired_slot).stat().st_size == 0
-
-    def test_creates_its_files_once(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-
-        _write_index(base, "FIRST")
-
-        assert sorted(p.name for p in tmp_path.iterdir()) == sorted(
-            p.name for p in index_artifact_paths(base)
-        )
-
-
-class TestCrashPoints:
-    def test_a_torn_index_write_is_invisible(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-        _write_index(base, "GOOD")
-        live = published_index_path(base)
-        assert live is not None
-
-        # Crash during step 1: the damaged file is the slot nobody reads.
-        free = 1 - int(live[-1])
-        _slot(base, free).write_text("HALF-WRITTEN")
-
-        assert published_index_path(base) == live
-        assert Path(live).read_text() == "GOOD"
-
-    def test_an_unpublished_index_is_invisible(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-        _write_index(base, "GOOD")
-        live = published_index_path(base)
-        assert live is not None
-
-        # Crash between steps 1 and 2: a complete new index that nothing named.
-        free = 1 - int(live[-1])
-        _slot(base, free).write_text("COMPLETE BUT UNPUBLISHED")
-
-        assert published_index_path(base) == live
-
-    def test_a_torn_record_reads_as_absent(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-        _write_index(base, "GOOD")
-        live = published_index_path(base)
-        assert live is not None
-        live_slot = int(live[-1])
-        free = 1 - live_slot
-
-        # Crash during step 2: halves from different writes. The higher
-        # generation is present but unbelievable, so the live slot still wins.
-        _slot(base, free).write_text("NEWER")
-        torn = struct.pack("<QQ", 2, 1 ^ _MASK)
-        _record(base, free).write_bytes(torn)
-
-        assert published_index_path(base) == live
-        assert Path(live).read_text() == "GOOD"
-
-    def test_a_short_record_reads_as_absent(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-        _write_index(base, "GOOD")
-        live = published_index_path(base)
-        assert live is not None
-        free = 1 - int(live[-1])
-
-        _slot(base, free).write_text("NEWER")
-        _record(base, free).write_bytes(struct.pack("<Q", 2))
-
-        assert published_index_path(base) == live
-
-    def test_the_higher_generation_wins(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-        first = _write_index(base, "FIRST")
-        second = _write_index(base, "SECOND")
-
-        # Crash between steps 2 and 3: both records valid, retired not yet
-        # emptied. Reconstruct that state by republishing the older record.
-        first_slot = int(first[-1])
-        _slot(base, first_slot).write_text("FIRST")
-        _record(base, first_slot).write_bytes(struct.pack("<QQ", 1, 1 ^ _MASK))
-
-        assert _generation(base, first_slot) == 1
-        assert published_index_path(base) == second
-
-    def test_a_failed_index_write_publishes_nothing(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
-        _write_index(base, "GOOD")
-        live = published_index_path(base)
-        assert live is not None
-
-        # The ordering itself: no state-based test can see a record written
-        # before its index, because the end state is identical either way.
         def write_then_fail() -> None:
-            with publish_index(base) as slot:
-                Path(slot).write_text("PARTIAL")
-                raise RuntimeError("engine exploded")
+            with atomic_index_write(str(path)) as temp:
+                Path(temp).write_text("PARTIAL")
+                raise RuntimeError("boom")
 
-        with pytest.raises(RuntimeError, match="engine exploded"):
+        with pytest.raises(RuntimeError, match="boom"):
             write_then_fail()
 
-        assert published_index_path(base) == live
-        assert Path(live).read_text() == "GOOD"
+        # The existing index is untouched and the temp file is cleaned up.
+        assert path.read_text() == "GOOD"
+        assert not (tmp_path / "index.idx.tmp").exists()
 
-    def test_a_failed_flush_publishes_nothing(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        base = str(tmp_path / "index.idx")
-        _write_index(base, "GOOD")
-        live = published_index_path(base)
-        assert live is not None
-
-        def fail(_fd: int) -> None:
-            raise OSError(errno.EIO, "Input/output error")
-
-        monkeypatch.setattr(index_persistence, "_fsync", fail)
-
-        # A flush that fails must fail the save: the caller trims its log on the
-        # strength of it, and EIO means the writeback already failed.
-        def write_index() -> None:
-            with publish_index(base) as slot:
-                Path(slot).write_text("NEWER")
-
-        with pytest.raises(OSError, match="Input/output error"):
-            write_index()
-
-        assert published_index_path(base) == live
-
-
-class TestDurability:
-    def test_flushes_the_index_before_the_record(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        base = str(tmp_path / "index.idx")
-        real_fsync = index_persistence._fsync
-        flushed: list[str] = []
-
-        def record(fd: int) -> None:
-            mode = os.fstat(fd).st_mode
-            flushed.append("dir" if stat.S_ISDIR(mode) else f"{os.fstat(fd).st_size}")
-            real_fsync(fd)
-
-        monkeypatch.setattr(index_persistence, "_fsync", record)
-
-        _write_index(base, "FIRST")
-
-        # A one-time parent flush for the created files (POSIX only), then the
-        # index, then the 16-byte record that publishes it.
-        assert flushed[-2:] == ["5", "16"]
-        if os.name != "nt":
-            assert flushed[0] == "dir"
-
-    @pytest.mark.skipif(
-        sys.platform != "darwin", reason="F_FULLFSYNC only exists on macOS"
-    )
-    def test_falls_back_when_full_fsync_is_unsupported(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ):
-        fcntl = pytest.importorskip("fcntl")
-        calls: list[str] = []
-
-        def unsupported(_fd: int, _cmd: int) -> None:
-            calls.append("full_fsync")
-            raise OSError(errno.ENOTSUP, "Operation not supported")
-
-        monkeypatch.setattr(fcntl, "fcntl", unsupported)
-        monkeypatch.setattr(os, "fsync", lambda fd: calls.append("fsync"))
-
+    def test_does_not_create_target_on_failure(self, tmp_path: Path):
         path = tmp_path / "index.idx"
-        path.write_text("DATA")
-        fd = os.open(str(path), os.O_RDWR)
-        try:
-            index_persistence._fsync(fd)
-        finally:
-            os.close(fd)
 
-        assert calls == ["full_fsync", "fsync"]
+        def write_then_fail() -> None:
+            with atomic_index_write(str(path)) as temp:
+                Path(temp).write_text("PARTIAL")
+                raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            write_then_fail()
+
+        assert not path.exists()
+        assert not (tmp_path / "index.idx.tmp").exists()
+
+    def test_clears_stale_temp_before_writing(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        # A temp file left by a previously interrupted save.
+        (tmp_path / "index.idx.tmp").write_text("STALE")
+
+        with atomic_index_write(str(path)) as temp:
+            assert not Path(temp).exists()
+            Path(temp).write_text("NEW")
+
+        assert path.read_text() == "NEW"
 
 
-class TestIndexArtifactPaths:
-    def test_lists_every_file_the_base_expands_into(self, tmp_path: Path):
-        base = str(tmp_path / "index.idx")
+class TestClearStaleIndexTemp:
+    def test_removes_leftover_temp(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        temp = tmp_path / "index.idx.tmp"
+        temp.write_text("STALE")
 
-        assert sorted(p.name for p in index_artifact_paths(base)) == [
-            "index.idx.0",
-            "index.idx.0.gen",
-            "index.idx.1",
-            "index.idx.1.gen",
-        ]
+        clear_stale_index_temp(str(path))
+
+        assert not temp.exists()
+
+    def test_no_temp_is_noop(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        # Must not raise when there is nothing to clear.
+        clear_stale_index_temp(str(path))
+
+    def test_leaves_index_file_untouched(self, tmp_path: Path):
+        path = tmp_path / "index.idx"
+        path.write_text("GOOD")
+
+        clear_stale_index_temp(str(path))
+
+        assert path.read_text() == "GOOD"

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -1,9 +1,16 @@
 """Tests for the shared atomic index persistence helpers."""
 
+import errno
+import os
+import stat
+import sys
 from pathlib import Path
 
 import pytest
 
+from memmachine_server.common.vector_store.vector_search_engine import (
+    index_persistence,
+)
 from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
     atomic_index_write,
     clear_stale_index_temp,
@@ -71,6 +78,103 @@ class TestAtomicIndexWrite:
             Path(temp).write_text("NEW")
 
         assert path.read_text() == "NEW"
+
+
+class TestDurability:
+    def test_flushes_the_file_then_the_parent_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        real_fsync = index_persistence._fsync
+        # True for a directory fd, False for a regular file.
+        flushed: list[bool] = []
+
+        def record(fd: int) -> None:
+            flushed.append(stat.S_ISDIR(os.fstat(fd).st_mode))
+            real_fsync(fd)
+
+        monkeypatch.setattr(index_persistence, "_fsync", record)
+
+        path = tmp_path / "index.idx"
+        with atomic_index_write(str(path)) as temp:
+            Path(temp).write_text("NEW")
+
+        if os.name == "nt":
+            # Windows cannot open a directory to flush it; the swap's
+            # durability follows NTFS metadata journaling instead.
+            assert flushed == [False]
+        else:
+            # The bytes first, then the directory entry the swap created.
+            assert flushed == [False, True]
+
+    def test_file_flush_failure_fails_the_save(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        def fail(fd: int) -> None:
+            raise OSError(errno.EIO, "Input/output error")
+
+        monkeypatch.setattr(index_persistence, "_fsync", fail)
+
+        path = tmp_path / "index.idx"
+        path.write_text("GOOD")
+
+        def write_index() -> None:
+            with atomic_index_write(str(path)) as temp:
+                Path(temp).write_text("NEW")
+
+        # Reported as a failure rather than swallowed: the caller trims its
+        # pending log on the strength of this save.
+        with pytest.raises(OSError, match="Input/output error"):
+            write_index()
+
+        assert path.read_text() == "GOOD"
+        assert not (tmp_path / "index.idx.tmp").exists()
+
+    def test_parent_directory_flush_failure_is_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        real_fsync = index_persistence._fsync
+
+        def fail_for_directories(fd: int) -> None:
+            if stat.S_ISDIR(os.fstat(fd).st_mode):
+                raise OSError(errno.EINVAL, "Invalid argument")
+            real_fsync(fd)
+
+        monkeypatch.setattr(index_persistence, "_fsync", fail_for_directories)
+
+        path = tmp_path / "index.idx"
+        # Filesystems that refuse a directory fsync must not fail every save.
+        with atomic_index_write(str(path)) as temp:
+            Path(temp).write_text("NEW")
+
+        assert path.read_text() == "NEW"
+
+
+class TestFsync:
+    @pytest.mark.skipif(
+        sys.platform != "darwin", reason="F_FULLFSYNC only exists on macOS"
+    )
+    def test_falls_back_when_full_fsync_is_unsupported(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        fcntl = pytest.importorskip("fcntl")
+        calls: list[str] = []
+
+        def unsupported(_fd: int, _cmd: int) -> None:
+            calls.append("full_fsync")
+            raise OSError(errno.ENOTSUP, "Operation not supported")
+
+        monkeypatch.setattr(fcntl, "fcntl", unsupported)
+        monkeypatch.setattr(os, "fsync", lambda fd: calls.append("fsync"))
+
+        path = tmp_path / "index.idx"
+        path.write_text("DATA")
+        fd = os.open(str(path), os.O_RDWR)
+        try:
+            index_persistence._fsync(fd)
+        finally:
+            os.close(fd)
+
+        assert calls == ["full_fsync", "fsync"]
 
 
 class TestClearStaleIndexTemp:

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -1,8 +1,18 @@
-"""Tests for the shared atomic index persistence helpers."""
+"""
+Tests for crash-safe index publication.
+
+The anomaly tests walk the crash points in the publish sequence by constructing
+the on-disk state each one would leave — stricter than killing a process, since
+every state is produced deterministically. The one property construction cannot
+observe is the *ordering* itself: a generation record written before its index
+would satisfy every state-based test here, so
+`test_a_failed_index_write_publishes_nothing` pins it separately.
+"""
 
 import errno
 import os
 import stat
+import struct
 import sys
 from pathlib import Path
 
@@ -12,144 +22,220 @@ from memmachine_server.common.vector_store.vector_search_engine import (
     index_persistence,
 )
 from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
-    atomic_index_write,
-    clear_stale_index_temp,
+    index_artifact_paths,
+    publish_index,
+    published_index_path,
 )
 
+_MASK = 0xFFFFFFFFFFFFFFFF
 
-class TestAtomicIndexWrite:
-    def test_swaps_temp_into_place_on_success(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-        path.write_text("OLD")
 
-        with atomic_index_write(str(path)) as temp:
-            Path(temp).write_text("NEW")
-            # Until the context exits, the target still holds the old contents.
-            assert path.read_text() == "OLD"
+def _write_index(base: str, contents: str) -> str:
+    """Publish `contents` as the next index generation, returning its slot."""
+    with publish_index(base) as slot:
+        Path(slot).write_text(contents)
+    return slot
 
-        assert path.read_text() == "NEW"
-        assert not (tmp_path / "index.idx.tmp").exists()
 
-    def test_creates_target_when_missing(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
+def _record(base: str, slot: int) -> Path:
+    return Path(f"{base}.{slot}.gen")
 
-        with atomic_index_write(str(path)) as temp:
-            Path(temp).write_text("NEW")
 
-        assert path.read_text() == "NEW"
+def _slot(base: str, slot: int) -> Path:
+    return Path(f"{base}.{slot}")
 
-    def test_preserves_existing_index_on_failure(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-        path.write_text("GOOD")
 
+def _generation(base: str, slot: int) -> int | None:
+    """The generation stored in a record, ignoring the complement check."""
+    data = _record(base, slot).read_bytes()
+    if len(data) != 16:
+        return None
+    return struct.unpack("<QQ", data)[0]
+
+
+class TestPublish:
+    def test_nothing_is_published_before_the_first_save(self, tmp_path: Path):
+        assert published_index_path(str(tmp_path / "index.idx")) is None
+
+    def test_publishes_and_reads_back(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+
+        _write_index(base, "FIRST")
+
+        published = published_index_path(base)
+        assert published is not None
+        assert Path(published).read_text() == "FIRST"
+
+    def test_alternates_slots_across_checkpoints(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+
+        first = _write_index(base, "FIRST")
+        second = _write_index(base, "SECOND")
+        third = _write_index(base, "THIRD")
+
+        assert first != second
+        assert third == first
+        published = published_index_path(base)
+        assert published is not None
+        assert Path(published).read_text() == "THIRD"
+
+    def test_empties_the_retired_slot(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+
+        retired = _write_index(base, "FIRST")
+        _write_index(base, "SECOND")
+
+        # The spare costs no disk at rest, and its record no longer publishes.
+        assert Path(retired).stat().st_size == 0
+        retired_slot = int(retired[-1])
+        assert _record(base, retired_slot).stat().st_size == 0
+
+    def test_creates_its_files_once(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+
+        _write_index(base, "FIRST")
+
+        assert sorted(p.name for p in tmp_path.iterdir()) == sorted(
+            p.name for p in index_artifact_paths(base)
+        )
+
+
+class TestCrashPoints:
+    def test_a_torn_index_write_is_invisible(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+        _write_index(base, "GOOD")
+        live = published_index_path(base)
+        assert live is not None
+
+        # Crash during step 1: the damaged file is the slot nobody reads.
+        free = 1 - int(live[-1])
+        _slot(base, free).write_text("HALF-WRITTEN")
+
+        assert published_index_path(base) == live
+        assert Path(live).read_text() == "GOOD"
+
+    def test_an_unpublished_index_is_invisible(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+        _write_index(base, "GOOD")
+        live = published_index_path(base)
+        assert live is not None
+
+        # Crash between steps 1 and 2: a complete new index that nothing named.
+        free = 1 - int(live[-1])
+        _slot(base, free).write_text("COMPLETE BUT UNPUBLISHED")
+
+        assert published_index_path(base) == live
+
+    def test_a_torn_record_reads_as_absent(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+        _write_index(base, "GOOD")
+        live = published_index_path(base)
+        assert live is not None
+        live_slot = int(live[-1])
+        free = 1 - live_slot
+
+        # Crash during step 2: halves from different writes. The higher
+        # generation is present but unbelievable, so the live slot still wins.
+        _slot(base, free).write_text("NEWER")
+        torn = struct.pack("<QQ", 2, 1 ^ _MASK)
+        _record(base, free).write_bytes(torn)
+
+        assert published_index_path(base) == live
+        assert Path(live).read_text() == "GOOD"
+
+    def test_a_short_record_reads_as_absent(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+        _write_index(base, "GOOD")
+        live = published_index_path(base)
+        assert live is not None
+        free = 1 - int(live[-1])
+
+        _slot(base, free).write_text("NEWER")
+        _record(base, free).write_bytes(struct.pack("<Q", 2))
+
+        assert published_index_path(base) == live
+
+    def test_the_higher_generation_wins(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+        first = _write_index(base, "FIRST")
+        second = _write_index(base, "SECOND")
+
+        # Crash between steps 2 and 3: both records valid, retired not yet
+        # emptied. Reconstruct that state by republishing the older record.
+        first_slot = int(first[-1])
+        _slot(base, first_slot).write_text("FIRST")
+        _record(base, first_slot).write_bytes(struct.pack("<QQ", 1, 1 ^ _MASK))
+
+        assert _generation(base, first_slot) == 1
+        assert published_index_path(base) == second
+
+    def test_a_failed_index_write_publishes_nothing(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
+        _write_index(base, "GOOD")
+        live = published_index_path(base)
+        assert live is not None
+
+        # The ordering itself: no state-based test can see a record written
+        # before its index, because the end state is identical either way.
         def write_then_fail() -> None:
-            with atomic_index_write(str(path)) as temp:
-                Path(temp).write_text("PARTIAL")
-                raise RuntimeError("boom")
+            with publish_index(base) as slot:
+                Path(slot).write_text("PARTIAL")
+                raise RuntimeError("engine exploded")
 
-        with pytest.raises(RuntimeError, match="boom"):
+        with pytest.raises(RuntimeError, match="engine exploded"):
             write_then_fail()
 
-        # The existing index is untouched and the temp file is cleaned up.
-        assert path.read_text() == "GOOD"
-        assert not (tmp_path / "index.idx.tmp").exists()
+        assert published_index_path(base) == live
+        assert Path(live).read_text() == "GOOD"
 
-    def test_does_not_create_target_on_failure(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-
-        def write_then_fail() -> None:
-            with atomic_index_write(str(path)) as temp:
-                Path(temp).write_text("PARTIAL")
-                raise RuntimeError("boom")
-
-        with pytest.raises(RuntimeError):
-            write_then_fail()
-
-        assert not path.exists()
-        assert not (tmp_path / "index.idx.tmp").exists()
-
-    def test_clears_stale_temp_before_writing(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-        # A temp file left by a previously interrupted save.
-        (tmp_path / "index.idx.tmp").write_text("STALE")
-
-        with atomic_index_write(str(path)) as temp:
-            assert not Path(temp).exists()
-            Path(temp).write_text("NEW")
-
-        assert path.read_text() == "NEW"
-
-
-class TestDurability:
-    def test_flushes_the_file_then_the_parent_directory(
+    def test_a_failed_flush_publishes_nothing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
-        real_fsync = index_persistence._fsync
-        # True for a directory fd, False for a regular file.
-        flushed: list[bool] = []
+        base = str(tmp_path / "index.idx")
+        _write_index(base, "GOOD")
+        live = published_index_path(base)
+        assert live is not None
 
-        def record(fd: int) -> None:
-            flushed.append(stat.S_ISDIR(os.fstat(fd).st_mode))
-            real_fsync(fd)
-
-        monkeypatch.setattr(index_persistence, "_fsync", record)
-
-        path = tmp_path / "index.idx"
-        with atomic_index_write(str(path)) as temp:
-            Path(temp).write_text("NEW")
-
-        if os.name == "nt":
-            # Windows cannot open a directory to flush it; the swap's
-            # durability follows NTFS metadata journaling instead.
-            assert flushed == [False]
-        else:
-            # The bytes first, then the directory entry the swap created.
-            assert flushed == [False, True]
-
-    def test_file_flush_failure_fails_the_save(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        def fail(fd: int) -> None:
+        def fail(_fd: int) -> None:
             raise OSError(errno.EIO, "Input/output error")
 
         monkeypatch.setattr(index_persistence, "_fsync", fail)
 
-        path = tmp_path / "index.idx"
-        path.write_text("GOOD")
-
+        # A flush that fails must fail the save: the caller trims its log on the
+        # strength of it, and EIO means the writeback already failed.
         def write_index() -> None:
-            with atomic_index_write(str(path)) as temp:
-                Path(temp).write_text("NEW")
+            with publish_index(base) as slot:
+                Path(slot).write_text("NEWER")
 
-        # Reported as a failure rather than swallowed: the caller trims its
-        # pending log on the strength of this save.
         with pytest.raises(OSError, match="Input/output error"):
             write_index()
 
-        assert path.read_text() == "GOOD"
-        assert not (tmp_path / "index.idx.tmp").exists()
+        assert published_index_path(base) == live
 
-    def test_parent_directory_flush_failure_is_ignored(
+
+class TestDurability:
+    def test_flushes_the_index_before_the_record(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
+        base = str(tmp_path / "index.idx")
         real_fsync = index_persistence._fsync
+        flushed: list[str] = []
 
-        def fail_for_directories(fd: int) -> None:
-            if stat.S_ISDIR(os.fstat(fd).st_mode):
-                raise OSError(errno.EINVAL, "Invalid argument")
+        def record(fd: int) -> None:
+            mode = os.fstat(fd).st_mode
+            flushed.append("dir" if stat.S_ISDIR(mode) else f"{os.fstat(fd).st_size}")
             real_fsync(fd)
 
-        monkeypatch.setattr(index_persistence, "_fsync", fail_for_directories)
+        monkeypatch.setattr(index_persistence, "_fsync", record)
 
-        path = tmp_path / "index.idx"
-        # Filesystems that refuse a directory fsync must not fail every save.
-        with atomic_index_write(str(path)) as temp:
-            Path(temp).write_text("NEW")
+        _write_index(base, "FIRST")
 
-        assert path.read_text() == "NEW"
+        # A one-time parent flush for the created files (POSIX only), then the
+        # index, then the 16-byte record that publishes it.
+        assert flushed[-2:] == ["5", "16"]
+        if os.name != "nt":
+            assert flushed[0] == "dir"
 
-
-class TestFsync:
     @pytest.mark.skipif(
         sys.platform != "darwin", reason="F_FULLFSYNC only exists on macOS"
     )
@@ -177,25 +263,13 @@ class TestFsync:
         assert calls == ["full_fsync", "fsync"]
 
 
-class TestClearStaleIndexTemp:
-    def test_removes_leftover_temp(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-        temp = tmp_path / "index.idx.tmp"
-        temp.write_text("STALE")
+class TestIndexArtifactPaths:
+    def test_lists_every_file_the_base_expands_into(self, tmp_path: Path):
+        base = str(tmp_path / "index.idx")
 
-        clear_stale_index_temp(str(path))
-
-        assert not temp.exists()
-
-    def test_no_temp_is_noop(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-        # Must not raise when there is nothing to clear.
-        clear_stale_index_temp(str(path))
-
-    def test_leaves_index_file_untouched(self, tmp_path: Path):
-        path = tmp_path / "index.idx"
-        path.write_text("GOOD")
-
-        clear_stale_index_temp(str(path))
-
-        assert path.read_text() == "GOOD"
+        assert sorted(p.name for p in index_artifact_paths(base)) == [
+            "index.idx.0",
+            "index.idx.0.gen",
+            "index.idx.1",
+            "index.idx.1.gen",
+        ]

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -68,7 +68,9 @@ class TestAtomicIndexWrite:
         (tmp_path / "index.idx.tmp").write_text("STALE")
 
         with atomic_index_write(str(path)) as temp:
-            assert not Path(temp).exists()
+            # The temp is opened for the caller to write into, so what matters
+            # is that none of the stale content survived into it.
+            assert Path(temp).read_text() == ""
             Path(temp).write_text("NEW")
 
         assert path.read_text() == "NEW"
@@ -114,6 +116,32 @@ class TestFlushFailsTheSave:
             atomic_index_write(str(target)) as temp,
         ):
             Path(temp).write_bytes(b"new")
+
+        assert target.read_bytes() == b"old"
+        assert not Path(f"{target}.tmp").exists()
+
+
+class TestFlushGuards:
+    def test_a_writer_that_replaces_the_file_fails_the_save(self, tmp_path: Path):
+        """Holding a descriptor across the write assumes the write is in place.
+
+        A caller that builds its own file and renames it over the temp leaves
+        the held descriptor on an orphaned inode, so the fsync would report on
+        a file nobody is about to publish. That must fail the save, not pass it.
+        """
+        target = tmp_path / "index.idx"
+        target.write_bytes(b"old")
+
+        def replace_the_temp_instead_of_writing_it(temp: str) -> None:
+            sneaky = tmp_path / "elsewhere"
+            sneaky.write_bytes(b"new")
+            sneaky.replace(temp)
+
+        with (
+            pytest.raises(OSError, match="replaced while it was being written"),
+            atomic_index_write(str(target)) as temp,
+        ):
+            replace_the_temp_instead_of_writing_it(temp)
 
         assert target.read_bytes() == b"old"
         assert not Path(f"{target}.tmp").exists()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -1,5 +1,6 @@
 """Tests for the shared atomic index persistence helpers."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -95,3 +96,24 @@ class TestClearStaleIndexTemp:
         clear_stale_index_temp(str(path))
 
         assert path.read_text() == "GOOD"
+
+
+class TestFlushFailsTheSave:
+    def test_failed_fsync_leaves_the_previous_index(self, tmp_path: Path, monkeypatch):
+        """An fsync that fails must not publish; it is evidence the bytes are bad."""
+        target = tmp_path / "index.idx"
+        target.write_bytes(b"old")
+
+        def failing_fsync(fd: int) -> None:
+            raise OSError(5, "Input/output error")
+
+        monkeypatch.setattr(os, "fsync", failing_fsync)
+
+        with (
+            pytest.raises(OSError, match="Input/output error"),
+            atomic_index_write(str(target)) as temp,
+        ):
+            Path(temp).write_bytes(b"new")
+
+        assert target.read_bytes() == b"old"
+        assert not Path(f"{target}.tmp").exists()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -1,7 +1,5 @@
 """Tests for the shared atomic index persistence helpers."""
 
-import os
-import sys
 from pathlib import Path
 
 import pytest
@@ -151,23 +149,3 @@ class TestFlushGuards:
 
         assert target.read_bytes() == b"old"
         assert not Path(f"{target}.tmp").exists()
-
-
-class TestFsyncFallback:
-    @pytest.mark.skipif(sys.platform != "darwin", reason="F_FULLFSYNC is Darwin-only")
-    def test_a_refused_full_fsync_falls_back(self):
-        """A descriptor that cannot take F_FULLFSYNC is still flushed.
-
-        `/dev/null` refuses it with ENODEV while accepting `fsync`, which is a
-        real instance of the case the fallback exists for -- and one an errno
-        allowlist would have to know about in advance to get right.
-        """
-        import fcntl
-
-        fd = os.open(os.devnull, os.O_RDWR)
-        try:
-            with pytest.raises(OSError, match="not supported by device"):
-                fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
-            index_persistence._fsync(fd)
-        finally:
-            os.close(fd)

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -1,10 +1,12 @@
 """Tests for the shared atomic index persistence helpers."""
 
-import os
 from pathlib import Path
 
 import pytest
 
+from memmachine_server.common.vector_store.vector_search_engine import (
+    index_persistence,
+)
 from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
     atomic_index_write,
     clear_stale_index_temp,
@@ -109,7 +111,9 @@ class TestFlushFailsTheSave:
         def failing_fsync(fd: int) -> None:
             raise OSError(5, "Input/output error")
 
-        monkeypatch.setattr(os, "fsync", failing_fsync)
+        # Patched at the module's own flush, which is what every platform
+        # reaches; `os.fsync` is not it on Darwin.
+        monkeypatch.setattr(index_persistence, "_fsync", failing_fsync)
 
         with (
             pytest.raises(OSError, match="Input/output error"),

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_index_persistence.py
@@ -1,5 +1,7 @@
 """Tests for the shared atomic index persistence helpers."""
 
+import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -149,3 +151,23 @@ class TestFlushGuards:
 
         assert target.read_bytes() == b"old"
         assert not Path(f"{target}.tmp").exists()
+
+
+class TestFsyncFallback:
+    @pytest.mark.skipif(sys.platform != "darwin", reason="F_FULLFSYNC is Darwin-only")
+    def test_a_refused_full_fsync_falls_back(self):
+        """A descriptor that cannot take F_FULLFSYNC is still flushed.
+
+        `/dev/null` refuses it with ENODEV while accepting `fsync`, which is a
+        real instance of the case the fallback exists for -- and one an errno
+        allowlist would have to know about in advance to get right.
+        """
+        import fcntl
+
+        fd = os.open(os.devnull, os.O_RDWR)
+        try:
+            with pytest.raises(OSError, match="not supported by device"):
+                fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
+            index_persistence._fsync(fd)
+        finally:
+            os.close(fd)

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
@@ -296,6 +296,42 @@ class TestPersistence:
         assert result.matches[0].key == 1
         assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
 
+    @pytest.mark.asyncio
+    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
+        engine = USearchVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine.add({1: _normalize([1, 0, 0])})
+
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
+
+        assert path.exists()
+        assert not (tmp_path / "test.idx.tmp").exists()
+
+    @pytest.mark.asyncio
+    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+        engine = USearchVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
+
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
+
+        # A temp file left behind by a previously interrupted save.
+        stale_temp = tmp_path / "test.idx.tmp"
+        stale_temp.write_text("STALE")
+
+        engine2 = USearchVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine2.load(str(path))
+
+        assert not stale_temp.exists()
+        result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
+        assert {m.key for m in result.matches} == {1, 2}
+
 
 # -- SearchResult types --
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
@@ -6,9 +6,6 @@ from pathlib import Path
 import pytest
 
 from memmachine_server.common.data_types import SimilarityMetric
-from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
-    published_index_path,
-)
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
 )
@@ -300,47 +297,38 @@ class TestPersistence:
         assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
-    async def test_save_publishes_under_the_base_path(self, tmp_path: Path):
+    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
         engine = USearchVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
         await engine.add({1: _normalize([1, 0, 0])})
 
-        base = tmp_path / "test.idx"
-        await engine.save(str(base))
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
 
-        # The base path is a name, not a file: the engine owns what sits under
-        # it, and something is published there.
-        assert not base.exists()
-        assert published_index_path(str(base)) is not None
+        assert path.exists()
+        assert not (tmp_path / "test.idx.tmp").exists()
 
     @pytest.mark.asyncio
-    async def test_load_without_a_published_index_raises(self, tmp_path: Path):
+    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
         engine = USearchVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
+        await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
-        with pytest.raises(OSError, match="No published index"):
-            await engine.load(str(tmp_path / "test.idx"))
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
 
-    @pytest.mark.asyncio
-    async def test_load_sees_the_latest_checkpoint(self, tmp_path: Path):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
-        base = tmp_path / "test.idx"
-
-        await engine.add({1: _normalize([1, 0, 0])})
-        await engine.save(str(base))
-        # A second checkpoint lands in the other slot; the load must follow it.
-        await engine.add({2: _normalize([0, 1, 0])})
-        await engine.save(str(base))
+        # A temp file left behind by a previously interrupted save.
+        stale_temp = tmp_path / "test.idx.tmp"
+        stale_temp.write_text("STALE")
 
         engine2 = USearchVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
-        await engine2.load(str(base))
+        await engine2.load(str(path))
 
+        assert not stale_temp.exists()
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
@@ -6,6 +6,9 @@ from pathlib import Path
 import pytest
 
 from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.vector_store.vector_search_engine.index_persistence import (
+    published_index_path,
+)
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
 )
@@ -297,38 +300,47 @@ class TestPersistence:
         assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
-    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
+    async def test_save_publishes_under_the_base_path(self, tmp_path: Path):
         engine = USearchVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
         await engine.add({1: _normalize([1, 0, 0])})
 
-        path = tmp_path / "test.idx"
-        await engine.save(str(path))
+        base = tmp_path / "test.idx"
+        await engine.save(str(base))
 
-        assert path.exists()
-        assert not (tmp_path / "test.idx.tmp").exists()
+        # The base path is a name, not a file: the engine owns what sits under
+        # it, and something is published there.
+        assert not base.exists()
+        assert published_index_path(str(base)) is not None
 
     @pytest.mark.asyncio
-    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+    async def test_load_without_a_published_index_raises(self, tmp_path: Path):
         engine = USearchVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
-        await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
-        path = tmp_path / "test.idx"
-        await engine.save(str(path))
+        with pytest.raises(OSError, match="No published index"):
+            await engine.load(str(tmp_path / "test.idx"))
 
-        # A temp file left behind by a previously interrupted save.
-        stale_temp = tmp_path / "test.idx.tmp"
-        stale_temp.write_text("STALE")
+    @pytest.mark.asyncio
+    async def test_load_sees_the_latest_checkpoint(self, tmp_path: Path):
+        engine = USearchVectorSearchEngine(
+            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
+        )
+        base = tmp_path / "test.idx"
+
+        await engine.add({1: _normalize([1, 0, 0])})
+        await engine.save(str(base))
+        # A second checkpoint lands in the other slot; the load must follow it.
+        await engine.add({2: _normalize([0, 1, 0])})
+        await engine.save(str(base))
 
         engine2 = USearchVectorSearchEngine(
             num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
         )
-        await engine2.load(str(path))
+        await engine2.load(str(base))
 
-        assert not stale_temp.exists()
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
 

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -4,6 +4,23 @@ Vector store backed by SQLite + pluggable vector search engine.
 Each logical collection gets its own records table and vector search engine.
 A pending operations table tracks search engine operations for crash recovery:
 on startup, unfinalized operations are replayed.
+
+What survives a crash
+---------------------
+
+`upsert` and `delete` commit to SQLite before they return, so a process crash
+loses nothing: the pending log carries every operation the search engine has
+not been checkpointed with, and startup replays it.
+
+A power failure is weaker, and callers should size their expectations to it.
+The index is published atomically but not durably (see
+`vector_search_engine.index_persistence`), so a power failure can revert the
+last publication while the records table -- and the trim that ran behind that
+publication -- stay committed. The result is records whose vectors are missing
+from the index: `get` still returns them, `query` cannot find them, and
+re-upserting them is the repair. Callers that need every record searchable
+after a power failure must be able to re-ingest; nothing here detects the gap
+for them.
 """
 
 import logging
@@ -59,17 +76,16 @@ from .data_types import (
 )
 from .utils import validate_filter, validate_identifier
 from .vector_search_engine import VectorSearchEngine
-from .vector_search_engine.index_persistence import index_artifact_paths
 from .vector_store import VectorStore, VectorStoreCollection
 
 logger = logging.getLogger(__name__)
 
 
 class IndexLoadError(RuntimeError):
-    """Raised when a collection's on-disk index cannot be loaded."""
+    """Raised when a collection's on-disk index file cannot be loaded."""
 
     def __init__(self, namespace: str, name: str, path: Path) -> None:
-        """Initialize with the collection namespace, name, and index base path."""
+        """Initialize with the collection namespace, name, and index file path."""
         self.namespace = namespace
         self.name = name
         self.path = path
@@ -91,10 +107,9 @@ class _CollectionRow(BaseSQLiteVectorStore):
     config_json: MappedColumn[dict[str, JsonValue]] = mapped_column(
         JSON, nullable=False
     )
-    # Flips to True after the first successful index save. Bookkeeping about the
-    # collection's own lifecycle rather than the engine's layout: once True, an
-    # engine reporting nothing published is a fault to raise on, not an empty
-    # collection to serve.
+    # Flips to True after the first successful index save.
+    # Once True, the on-disk index file is part of the durable contract:
+    # missing or corrupt is treated as an error rather than silently rebuilt empty.
     index_saved: MappedColumn[bool] = mapped_column(
         Boolean, nullable=False, default=False
     )
@@ -142,13 +157,16 @@ async def _save_collection_index(
     search_engine: VectorSearchEngine,
     path: str,
 ) -> None:
-    """Save a collection's index to disk."""
-    # The one rule this checkpoint rests on: never trim the log past what the
-    # engine says is durable. `save` returning is that statement — a later
-    # `load` produces this index even if the machine loses power on the next
-    # instruction — so these two steps need no shared transaction, only this
-    # order. A crash between them costs a replay of operations the index
-    # already holds, and replay is idempotent.
+    """Publish a collection's index to disk and trim the operations it holds.
+
+    The order is the whole protocol. The pending log is the only other copy of
+    these vectors -- the records table has no vector column -- so an applied row
+    may be deleted only once the index that holds it has been published.
+    `save` returning is that statement, and no more than that: publication is
+    atomic, not durable, so a power failure can revert it after this trim has
+    committed. See the module docstring for what that leaves behind.
+    """
+    # Write index to path.
     await search_engine.save(path)
 
     # Delete applied pending operations and flip index_saved to True.
@@ -231,7 +249,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         namespace: str,
         name: str,
         config: VectorStoreCollectionConfig,
-        index_base_path: str | None,
+        index_path: str | None,
         save_threshold: int,
     ) -> None:
         """Initialize a collection handle."""
@@ -245,7 +263,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
         self._config = config
 
-        self._index_base_path = index_base_path
+        self._index_path = index_path
         self._save_threshold = save_threshold
 
     @property
@@ -255,7 +273,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
     async def _maybe_save_index(self) -> None:
         """Save the index to disk if applied pending operations exceed the threshold."""
-        if self._index_base_path is None:
+        if self._index_path is None:
             return
 
         async with self._create_session() as session:
@@ -275,7 +293,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 namespace=self._namespace,
                 name=self._name,
                 search_engine=self._search_engine,
-                path=self._index_base_path,
+                path=self._index_path,
             )
 
     @override
@@ -794,7 +812,7 @@ class SQLiteVectorStore(VectorStore):
         self._require_started()
         if self._index_directory is not None:
             for (namespace, name), search_engine in self._search_engines.items():
-                path = self._index_base_path(namespace, name)
+                path = self._index_path(namespace, name)
                 assert path is not None
                 await _save_collection_index(
                     create_session=self._create_session,
@@ -845,7 +863,7 @@ class SQLiteVectorStore(VectorStore):
         if not validate_identifier(namespace) or not validate_identifier(name):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
 
-        index_base_path = self._index_base_path(namespace, name)
+        index_path = self._index_path(namespace, name)
 
         async with self._create_session() as session, session.begin():
             existing_config = await self._get_stored_config(session, namespace, name)
@@ -865,9 +883,7 @@ class SQLiteVectorStore(VectorStore):
                     namespace=namespace,
                     name=name,
                     config=existing_config,
-                    index_base_path=(
-                        str(index_base_path) if index_base_path is not None else None
-                    ),
+                    index_path=str(index_path) if index_path is not None else None,
                     save_threshold=self._save_threshold,
                 )
 
@@ -891,9 +907,7 @@ class SQLiteVectorStore(VectorStore):
             namespace=namespace,
             name=name,
             config=config,
-            index_base_path=(
-                str(index_base_path) if index_base_path is not None else None
-            ),
+            index_path=str(index_path) if index_path is not None else None,
             save_threshold=self._save_threshold,
         )
 
@@ -918,7 +932,7 @@ class SQLiteVectorStore(VectorStore):
             namespace, name, existing
         )
 
-        index_base_path = self._index_base_path(namespace, name)
+        index_path = self._index_path(namespace, name)
         return SQLiteVectorStoreCollection(
             create_session=self._create_session,
             sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
@@ -927,9 +941,7 @@ class SQLiteVectorStore(VectorStore):
             namespace=namespace,
             name=name,
             config=existing,
-            index_base_path=(
-                str(index_base_path) if index_base_path is not None else None
-            ),
+            index_path=str(index_path) if index_path is not None else None,
             save_threshold=self._save_threshold,
         )
 
@@ -966,7 +978,9 @@ class SQLiteVectorStore(VectorStore):
 
         # If unlink fails, the orphan is harmless.
         # _clear_search_engine_state will clean it up if a new collection with the same name is created.
-        self._remove_index_files(namespace, name)
+        index_path = self._index_path(namespace, name)
+        if index_path is not None and index_path.exists():
+            index_path.unlink()
         self._search_engines.pop((namespace, name), None)
 
     # Helpers.
@@ -987,30 +1001,18 @@ class SQLiteVectorStore(VectorStore):
             extend_existing=True,
         )
 
-    def _index_base_path(self, namespace: str, name: str) -> Path | None:
-        """
-        Return a collection's index base path, or None if in-memory.
-
-        A base name, not a file: what an engine keeps under it — one file, two
-        slots, a set of segments — is the engine's business, and no caller may
-        hold this believing it is the index.
-        """
+    def _index_path(self, namespace: str, name: str) -> Path | None:
+        """Return the on-disk index path for a collection, or None if in-memory."""
         if self._index_directory is None:
             return None
         return self._index_directory / f"{self._collection_prefix(namespace, name)}.idx"
 
-    def _remove_index_files(self, namespace: str, name: str) -> None:
-        """Discard a collection's index, whatever the engine keeps under it."""
-        index_base_path = self._index_base_path(namespace, name)
-        if index_base_path is None:
-            return
-        for path in index_artifact_paths(str(index_base_path)):
-            path.unlink(missing_ok=True)
-
     def _clear_search_engine_state(self, namespace: str, name: str) -> None:
         """Remove any in-memory engine and on-disk index for a collection."""
         self._search_engines.pop((namespace, name), None)
-        self._remove_index_files(namespace, name)
+        index_path = self._index_path(namespace, name)
+        if index_path is not None and index_path.exists():
+            index_path.unlink()
 
     async def _get_stored_config(
         self,
@@ -1044,8 +1046,8 @@ class SQLiteVectorStore(VectorStore):
             config.vector_dimensions, config.similarity_metric
         )
 
-        index_base_path = self._index_base_path(namespace, name)
-        if index_base_path is not None:
+        index_path = self._index_path(namespace, name)
+        if index_path is not None:
             async with self._create_session() as session:
                 saved = (
                     await session.execute(
@@ -1060,9 +1062,9 @@ class SQLiteVectorStore(VectorStore):
                 # The engine just propagates whatever its backend raises.
                 # Wrap any failure as IndexLoadError so callers see one type.
                 try:
-                    await search_engine.load(str(index_base_path))
+                    await search_engine.load(str(index_path))
                 except Exception as e:
-                    raise IndexLoadError(namespace, name, index_base_path) from e
+                    raise IndexLoadError(namespace, name, index_path) from e
 
         self._search_engines[cache_key] = search_engine
         return search_engine

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -59,16 +59,17 @@ from .data_types import (
 )
 from .utils import validate_filter, validate_identifier
 from .vector_search_engine import VectorSearchEngine
+from .vector_search_engine.index_persistence import index_artifact_paths
 from .vector_store import VectorStore, VectorStoreCollection
 
 logger = logging.getLogger(__name__)
 
 
 class IndexLoadError(RuntimeError):
-    """Raised when a collection's on-disk index file cannot be loaded."""
+    """Raised when a collection's on-disk index cannot be loaded."""
 
     def __init__(self, namespace: str, name: str, path: Path) -> None:
-        """Initialize with the collection namespace, name, and index file path."""
+        """Initialize with the collection namespace, name, and index base path."""
         self.namespace = namespace
         self.name = name
         self.path = path
@@ -90,9 +91,10 @@ class _CollectionRow(BaseSQLiteVectorStore):
     config_json: MappedColumn[dict[str, JsonValue]] = mapped_column(
         JSON, nullable=False
     )
-    # Flips to True after the first successful index save.
-    # Once True, the on-disk index file is part of the durable contract:
-    # missing or corrupt is treated as an error rather than silently rebuilt empty.
+    # Flips to True after the first successful index save. Bookkeeping about the
+    # collection's own lifecycle rather than the engine's layout: once True, an
+    # engine reporting nothing published is a fault to raise on, not an empty
+    # collection to serve.
     index_saved: MappedColumn[bool] = mapped_column(
         Boolean, nullable=False, default=False
     )
@@ -141,7 +143,12 @@ async def _save_collection_index(
     path: str,
 ) -> None:
     """Save a collection's index to disk."""
-    # Write index to path.
+    # The one rule this checkpoint rests on: never trim the log past what the
+    # engine says is durable. `save` returning is that statement — a later
+    # `load` produces this index even if the machine loses power on the next
+    # instruction — so these two steps need no shared transaction, only this
+    # order. A crash between them costs a replay of operations the index
+    # already holds, and replay is idempotent.
     await search_engine.save(path)
 
     # Delete applied pending operations and flip index_saved to True.
@@ -224,7 +231,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         namespace: str,
         name: str,
         config: VectorStoreCollectionConfig,
-        index_path: str | None,
+        index_base_path: str | None,
         save_threshold: int,
     ) -> None:
         """Initialize a collection handle."""
@@ -238,7 +245,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
         self._config = config
 
-        self._index_path = index_path
+        self._index_base_path = index_base_path
         self._save_threshold = save_threshold
 
     @property
@@ -248,7 +255,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
     async def _maybe_save_index(self) -> None:
         """Save the index to disk if applied pending operations exceed the threshold."""
-        if self._index_path is None:
+        if self._index_base_path is None:
             return
 
         async with self._create_session() as session:
@@ -268,7 +275,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 namespace=self._namespace,
                 name=self._name,
                 search_engine=self._search_engine,
-                path=self._index_path,
+                path=self._index_base_path,
             )
 
     @override
@@ -787,7 +794,7 @@ class SQLiteVectorStore(VectorStore):
         self._require_started()
         if self._index_directory is not None:
             for (namespace, name), search_engine in self._search_engines.items():
-                path = self._index_path(namespace, name)
+                path = self._index_base_path(namespace, name)
                 assert path is not None
                 await _save_collection_index(
                     create_session=self._create_session,
@@ -838,7 +845,7 @@ class SQLiteVectorStore(VectorStore):
         if not validate_identifier(namespace) or not validate_identifier(name):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
 
-        index_path = self._index_path(namespace, name)
+        index_base_path = self._index_base_path(namespace, name)
 
         async with self._create_session() as session, session.begin():
             existing_config = await self._get_stored_config(session, namespace, name)
@@ -858,7 +865,9 @@ class SQLiteVectorStore(VectorStore):
                     namespace=namespace,
                     name=name,
                     config=existing_config,
-                    index_path=str(index_path) if index_path is not None else None,
+                    index_base_path=(
+                        str(index_base_path) if index_base_path is not None else None
+                    ),
                     save_threshold=self._save_threshold,
                 )
 
@@ -882,7 +891,9 @@ class SQLiteVectorStore(VectorStore):
             namespace=namespace,
             name=name,
             config=config,
-            index_path=str(index_path) if index_path is not None else None,
+            index_base_path=(
+                str(index_base_path) if index_base_path is not None else None
+            ),
             save_threshold=self._save_threshold,
         )
 
@@ -907,7 +918,7 @@ class SQLiteVectorStore(VectorStore):
             namespace, name, existing
         )
 
-        index_path = self._index_path(namespace, name)
+        index_base_path = self._index_base_path(namespace, name)
         return SQLiteVectorStoreCollection(
             create_session=self._create_session,
             sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
@@ -916,7 +927,9 @@ class SQLiteVectorStore(VectorStore):
             namespace=namespace,
             name=name,
             config=existing,
-            index_path=str(index_path) if index_path is not None else None,
+            index_base_path=(
+                str(index_base_path) if index_base_path is not None else None
+            ),
             save_threshold=self._save_threshold,
         )
 
@@ -953,9 +966,7 @@ class SQLiteVectorStore(VectorStore):
 
         # If unlink fails, the orphan is harmless.
         # _clear_search_engine_state will clean it up if a new collection with the same name is created.
-        index_path = self._index_path(namespace, name)
-        if index_path is not None and index_path.exists():
-            index_path.unlink()
+        self._remove_index_files(namespace, name)
         self._search_engines.pop((namespace, name), None)
 
     # Helpers.
@@ -976,18 +987,30 @@ class SQLiteVectorStore(VectorStore):
             extend_existing=True,
         )
 
-    def _index_path(self, namespace: str, name: str) -> Path | None:
-        """Return the on-disk index path for a collection, or None if in-memory."""
+    def _index_base_path(self, namespace: str, name: str) -> Path | None:
+        """
+        Return a collection's index base path, or None if in-memory.
+
+        A base name, not a file: what an engine keeps under it — one file, two
+        slots, a set of segments — is the engine's business, and no caller may
+        hold this believing it is the index.
+        """
         if self._index_directory is None:
             return None
         return self._index_directory / f"{self._collection_prefix(namespace, name)}.idx"
 
+    def _remove_index_files(self, namespace: str, name: str) -> None:
+        """Discard a collection's index, whatever the engine keeps under it."""
+        index_base_path = self._index_base_path(namespace, name)
+        if index_base_path is None:
+            return
+        for path in index_artifact_paths(str(index_base_path)):
+            path.unlink(missing_ok=True)
+
     def _clear_search_engine_state(self, namespace: str, name: str) -> None:
         """Remove any in-memory engine and on-disk index for a collection."""
         self._search_engines.pop((namespace, name), None)
-        index_path = self._index_path(namespace, name)
-        if index_path is not None and index_path.exists():
-            index_path.unlink()
+        self._remove_index_files(namespace, name)
 
     async def _get_stored_config(
         self,
@@ -1021,8 +1044,8 @@ class SQLiteVectorStore(VectorStore):
             config.vector_dimensions, config.similarity_metric
         )
 
-        index_path = self._index_path(namespace, name)
-        if index_path is not None:
+        index_base_path = self._index_base_path(namespace, name)
+        if index_base_path is not None:
             async with self._create_session() as session:
                 saved = (
                     await session.execute(
@@ -1037,9 +1060,9 @@ class SQLiteVectorStore(VectorStore):
                 # The engine just propagates whatever its backend raises.
                 # Wrap any failure as IndexLoadError so callers see one type.
                 try:
-                    await search_engine.load(str(index_path))
+                    await search_engine.load(str(index_base_path))
                 except Exception as e:
-                    raise IndexLoadError(namespace, name, index_path) from e
+                    raise IndexLoadError(namespace, name, index_base_path) from e
 
         self._search_engines[cache_key] = search_engine
         return search_engine

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -12,6 +12,7 @@ import numpy as np
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
+from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -321,7 +322,8 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        self._index.save_index(path)
+        with atomic_index_write(path) as temp_path:
+            self._index.save_index(temp_path)
         # Reconcile _known_labels with hnswlib's label_lookup_.
         if self._allow_replace_deleted:
             self._known_labels = {int(k) for k in self._index.get_ids_list()}
@@ -332,6 +334,7 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> None:
+        clear_stale_index_temp(path)
         self._index = hnswlib.Index(space=self._space, dim=self._num_dimensions)
         self._index.load_index(path, allow_replace_deleted=self._allow_replace_deleted)
         self._index.set_ef(self._ef_search)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -12,7 +12,7 @@ import numpy as np
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
-from .index_persistence import publish_index, published_index_path
+from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -322,8 +322,8 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        with publish_index(path) as slot_path:
-            self._index.save_index(slot_path)
+        with atomic_index_write(path) as temp_path:
+            self._index.save_index(temp_path)
         # Reconcile _known_labels with hnswlib's label_lookup_.
         if self._allow_replace_deleted:
             self._known_labels = {int(k) for k in self._index.get_ids_list()}
@@ -334,13 +334,9 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> None:
-        published = published_index_path(path)
-        if published is None:
-            raise FileNotFoundError(f"No published index for {path}")
+        clear_stale_index_temp(path)
         self._index = hnswlib.Index(space=self._space, dim=self._num_dimensions)
-        self._index.load_index(
-            published, allow_replace_deleted=self._allow_replace_deleted
-        )
+        self._index.load_index(path, allow_replace_deleted=self._allow_replace_deleted)
         self._index.set_ef(self._ef_search)
         # Reconcile _known_labels with hnswlib's label_lookup_.
         if self._allow_replace_deleted:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -12,7 +12,7 @@ import numpy as np
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
-from .index_persistence import atomic_index_write, clear_stale_index_temp
+from .index_persistence import publish_index, published_index_path
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -322,8 +322,8 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        with atomic_index_write(path) as temp_path:
-            self._index.save_index(temp_path)
+        with publish_index(path) as slot_path:
+            self._index.save_index(slot_path)
         # Reconcile _known_labels with hnswlib's label_lookup_.
         if self._allow_replace_deleted:
             self._known_labels = {int(k) for k in self._index.get_ids_list()}
@@ -334,9 +334,13 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> None:
-        clear_stale_index_temp(path)
+        published = published_index_path(path)
+        if published is None:
+            raise FileNotFoundError(f"No published index for {path}")
         self._index = hnswlib.Index(space=self._space, dim=self._num_dimensions)
-        self._index.load_index(path, allow_replace_deleted=self._allow_replace_deleted)
+        self._index.load_index(
+            published, allow_replace_deleted=self._allow_replace_deleted
+        )
         self._index.set_ef(self._ef_search)
         # Reconcile _known_labels with hnswlib's label_lookup_.
         if self._allow_replace_deleted:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -1,0 +1,92 @@
+"""
+Atomic on-disk index persistence helpers, shared by vector search engines.
+
+Each engine owns its index file layout, so the atomic-swap logic lives here
+(shared by the engines) rather than in the vector store: the index save
+location and the number of files written differ across engine implementations.
+
+The core guarantee is that a reader never observes a partially written index at
+the target path. The index is written to a sibling temp file and swapped into
+place with ``Path.replace`` (``os.replace``), which is atomic on POSIX and
+Windows when source and destination share a filesystem (guaranteed here, since
+the temp file is a sibling of the target). A save that is interrupted (crash,
+exception) therefore leaves the previous index untouched rather than corrupting
+it, which matters because the vector store treats a saved-but-unloadable index
+as a hard error rather than silently rebuilding it empty.
+"""
+
+import contextlib
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+# Deterministic suffix so a crash leaves at most one stale temp per index file.
+# The next save overwrites it and load clears it, rather than accumulating
+# uniquely named leftovers.
+_TEMP_SUFFIX = ".tmp"
+
+
+def _temp_path(path: str) -> str:
+    """Return the sibling temp path used while writing the index at `path`."""
+    return f"{path}{_TEMP_SUFFIX}"
+
+
+def clear_stale_index_temp(path: str) -> None:
+    """
+    Remove a temp file left behind by a previously interrupted save.
+
+    Call this on load/startup so a save that crashed before the atomic swap
+    does not leak a temp file across restarts. A missing temp file is a no-op.
+
+    Args:
+        path (str):
+            The index file path whose sibling temp file should be cleared.
+    """
+    Path(_temp_path(path)).unlink(missing_ok=True)
+
+
+@contextlib.contextmanager
+def atomic_index_write(path: str) -> Iterator[str]:
+    """
+    Write an index to a temp file, then atomically swap it into `path`.
+
+    Yields a sibling temp path for the caller to write the index to. On normal
+    exit the temp file is flushed and atomically renamed onto `path`, so a
+    reader sees either the old index or the new one, never a partial write. If
+    the body raises, the temp file is removed and the exception propagates,
+    leaving any existing index at `path` intact.
+
+    Args:
+        path (str):
+            The final index file path to swap the written index into.
+
+    Yields:
+        str:
+            The temp path to write the index to.
+    """
+    temp = _temp_path(path)
+    # Clear any temp left by a previously interrupted save before reusing it.
+    Path(temp).unlink(missing_ok=True)
+    try:
+        yield temp
+        _flush_to_disk(temp)
+        Path(temp).replace(path)
+    except BaseException:
+        Path(temp).unlink(missing_ok=True)
+        raise
+
+
+def _flush_to_disk(path: str) -> None:
+    """
+    Best-effort fsync so the temp file's bytes are durable before the swap.
+
+    Guards against a crash where the rename is durable but the data behind it
+    is not. Failures are ignored: durability is a bonus on top of the atomic
+    swap, which is the actual correctness guarantee.
+    """
+    with contextlib.suppress(OSError):
+        fd = os.open(path, os.O_RDWR)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -4,21 +4,65 @@ Atomic on-disk index persistence helpers, shared by vector search engines.
 Each engine owns its index file layout, so the atomic-swap logic lives here
 (shared by the engines) rather than in the vector store: the index save
 location and the number of files written differ across engine implementations.
+An engine whose backend implements this protocol natively can satisfy
+`VectorSearchEngine.save` by delegating to it and skip these helpers.
 
-The core guarantee is that a reader never observes a partially written index at
-the target path. The index is written to a sibling temp file and swapped into
-place with ``Path.replace`` (``os.replace``), which is atomic on POSIX and
-Windows when source and destination share a filesystem (guaranteed here, since
-the temp file is a sibling of the target). A save that is interrupted (crash,
-exception) therefore leaves the previous index untouched rather than corrupting
-it, which matters because the vector store treats a saved-but-unloadable index
-as a hard error rather than silently rebuilding it empty.
+The two guarantees fail differently, which is why they are separated below:
+
+- **Atomic.** A reader never observes a partially written index at the target
+  path. The index is written to a sibling temp file and swapped into place with
+  ``Path.replace`` (``os.replace``), which is atomic on POSIX and Windows when
+  source and destination share a filesystem (guaranteed here, since the temp
+  file is a sibling of the target). A save that is interrupted (crash,
+  exception) leaves the previous index untouched rather than corrupting it,
+  which matters because the vector store treats a saved-but-unloadable index as
+  a hard error rather than silently rebuilding it empty.
+- **Durable.** A save that returns has put the new index on stable storage, and
+  on POSIX the swap itself too. This is not a bonus on top of the atomicity:
+  the vector store trims its pending-operation log — the only other copy of
+  these vectors — once ``save`` returns, so a swap that quietly fails to reach
+  disk costs data rather than performance.
+
+Durability is platform-limited in one place. On POSIX the swap is made durable
+by fsyncing the parent directory, since ``rename(2)`` leaves the new directory
+entry in the page cache. Windows has no equivalent operation: the swap is
+atomic through NTFS metadata journaling, but that journal record is not
+necessarily flushed when the call returns, so power loss (a process crash is
+not enough) within a sub-second window can roll it back. The residue is bounded
+— the previous index reappears, and the records whose vectors that checkpoint
+added are still in SQLite but no longer in the index, so they stop matching
+queries rather than matching them wrongly.
 """
 
 import contextlib
 import os
+import sys
 from collections.abc import Iterator
 from pathlib import Path
+
+if sys.platform == "darwin":
+    import fcntl
+
+    def _fsync(fd: int) -> None:
+        """
+        Flush `fd` to stable storage, through the drive's write cache.
+
+        macOS ``fsync`` only pushes the data to the drive, which may hold it in
+        a volatile write cache; ``F_FULLFSYNC`` is the documented request for
+        the stronger flush. Not every filesystem implements it, so a refusal
+        falls back to ``fsync`` rather than failing the caller.
+        """
+        try:
+            fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
+        except OSError:
+            os.fsync(fd)
+
+else:
+
+    def _fsync(fd: int) -> None:
+        """Flush `fd` to stable storage, as far as the platform allows."""
+        os.fsync(fd)
+
 
 # Deterministic suffix so a crash leaves at most one stale temp per index file.
 # The next save overwrites it and load clears it, rather than accumulating
@@ -51,10 +95,14 @@ def atomic_index_write(path: str) -> Iterator[str]:
     Write an index to a temp file, then atomically swap it into `path`.
 
     Yields a sibling temp path for the caller to write the index to. On normal
-    exit the temp file is flushed and atomically renamed onto `path`, so a
-    reader sees either the old index or the new one, never a partial write. If
-    the body raises, the temp file is removed and the exception propagates,
-    leaving any existing index at `path` intact.
+    exit the temp file is flushed, atomically renamed onto `path`, and the
+    rename itself flushed where the platform allows — so a reader sees either
+    the old index or the new one, never a partial write, and a return means the
+    new index is on disk. If the body raises, the temp file is removed and the
+    exception propagates, leaving any existing index at `path` intact.
+
+    The rename is the commit point: nothing after it may raise, or a caller
+    would roll back against an index that has already been replaced.
 
     Args:
         path (str):
@@ -71,6 +119,7 @@ def atomic_index_write(path: str) -> Iterator[str]:
         yield temp
         _flush_to_disk(temp)
         Path(temp).replace(path)
+        _flush_parent_dir(path)
     except BaseException:
         Path(temp).unlink(missing_ok=True)
         raise
@@ -78,15 +127,48 @@ def atomic_index_write(path: str) -> Iterator[str]:
 
 def _flush_to_disk(path: str) -> None:
     """
-    Best-effort fsync so the temp file's bytes are durable before the swap.
+    Flush the temp file's bytes to disk before the swap. Errors propagate.
 
-    Guards against a crash where the rename is durable but the data behind it
-    is not. Failures are ignored: durability is a bonus on top of the atomic
-    swap, which is the actual correctness guarantee.
+    The vector store trims its pending-operation log — its only other copy of
+    these vectors — once the save returns, so a failed flush has to fail the
+    save rather than be reported as success. ``EIO`` here is not hypothetical:
+    a writeback error is reported to ``fsync`` once and the dirty pages are
+    then dropped, which is exactly when the save must not be treated as
+    committed. `atomic_index_write` removes the temp file and leaves the
+    previous index in place, so the next save retries. (SQLite draws the same
+    line: a file fsync failure raises ``SQLITE_IOERR_FSYNC``, while a directory
+    fsync failure is ignored — see `_flush_parent_dir`.)
+    """
+    # O_RDWR rather than O_RDONLY: os.fsync is `_commit` on Windows, which
+    # needs a writable handle. Opening for write does not truncate.
+    fd = os.open(path, os.O_RDWR)
+    try:
+        _fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _flush_parent_dir(path: str) -> None:
+    """
+    Flush the directory holding `path`, making the swap itself durable.
+
+    Without this the swap is atomic but not durable: POSIX ``rename(2)`` leaves
+    the new directory entry in the page cache, so power loss can roll it back to
+    the previous file.
+
+    Best-effort, matching SQLite's ``unixSync``, which fsyncs the directory
+    holding a journal for exactly this reason and treats a directory it cannot
+    open as success. A filesystem that refuses this gives the SQLite database
+    beside the index no guarantee either, so hardening the index alone would
+    buy nothing, and failing the save would instead grow the pending log
+    without bound. Windows cannot open a directory this way at all, so this is
+    a no-op there and the swap's durability follows NTFS metadata journaling.
     """
     with contextlib.suppress(OSError):
-        fd = os.open(path, os.O_RDWR)
+        # `.parent` before `.resolve()`: the entry the swap created lives in the
+        # directory the path names, not in a symlink target's directory.
+        fd = os.open(Path(path).parent.resolve(), os.O_RDONLY)
         try:
-            os.fsync(fd)
+            _fsync(fd)
         finally:
             os.close(fd)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -1,306 +1,125 @@
 """
-Crash-safe index publication, shared by vector search engines.
+Atomic on-disk index publication, shared by vector search engines.
 
-An engine's `save` may only return once a later `load` would produce that index
-even if the machine lost power on the next instruction, because the vector store
-trims its pending-operation log — the only other copy of those vectors — as soon
-as it returns. This module implements that guarantee for engines whose backend
-writes an index to a path.
+Each engine owns its index file layout, so the atomic-swap logic lives here
+(shared by the engines) rather than in the vector store: the index save
+location and the number of files written differ across engine implementations.
 
-Why not the obvious protocol
-----------------------------
+What a save guarantees
+----------------------
 
-Writing a temp file and renaming it over the destination is atomic, but the
-rename cannot be made durable. A rename changes a *directory entry*, and the two
-kinds of state have very different guarantees:
+A reader never observes a partially written index at the target path. The index
+is written to a sibling temp file and swapped into place with ``Path.replace``
+(``os.replace``), which is atomic on POSIX and Windows when source and
+destination share a filesystem (guaranteed here, since the temp file is a
+sibling of the target). A save that is interrupted (crash, exception) therefore
+leaves the previous index untouched rather than corrupting it, which matters
+because the vector store treats a saved-but-unloadable index as a hard error
+rather than silently rebuilding it empty.
 
-===================  ==========================================  ==============
-state                make it durable                             available
-===================  ==========================================  ==============
-file contents        ``fsync`` / ``F_FULLFSYNC`` / FlushFileBuffers  everywhere
-directory entry      ``fsync`` on a directory file descriptor     POSIX only
-===================  ==========================================  ==============
+What it does not
+----------------
 
-On POSIX a parent-directory fsync closes the gap, but only best-effort — network
-and FUSE filesystems refuse it. Windows has no equivalent at all: you cannot open
-a directory as a file, and `MOVEFILE_WRITE_THROUGH` does not help, since its
-documented guarantee is scoped to moves performed as a copy and delete. The
-decisive evidence is SQLite's own: its VFS threads a directory-sync flag through
-every commit-relevant directory operation, honors it in ``unixDelete``, and
-declares it ``/* Not used on win32 */`` in ``winDelete``. So the rename could
-return, the store's trim could commit durably behind it, and a power cut could
-still roll the rename back — leaving the mapping forward, the index back, and no
-copy of the difference anywhere.
+The publication is atomic, not durable. A rename changes a *directory entry*,
+and a directory entry cannot be flushed portably: POSIX needs an fsync on a
+directory file descriptor, which network and FUSE filesystems may refuse, and
+Windows has no equivalent at all. SQLite's own VFS is the precedent -- it
+threads a directory-sync flag through every commit-relevant directory
+operation, honors it in ``unixDelete``, and declares it
+``/* Not used on win32 */`` in ``winDelete``.
 
-What we do instead
-------------------
+So a power failure can roll a save back to the previously published index even
+though ``save`` returned, while the SQLite side -- including the
+pending-operation trim that ran behind that save -- stays committed. What that
+leaves is records whose vectors are missing from the index: they still resolve
+by uuid, but they cannot be found by search until they are re-upserted.
 
-SQLite's answer was not to harden the directory operation but to stop using one
-as a commit point: ``PERSIST`` commits by zeroing a journal header, ``TRUNCATE``
-by truncating, WAL by appending frames. This module does the same.
-
-A base path expands into four files — two index slots and a generation record
-for each — created once and thereafter only overwritten. A checkpoint is:
-
-1. Write the index over the inactive slot and flush it. In-place file data,
-   which every platform can make durable.
-2. Write that slot's generation record and flush it. **This is the commit
-   point**, and it is a write into a file that already exists.
-3. Empty the retired slot and its record, so the spare costs no disk at rest.
-
-`load` reads both records, keeps the ones whose halves agree, and takes the
-higher generation. That comparison is the entire bookkeeping: no pointer,
-manifest, or generation is kept anywhere else, so nothing about this layout
-leaks into the vector store.
-
-The record is 16 bytes — a generation and its bitwise complement. That is what
-makes step 2 atomic without asking the hardware for single-sector-write
-atomicity: every byte of a torn write comes from either the new record or the
-slot's previous one, so the result is the new generation, the old one (which
-loses to the live slot, correctly, since the caller had not trimmed), or a mix
-whose halves disagree and is rejected. A torn record reads as *absent*, never as
-some other generation.
-
-Every crash window is benign:
-
-- **during step 1** — the damaged file is the inactive slot, which nothing
-  reads. The older record still wins and the log is intact.
-- **between steps 1 and 2** — a complete new index exists and is invisible,
-  because nothing published it. Correct: the caller has not trimmed either.
-- **during step 2** — torn record, reads as absent, previous generation wins.
-- **after step 2** — the index it names was flushed before it was written.
-- **between steps 2 and 3** — two valid records; the higher generation wins.
-
-There is no directory operation anywhere in this after the four files exist,
-which is the whole point.
+That is the direction this store tolerates, and it is a deliberate trade. A
+stronger guarantee needs a commit protocol that never uses a directory
+operation as its commit point (two index slots plus a generation record, or an
+equivalent), which every engine would then have to implement and maintain. The
+failure it buys out is bounded -- search recall for at most the records applied
+since the last checkpoint, repaired by re-ingesting them -- so the machinery
+costs more than it saves.
 """
 
 import contextlib
 import os
-import struct
-import sys
 from collections.abc import Iterator
 from pathlib import Path
 
-if sys.platform == "darwin":
-    import fcntl
-
-    def _fsync(fd: int) -> None:
-        """
-        Flush `fd` to stable storage, through the drive's write cache.
-
-        macOS ``fsync`` only pushes the data to the drive, which may hold it in
-        a volatile write cache; ``F_FULLFSYNC`` is the documented request for
-        the stronger flush. Not every filesystem implements it, so a refusal
-        falls back to ``fsync`` rather than failing the caller.
-        """
-        try:
-            fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
-        except OSError:
-            os.fsync(fd)
-
-else:
-
-    def _fsync(fd: int) -> None:
-        """Flush `fd` to stable storage, as far as the platform allows."""
-        os.fsync(fd)
+# Deterministic suffix so a crash leaves at most one stale temp per index file.
+# The next save overwrites it and load clears it, rather than accumulating
+# uniquely named leftovers.
+_TEMP_SUFFIX = ".tmp"
 
 
-_SLOTS = (0, 1)
-
-# Generation, then its bitwise complement.
-_RECORD_FORMAT = "<QQ"
-_RECORD_SIZE = struct.calcsize(_RECORD_FORMAT)
-_COMPLEMENT_MASK = 0xFFFFFFFFFFFFFFFF
+def _temp_path(path: str) -> str:
+    """Return the sibling temp path used while writing the index at `path`."""
+    return f"{path}{_TEMP_SUFFIX}"
 
 
-def _slot_path(base: str, slot: int) -> Path:
-    """Path of an index slot under `base`."""
-    return Path(f"{base}.{slot}")
-
-
-def _record_path(base: str, slot: int) -> Path:
-    """Path of a slot's generation record."""
-    return Path(f"{base}.{slot}.gen")
-
-
-def index_artifact_paths(base: str) -> list[Path]:
+def clear_stale_index_temp(path: str) -> None:
     """
-    Every file `base` expands into.
+    Remove a temp file left behind by a previously interrupted save.
 
-    The vector store uses this to discard a collection's index without having to
-    know how many files an engine keeps or what they are called.
+    Call this on load/startup so a save that crashed before the atomic swap
+    does not leak a temp file across restarts. A missing temp file is a no-op.
 
     Args:
-        base (str):
-            The index base path.
-
-    Returns:
-        list[Path]:
-            The slot and generation-record paths, in no particular order.
+        path (str):
+            The index file path whose sibling temp file should be cleared.
     """
-    return [
-        path
-        for slot in _SLOTS
-        for path in (_slot_path(base, slot), _record_path(base, slot))
-    ]
-
-
-def published_index_path(base: str) -> str | None:
-    """
-    The index a `load` should read, or None if nothing has been published.
-
-    Reads both generation records, discards any whose halves disagree — a torn
-    or absent record — and returns the slot holding the higher generation.
-
-    A caller must **not** fall back to the other slot when the returned index
-    fails to parse. The log was trimmed against the published one, so the other
-    is stale by exactly the operations that can no longer be replayed; failing
-    loudly is right, and quietly serving the previous generation would be data
-    loss dressed as success.
-
-    Args:
-        base (str):
-            The index base path.
-
-    Returns:
-        str | None:
-            Path of the published index slot, or None if there is none.
-    """
-    published = _published_slot(base)
-    return None if published is None else str(_slot_path(base, published[0]))
+    Path(_temp_path(path)).unlink(missing_ok=True)
 
 
 @contextlib.contextmanager
-def publish_index(base: str) -> Iterator[str]:
+def atomic_index_write(path: str) -> Iterator[str]:
     """
-    Write an index into the free slot and publish it.
+    Write an index to a temp file, then atomically swap it into `path`.
 
-    Yields the path of the slot that is not currently published, for the caller
-    to write the index to. On normal exit that slot is flushed, its generation
-    record is written and flushed — the commit — and the retired slot is
-    emptied.
+    Yields a sibling temp path for the caller to write the index to. On normal
+    exit the temp file is flushed and atomically renamed onto `path`, so a
+    reader sees either the old index or the new one, never a partial write. If
+    the body raises, the temp file is removed and the exception propagates,
+    leaving any existing index at `path` intact.
 
-    If the body raises, nothing is published and the exception propagates: the
-    previously published index stays live, and the half-written slot is
-    invisible until the next checkpoint overwrites it. The same holds for a
-    failed flush, which is why flush errors are not suppressed — the store trims
-    its log on the strength of this call, and ``EIO`` from ``fsync`` means the
-    writeback already failed and the dirty pages were dropped.
+    The swap is atomic, not durable: after a power failure the index at `path`
+    may be the previous one. See the module docstring for what that costs.
 
     Args:
-        base (str):
-            The index base path.
+        path (str):
+            The final index file path to swap the written index into.
 
     Yields:
         str:
-            Path of the slot to write the index to.
+            The temp path to write the index to.
     """
-    live = _published_slot(base)
-    if live is None:
-        target, generation = _SLOTS[0], 1
-    else:
-        live_slot, live_generation = live
-        target, generation = 1 - live_slot, live_generation + 1
-
-    _create_artifacts(base)
-
-    yield str(_slot_path(base, target))
-
-    # 1. The index itself, durable before anything names it.
-    _flush_file(_slot_path(base, target))
-    # 2. The commit point.
-    _write_generation(base, target, generation)
-    # 3. Reclaim the retired pair. Best-effort: this runs after the commit, so
-    #    it must not fail the save, and a slot left full is harmless — its
-    #    record holds the lower generation and loses the comparison.
-    if live is not None:
-        _empty_slot(base, live[0])
-
-
-def _published_slot(base: str) -> tuple[int, int] | None:
-    """The (slot, generation) with the highest believable generation, if any."""
-    published = [
-        (generation, slot)
-        for slot in _SLOTS
-        if (generation := _read_generation(base, slot)) is not None
-    ]
-    if not published:
-        return None
-    generation, slot = max(published)
-    return slot, generation
-
-
-def _read_generation(base: str, slot: int) -> int | None:
-    """The generation published in `slot`, or None if no believable record."""
+    temp = _temp_path(path)
+    # Clear any temp left by a previously interrupted save before reusing it.
+    Path(temp).unlink(missing_ok=True)
     try:
-        record = _record_path(base, slot).read_bytes()
-    except OSError:
-        return None
-    if len(record) != _RECORD_SIZE:
-        return None
-    generation, complement = struct.unpack(_RECORD_FORMAT, record)
-    # Generations start at 1, so an all-zero record is never a publication.
-    if generation == 0 or complement != generation ^ _COMPLEMENT_MASK:
-        return None
-    return generation
+        yield temp
+        _flush_to_disk(temp)
+        Path(temp).replace(path)
+    except BaseException:
+        Path(temp).unlink(missing_ok=True)
+        raise
 
 
-def _write_generation(base: str, slot: int, generation: int) -> None:
-    """Publish `slot` by writing and flushing its generation record."""
-    record = struct.pack(_RECORD_FORMAT, generation, generation ^ _COMPLEMENT_MASK)
-    fd = os.open(_record_path(base, slot), os.O_RDWR)
-    try:
-        os.write(fd, record)
-        _fsync(fd)
-    finally:
-        os.close(fd)
-
-
-def _empty_slot(base: str, slot: int) -> None:
-    """Unpublish a slot and reclaim its space, best-effort."""
-    # The record first: no valid record may ever name an emptied slot.
-    for path in (_record_path(base, slot), _slot_path(base, slot)):
-        with contextlib.suppress(OSError):
-            os.truncate(path, 0)
-
-
-def _flush_file(path: Path) -> None:
-    """Flush a file's contents to stable storage. Errors propagate."""
-    # O_RDWR rather than O_RDONLY: os.fsync is `_commit` on Windows, which needs
-    # a writable handle. Opening for write does not truncate.
-    fd = os.open(path, os.O_RDWR)
-    try:
-        _fsync(fd)
-    finally:
-        os.close(fd)
-
-
-def _create_artifacts(base: str) -> None:
+def _flush_to_disk(path: str) -> None:
     """
-    Create any missing slot or record files, once per collection.
+    Best-effort fsync so the temp file's bytes are durable before the swap.
 
-    This is the only directory operation in the protocol, and it happens when
-    there is nothing to lose: before anything has been published, the store's
-    log still holds every vector. The parent directory is flushed afterwards so
-    that even this is durable where the platform allows it — a POSIX-only,
-    best-effort step, and the one place where a filesystem that refuses it costs
-    nothing more than a loud missing-index error at the next open.
+    Guards against a crash where the rename is durable but the data behind it
+    is not, which is the direction that costs: a published index that will not
+    parse is a hard error, while a publication that reverts is only missing
+    vectors. Failures are ignored -- this narrows a window rather than closing
+    one, since the swap itself is not durable either.
     """
-    created = False
-    for path in index_artifact_paths(base):
-        try:
-            os.close(os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644))
-        except FileExistsError:
-            continue
-        created = True
-
-    if not created:
-        return
-
     with contextlib.suppress(OSError):
-        fd = os.open(Path(base).parent.resolve(), os.O_RDONLY)
+        fd = os.open(path, os.O_RDWR)
         try:
-            _fsync(fd)
+            os.fsync(fd)
         finally:
             os.close(fd)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -1,41 +1,83 @@
 """
-Atomic on-disk index persistence helpers, shared by vector search engines.
+Crash-safe index publication, shared by vector search engines.
 
-Each engine owns its index file layout, so the atomic-swap logic lives here
-(shared by the engines) rather than in the vector store: the index save
-location and the number of files written differ across engine implementations.
-An engine whose backend implements this protocol natively can satisfy
-`VectorSearchEngine.save` by delegating to it and skip these helpers.
+An engine's `save` may only return once a later `load` would produce that index
+even if the machine lost power on the next instruction, because the vector store
+trims its pending-operation log — the only other copy of those vectors — as soon
+as it returns. This module implements that guarantee for engines whose backend
+writes an index to a path.
 
-The two guarantees fail differently, which is why they are separated below:
+Why not the obvious protocol
+----------------------------
 
-- **Atomic.** A reader never observes a partially written index at the target
-  path. The index is written to a sibling temp file and swapped into place with
-  ``Path.replace`` (``os.replace``), which is atomic on POSIX and Windows when
-  source and destination share a filesystem (guaranteed here, since the temp
-  file is a sibling of the target). A save that is interrupted (crash,
-  exception) leaves the previous index untouched rather than corrupting it,
-  which matters because the vector store treats a saved-but-unloadable index as
-  a hard error rather than silently rebuilding it empty.
-- **Durable.** A save that returns has put the new index on stable storage, and
-  on POSIX the swap itself too. This is not a bonus on top of the atomicity:
-  the vector store trims its pending-operation log — the only other copy of
-  these vectors — once ``save`` returns, so a swap that quietly fails to reach
-  disk costs data rather than performance.
+Writing a temp file and renaming it over the destination is atomic, but the
+rename cannot be made durable. A rename changes a *directory entry*, and the two
+kinds of state have very different guarantees:
 
-Durability is platform-limited in one place. On POSIX the swap is made durable
-by fsyncing the parent directory, since ``rename(2)`` leaves the new directory
-entry in the page cache. Windows has no equivalent operation: the swap is
-atomic through NTFS metadata journaling, but that journal record is not
-necessarily flushed when the call returns, so power loss (a process crash is
-not enough) within a sub-second window can roll it back. The residue is bounded
-— the previous index reappears, and the records whose vectors that checkpoint
-added are still in SQLite but no longer in the index, so they stop matching
-queries rather than matching them wrongly.
+===================  ==========================================  ==============
+state                make it durable                             available
+===================  ==========================================  ==============
+file contents        ``fsync`` / ``F_FULLFSYNC`` / FlushFileBuffers  everywhere
+directory entry      ``fsync`` on a directory file descriptor     POSIX only
+===================  ==========================================  ==============
+
+On POSIX a parent-directory fsync closes the gap, but only best-effort — network
+and FUSE filesystems refuse it. Windows has no equivalent at all: you cannot open
+a directory as a file, and `MOVEFILE_WRITE_THROUGH` does not help, since its
+documented guarantee is scoped to moves performed as a copy and delete. The
+decisive evidence is SQLite's own: its VFS threads a directory-sync flag through
+every commit-relevant directory operation, honors it in ``unixDelete``, and
+declares it ``/* Not used on win32 */`` in ``winDelete``. So the rename could
+return, the store's trim could commit durably behind it, and a power cut could
+still roll the rename back — leaving the mapping forward, the index back, and no
+copy of the difference anywhere.
+
+What we do instead
+------------------
+
+SQLite's answer was not to harden the directory operation but to stop using one
+as a commit point: ``PERSIST`` commits by zeroing a journal header, ``TRUNCATE``
+by truncating, WAL by appending frames. This module does the same.
+
+A base path expands into four files — two index slots and a generation record
+for each — created once and thereafter only overwritten. A checkpoint is:
+
+1. Write the index over the inactive slot and flush it. In-place file data,
+   which every platform can make durable.
+2. Write that slot's generation record and flush it. **This is the commit
+   point**, and it is a write into a file that already exists.
+3. Empty the retired slot and its record, so the spare costs no disk at rest.
+
+`load` reads both records, keeps the ones whose halves agree, and takes the
+higher generation. That comparison is the entire bookkeeping: no pointer,
+manifest, or generation is kept anywhere else, so nothing about this layout
+leaks into the vector store.
+
+The record is 16 bytes — a generation and its bitwise complement. That is what
+makes step 2 atomic without asking the hardware for single-sector-write
+atomicity: every byte of a torn write comes from either the new record or the
+slot's previous one, so the result is the new generation, the old one (which
+loses to the live slot, correctly, since the caller had not trimmed), or a mix
+whose halves disagree and is rejected. A torn record reads as *absent*, never as
+some other generation.
+
+Every crash window is benign:
+
+- **during step 1** — the damaged file is the inactive slot, which nothing
+  reads. The older record still wins and the log is intact.
+- **between steps 1 and 2** — a complete new index exists and is invisible,
+  because nothing published it. Correct: the caller has not trimmed either.
+- **during step 2** — torn record, reads as absent, previous generation wins.
+- **after step 2** — the index it names was flushed before it was written.
+- **between steps 2 and 3** — two valid records; the higher generation wins.
+
+There is no directory operation anywhere in this after the four files exist,
+which is the whole point.
 """
 
 import contextlib
 import os
+import struct
 import sys
 from collections.abc import Iterator
 from pathlib import Path
@@ -64,83 +106,169 @@ else:
         os.fsync(fd)
 
 
-# Deterministic suffix so a crash leaves at most one stale temp per index file.
-# The next save overwrites it and load clears it, rather than accumulating
-# uniquely named leftovers.
-_TEMP_SUFFIX = ".tmp"
+_SLOTS = (0, 1)
+
+# Generation, then its bitwise complement.
+_RECORD_FORMAT = "<QQ"
+_RECORD_SIZE = struct.calcsize(_RECORD_FORMAT)
+_COMPLEMENT_MASK = 0xFFFFFFFFFFFFFFFF
 
 
-def _temp_path(path: str) -> str:
-    """Return the sibling temp path used while writing the index at `path`."""
-    return f"{path}{_TEMP_SUFFIX}"
+def _slot_path(base: str, slot: int) -> Path:
+    """Path of an index slot under `base`."""
+    return Path(f"{base}.{slot}")
 
 
-def clear_stale_index_temp(path: str) -> None:
+def _record_path(base: str, slot: int) -> Path:
+    """Path of a slot's generation record."""
+    return Path(f"{base}.{slot}.gen")
+
+
+def index_artifact_paths(base: str) -> list[Path]:
     """
-    Remove a temp file left behind by a previously interrupted save.
+    Every file `base` expands into.
 
-    Call this on load/startup so a save that crashed before the atomic swap
-    does not leak a temp file across restarts. A missing temp file is a no-op.
+    The vector store uses this to discard a collection's index without having to
+    know how many files an engine keeps or what they are called.
 
     Args:
-        path (str):
-            The index file path whose sibling temp file should be cleared.
+        base (str):
+            The index base path.
+
+    Returns:
+        list[Path]:
+            The slot and generation-record paths, in no particular order.
     """
-    Path(_temp_path(path)).unlink(missing_ok=True)
+    return [
+        path
+        for slot in _SLOTS
+        for path in (_slot_path(base, slot), _record_path(base, slot))
+    ]
+
+
+def published_index_path(base: str) -> str | None:
+    """
+    The index a `load` should read, or None if nothing has been published.
+
+    Reads both generation records, discards any whose halves disagree — a torn
+    or absent record — and returns the slot holding the higher generation.
+
+    A caller must **not** fall back to the other slot when the returned index
+    fails to parse. The log was trimmed against the published one, so the other
+    is stale by exactly the operations that can no longer be replayed; failing
+    loudly is right, and quietly serving the previous generation would be data
+    loss dressed as success.
+
+    Args:
+        base (str):
+            The index base path.
+
+    Returns:
+        str | None:
+            Path of the published index slot, or None if there is none.
+    """
+    published = _published_slot(base)
+    return None if published is None else str(_slot_path(base, published[0]))
 
 
 @contextlib.contextmanager
-def atomic_index_write(path: str) -> Iterator[str]:
+def publish_index(base: str) -> Iterator[str]:
     """
-    Write an index to a temp file, then atomically swap it into `path`.
+    Write an index into the free slot and publish it.
 
-    Yields a sibling temp path for the caller to write the index to. On normal
-    exit the temp file is flushed, atomically renamed onto `path`, and the
-    rename itself flushed where the platform allows — so a reader sees either
-    the old index or the new one, never a partial write, and a return means the
-    new index is on disk. If the body raises, the temp file is removed and the
-    exception propagates, leaving any existing index at `path` intact.
+    Yields the path of the slot that is not currently published, for the caller
+    to write the index to. On normal exit that slot is flushed, its generation
+    record is written and flushed — the commit — and the retired slot is
+    emptied.
 
-    The rename is the commit point: nothing after it may raise, or a caller
-    would roll back against an index that has already been replaced.
+    If the body raises, nothing is published and the exception propagates: the
+    previously published index stays live, and the half-written slot is
+    invisible until the next checkpoint overwrites it. The same holds for a
+    failed flush, which is why flush errors are not suppressed — the store trims
+    its log on the strength of this call, and ``EIO`` from ``fsync`` means the
+    writeback already failed and the dirty pages were dropped.
 
     Args:
-        path (str):
-            The final index file path to swap the written index into.
+        base (str):
+            The index base path.
 
     Yields:
         str:
-            The temp path to write the index to.
+            Path of the slot to write the index to.
     """
-    temp = _temp_path(path)
-    # Clear any temp left by a previously interrupted save before reusing it.
-    Path(temp).unlink(missing_ok=True)
+    live = _published_slot(base)
+    if live is None:
+        target, generation = _SLOTS[0], 1
+    else:
+        live_slot, live_generation = live
+        target, generation = 1 - live_slot, live_generation + 1
+
+    _create_artifacts(base)
+
+    yield str(_slot_path(base, target))
+
+    # 1. The index itself, durable before anything names it.
+    _flush_file(_slot_path(base, target))
+    # 2. The commit point.
+    _write_generation(base, target, generation)
+    # 3. Reclaim the retired pair. Best-effort: this runs after the commit, so
+    #    it must not fail the save, and a slot left full is harmless — its
+    #    record holds the lower generation and loses the comparison.
+    if live is not None:
+        _empty_slot(base, live[0])
+
+
+def _published_slot(base: str) -> tuple[int, int] | None:
+    """The (slot, generation) with the highest believable generation, if any."""
+    published = [
+        (generation, slot)
+        for slot in _SLOTS
+        if (generation := _read_generation(base, slot)) is not None
+    ]
+    if not published:
+        return None
+    generation, slot = max(published)
+    return slot, generation
+
+
+def _read_generation(base: str, slot: int) -> int | None:
+    """The generation published in `slot`, or None if no believable record."""
     try:
-        yield temp
-        _flush_to_disk(temp)
-        Path(temp).replace(path)
-        _flush_parent_dir(path)
-    except BaseException:
-        Path(temp).unlink(missing_ok=True)
-        raise
+        record = _record_path(base, slot).read_bytes()
+    except OSError:
+        return None
+    if len(record) != _RECORD_SIZE:
+        return None
+    generation, complement = struct.unpack(_RECORD_FORMAT, record)
+    # Generations start at 1, so an all-zero record is never a publication.
+    if generation == 0 or complement != generation ^ _COMPLEMENT_MASK:
+        return None
+    return generation
 
 
-def _flush_to_disk(path: str) -> None:
-    """
-    Flush the temp file's bytes to disk before the swap. Errors propagate.
+def _write_generation(base: str, slot: int, generation: int) -> None:
+    """Publish `slot` by writing and flushing its generation record."""
+    record = struct.pack(_RECORD_FORMAT, generation, generation ^ _COMPLEMENT_MASK)
+    fd = os.open(_record_path(base, slot), os.O_RDWR)
+    try:
+        os.write(fd, record)
+        _fsync(fd)
+    finally:
+        os.close(fd)
 
-    The vector store trims its pending-operation log — its only other copy of
-    these vectors — once the save returns, so a failed flush has to fail the
-    save rather than be reported as success. ``EIO`` here is not hypothetical:
-    a writeback error is reported to ``fsync`` once and the dirty pages are
-    then dropped, which is exactly when the save must not be treated as
-    committed. `atomic_index_write` removes the temp file and leaves the
-    previous index in place, so the next save retries. (SQLite draws the same
-    line: a file fsync failure raises ``SQLITE_IOERR_FSYNC``, while a directory
-    fsync failure is ignored — see `_flush_parent_dir`.)
-    """
-    # O_RDWR rather than O_RDONLY: os.fsync is `_commit` on Windows, which
-    # needs a writable handle. Opening for write does not truncate.
+
+def _empty_slot(base: str, slot: int) -> None:
+    """Unpublish a slot and reclaim its space, best-effort."""
+    # The record first: no valid record may ever name an emptied slot.
+    for path in (_record_path(base, slot), _slot_path(base, slot)):
+        with contextlib.suppress(OSError):
+            os.truncate(path, 0)
+
+
+def _flush_file(path: Path) -> None:
+    """Flush a file's contents to stable storage. Errors propagate."""
+    # O_RDWR rather than O_RDONLY: os.fsync is `_commit` on Windows, which needs
+    # a writable handle. Opening for write does not truncate.
     fd = os.open(path, os.O_RDWR)
     try:
         _fsync(fd)
@@ -148,26 +276,30 @@ def _flush_to_disk(path: str) -> None:
         os.close(fd)
 
 
-def _flush_parent_dir(path: str) -> None:
+def _create_artifacts(base: str) -> None:
     """
-    Flush the directory holding `path`, making the swap itself durable.
+    Create any missing slot or record files, once per collection.
 
-    Without this the swap is atomic but not durable: POSIX ``rename(2)`` leaves
-    the new directory entry in the page cache, so power loss can roll it back to
-    the previous file.
-
-    Best-effort, matching SQLite's ``unixSync``, which fsyncs the directory
-    holding a journal for exactly this reason and treats a directory it cannot
-    open as success. A filesystem that refuses this gives the SQLite database
-    beside the index no guarantee either, so hardening the index alone would
-    buy nothing, and failing the save would instead grow the pending log
-    without bound. Windows cannot open a directory this way at all, so this is
-    a no-op there and the swap's durability follows NTFS metadata journaling.
+    This is the only directory operation in the protocol, and it happens when
+    there is nothing to lose: before anything has been published, the store's
+    log still holds every vector. The parent directory is flushed afterwards so
+    that even this is durable where the platform allows it — a POSIX-only,
+    best-effort step, and the one place where a filesystem that refuses it costs
+    nothing more than a loud missing-index error at the next open.
     """
+    created = False
+    for path in index_artifact_paths(base):
+        try:
+            os.close(os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644))
+        except FileExistsError:
+            continue
+        created = True
+
+    if not created:
+        return
+
     with contextlib.suppress(OSError):
-        # `.parent` before `.resolve()`: the entry the swap created lives in the
-        # directory the path names, not in a symlink target's directory.
-        fd = os.open(Path(path).parent.resolve(), os.O_RDONLY)
+        fd = os.open(Path(base).parent.resolve(), os.O_RDONLY)
         try:
             _fsync(fd)
         finally:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -80,18 +80,24 @@ def atomic_index_write(path: str) -> Iterator[str]:
     temp = _temp_path(path)
     # Clear any temp left by a previously interrupted save before reusing it.
     Path(temp).unlink(missing_ok=True)
+    # Opened before the caller writes and held across that write, so the fsync
+    # below is on a descriptor that predates it. See `_flush_to_disk`.
+    fd = os.open(temp, os.O_RDWR | os.O_CREAT, 0o644)
     try:
-        yield temp
-        _flush_to_disk(temp)
+        try:
+            yield temp
+            _flush_to_disk(fd, temp)
+        finally:
+            os.close(fd)
         Path(temp).replace(path)
     except BaseException:
         Path(temp).unlink(missing_ok=True)
         raise
 
 
-def _flush_to_disk(path: str) -> None:
+def _flush_to_disk(fd: int, path: str) -> None:
     """
-    Fsync the temp file so its bytes are on disk before the swap.
+    Fsync the index bytes, on a descriptor that predates them.
 
     This is what rules out publishing the new name over incomplete bytes: the
     data is durable before the rename is issued, and a durable write does not
@@ -99,18 +105,24 @@ def _flush_to_disk(path: str) -> None:
     the temp and the previously published index stands -- because a failure
     here is exactly the evidence that the bytes are not safe to publish.
 
-    The descriptor is a fresh one, because the engine writes through its own
-    and closes it before returning. Flushing works regardless: dirty pages
-    belong to the file, not to the descriptor that dirtied them. Error
-    reporting does not. Linux hands a writeback error to descriptors that were
-    open when it was recorded, so one recorded in the gap between the engine's
-    close and this open is never reported here and the save proceeds. What
-    closes that window is fsyncing the descriptor the bytes were written
-    through, which needs an engine that writes through a caller-supplied
-    handle rather than to a path.
+    The descriptor has to predate the write for that to hold. Flushing would
+    work on one opened afterwards, since dirty pages belong to the file rather
+    than to the descriptor that dirtied them, but error reporting would not:
+    Linux samples the writeback error sequence when a file is opened, so a
+    descriptor opened after an error was recorded never learns of it and the
+    fsync returns success over bytes already known bad.
+
+    Holding a descriptor across someone else's write assumes they write in
+    place. An engine that wrote a file of its own and renamed it over this one
+    would leave this descriptor on an orphaned inode, and the fsync would
+    report on a file nobody is about to publish -- so that is checked rather
+    than assumed.
     """
-    fd = os.open(path, os.O_RDWR)
-    try:
-        os.fsync(fd)
-    finally:
-        os.close(fd)
+    written = Path(path).stat()
+    held = os.fstat(fd)
+    if (held.st_dev, held.st_ino) != (written.st_dev, written.st_ino):
+        raise OSError(
+            f"{path} was replaced while it was being written, so the "
+            f"descriptor held across the write no longer refers to it"
+        )
+    os.fsync(fd)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -26,7 +26,9 @@ already commits that way needs none of this.
 """
 
 import contextlib
+import errno
 import os
+import sys
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -139,4 +141,33 @@ def _flush_to_disk(fd: int, path: str) -> None:
             f"{path} was replaced while it was being written, so the "
             f"descriptor held across the write no longer refers to it"
         )
+    _fsync(fd)
+
+
+def _fsync(fd: int) -> None:
+    """
+    Flush `fd` as hard as the platform can be asked to.
+
+    Darwin's `fsync` returns once the data reaches the drive, which may hold it
+    in a volatile write cache -- so on macOS alone it does not order the data
+    ahead of the rename at the device, which is the whole point of flushing
+    here. `F_FULLFSYNC` asks the drive to flush that cache. Filesystems that
+    cannot do it refuse the request, and there `fsync` is the most that can be
+    asked; a refusal is a statement about the filesystem, so it falls back,
+    while any other error is a write failure and propagates.
+
+    Elsewhere `os.fsync` is already the strongest ordinary flush -- `fsync` on
+    Linux, `FlushFileBuffers` on Windows.
+    """
+    if sys.platform == "darwin":
+        import fcntl
+
+        try:
+            fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
+        except OSError as error:
+            if error.errno not in (errno.ENOTSUP, errno.EOPNOTSUPP, errno.EINVAL):
+                raise
+        else:
+            return
+
     os.fsync(fd)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -14,6 +14,15 @@ can still roll a save back to the previously published index after ``save``
 returned, while the SQLite side stays committed. Records applied since the
 last checkpoint then resolve by uuid but cannot be found by search. That is
 the direction this store tolerates; #1588 records why.
+
+Why a rename at all: the stronger answer is to put the commit point inside the
+file, where an fsync reaches it portably. SQLite never renames -- it commits by
+truncating or zeroing its rollback journal, and in WAL mode by appending frames
+whose checksums make a torn tail self-identifying, so recovery keeps everything
+up to the last frame that verifies. Both need the writer to own the file
+format. A search engine owns its own and exposes ``save(path)``, so above that
+call a rename is the only atomicity primitive left. An engine whose format
+already commits that way needs none of this.
 """
 
 import contextlib
@@ -89,6 +98,16 @@ def _flush_to_disk(path: str) -> None:
     un-happen. A failed fsync therefore fails the save -- the caller discards
     the temp and the previously published index stands -- because a failure
     here is exactly the evidence that the bytes are not safe to publish.
+
+    The descriptor is a fresh one, because the engine writes through its own
+    and closes it before returning. Flushing works regardless: dirty pages
+    belong to the file, not to the descriptor that dirtied them. Error
+    reporting does not. Linux hands a writeback error to descriptors that were
+    open when it was recorded, so one recorded in the gap between the engine's
+    close and this open is never reported here and the save proceeds. What
+    closes that window is fsyncing the descriptor the bytes were written
+    through, which needs an engine that writes through a caller-supplied
+    handle rather than to a path.
     """
     fd = os.open(path, os.O_RDWR)
     try:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -69,13 +69,28 @@ def atomic_index_write(path: str) -> Iterator[str]:
     The swap is atomic, not durable: after a power failure the index at `path`
     may be the previous one.
 
+    The body must write the yielded path **in place** -- opening it, or
+    truncating and rewriting it, is fine; replacing it is not. A descriptor on
+    the temp file is held open across the body so that the flush reports errors
+    from the body's own write (see `_flush_to_disk`), and a body that builds a
+    different file and renames it over the yielded path leaves that descriptor
+    on an orphaned inode. That is checked rather than trusted: it raises
+    `OSError` and publishes nothing, so a caller that breaks the rule finds out
+    at its first save rather than at a power cut.
+
     Args:
         path (str):
             The final index file path to swap the written index into.
 
     Yields:
         str:
-            The temp path to write the index to.
+            The temp path to write the index to, in place.
+
+    Raises:
+        OSError:
+            If the yielded path was replaced rather than written in place, or
+            if the index bytes could not be flushed to disk. In both cases any
+            existing index at `path` is left as it was.
     """
     temp = _temp_path(path)
     # Clear any temp left by a previously interrupted save before reusing it.
@@ -112,11 +127,10 @@ def _flush_to_disk(fd: int, path: str) -> None:
     descriptor opened after an error was recorded never learns of it and the
     fsync returns success over bytes already known bad.
 
-    Holding a descriptor across someone else's write assumes they write in
-    place. An engine that wrote a file of its own and renamed it over this one
-    would leave this descriptor on an orphaned inode, and the fsync would
-    report on a file nobody is about to publish -- so that is checked rather
-    than assumed.
+    Predating the write is also what makes the in-place rule `atomic_index_write`
+    states enforceable here: a body that replaced the file rather than writing
+    it leaves this descriptor on an orphaned inode, and fsyncing that would
+    report on a file nobody is about to publish.
     """
     written = Path(path).stat()
     held = os.fstat(fd)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -26,7 +26,6 @@ already commits that way needs none of this.
 """
 
 import contextlib
-import errno
 import os
 import sys
 from collections.abc import Iterator
@@ -151,10 +150,16 @@ def _fsync(fd: int) -> None:
     Darwin's `fsync` returns once the data reaches the drive, which may hold it
     in a volatile write cache -- so on macOS alone it does not order the data
     ahead of the rename at the device, which is the whole point of flushing
-    here. `F_FULLFSYNC` asks the drive to flush that cache. Filesystems that
-    cannot do it refuse the request, and there `fsync` is the most that can be
-    asked; a refusal is a statement about the filesystem, so it falls back,
-    while any other error is a write failure and propagates.
+    here. `F_FULLFSYNC` asks the drive to flush that cache.
+
+    Any failure of it falls through to `fsync`, without inspecting the errno.
+    The refusals cannot be enumerated: `ENOTSUP` and `EOPNOTSUPP` are distinct
+    values here, `/dev/null` refuses with `ENODEV`, and what a network mount
+    answers is not knowable from here, so a list would be a guess that fails
+    closed on whatever it missed. Falling through is not a suppression: `fsync`
+    runs on the same descriptor and raises in its turn, so a flush that cannot
+    happen still fails the save. What it gives up is the drive-cache flush,
+    leaving the guarantee this had before `F_FULLFSYNC` was asked for at all.
 
     Elsewhere `os.fsync` is already the strongest ordinary flush -- `fsync` on
     Linux, `FlushFileBuffers` on Windows.
@@ -164,9 +169,8 @@ def _fsync(fd: int) -> None:
 
         try:
             fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
-        except OSError as error:
-            if error.errno not in (errno.ENOTSUP, errno.EOPNOTSUPP, errno.EINVAL):
-                raise
+        except OSError:
+            pass
         else:
             return
 

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -1,46 +1,19 @@
 """
 Atomic on-disk index publication, shared by vector search engines.
 
-Each engine owns its index file layout, so the atomic-swap logic lives here
-(shared by the engines) rather than in the vector store: the index save
-location and the number of files written differ across engine implementations.
+The index is written to a sibling temp file, flushed, and swapped into place
+with ``os.replace``. Because the flush completes before the rename is issued,
+a crash leaves either the previous index or the new one -- never the new name
+over incomplete bytes, which is the case that matters: the vector store treats
+a saved-but-unloadable index as a hard error, while an index that reverts is
+only missing vectors until they are upserted again.
 
-What a save guarantees
-----------------------
-
-A reader never observes a partially written index at the target path. The index
-is written to a sibling temp file and swapped into place with ``Path.replace``
-(``os.replace``), which is atomic on POSIX and Windows when source and
-destination share a filesystem (guaranteed here, since the temp file is a
-sibling of the target). A save that is interrupted (crash, exception) therefore
-leaves the previous index untouched rather than corrupting it, which matters
-because the vector store treats a saved-but-unloadable index as a hard error
-rather than silently rebuilding it empty.
-
-What it does not
-----------------
-
-The publication is atomic, not durable. A rename changes a *directory entry*,
-and a directory entry cannot be flushed portably: POSIX needs an fsync on a
-directory file descriptor, which network and FUSE filesystems may refuse, and
-Windows has no equivalent at all. SQLite's own VFS is the precedent -- it
-threads a directory-sync flag through every commit-relevant directory
-operation, honors it in ``unixDelete``, and declares it
-``/* Not used on win32 */`` in ``winDelete``.
-
-So a power failure can roll a save back to the previously published index even
-though ``save`` returned, while the SQLite side -- including the
-pending-operation trim that ran behind that save -- stays committed. What that
-leaves is records whose vectors are missing from the index: they still resolve
-by uuid, but they cannot be found by search until they are re-upserted.
-
-That is the direction this store tolerates, and it is a deliberate trade. A
-stronger guarantee needs a commit protocol that never uses a directory
-operation as its commit point (two index slots plus a generation record, or an
-equivalent), which every engine would then have to implement and maintain. The
-failure it buys out is bounded -- search recall for at most the records applied
-since the last checkpoint, repaired by re-ingesting them -- so the machinery
-costs more than it saves.
+The rename itself is not made durable -- that needs an fsync on a directory
+fd, which POSIX offers unevenly and Windows not at all -- so a power failure
+can still roll a save back to the previously published index after ``save``
+returned, while the SQLite side stays committed. Records applied since the
+last checkpoint then resolve by uuid but cannot be found by search. That is
+the direction this store tolerates; #1588 records why.
 """
 
 import contextlib
@@ -85,7 +58,7 @@ def atomic_index_write(path: str) -> Iterator[str]:
     leaving any existing index at `path` intact.
 
     The swap is atomic, not durable: after a power failure the index at `path`
-    may be the previous one. See the module docstring for what that costs.
+    may be the previous one.
 
     Args:
         path (str):
@@ -109,17 +82,16 @@ def atomic_index_write(path: str) -> Iterator[str]:
 
 def _flush_to_disk(path: str) -> None:
     """
-    Best-effort fsync so the temp file's bytes are durable before the swap.
+    Fsync the temp file so its bytes are on disk before the swap.
 
-    Guards against a crash where the rename is durable but the data behind it
-    is not, which is the direction that costs: a published index that will not
-    parse is a hard error, while a publication that reverts is only missing
-    vectors. Failures are ignored -- this narrows a window rather than closing
-    one, since the swap itself is not durable either.
+    This is what rules out publishing the new name over incomplete bytes: the
+    data is durable before the rename is issued, and a durable write does not
+    un-happen. A failed fsync therefore fails the save -- the caller discards
+    the temp and the previously published index stands -- because a failure
+    here is exactly the evidence that the bytes are not safe to publish.
     """
-    with contextlib.suppress(OSError):
-        fd = os.open(path, os.O_RDWR)
-        try:
-            os.fsync(fd)
-        finally:
-            os.close(fd)
+    fd = os.open(path, os.O_RDWR)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/index_persistence.py
@@ -148,30 +148,27 @@ def _fsync(fd: int) -> None:
     Flush `fd` as hard as the platform can be asked to.
 
     Darwin's `fsync` returns once the data reaches the drive, which may hold it
-    in a volatile write cache -- so on macOS alone it does not order the data
-    ahead of the rename at the device, which is the whole point of flushing
-    here. `F_FULLFSYNC` asks the drive to flush that cache.
+    in a volatile write cache. That is not enough here. The data and the rename
+    that follows it land in the same cache with nothing ordering them, and the
+    rename is a few bytes of metadata against an index of megabytes, so a drive
+    flushing as it pleases can easily put the new name on media while the bytes
+    behind it are still queued -- the torn publication this module exists to
+    prevent. `F_FULLFSYNC` forces the cache out, which restores the ordering.
 
-    Any failure of it falls through to `fsync`, without inspecting the errno.
-    The refusals cannot be enumerated: `ENOTSUP` and `EOPNOTSUPP` are distinct
-    values here, `/dev/null` refuses with `ENODEV`, and what a network mount
-    answers is not knowable from here, so a list would be a guess that fails
-    closed on whatever it missed. Falling through is not a suppression: `fsync`
-    runs on the same descriptor and raises in its turn, so a flush that cannot
-    happen still fails the save. What it gives up is the drive-cache flush,
-    leaving the guarantee this had before `F_FULLFSYNC` was asked for at all.
+    A failure is not softened into `fsync`. Falling back would answer a request
+    for ordering with a flush that does not provide it under power loss, and
+    say nothing -- and a filesystem that cannot order data ahead of a rename is
+    not one to publish an index onto. Point `index_directory` at storage that
+    can. This also means no errno is inspected: refusal and failure take the
+    same path, so there is no line to draw and no list to get wrong.
 
-    Elsewhere `os.fsync` is already the strongest ordinary flush -- `fsync` on
-    Linux, `FlushFileBuffers` on Windows.
+    Elsewhere `os.fsync` already reaches the device -- `fsync` on Linux,
+    `FlushFileBuffers` on Windows.
     """
     if sys.platform == "darwin":
         import fcntl
 
-        try:
-            fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
-        except OSError:
-            pass
-        else:
-            return
+        fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
+        return
 
     os.fsync(fd)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
@@ -11,6 +11,7 @@ from usearch.index import Index, MetricKind
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
+from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -186,9 +187,17 @@ class USearchVectorSearchEngine(VectorSearchEngine):
     @override
     async def save(self, path: str) -> None:
         async with self._lock.write_lock():
-            await asyncio.to_thread(self._index.save, path)
+            await asyncio.to_thread(self._sync_save, path)
+
+    def _sync_save(self, path: str) -> None:
+        with atomic_index_write(path) as temp_path:
+            self._index.save(temp_path)
 
     @override
     async def load(self, path: str) -> None:
         async with self._lock.write_lock():
-            await asyncio.to_thread(self._index.load, path)
+            await asyncio.to_thread(self._sync_load, path)
+
+    def _sync_load(self, path: str) -> None:
+        clear_stale_index_temp(path)
+        self._index.load(path)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
@@ -11,7 +11,7 @@ from usearch.index import Index, MetricKind
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
-from .index_persistence import publish_index, published_index_path
+from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -190,8 +190,8 @@ class USearchVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        with publish_index(path) as slot_path:
-            self._index.save(slot_path)
+        with atomic_index_write(path) as temp_path:
+            self._index.save(temp_path)
 
     @override
     async def load(self, path: str) -> None:
@@ -199,7 +199,5 @@ class USearchVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> None:
-        published = published_index_path(path)
-        if published is None:
-            raise FileNotFoundError(f"No published index for {path}")
-        self._index.load(published)
+        clear_stale_index_temp(path)
+        self._index.load(path)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
@@ -11,7 +11,7 @@ from usearch.index import Index, MetricKind
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
-from .index_persistence import atomic_index_write, clear_stale_index_temp
+from .index_persistence import publish_index, published_index_path
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -190,8 +190,8 @@ class USearchVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        with atomic_index_write(path) as temp_path:
-            self._index.save(temp_path)
+        with publish_index(path) as slot_path:
+            self._index.save(slot_path)
 
     @override
     async def load(self, path: str) -> None:
@@ -199,5 +199,7 @@ class USearchVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> None:
-        clear_stale_index_temp(path)
-        self._index.load(path)
+        published = published_index_path(path)
+        if published is None:
+            raise FileNotFoundError(f"No published index for {path}")
+        self._index.load(published)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
@@ -122,42 +122,30 @@ class VectorSearchEngine(ABC):
     @abstractmethod
     async def save(self, path: str) -> None:
         """
-        Persist the index under `path`, durably.
+        Publish the index at `path`, replacing whatever index is there.
 
-        Returning must mean that a later `load` produces this index even if the
-        machine loses power on the next instruction. Not "written", not "handed
-        to the OS", not "renamed on a filesystem that has yet to flush the
-        directory". The caller trims its pending-operation log — the only other
-        copy of these vectors — as soon as this returns, so anything weaker
-        loses data.
+        Returning must mean a later `load` reads this index or the one it
+        replaced, never a half-written mixture of the two. It does *not* mean
+        the publication survives a power failure: implementations may publish
+        with an atomic rename, which a power failure can roll back after this
+        returns.
 
-        Durability is entirely the implementation's, including which artifact is
-        live: nothing about the layout may leak out, and the caller keeps no
-        pointer, manifest, or generation of its own. `path` is therefore a base
-        name rather than a promise about the files on disk — an engine may keep
-        one file, two slots, or a set of segments under it.
-
-        `index_persistence.publish_index` provides this for a backend that can
-        only write an index to a path; an engine whose backend publishes durably
-        on its own may delegate to that instead.
+        Callers must therefore treat a published index as possibly stale, but
+        never as corrupt. `SQLiteVectorStore` trims its pending-operation log
+        once this returns, so a rolled-back publication leaves records whose
+        vectors are missing from the index until they are re-upserted.
 
         Args:
             path (str):
-                Base path for the index files.
+                File path to write the index to.
         """
 
     @abstractmethod
     async def load(self, path: str) -> None:
         """
-        Load the index most recently published under `path`.
-
-        Raising is correct when nothing is published or the published index does
-        not parse. Implementations must **not** substitute an older copy they
-        may still hold: the caller trimmed its log against the published one, so
-        an older copy is stale by exactly the operations that can no longer be
-        replayed, and serving it would be data loss dressed as success.
+        Load the index from disk.
 
         Args:
             path (str):
-                Base path for the index files.
+                File path to read the index from.
         """

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
@@ -122,7 +122,26 @@ class VectorSearchEngine(ABC):
     @abstractmethod
     async def save(self, path: str) -> None:
         """
-        Persist the index to disk.
+        Persist the index to `path`, atomically and durably.
+
+        Write elsewhere, flush, and replace `path` in one step, so a crash
+        leaves either the previous index or the new one and never a partial
+        file — then make that replacement durable by whatever means the
+        platform provides.
+
+        The caller trims its pending-operation log — its only other copy of
+        these vectors — once this returns, so an implementation that merely
+        writes and flushes, leaving a half-written file reachable at `path`,
+        does not satisfy this. An engine whose backend implements the whole
+        protocol natively may delegate to it; the rest should use
+        `index_persistence.atomic_index_write`, which implements it against a
+        backend that can only write to a path.
+
+        "As durably as the platform allows" is deliberate rather than a hedge.
+        On POSIX the replacement is made durable by fsyncing the parent
+        directory. Windows has no equivalent operation, so the replacement is
+        atomic through NTFS metadata journaling but is not necessarily flushed
+        when the call returns.
 
         Args:
             path (str):
@@ -133,6 +152,10 @@ class VectorSearchEngine(ABC):
     async def load(self, path: str) -> None:
         """
         Load the index from disk.
+
+        Implementations should clear any temp file a previously interrupted
+        save left beside `path` (`index_persistence.clear_stale_index_temp`),
+        so a crash does not leak one across restarts.
 
         Args:
             path (str):

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
@@ -122,42 +122,42 @@ class VectorSearchEngine(ABC):
     @abstractmethod
     async def save(self, path: str) -> None:
         """
-        Persist the index to `path`, atomically and durably.
+        Persist the index under `path`, durably.
 
-        Write elsewhere, flush, and replace `path` in one step, so a crash
-        leaves either the previous index or the new one and never a partial
-        file — then make that replacement durable by whatever means the
-        platform provides.
+        Returning must mean that a later `load` produces this index even if the
+        machine loses power on the next instruction. Not "written", not "handed
+        to the OS", not "renamed on a filesystem that has yet to flush the
+        directory". The caller trims its pending-operation log — the only other
+        copy of these vectors — as soon as this returns, so anything weaker
+        loses data.
 
-        The caller trims its pending-operation log — its only other copy of
-        these vectors — once this returns, so an implementation that merely
-        writes and flushes, leaving a half-written file reachable at `path`,
-        does not satisfy this. An engine whose backend implements the whole
-        protocol natively may delegate to it; the rest should use
-        `index_persistence.atomic_index_write`, which implements it against a
-        backend that can only write to a path.
+        Durability is entirely the implementation's, including which artifact is
+        live: nothing about the layout may leak out, and the caller keeps no
+        pointer, manifest, or generation of its own. `path` is therefore a base
+        name rather than a promise about the files on disk — an engine may keep
+        one file, two slots, or a set of segments under it.
 
-        "As durably as the platform allows" is deliberate rather than a hedge.
-        On POSIX the replacement is made durable by fsyncing the parent
-        directory. Windows has no equivalent operation, so the replacement is
-        atomic through NTFS metadata journaling but is not necessarily flushed
-        when the call returns.
+        `index_persistence.publish_index` provides this for a backend that can
+        only write an index to a path; an engine whose backend publishes durably
+        on its own may delegate to that instead.
 
         Args:
             path (str):
-                File path to write the index to.
+                Base path for the index files.
         """
 
     @abstractmethod
     async def load(self, path: str) -> None:
         """
-        Load the index from disk.
+        Load the index most recently published under `path`.
 
-        Implementations should clear any temp file a previously interrupted
-        save left beside `path` (`index_persistence.clear_stale_index_temp`),
-        so a crash does not leak one across restarts.
+        Raising is correct when nothing is published or the published index does
+        not parse. Implementations must **not** substitute an older copy they
+        may still hold: the caller trimmed its log against the published one, so
+        an older copy is stale by exactly the operations that can no longer be
+        replayed, and serving it would be data loss dressed as success.
 
         Args:
             path (str):
-                File path to read the index from.
+                Base path for the index files.
         """

--- a/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
@@ -621,13 +621,28 @@ class VectorStoreSemanticStorage(SemanticStorage):
         )
 
     async def _get_existing_vector_record(self, feature_id: FeatureIdT) -> Record:
+        """Read back a feature's stored embedding.
+
+        A vector store publishes its index atomically but not durably (see
+        `common.vector_store.sqlite_vector_store`), so a power failure can
+        leave a record the store still knows about but whose vector the index
+        no longer holds. The two cases are reported apart because the caller
+        can act on them differently: a missing embedding is repaired by
+        passing a fresh one to `update_feature`, while a missing record is
+        not.
+        """
         records = await self._vector_collection.get(
             record_uuids=[feature_vector_uuid(feature_id)],
             return_vector=True,
             return_properties=False,
         )
-        if not records or records[0].vector is None:
+        if not records:
             raise ResourceNotFoundError(f"Vector record not found: {feature_id}")
+        if records[0].vector is None:
+            raise ResourceNotFoundError(
+                f"Vector record {feature_id} has no stored embedding; "
+                "pass an embedding to update this feature"
+            )
         return records[0]
 
     async def _delete_vector_records(self, feature_ids: Sequence[FeatureIdT]) -> None:


### PR DESCRIPTION
Copy of #1460 onto `speedkick`. Cherry-picked cleanly; no conflicts and no changes were needed. Targeted suites `common/vector_store` and `semantic_memory` pass (656 passed, 2 skipped).

## Problem

`SQLiteVectorStore` persists each collection's index by calling the search engine's `save()`, which writes directly to the final path. A crash partway through leaves a truncated file on disk.

The torn file is only half of it. `_save_collection_index` trims the applied `_PendingOperationRow`s as soon as `save()` returns, and that log is the **only** other copy of those vectors — the records table has no vector column. So the trim is safe at exactly one instant: when the index at the published path holds them. Getting that instant wrong is silent, because a missing vector is indistinguishable from a vector that simply doesn't match.

## Fix

A shared `index_persistence` helper writes the index to a sibling temp file, flushes it, and swaps it into place with `os.replace`; both engines adopt it and neither gains anything else. `load` clears a temp left by an interrupted save, so a crash leaks at most one stale file per index.

After this, a save either publishes a complete index or leaves the previous one exactly where it was. Nothing else changes: no schema change, no migration, no rename of `index_path`, and no new file at the base path.

## What a save does not promise

It does not promise that the publication is **durable**. That is a decision rather than an oversight, so the reasoning is below.

A rename changes a **directory entry**, not file data, and the two have very different guarantees:

| | make it durable | available |
|---|---|---|
| file contents | `fsync` / `F_FULLFSYNC` / `FlushFileBuffers` | everywhere, documented |
| directory entry | `fsync` on a directory file descriptor | POSIX only, and not on every filesystem |

- **POSIX** closes the gap with a parent-directory fsync, but only best-effort — network and FUSE filesystems are where that bites.
- **Windows** has no equivalent at all. `os.fsync` is `_commit`, which is `FlushFileBuffers`, which is for file data; you cannot open a directory to fsync it. `MOVEFILE_WRITE_THROUGH` does not help either: its documented guarantee is scoped to "a move performed as a copy and delete operation", the cross-volume path, and says nothing about flushing NTFS metadata for a same-volume rename. The decisive evidence is SQLite's — its VFS threads a directory-sync flag through every commit-relevant directory operation, `unixDelete` honors it, and `winDelete` declares the same parameter `/* Not used on win32 */`. SQLite cares about this more than almost any software and makes no attempt on Windows.

So a power failure can roll the rename back after `save` returned, while the trim behind it stays committed.

## Why that gap stays open

Closing it means never using a directory operation as the commit point: two index slots plus a generation record written into a file that already exists, in the spirit of SQLite's `PERSIST` journal mode. An earlier revision of this PR implemented exactly that, and it worked. It was still the wrong trade, for four reasons.

**The window is narrow, and only one kind of failure lands in it.** A clean shutdown, an unhandled exception, an OOM kill, a `SIGKILL` — none of these lose a rename, because the kernel still owns the page cache and writes it back. Those failures are already covered: the pending log holds everything the engine has not been checkpointed with, and startup replays it. What is left is the machine itself dying between the rename and writeback — a power cut, a host failure, a panic — plus the filesystems where a directory fsync is best-effort or unavailable anyway.

**What it costs is recall, not correctness.** The records table is the authority on what exists, and every query hit resolves through it, so a reverted publication cannot produce a wrong or stale result — only fewer results. Concretely: the records survive, `get` still returns them, `query` stops finding them, and the exposure is bounded by the operations applied since the previous checkpoint, i.e. at most `save_threshold`. Re-upserting an affected record repairs it. That is the direction this store already tolerates, and it is repairable by the same ingest path that created the record.

**Detecting it is not cheap enough to be worth it.** Comparing the index's size against the record count is the obvious check and it does not work: `row_id`s are `AUTOINCREMENT` and never reused, so deleting a record and upserting the same uuid again moves it to a new id. A rollback spanning that pair leaves the index holding the old id and missing the new one — one extra, one missing, identical count — and a re-embedding workload produces that shape constantly. A check that does work needs an id-set digest maintained by every engine, or a full reconcile scan at every boot, which is most expensive precisely where the index is large. Neither earns its keep against a bounded recall gap.

**And the guarantee is not free to hold.** It cannot be delegated to a rename, so it has to become a layout: two slots and a generation record per index, which every engine has to implement and every future engine has to be audited against. Engines that persist by writing one file — which is what both engines here do, and what most ANN libraries expose — stop being usable as they ship. Existing indexes stop loading until they are cleared and re-ingested, which is a migration this revision no longer asks anyone to perform. Fewer guarantees, less machinery to keep correct, and a wider set of engines that can plug in unmodified.

The direction that *would* cost — a published index that will not parse — stays closed: the atomic swap prevents it, the pre-swap `fsync` narrows the window where a rename outlives the data behind it, and a saved-but-unloadable index remains a loud `IndexLoadError` rather than a silently empty rebuild.

Nothing here detects a lost publication for the caller. A deployment that needs every record searchable after a power failure must be able to re-ingest.

## Where the contract is stated

The guarantee is only useful if callers can find it, so it is written where each of them looks:

- `VectorSearchEngine.save` — returning means a later `load` reads this index or the one it replaced, never a mixture; it does **not** mean the publication survives a power failure.
- `index_persistence` — the mechanism, and why a stronger guarantee is not portable.
- `sqlite_vector_store` — what survives a process crash, what a power failure costs, and that re-ingest is the repair.
- `_save_collection_index` — why the save-then-trim order is the whole protocol.

One consumer needed more than a docstring. `VectorStoreSemanticStorage.update_feature` reads a feature's stored embedding back when the caller updates the feature without supplying one — the only place in the server that depends on the index still holding a vector. It reported a lost vector as `Vector record not found`, naming the feature, which points at the wrong thing and hides the repair; it now separates a record that is genuinely absent from one whose embedding is gone, and the second says to pass a fresh embedding.

## Tests

- `test_index_persistence.py`: the swap publishes completely or not at all, a failed write leaves the previous index intact and removes the temp, and a stale temp is cleared on load.
- Per-engine (hnswlib + usearch): repeated saves leave no stray files, and a reload after two checkpoints sees the newer index.
- Store-level: `test_a_reverted_publication_costs_search_not_records` reconstructs a lost publication deterministically — restore the previous index bytes after the trim has committed — and pins the direction it fails in: the record still resolves by uuid, and only search loses it. Missing and corrupt indexes each still raise `IndexLoadError` once `index_saved` is set.

`vector_store` suites pass (284 passed, 140 integration deselected) and `semantic_memory` suites pass (345 passed, 2 skipped, 999 integration deselected); `ruff` and `ty` clean.

## Changed from the earlier revision

This PR previously shipped the two-slot generation-record protocol and its breaking on-disk change. That guarantee has been dropped in favor of the atomic swap plus an explicit contract, so **the breaking-change notice no longer applies**: indexes written by the current code keep loading, and there is nothing to migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKmF9xNph9QH3ozNw3ZnJL
