### PR TITLE
Never reuse a row id in SQLiteVectorStore (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -1,5 +1,6 @@
 """Tests for SQLiteVectorStore."""
 
+import asyncio
 import math
 from datetime import UTC, datetime, timedelta, timezone
 from uuid import UUID, uuid4
@@ -33,6 +34,9 @@ from memmachine_server.common.vector_store.sqlite_vector_store import (
 )
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
+)
+from memmachine_server.common.vector_store.vector_search_engine.vector_search_engine import (
+    VectorSearchEngine,
 )
 
 NAMESPACE = "test_namespace"
@@ -961,6 +965,138 @@ class TestConcurrentAsync:
             await collection.upsert(records=more_records)
 
         await asyncio.gather(query_loop(), upsert_more())
+
+
+# ── row_id reuse (issue #1468) ──
+
+
+class _GatedSearchEngine(VectorSearchEngine):
+    """Delegates to a real engine; the next search() parks after scoring.
+
+    query() scores keys and then resolves them to rows without a lock, so a
+    write can retire a scored row in the gap. The gate parks in that gap.
+    """
+
+    def __init__(self, inner: VectorSearchEngine) -> None:
+        self.inner = inner
+        self.gate: asyncio.Event | None = None
+        self.gate_reached = asyncio.Event()
+
+    async def add(self, vectors):
+        await self.inner.add(vectors)
+
+    async def remove(self, keys):
+        await self.inner.remove(keys)
+
+    async def search(self, vectors, *, limit, allowed_keys=None):
+        results = await self.inner.search(
+            vectors, limit=limit, allowed_keys=allowed_keys
+        )
+        if self.gate is not None:
+            gate, self.gate = self.gate, None
+            self.gate_reached.set()
+            await gate.wait()
+        return results
+
+    async def save(self, path):
+        await self.inner.save(path)
+
+    async def load(self, path):
+        await self.inner.load(path)
+
+
+class TestRowIdReuse:
+    """Regression tests for row_id reuse (issue #1468).
+
+    Without AUTOINCREMENT, SQLite assigns max(rowid) + 1, so a deleted record's
+    id can go to the next insert. Serialized writes do not cover the read path,
+    which resolves scored keys to rows without a lock, so these tests pin the
+    id policy itself.
+    """
+
+    async def _row_id_of(self, collection, record_uuid):
+        async with collection._create_session() as session:
+            return (
+                await session.execute(
+                    select(collection._records_table.c.row_id).where(
+                        collection._records_table.c.uuid == record_uuid
+                    )
+                )
+            ).scalar_one()
+
+    @pytest.mark.asyncio
+    async def test_row_ids_are_never_reused(self, collection):
+        """A new record must not be assigned a previously deleted row_id."""
+        record_a = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
+        await collection.upsert(records=[record_a])
+        row_id_a = await self._row_id_of(collection, record_a.uuid)
+
+        await collection.delete(record_uuids=[record_a.uuid])
+
+        record_b = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+        await collection.upsert(records=[record_b])
+        row_id_b = await self._row_id_of(collection, record_b.uuid)
+
+        assert row_id_b != row_id_a
+
+    @pytest.mark.asyncio
+    async def test_a_query_cannot_return_a_record_it_never_scored(self, tmp_path):
+        """A key the engine scored must never resolve to a later record.
+
+        Writes run freely between scoring and row lookup, so a reused row_id
+        would return a never-scored record with another's score: here, a
+        record orthogonal to the query as a perfect hit. With ids never reused
+        the stale key matches no row and is dropped.
+        """
+        db_path = tmp_path / "test.db"
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+        gated_engines: list[_GatedSearchEngine] = []
+
+        def factory(ndim):
+            gated = _GatedSearchEngine(USearchVectorSearchEngine(num_dimensions=ndim))
+            gated_engines.append(gated)
+            return gated
+
+        store = SQLiteVectorStore(
+            SQLiteVectorStoreParams(
+                sqlalchemy_engine=engine,
+                vector_search_engine_factory=factory,
+            )
+        )
+        await store.startup()
+        try:
+            collection = await store.open_or_create_collection(
+                namespace=NAMESPACE,
+                name=NAME,
+                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
+            )
+            (gated_engine,) = gated_engines
+
+            scored = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
+            await collection.upsert(records=[scored])
+
+            # The query parks holding the scored key: the highest row_id, and
+            # so the one a reused id would hand out next.
+            gate = asyncio.Event()
+            gated_engine.gate = gate
+            query_task = asyncio.create_task(
+                collection.query(query_vectors=[_normalize([1.0, 0.0, 0.0])], limit=1)
+            )
+            await gated_engine.gate_reached.wait()
+
+            await collection.delete(record_uuids=[scored.uuid])
+            successor = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+            await collection.upsert(records=[successor])
+
+            gate.set()
+            results = await query_task
+
+            assert [match.record_uuid for match in results[0].matches] == [], (
+                "a record the engine never scored was returned"
+            )
+        finally:
+            await store.shutdown()
+            await engine.dispose()
 
 
 # ── Crash recovery & pending operations ──

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -923,6 +923,10 @@ class SQLiteVectorStore(VectorStore):
             Column("uuid", Uuid, nullable=False, unique=True),
             Column("properties", JSON, nullable=False, default=dict),
             extend_existing=True,
+            # A plain rowid is reused once the highest row is deleted. query()
+            # resolves scored keys to rows without a lock, so a scored key could
+            # resolve to a record other than the one the engine scored.
+            sqlite_autoincrement=True,
         )
 
     def _index_path(self, namespace: str, name: str) -> Path | None:


### PR DESCRIPTION
### Purpose of the change

`SQLiteVectorStoreCollection` keeps records in SQLite and vectors in a search engine keyed by the record's row id. The records table used a plain `INTEGER PRIMARY KEY`, which *is* SQLite's rowid, assigned as `max(rowid) + 1`: deleting the highest row freed its id for the very next insert, so a new record inherited the id an old one was being served under.

`query` scores keys in the search engine, then resolves them to rows in a second step, holding nothing in between, because readers are not made to wait on writers. A reused id lets a record that was never scored come back wearing the score of the record that was. Nothing about that result looks wrong from outside: the record exists, the score is in range, and no row or vector is left dangling to find the mix-up by.

`sqlite_autoincrement=True`, so ids are never reused. A stale engine key then matches no row and is dropped.

First half of #1468. The other half, concurrent writers reaching the engine out of commit order, is #1607, stacked on this.

### Tests

Both fail without the flag. `test_row_ids_are_never_reused` pins the id policy directly. `test_a_query_cannot_return_a_record_it_never_scored` gates the engine so a query parks between scoring and row lookup, deletes the scored record and inserts another in that window, and asserts the query returns nothing.

### Verification

- `test_sqlite_vector_store.py`: 72 passed. The 2 new tests fail against `speedkick`'s store.
- `ruff check` / `ruff format --check`: clean.

Bottom of a four-PR stack (this → #1607 → #1608 → #1609), split from the earlier single PR for readability.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESpWYTmCR7X3bJEpoA8SAn
