### PR TITLE
Use async Cohere client in CohereReranker (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/reranker/test_cohere_reranker_unit.py
+++ b/packages/server/server_tests/memmachine_server/common/reranker/test_cohere_reranker_unit.py
@@ -1,0 +1,134 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from memmachine_server.common.data_types import ExternalServiceAPIError
+from memmachine_server.common.reranker.cohere_reranker import (
+    CohereReranker,
+    CohereRerankerParams,
+)
+
+
+class StubAsyncCohereClient:
+    """Stub of cohere.AsyncClientV2 returning canned rerank results."""
+
+    def __init__(self, relevance_scores: list[float] | None = None):
+        self.calls: list[dict] = []
+        self._relevance_scores = relevance_scores
+
+    async def rerank(self, *, model, query, documents):
+        self.calls.append({"model": model, "query": query, "documents": documents})
+
+        relevance_scores = self._relevance_scores or [
+            1.0 / (index + 1) for index in range(len(documents))
+        ]
+
+        # Return results in descending relevance order like the real API.
+        results = sorted(
+            (
+                SimpleNamespace(index=index, relevance_score=relevance_score)
+                for index, relevance_score in enumerate(relevance_scores)
+            ),
+            key=lambda result: result.relevance_score,
+            reverse=True,
+        )
+        return SimpleNamespace(results=results)
+
+
+@pytest.fixture
+def client():
+    return StubAsyncCohereClient()
+
+
+@pytest.fixture
+def reranker(client):
+    return CohereReranker(
+        CohereRerankerParams(
+            client=client,
+            model="rerank-v3.5",
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_scores_map_back_to_original_positions(client):
+    reranker = CohereReranker(
+        CohereRerankerParams(
+            client=StubAsyncCohereClient(relevance_scores=[0.2, 0.9, 0.5]),
+            model="rerank-v3.5",
+        )
+    )
+
+    scores = await reranker.score("query", ["a", "b", "c"])
+
+    assert scores == [0.2, 0.9, 0.5]
+
+
+@pytest.mark.asyncio
+async def test_empty_candidates_do_not_call_api(reranker, client):
+    assert await reranker.score("query", []) == []
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_blank_candidates_do_not_call_api(reranker, client):
+    assert await reranker.score("query", ["", "  "]) == [0.0, 0.0]
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_blank_query_is_replaced(reranker, client):
+    await reranker.score("  ", ["a"])
+
+    assert client.calls[0]["query"] == "."
+
+
+@pytest.mark.asyncio
+async def test_request_parameters_passed_through(reranker, client):
+    await reranker.score("query", ["a", "b"])
+
+    assert client.calls == [
+        {"model": "rerank-v3.5", "query": "query", "documents": ["a", "b"]}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_client_error_wrapped(reranker, client):
+    class FailingClient:
+        async def rerank(self, *, model, query, documents):
+            raise RuntimeError("boom")
+
+    reranker = CohereReranker(
+        CohereRerankerParams(client=FailingClient(), model="rerank-v3.5")
+    )
+
+    with pytest.raises(ExternalServiceAPIError):
+        await reranker.score("query", ["a"])
+
+
+@pytest.mark.asyncio
+async def test_concurrent_scores_are_in_flight_simultaneously():
+    num_calls = 64
+    in_flight = 0
+    all_in_flight = asyncio.Event()
+
+    class BlockingClient(StubAsyncCohereClient):
+        async def rerank(self, *, model, query, documents):
+            nonlocal in_flight
+            in_flight += 1
+            if in_flight == num_calls:
+                all_in_flight.set()
+            # Deadlocks (and times out) if calls are serialized by a
+            # bounded worker pool instead of running concurrently.
+            await all_in_flight.wait()
+            return await super().rerank(model=model, query=query, documents=documents)
+
+    reranker = CohereReranker(
+        CohereRerankerParams(client=BlockingClient(), model="rerank-v3.5")
+    )
+
+    await asyncio.wait_for(
+        asyncio.gather(*(reranker.score("query", ["a"]) for _ in range(num_calls))),
+        timeout=5,
+    )

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_reranker_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_reranker_manager.py
@@ -144,7 +144,7 @@ async def test_build_cohere_reranker_passes_base_url(monkeypatch):
         captured_kwargs.update(kwargs)
         return FakeCohereClient()
 
-    monkeypatch.setattr("cohere.ClientV2", fake_client_v2)
+    monkeypatch.setattr("cohere.AsyncClientV2", fake_client_v2)
 
     conf = RerankersConf(
         cohere={
@@ -179,7 +179,7 @@ async def test_build_cohere_reranker_omits_base_url_when_not_configured(monkeypa
         captured_kwargs.update(kwargs)
         return FakeCohereClient()
 
-    monkeypatch.setattr("cohere.ClientV2", fake_client_v2)
+    monkeypatch.setattr("cohere.AsyncClientV2", fake_client_v2)
 
     conf = RerankersConf(
         cohere={

--- a/packages/server/server_tests/memmachine_server/conftest.py
+++ b/packages/server/server_tests/memmachine_server/conftest.py
@@ -205,9 +205,9 @@ def cohere_integration_config():
 
 @pytest.fixture(scope="session")
 def cohere_client(cohere_integration_config):
-    from cohere import ClientV2
+    from cohere import AsyncClientV2
 
-    return ClientV2(api_key=cohere_integration_config["api_key"])
+    return AsyncClientV2(api_key=cohere_integration_config["api_key"])
 
 
 @pytest.fixture(scope="session")

--- a/packages/server/src/memmachine_server/common/reranker/cohere_reranker.py
+++ b/packages/server/src/memmachine_server/common/reranker/cohere_reranker.py
@@ -1,10 +1,8 @@
 """Cohere reranker implementation."""
 
-import asyncio
 import logging
 from typing import Any
 
-import cohere
 from pydantic import BaseModel, Field
 
 from memmachine_server.common.data_types import ExternalServiceAPIError
@@ -19,7 +17,7 @@ class CohereRerankerParams(BaseModel):
 
     client: Any = Field(
         ...,
-        description="Cohere client instance for making API calls",
+        description="Async Cohere client instance for making API calls",
     )
     model: str = Field(
         "rerank-english-v3.0",
@@ -46,16 +44,12 @@ class CohereReranker(Reranker):
         if all(not candidate.strip() for candidate in candidates):
             return [0.0] * len(candidates)
 
-        # Build request parameters
-        def _call_rerank() -> cohere.RerankResponse:
-            return self._client.rerank(
+        try:
+            response = await self._client.rerank(
                 model=self._model,
                 query=query,
                 documents=candidates,
             )
-
-        try:
-            response = await asyncio.to_thread(_call_rerank)
         except Exception as e:
             error_message = (
                 f"Failed to score candidates with Cohere model {self._model} "

--- a/packages/server/src/memmachine_server/common/resource_manager/reranker_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/reranker_manager.py
@@ -168,7 +168,7 @@ class RerankerManager(BaseResourceManager[Reranker]):
         return self._rerankers[name]
 
     async def _build_cohere_reranker(self, name: str) -> Reranker:
-        from cohere import ClientV2
+        from cohere import AsyncClientV2
 
         from memmachine_server.common.reranker.cohere_reranker import (
             CohereReranker,
@@ -179,9 +179,9 @@ class RerankerManager(BaseResourceManager[Reranker]):
 
         cohere_api_key = conf.cohere_key.get_secret_value() if conf.cohere_key else None
         if conf.base_url is not None:
-            client = ClientV2(api_key=cohere_api_key, base_url=conf.base_url)
+            client = AsyncClientV2(api_key=cohere_api_key, base_url=conf.base_url)
         else:
-            client = ClientV2(api_key=cohere_api_key)
+            client = AsyncClientV2(api_key=cohere_api_key)
         params = CohereRerankerParams(
             client=client,
             model=conf.model,


### PR DESCRIPTION
Copy of #1522 onto `speedkick`. Cherry-picked cleanly; no conflicts and no changes were needed. Targeted suites `common/reranker` and `common/resource_manager` pass (247 passed).

### Purpose of the change

Remove a hard throughput ceiling on Cohere reranking. `CohereReranker.score` currently runs the sync `ClientV2.rerank` call through `asyncio.to_thread`, which draws from asyncio's default executor: at most `min(32, cpu_count + 4)` worker threads. Each in-flight rerank pins one of those threads for its full network round trip (typically ~0.3-0.5 s), so rerank throughput is capped at roughly `threads / latency` RPS regardless of how much concurrency the caller offers:

- 8-core host: 12 threads -> ~24-40 rerank RPS
- even at the 32-thread max: ~65-105 RPS

Beyond the cap, calls queue inside the executor and observed latency grows linearly with load. The default executor is also shared with every other `asyncio.to_thread` call in the process (e.g. `SentenceTransformerEmbedder`, `CrossEncoderReranker`), so saturating it with reranks starves local model inference too.

This PR switches to the Cohere SDK's native async client (`AsyncClientV2`, httpx-based), making rerank plain event-loop I/O. Concurrency is then bounded by the HTTP connection pool and the API itself, not by a thread pool.

### Description

- `cohere_reranker.py`: `score` now awaits `client.rerank(...)` directly; the `asyncio.to_thread` wrapper is gone. Score mapping and empty/blank input handling are unchanged.
- `reranker_manager.py`: `_build_cohere_reranker` constructs `AsyncClientV2` (same `api_key` / `base_url` kwargs as `ClientV2`).
- Tests: conftest's `cohere_client` fixture and the reranker manager tests updated to `AsyncClientV2`; new keyless unit tests added (see below).

No config or API surface changes; `AsyncClientV2` is generated from the same spec as `ClientV2` and is already part of the pinned `cohere>=5.20.0` dependency.

Measured effect (stub client with 0.2 s simulated latency): 128 concurrent `score()` calls complete in 0.20 s wall on this branch, vs ~1.7 s when serialized through a 15-thread default executor. The gap widens with load.

Breaking for usage as a library.

### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g., code style improvements, linting) - performance only; behavior and outputs are unchanged

### How Has This Been Tested?

- [x] Unit Test
- [x] Manual verification (list step-by-step instructions)

**Unit tests (no API key needed):** new `test_cohere_reranker_unit.py` runs `CohereReranker` against a stub async client: relevance scores map back to original candidate positions, empty/blank candidates skip the API, blank queries are replaced, request parameters pass through verbatim, client errors are wrapped in `ExternalServiceAPIError`, and a 64-way concurrency canary fails by timeout if calls ever get serialized through a bounded worker pool. Full reranker + reranker manager suite: 186 passed, ruff clean.

**Wire equivalence (no API key needed):** pointed both `ClientV2` (current production path) and `AsyncClientV2` at a local capture HTTP server via `base_url` and issued the same rerank call. Results: byte-identical requests (`POST /v2/rerank`, identical JSON body, no header differences including `authorization`), both parse into equal `V2RerankResponse` objects, and `CohereReranker` end-to-end over real HTTP returns correctly mapped scores. Since the async client emits exactly the bytes the sync client already sends in production, server-side behavior is unchanged by this PR.

**Integration:** the existing `test_cohere_reranker.py` (integration-marked) is updated to the async client with identical coverage; it needs `COHERE_API_KEY` to run. Note the pytest-integration workflow does not currently set that secret, so these tests also skip in CI today - the keyless wire-equivalence check above was run in their place.

**Test Results:**

```
186 passed, 3 skipped, 54 deselected in 0.32s

wire equivalence probe:
sync:  POST /v2/rerank
async: POST /v2/rerank
body identical: True
header diffs: none
auth header identical: True
parsed responses identical: True
reranker scores (expect [0.1, 0.9, 0.5]): [0.1, 0.9, 0.5]
```

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Screenshots/Gifs

N/A

### Further comments

- If very high rerank concurrency exposes connection churn (httpx defaults: 20 keepalive / 100 max connections), the next lever is passing a custom `httpx_client` to `AsyncClientV2`; left at defaults here.
- `AmazonBedrockReranker` has the same to_thread ceiling (boto3 has no async client); out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKmF9xNph9QH3ozNw3ZnJL
