### PR TITLE
Add VectorSearchEngine backed by turbovec, and take vector read-back out of the vector store contract (speedkick)

### DIFF
--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -80,7 +80,7 @@ litellm = [
     "litellm>=1.63.0,<1.86",
 ]
 turbovec = [
-    "turbovec>=0.7.0",
+    "turbovec>=1.0.0",
 ]
 
 [project.scripts]

--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -79,6 +79,9 @@ milvus = [
 litellm = [
     "litellm>=1.63.0,<1.86",
 ]
+turbovec = [
+    "turbovec>=0.7.0",
+]
 
 [project.scripts]
 memmachine-server = "memmachine_server.server.app:main"

--- a/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_collection.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_collection.py
@@ -2,7 +2,7 @@
 
 import math
 import operator
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from uuid import UUID
 
 from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
@@ -138,7 +138,6 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
         score_threshold: float | None = None,
         limit: int | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         metric = self.collection_config.similarity_metric
@@ -163,9 +162,7 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
                 matches.append(
                     QueryMatch(
                         score=score,
-                        record=self._project_record(
-                            record, return_vector, return_properties
-                        ),
+                        record=self._project_record(record, return_properties),
                     )
                 )
             matches.sort(key=lambda m: m.score, reverse=higher_is_better)
@@ -174,37 +171,30 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
             results.append(QueryResult(matches=matches))
         return results
 
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        out: list[Record] = []
-        for uid in record_uuids:
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        for uid, properties in record_properties.items():
             record = self.records.get(uid)
             if record is None:
                 continue
-            out.append(self._project_record(record, return_vector, return_properties))
-        return out
+            self.records[uid] = Record(
+                uuid=record.uuid,
+                vector=list(record.vector) if record.vector is not None else None,
+                properties=dict(properties),
+            )
 
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:
         for uid in record_uuids:
             self.records.pop(uid, None)
 
     @staticmethod
-    def _project_record(
-        record: Record, return_vector: bool, return_properties: bool
-    ) -> Record:
+    def _project_record(record: Record, return_properties: bool) -> Record:
         """Return a copy of the record with only the requested fields."""
         return Record(
             uuid=record.uuid,
-            vector=(
-                list(record.vector)
-                if return_vector and record.vector is not None
-                else None
-            ),
             properties=(
                 dict(record.properties)
                 if return_properties and record.properties

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -45,6 +45,26 @@ def _normalize(vector: list[float]) -> list[float]:
     return [x / magnitude for x in vector]
 
 
+_FETCH_LIMIT = 1000
+
+
+async def _fetch_records(collection, record_uuids) -> list[Record]:
+    """Read records back by UUID.
+
+    The collection contract has no read-by-UUID: `query` is the only read, and
+    with no score threshold it returns every record it holds, so a probe vector
+    in any direction lists the collection for a test to pick out of.
+    """
+    record_uuids = list(record_uuids)
+    if not record_uuids:
+        return []
+    dimensions = collection.config.vector_dimensions
+    probe = [1.0] + [0.0] * (dimensions - 1)
+    [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
+    by_uuid = {match.record.uuid: match.record for match in result.matches}
+    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+
+
 def _make_record(
     *,
     uuid: UUID | None = None,
@@ -284,19 +304,15 @@ class TestUpsertAndQuery:
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        no_vector = await collection.query(
-            query_vectors=[v1], limit=10, return_vector=False
-        )
-        assert no_vector[0].matches[0].record.vector is None
-        assert no_vector[0].matches[0].record.properties is not None
+        with_properties = await collection.query(query_vectors=[v1], limit=10)
+        assert with_properties[0].matches[0].record.vector is None
+        assert with_properties[0].matches[0].record.properties is not None
 
         no_properties = await collection.query(
             query_vectors=[v1],
             limit=10,
-            return_vector=True,
             return_properties=False,
         )
-        assert no_properties[0].matches[0].record.vector is not None
         assert no_properties[0].matches[0].record.properties is None
 
     @pytest.mark.asyncio
@@ -356,14 +372,13 @@ class TestUpsertAndQuery:
                 ]
             )
 
-        records = await collection.get(
-            record_uuids=[record.uuid],
-            return_vector=True,
-            return_properties=True,
-        )
+        records = await _fetch_records(collection, [record.uuid])
         assert len(records) == 1
-        assert records[0].vector == old_vector
         assert records[0].properties == {"name": "old"}
+
+        # The old vector is still the indexed one.
+        results = await collection.query(query_vectors=[old_vector], limit=1)
+        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
 
 
 class TestFilters:
@@ -432,8 +447,10 @@ class TestFilters:
         uuids = await self._query(collection, v1, "created_at", "=", dt_filter)
         assert uuids == {r1.uuid}
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        assert results[0].properties["created_at"] == dt_utc
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt_utc
 
     @pytest.mark.asyncio
     async def test_is_null_and_not_null(self, collection):
@@ -491,23 +508,37 @@ class TestFilters:
         assert {m.record.uuid for m in or_results[0].matches} == {r1.uuid, r2.uuid}
 
 
-class TestGetAndDelete:
+class TestSetPropertiesAndDelete:
     @pytest.mark.asyncio
-    async def test_get_by_uuids_preserves_order_and_return_flags(self, collection):
+    async def test_set_properties_replaces_properties_and_keeps_the_vector(
+        self, collection
+    ):
         v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a"})
-        r2 = _make_record(vector=v2, properties={"name": "b"})
-        await collection.upsert(records=[r1, r2])
+        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
+        await collection.upsert(records=[r1])
 
-        results = await collection.get(
-            record_uuids=[r2.uuid, r1.uuid],
-            return_vector=True,
-            return_properties=False,
-        )
-        assert [record.uuid for record in results] == [r2.uuid, r1.uuid]
-        assert results[0].vector is not None
-        assert results[0].properties is None
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "b"}
+
+        # The vector is untouched, so the record still answers its own query.
+        results = await collection.query(query_vectors=[v1], limit=1)
+        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_set_properties_ignores_uuids_the_collection_does_not_hold(
+        self, collection
+    ):
+        v1 = _normalize([1.0, 0.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a"})
+        await collection.upsert(records=[r1])
+
+        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "a"}
 
     @pytest.mark.asyncio
     async def test_delete_records(self, collection):
@@ -519,7 +550,7 @@ class TestGetAndDelete:
 
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = await collection.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
         assert [record.uuid for record in results] == [r2.uuid]
 
 
@@ -547,8 +578,8 @@ class TestPartitionIsolation:
             records=[Record(uuid=record_uuid, vector=v1, properties={"name": "b"})]
         )
 
-        results_a = await coll_a.get(record_uuids=[record_uuid])
-        results_b = await coll_b.get(record_uuids=[record_uuid])
+        results_a = await _fetch_records(coll_a, [record_uuid])
+        results_b = await _fetch_records(coll_b, [record_uuid])
 
         assert results_a[0].properties == {"name": "a"}
         assert results_b[0].properties == {"name": "b"}

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -90,6 +90,26 @@ def _normalize(v: list[float]) -> list[float]:
     return [x / mag for x in v]
 
 
+_FETCH_LIMIT = 1000
+
+
+async def _fetch_records(collection, record_uuids) -> list[Record]:
+    """Read records back by UUID.
+
+    The collection contract has no read-by-UUID: `query` is the only read, and
+    with no score threshold it returns every record it holds, so a probe vector
+    in any direction lists the collection for a test to pick out of.
+    """
+    record_uuids = list(record_uuids)
+    if not record_uuids:
+        return []
+    dimensions = collection.config.vector_dimensions
+    probe = [1.0] + [0.0] * (dimensions - 1)
+    [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
+    by_uuid = {match.record.uuid: match.record for match in result.matches}
+    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+
+
 def _make_record(
     *,
     uuid: UUID | None = None,
@@ -259,14 +279,12 @@ class TestUpsertAndQuery:
         assert len(query_results[0].matches) == 2
 
     @pytest.mark.asyncio
-    async def test_query_return_vector_false(self, collection):
+    async def test_query_never_returns_vectors(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        query_results = list(
-            await collection.query(query_vectors=[v1], limit=10, return_vector=False)
-        )
+        query_results = list(await collection.query(query_vectors=[v1], limit=10))
         matches = query_results[0].matches
         assert len(matches) == 1
         assert matches[0].record.vector is None
@@ -282,13 +300,11 @@ class TestUpsertAndQuery:
             await collection.query(
                 query_vectors=[v1],
                 limit=10,
-                return_vector=True,
                 return_properties=False,
             )
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.vector is not None
         assert matches[0].record.properties is None
 
     @pytest.mark.asyncio
@@ -580,8 +596,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "test", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = list(await collection.get(record_uuids=[r1.uuid]))
-        assert results[0].properties["created_at"] == dt
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt
 
     @pytest.mark.asyncio
     async def test_datetime_microseconds_roundtrip(self, collection):
@@ -591,8 +609,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "micro", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = list(await collection.get(record_uuids=[r1.uuid]))
-        assert results[0].properties["created_at"] == dt
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt
 
     @pytest.mark.asyncio
     async def test_eq_datetime(self, collection):
@@ -728,8 +748,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "n", "created_at": naive_dt})
         await collection.upsert(records=[r1])
 
-        results = list(await collection.get(record_uuids=[r1.uuid]))
-        got = results[0].properties["created_at"]
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        got = properties["created_at"]
         assert isinstance(got, datetime)
         assert got.tzinfo is not None
         assert got == datetime(2024, 6, 15, 12, 30, 0, tzinfo=UTC)
@@ -920,72 +942,62 @@ class TestFilters:
         assert len(matches) == 2
 
 
-# ── Get ──
+# ── Set properties ──
 
 
-class TestGet:
+class TestSetProperties:
     @pytest.mark.asyncio
-    async def test_get_by_uuids(self, collection):
+    async def test_replaces_properties_and_keeps_the_vector(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
-        v3 = _normalize([0.0, 0.0, 1.0])
+        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
+        await collection.upsert(records=[r1])
 
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "b"}
+
+        # The vector is untouched, so the record still answers its own query.
+        results = await collection.query(query_vectors=[v1], limit=1)
+        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_replaced_properties_are_filterable(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "a"})
-        r2 = _make_record(vector=v2, properties={"name": "b"})
-        r3 = _make_record(vector=v3, properties={"name": "c"})
-
-        await collection.upsert(records=[r1, r2, r3])
-
-        results = list(await collection.get(record_uuids=[r3.uuid, r1.uuid]))
-        assert len(results) == 2
-        assert results[0].uuid == r3.uuid
-        assert results[1].uuid == r1.uuid
-
-    @pytest.mark.asyncio
-    async def test_get_missing_uuids(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1)
         await collection.upsert(records=[r1])
 
-        missing_uuid = uuid4()
-        results = list(await collection.get(record_uuids=[r1.uuid, missing_uuid]))
-        assert len(results) == 1
-        assert results[0].uuid == r1.uuid
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
 
-    @pytest.mark.asyncio
-    async def test_get_empty_list(self, collection):
-        results = list(await collection.get(record_uuids=[]))
-        assert len(results) == 0
-
-    @pytest.mark.asyncio
-    async def test_get_return_vector_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = list(
-            await collection.get(record_uuids=[r1.uuid], return_vector=False)
+        stale = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="a"),
         )
-        assert len(results) == 1
-        assert results[0].vector is None
-        assert results[0].properties is not None
+        assert stale[0].matches == []
+
+        fresh = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="b"),
+        )
+        assert [match.record.uuid for match in fresh[0].matches] == [r1.uuid]
 
     @pytest.mark.asyncio
-    async def test_get_return_properties_false(self, collection):
+    async def test_ignores_uuids_the_collection_does_not_hold(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
+        r1 = _make_record(vector=v1, properties={"name": "a"})
         await collection.upsert(records=[r1])
 
-        results = list(
-            await collection.get(
-                record_uuids=[r1.uuid],
-                return_vector=True,
-                return_properties=False,
-            )
-        )
-        assert len(results) == 1
-        assert results[0].vector is not None
-        assert results[0].properties is None
+        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "a"}
+
+    @pytest.mark.asyncio
+    async def test_empty_mapping(self, collection):
+        await collection.set_properties(record_properties={})
 
 
 # ── Delete ──
@@ -1003,7 +1015,7 @@ class TestDelete:
         await collection.upsert(records=[r1, r2])
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = list(await collection.get(record_uuids=[r1.uuid, r2.uuid]))
+        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -1071,7 +1083,7 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        results = list(await coll_a.get(record_uuids=[r1.uuid, r2.uuid]))
+        results = await _fetch_records(coll_a, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r1.uuid
 
@@ -1105,7 +1117,7 @@ class TestPartitionIsolation:
         # Attempt to delete r2 using tenant_a's collection — should not work
         await coll_a.delete(record_uuids=[r2.uuid])
 
-        results = list(await coll_b.get(record_uuids=[r2.uuid]))
+        results = await _fetch_records(coll_b, [r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -1201,12 +1213,12 @@ class TestDistributedSharding:
         assert len(results) == 1
         assert results[0].matches[0].record.uuid == r1.uuid
 
-        got = await coll.get(record_uuids=[r1.uuid])
+        got = await _fetch_records(coll, [r1.uuid])
         assert len(got) == 1
         assert got[0].uuid == r1.uuid
 
         await coll.delete(record_uuids=[r1.uuid])
-        got = await coll.get(record_uuids=[r1.uuid])
+        got = await _fetch_records(coll, [r1.uuid])
         assert len(got) == 0
 
         await store.delete_collection(namespace=ns, name=name)
@@ -1239,7 +1251,7 @@ class TestDistributedSharding:
         await store.delete_collection(namespace=ns, name="tenant_a")
 
         # tenant_b data should be untouched.
-        got = await coll_b.get(record_uuids=[r_b.uuid])
+        got = await _fetch_records(coll_b, [r_b.uuid])
         assert len(got) == 1
         assert got[0].uuid == r_b.uuid
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -44,6 +44,26 @@ def _normalize(vector: list[float]) -> list[float]:
     return [x / magnitude for x in vector]
 
 
+_FETCH_LIMIT = 1000
+
+
+async def _fetch_records(collection, record_uuids) -> list[Record]:
+    """Read records back by UUID.
+
+    The collection contract has no read-by-UUID: `query` is the only read, and
+    with no score threshold it returns every record it holds, so a probe vector
+    in any direction lists the collection for a test to pick out of.
+    """
+    record_uuids = list(record_uuids)
+    if not record_uuids:
+        return []
+    dimensions = collection.config.vector_dimensions
+    probe = [1.0] + [0.0] * (dimensions - 1)
+    [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
+    by_uuid = {match.record.uuid: match.record for match in result.matches}
+    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+
+
 def _make_record(
     *,
     uuid=None,
@@ -242,8 +262,10 @@ class TestUpsertAndQuery:
         )
         await collection.upsert(records=[updated])
 
-        results = await collection.get(record_uuids=[record.uuid])
-        assert results[0].properties["name"] == "updated"
+        results = await _fetch_records(collection, [record.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["name"] == "updated"
 
     @pytest.mark.asyncio
     async def test_query_with_similarity_threshold(self, collection):
@@ -273,14 +295,12 @@ class TestUpsertAndQuery:
         assert len(query_results[0].matches) == 2
 
     @pytest.mark.asyncio
-    async def test_query_return_vector_false(self, collection):
+    async def test_query_never_returns_vectors(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        query_results = await collection.query(
-            query_vectors=[v1], limit=10, return_vector=False
-        )
+        query_results = await collection.query(query_vectors=[v1], limit=10)
         matches = query_results[0].matches
         assert len(matches) == 1
         assert matches[0].record.vector is None
@@ -295,12 +315,10 @@ class TestUpsertAndQuery:
         query_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            return_vector=True,
             return_properties=False,
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.vector is not None
         assert matches[0].record.properties is None
 
     @pytest.mark.asyncio
@@ -487,8 +505,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "test", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        assert results[0].properties["created_at"] == dt
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt
 
     @pytest.mark.asyncio
     async def test_eq_datetime(self, collection):
@@ -545,8 +565,11 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "tz", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        got = results[0].properties["created_at"]
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        got = properties["created_at"]
+        assert isinstance(got, datetime)
         assert got == dt
         assert got.utcoffset() == timedelta(hours=-5)
 
@@ -610,61 +633,62 @@ class TestFilters:
         assert len(uuids) == 2
 
 
-# ── Get ──
+# ── Set properties ──
 
 
-class TestGet:
+class TestSetProperties:
     @pytest.mark.asyncio
-    async def test_get_by_uuids(self, collection):
+    async def test_replaces_properties_and_keeps_the_vector(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
+        await collection.upsert(records=[r1])
 
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "b"}
+
+        # The vector is untouched, so the record still answers its own query.
+        results = await collection.query(query_vectors=[v1], limit=1)
+        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_replaced_properties_are_filterable(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "a"})
-        r2 = _make_record(vector=v2, properties={"name": "b"})
-        await collection.upsert(records=[r1, r2])
-
-        results = await collection.get(record_uuids=[r2.uuid, r1.uuid])
-        assert len(results) == 2
-        assert results[0].uuid == r2.uuid
-        assert results[1].uuid == r1.uuid
-
-    @pytest.mark.asyncio
-    async def test_get_missing_uuids(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1)
         await collection.upsert(records=[r1])
 
-        missing = uuid4()
-        results = await collection.get(record_uuids=[r1.uuid, missing])
-        assert len(results) == 1
-        assert results[0].uuid == r1.uuid
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
 
-    @pytest.mark.asyncio
-    async def test_get_empty_list(self, collection):
-        results = await collection.get(record_uuids=[])
-        assert len(results) == 0
-
-    @pytest.mark.asyncio
-    async def test_get_return_vector_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = await collection.get(record_uuids=[r1.uuid], return_vector=False)
-        assert results[0].vector is None
-        assert results[0].properties is not None
-
-    @pytest.mark.asyncio
-    async def test_get_return_properties_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = await collection.get(
-            record_uuids=[r1.uuid], return_vector=True, return_properties=False
+        stale = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="a"),
         )
-        assert results[0].vector is not None
-        assert results[0].properties is None
+        assert stale[0].matches == []
+
+        fresh = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="b"),
+        )
+        assert [match.record.uuid for match in fresh[0].matches] == [r1.uuid]
+
+    @pytest.mark.asyncio
+    async def test_ignores_uuids_the_collection_does_not_hold(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a"})
+        await collection.upsert(records=[r1])
+
+        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "a"}
+
+    @pytest.mark.asyncio
+    async def test_empty_mapping(self, collection):
+        await collection.set_properties(record_properties={})
 
 
 # ── Delete ──
@@ -682,7 +706,7 @@ class TestDelete:
         await collection.upsert(records=[r1, r2])
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = await collection.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -762,7 +786,7 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        results = await coll_a.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(coll_a, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r1.uuid
 
@@ -792,7 +816,7 @@ class TestPartitionIsolation:
 
         await coll_a.delete(record_uuids=[r2.uuid])
 
-        results = await coll_b.get(record_uuids=[r2.uuid])
+        results = await _fetch_records(coll_b, [r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -909,9 +933,7 @@ class TestInputValidation:
         v1 = _normalize([1.0, 0.0, 0.0])
         record = _make_record(vector=v1, properties=None)
         await collection.upsert(records=[record])
-        fetched = await collection.get(
-            record_uuids=[record.uuid], return_properties=True
-        )
+        fetched = await _fetch_records(collection, [record.uuid])
         assert len(fetched) == 1
         assert fetched[0].properties == {}
 
@@ -975,11 +997,11 @@ class TestUpsertBehavior:
             ]
         )
 
-        fetched = await collection.get(
-            record_uuids=[record_uuid], return_vector=True, return_properties=True
-        )
+        fetched = await _fetch_records(collection, [record_uuid])
         assert len(fetched) == 1
-        assert fetched[0].properties["name"] == "bob"
+        properties = fetched[0].properties
+        assert properties is not None
+        assert properties["name"] == "bob"
 
         results = await collection.query(query_vectors=[v2], limit=1)
         assert results[0].matches[0].record.uuid == record_uuid

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -45,6 +45,26 @@ def _normalize(vector: list[float]) -> list[float]:
     return [x / magnitude for x in vector]
 
 
+_FETCH_LIMIT = 1000
+
+
+async def _fetch_records(collection, record_uuids) -> list[Record]:
+    """Read records back by UUID.
+
+    The collection contract has no read-by-UUID: `query` is the only read, and
+    with no score threshold it returns every record it holds, so a probe vector
+    in any direction lists the collection for a test to pick out of.
+    """
+    record_uuids = list(record_uuids)
+    if not record_uuids:
+        return []
+    dimensions = collection.config.vector_dimensions
+    probe = [1.0] + [0.0] * (dimensions - 1)
+    [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
+    by_uuid = {match.record.uuid: match.record for match in result.matches}
+    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+
+
 def _make_record(
     *,
     uuid=None,
@@ -248,8 +268,10 @@ class TestUpsertAndQuery:
         )
         await collection.upsert(records=[updated])
 
-        results = await collection.get(record_uuids=[record.uuid])
-        assert results[0].properties["name"] == "updated"
+        results = await _fetch_records(collection, [record.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["name"] == "updated"
 
     @pytest.mark.asyncio
     async def test_query_with_similarity_threshold(self, collection):
@@ -279,14 +301,12 @@ class TestUpsertAndQuery:
         assert len(query_results[0].matches) == 2
 
     @pytest.mark.asyncio
-    async def test_query_return_vector_false(self, collection):
+    async def test_query_never_returns_vectors(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        query_results = await collection.query(
-            query_vectors=[v1], limit=10, return_vector=False
-        )
+        query_results = await collection.query(query_vectors=[v1], limit=10)
         matches = query_results[0].matches
         assert len(matches) == 1
         assert matches[0].record.vector is None
@@ -301,12 +321,10 @@ class TestUpsertAndQuery:
         query_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            return_vector=True,
             return_properties=False,
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.vector is not None
         assert matches[0].record.properties is None
 
     @pytest.mark.asyncio
@@ -493,8 +511,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "test", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        assert results[0].properties["created_at"] == dt
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt
 
     @pytest.mark.asyncio
     async def test_eq_datetime(self, collection):
@@ -551,8 +571,11 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "tz", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        got = results[0].properties["created_at"]
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        got = properties["created_at"]
+        assert isinstance(got, datetime)
         assert got == dt
         assert got.utcoffset() == timedelta(hours=-5)
 
@@ -616,61 +639,62 @@ class TestFilters:
         assert len(uuids) == 2
 
 
-# ── Get ──
+# ── Set properties ──
 
 
-class TestGet:
+class TestSetProperties:
     @pytest.mark.asyncio
-    async def test_get_by_uuids(self, collection):
+    async def test_replaces_properties_and_keeps_the_vector(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
+        await collection.upsert(records=[r1])
 
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "b"}
+
+        # The vector is untouched, so the record still answers its own query.
+        results = await collection.query(query_vectors=[v1], limit=1)
+        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_replaced_properties_are_filterable(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "a"})
-        r2 = _make_record(vector=v2, properties={"name": "b"})
-        await collection.upsert(records=[r1, r2])
-
-        results = await collection.get(record_uuids=[r2.uuid, r1.uuid])
-        assert len(results) == 2
-        assert results[0].uuid == r2.uuid
-        assert results[1].uuid == r1.uuid
-
-    @pytest.mark.asyncio
-    async def test_get_missing_uuids(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1)
         await collection.upsert(records=[r1])
 
-        missing = uuid4()
-        results = await collection.get(record_uuids=[r1.uuid, missing])
-        assert len(results) == 1
-        assert results[0].uuid == r1.uuid
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
 
-    @pytest.mark.asyncio
-    async def test_get_empty_list(self, collection):
-        results = await collection.get(record_uuids=[])
-        assert len(results) == 0
-
-    @pytest.mark.asyncio
-    async def test_get_return_vector_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = await collection.get(record_uuids=[r1.uuid], return_vector=False)
-        assert results[0].vector is None
-        assert results[0].properties is not None
-
-    @pytest.mark.asyncio
-    async def test_get_return_properties_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = await collection.get(
-            record_uuids=[r1.uuid], return_vector=True, return_properties=False
+        stale = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="a"),
         )
-        assert results[0].vector is not None
-        assert results[0].properties is None
+        assert stale[0].matches == []
+
+        fresh = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="b"),
+        )
+        assert [match.record.uuid for match in fresh[0].matches] == [r1.uuid]
+
+    @pytest.mark.asyncio
+    async def test_ignores_uuids_the_collection_does_not_hold(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a"})
+        await collection.upsert(records=[r1])
+
+        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "a"}
+
+    @pytest.mark.asyncio
+    async def test_empty_mapping(self, collection):
+        await collection.set_properties(record_properties={})
 
 
 # ── Delete ──
@@ -688,7 +712,7 @@ class TestDelete:
         await collection.upsert(records=[r1, r2])
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = await collection.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -768,7 +792,7 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        results = await coll_a.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(coll_a, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r1.uuid
 
@@ -798,7 +822,7 @@ class TestPartitionIsolation:
 
         await coll_a.delete(record_uuids=[r2.uuid])
 
-        results = await coll_b.get(record_uuids=[r2.uuid])
+        results = await _fetch_records(coll_b, [r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -942,9 +966,7 @@ class TestInputValidation:
         v1 = _normalize([1.0, 0.0, 0.0])
         record = _make_record(vector=v1, properties=None)
         await collection.upsert(records=[record])
-        fetched = await collection.get(
-            record_uuids=[record.uuid], return_properties=True
-        )
+        fetched = await _fetch_records(collection, [record.uuid])
         assert len(fetched) == 1
         assert fetched[0].properties == {}
 
@@ -1008,11 +1030,11 @@ class TestUpsertBehavior:
             ]
         )
 
-        fetched = await collection.get(
-            record_uuids=[record_uuid], return_vector=True, return_properties=True
-        )
+        fetched = await _fetch_records(collection, [record_uuid])
         assert len(fetched) == 1
-        assert fetched[0].properties["name"] == "bob"
+        properties = fetched[0].properties
+        assert properties is not None
+        assert properties["name"] == "bob"
 
         results = await collection.query(query_vectors=[v2], limit=1)
         assert results[0].matches[0].record.uuid == record_uuid
@@ -1045,7 +1067,7 @@ class TestConcurrentAsync:
         )
 
         # Verify all records were persisted (deterministic, not ANN-dependent).
-        fetched = await collection.get(record_uuids=all_uuids)
+        fetched = await _fetch_records(collection, all_uuids)
         assert len(fetched) == 30
 
     @pytest.mark.asyncio
@@ -1099,6 +1121,19 @@ async def _fresh_store(db_path, tmp_path, *, save_threshold=1000):
     store = SQLiteVectorStore(params)
     await store.startup()
     return store, engine
+
+
+async def _stored_record_uuids(engine, store) -> set[UUID]:
+    """Read a collection's record UUIDs straight out of SQLite.
+
+    The collection contract cannot see a record whose vector the index lost, so
+    a test about surviving that loss has to look past the contract at the row.
+    """
+    records_table = store._records_table(NAMESPACE, NAME)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        rows = (await session.execute(select(records_table.c.uuid))).all()
+    return {row.uuid for row in rows}
 
 
 async def _pending_operation_count(engine) -> int:
@@ -1212,7 +1247,7 @@ class TestCrashRecovery:
         )
         assert len(results[0].matches) == 1
 
-        fetched = await coll2.get(record_uuids=[r1.uuid])
+        fetched = await _fetch_records(coll2, [r1.uuid])
         assert len(fetched) == 0
 
         await store2.shutdown()
@@ -1245,7 +1280,7 @@ class TestCrashRecovery:
         )
         assert len(results[0].matches) == 2
 
-        fetched = await coll2.get(record_uuids=[r1.uuid, r2.uuid, r3.uuid])
+        fetched = await _fetch_records(coll2, [r1.uuid, r2.uuid, r3.uuid])
         fetched_uuids = {r.uuid for r in fetched}
         assert r1.uuid in fetched_uuids
         assert r2.uuid not in fetched_uuids
@@ -1485,15 +1520,19 @@ class TestIndexFileDurability:
         await engine2.dispose()
 
     @pytest.mark.asyncio
-    async def test_a_reverted_publication_costs_search_not_records(self, tmp_path):
+    async def test_a_reverted_publication_costs_search_not_the_record_row(
+        self, tmp_path
+    ):
         """A publication lost to power failure leaves records unsearchable.
 
         The swap is atomic, not durable, so a power failure can revert the last
         publication after the trim behind it has committed. Restoring the
         previous index bytes reconstructs exactly that state, deterministically
         rather than by pulling a plug, and pins the direction it fails in: the
-        record survives and still resolves by uuid, it simply cannot be found
-        by search until it is upserted again.
+        row survives, and only search loses the record, until it is upserted
+        again. The collection contract has no read that can show the survivor --
+        `query` is the only read and it goes through the index that lost it --
+        so this looks at the row directly.
         """
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=1)
@@ -1524,9 +1563,8 @@ class TestIndexFileDurability:
         coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
         assert coll2 is not None
 
-        # The record is still a record.
-        fetched = await coll2.get(record_uuids=[r2.uuid])
-        assert [record.uuid for record in fetched] == [r2.uuid]
+        # The record is still a row.
+        assert await _stored_record_uuids(engine2, store2) == {r1.uuid, r2.uuid}
 
         # The index just cannot find it any more.
         results = await coll2.query(query_vectors=[r2.vector], limit=10)

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -1,0 +1,440 @@
+"""Tests for TurboVecVectorSearchEngine.
+
+turbovec stores TurboQuant-compressed vectors, so scores are approximate: a
+self-match lands near (and may slightly exceed) the exact value, and orthogonal
+pairs land near zero rather than exactly zero. Tests therefore assert ranking
+and membership (robust under quantization) and only loosely assert score
+magnitudes.
+"""
+
+import math
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("turbovec")
+
+from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.vector_store.vector_search_engine.turbovec_engine import (
+    TurboVecVectorSearchEngine,
+)
+
+NDIM = 8
+
+QUANT_ABS = 0.05
+
+
+def _normalize(v: list[float]) -> list[float]:
+    magnitude = math.sqrt(sum(x * x for x in v))
+    return [x / magnitude for x in v]
+
+
+def _one_hot(index: int, value: float = 1.0) -> list[float]:
+    """A length-NDIM vector with `value` at `index`, zeros elsewhere."""
+    vector = [0.0] * NDIM
+    vector[index] = value
+    return vector
+
+
+async def _search_one(engine, vector, limit=10, **kwargs):
+    """Helper: search a single vector, return the one SearchResult."""
+    results = await engine.search([vector], limit=limit, **kwargs)
+    return results[0]
+
+
+def _make_engine(metric=SimilarityMetric.COSINE, **kwargs):
+    return TurboVecVectorSearchEngine(
+        num_dimensions=NDIM, similarity_metric=metric, **kwargs
+    )
+
+
+# -- Construction --
+
+
+class TestConstruction:
+    def test_supported_metrics(self):
+        for metric in (SimilarityMetric.COSINE, SimilarityMetric.DOT):
+            _make_engine(metric)
+
+    def test_unsupported_metric_raises(self):
+        for metric in (SimilarityMetric.EUCLIDEAN, SimilarityMetric.MANHATTAN):
+            with pytest.raises(NotImplementedError, match="does not support"):
+                _make_engine(metric)
+
+    def test_valid_bit_widths(self):
+        for bit_width in (2, 3, 4):
+            _make_engine(bit_width=bit_width)
+
+    def test_invalid_bit_width_raises(self):
+        with pytest.raises(ValueError, match="bit_width"):
+            _make_engine(bit_width=5)
+
+    def test_dimensions_must_be_multiple_of_8(self):
+        with pytest.raises(ValueError, match="multiple of 8"):
+            TurboVecVectorSearchEngine(
+                num_dimensions=7, similarity_metric=SimilarityMetric.COSINE
+            )
+
+
+# -- Add --
+
+
+class TestAdd:
+    @pytest.mark.asyncio
+    async def test_add_single(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches[0].key == 1
+
+    @pytest.mark.asyncio
+    async def test_add_batch(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                10: _normalize(_one_hot(0)),
+                20: _normalize(_one_hot(1)),
+                30: _normalize(_one_hot(2)),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        assert {m.key for m in result.matches} == {10, 20, 30}
+
+    @pytest.mark.asyncio
+    async def test_add_empty(self):
+        engine = _make_engine()
+        await engine.add({})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_remove_then_add_replaces_key(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        await engine.remove([1])
+        await engine.add({1: _normalize(_one_hot(1))})
+        result = await _search_one(engine, _normalize(_one_hot(1)), limit=1)
+        assert result.matches[0].key == 1
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_repeated_reupsert_of_same_key(self):
+        engine = _make_engine()
+        for index in range(NDIM):
+            await engine.remove([7])
+            await engine.add({7: _normalize(_one_hot(index))})
+        result = await _search_one(engine, _normalize(_one_hot(NDIM - 1)), limit=1)
+        assert result.matches[0].key == 7
+
+
+# -- Remove --
+
+
+class TestRemove:
+    @pytest.mark.asyncio
+    async def test_remove_existing(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        await engine.remove([1])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=2)
+        keys = {m.key for m in result.matches}
+        assert 1 not in keys
+        assert 2 in keys
+
+    @pytest.mark.asyncio
+    async def test_remove_missing_is_ignored(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        await engine.remove([99, 100])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches[0].key == 1
+
+    @pytest.mark.asyncio
+    async def test_remove_all(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize(_one_hot(2)),
+            }
+        )
+        await engine.remove([1, 2, 3])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_remove_empty_iterable(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        await engine.remove([])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches[0].key == 1
+
+
+# -- Search: Cosine --
+
+
+class TestSearchCosine:
+    @pytest.mark.asyncio
+    async def test_basic_knn(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize([1, 1, 0, 0, 0, 0, 0, 0]),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        assert len(result.matches) == 3
+        assert result.matches[0].key == 1
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[1].key == 3
+        assert result.matches[2].key == 2
+
+    @pytest.mark.asyncio
+    async def test_orthogonal_scores_near_zero(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=2)
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[1].score == pytest.approx(0.0, abs=0.1)
+
+    @pytest.mark.asyncio
+    async def test_scores_ordered_best_first(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize([1, 1, 0, 0, 0, 0, 0, 0]),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        for i in range(len(result.matches) - 1):
+            assert result.matches[i].score >= result.matches[i + 1].score
+
+    @pytest.mark.asyncio
+    async def test_k_larger_than_index(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=10)
+        assert len(result.matches) == 1
+
+    @pytest.mark.asyncio
+    async def test_search_empty_index(self):
+        engine = _make_engine()
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=5)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_limit_zero_returns_empty(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=0)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_empty_query_list(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        results = await engine.search([], limit=3)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_batched_search(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        results = await engine.search(
+            [_normalize(_one_hot(0)), _normalize(_one_hot(1))], limit=1
+        )
+        assert len(results) == 2
+        assert results[0].matches[0].key == 1
+        assert results[1].matches[0].key == 2
+
+
+# -- Search: Dot product --
+
+
+class TestSearchDot:
+    @pytest.mark.asyncio
+    async def test_self_match_highest(self):
+        engine = _make_engine(SimilarityMetric.DOT)
+        v1 = _normalize(_one_hot(0))
+        v2 = _normalize(_one_hot(1))
+        await engine.add({1: v1, 2: v2})
+        result = await _search_one(engine, v1, limit=2)
+        assert result.matches[0].key == 1
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[1].score == pytest.approx(0.0, abs=0.1)
+
+    @pytest.mark.asyncio
+    async def test_scores_ordered_best_first(self):
+        engine = _make_engine(SimilarityMetric.DOT)
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize([1, 1, 0, 0, 0, 0, 0, 0]),
+                3: _normalize(_one_hot(1)),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        for i in range(len(result.matches) - 1):
+            assert result.matches[i].score >= result.matches[i + 1].score
+
+
+# -- Search: allowed_keys filtering --
+
+
+class TestSearchFiltered:
+    @pytest.mark.asyncio
+    async def test_allowed_keys_restricts_results(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize(_one_hot(2)),
+                4: _normalize(_one_hot(3)),
+            }
+        )
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=4, allowed_keys={2, 3}
+        )
+        assert {m.key for m in result.matches} == {2, 3}
+
+    @pytest.mark.asyncio
+    async def test_allowed_keys_excludes_best_match(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize(_one_hot(2)),
+            }
+        )
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=1, allowed_keys={2, 3}
+        )
+        assert len(result.matches) == 1
+        assert result.matches[0].key in {2, 3}
+
+    @pytest.mark.asyncio
+    async def test_allowed_keys_empty_returns_nothing(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=2, allowed_keys=set()
+        )
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_allowed_keys_found_beyond_overfetch_window(self):
+        engine = _make_engine()
+        vectors = {
+            index: _normalize(_one_hot(index % NDIM, value=1.0 + index))
+            for index in range(2 * NDIM)
+        }
+        await engine.add(vectors)
+        target = 2 * NDIM - 1
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=1, allowed_keys={target}
+        )
+        assert [m.key for m in result.matches] == [target]
+
+
+# -- get_vectors --
+
+
+class TestGetVectors:
+    @pytest.mark.asyncio
+    async def test_get_vectors_raises(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        with pytest.raises(NotImplementedError, match="cannot be retrieved"):
+            await engine.get_vectors([1])
+
+
+# -- Persistence --
+
+
+class TestPersistence:
+    @pytest.mark.asyncio
+    async def test_save_and_load(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        engine2 = _make_engine()
+        await engine2.load(path)
+
+        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=2)
+        assert {m.key for m in result.matches} == {1, 2}
+        assert result.matches[0].key == 1
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
+
+        assert path.exists()
+        assert not (tmp_path / "test.idx.tmp").exists()
+
+    @pytest.mark.asyncio
+    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
+
+        stale_temp = tmp_path / "test.idx.tmp"
+        stale_temp.write_text("STALE")
+
+        engine2 = _make_engine()
+        await engine2.load(str(path))
+
+        assert not stale_temp.exists()
+        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=2)
+        assert {m.key for m in result.matches} == {1, 2}
+
+    @pytest.mark.asyncio
+    async def test_load_replaces_existing_index(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        engine2 = _make_engine()
+        await engine2.add({2: _normalize(_one_hot(1))})
+        await engine2.load(path)
+
+        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=5)
+        keys = {m.key for m in result.matches}
+        assert keys == {1}
+
+
+# -- SearchResult types --
+
+
+class TestSearchResultTypes:
+    @pytest.mark.asyncio
+    async def test_keys_are_ints(self):
+        engine = _make_engine()
+        await engine.add({42: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert isinstance(result.matches[0].key, int)
+
+    @pytest.mark.asyncio
+    async def test_scores_are_floats(self):
+        engine = _make_engine()
+        await engine.add({42: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert isinstance(result.matches[0].score, float)

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -36,6 +36,18 @@ def _one_hot(index: int, value: float = 1.0) -> list[float]:
     return vector
 
 
+def _entry_names(directory: Path) -> list[str]:
+    """Names of everything in `directory`. Sync: the tests calling it are not."""
+    return [entry.name for entry in directory.iterdir()]
+
+
+def _spread(seed: int) -> list[float]:
+    """A deterministic unit vector, distinct per `seed`."""
+    return _normalize(
+        [math.cos(seed * (axis + 1) * 0.7 + axis) for axis in range(NDIM)]
+    )
+
+
 async def _search_one(engine, vector, limit=10, **kwargs):
     """Helper: search a single vector, return the one SearchResult."""
     results = await engine.search([vector], limit=limit, **kwargs)
@@ -384,26 +396,27 @@ class TestPersistence:
         path = tmp_path / "test.idx"
         await engine.save(str(path))
 
-        assert path.exists()
-        assert not (tmp_path / "test.idx.tmp").exists()
+        assert _entry_names(tmp_path) == ["test.idx"]
 
     @pytest.mark.asyncio
-    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+    async def test_checkpoint_carries_adds_and_mass_removals(self, tmp_path: Path):
         engine = _make_engine()
-        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        await engine.add({key: _spread(key) for key in range(1, 2001)})
 
-        path = tmp_path / "test.idx"
-        await engine.save(str(path))
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
 
-        stale_temp = tmp_path / "test.idx.tmp"
-        stale_temp.write_text("STALE")
+        doomed = [key for key in range(1, 2001) if key % 4 != 0]
+        await engine.remove(doomed)
+        await engine.add({key: _spread(key) for key in range(10_001, 10_033)})
+        await engine.save(path)
 
         engine2 = _make_engine()
-        await engine2.load(str(path))
+        await engine2.load(path)
 
-        assert not stale_temp.exists()
-        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=2)
-        assert {m.key for m in result.matches} == {1, 2}
+        expected = set(range(4, 2001, 4)) | set(range(10_001, 10_033))
+        result = await _search_one(engine2, _spread(1), limit=len(expected) + 10)
+        assert {match.key for match in result.matches} == expected
 
     @pytest.mark.asyncio
     async def test_load_replaces_existing_index(self, tmp_path: Path):

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -1,10 +1,10 @@
 """Tests for TurboVecVectorSearchEngine.
 
 turbovec stores TurboQuant-compressed vectors, so scores are approximate: a
-self-match lands near (and may slightly exceed) the exact value, and orthogonal
-pairs land near zero rather than exactly zero. Tests therefore assert ranking
-and membership (robust under quantization) and only loosely assert score
-magnitudes.
+self-match lands near the exact value, and orthogonal pairs land near zero
+rather than exactly zero. Tests therefore assert ranking and membership (robust
+under quantization) and only loosely assert score magnitudes. The one exact
+bound is the cosine range, which the engine clamps.
 """
 
 import math
@@ -435,6 +435,27 @@ class TestPersistence:
 
 
 # -- SearchResult types --
+
+
+class TestScoreRange:
+    @pytest.mark.asyncio
+    async def test_cosine_scores_stay_within_range(self):
+        engine = _make_engine()
+        vectors = {key: _spread(key) for key in range(1, 51)}
+        await engine.add(vectors)
+
+        for vector in vectors.values():
+            result = await _search_one(engine, vector, limit=5)
+            for match in result.matches:
+                assert -1.0 <= match.score <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_dot_scores_are_not_clamped(self):
+        engine = _make_engine(SimilarityMetric.DOT)
+        await engine.add({1: [4.0] + [0.0] * (NDIM - 1)})
+
+        result = await _search_one(engine, [4.0] + [0.0] * (NDIM - 1), limit=1)
+        assert result.matches[0].score > 1.0
 
 
 class TestSearchResultTypes:

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -81,11 +81,10 @@ class TestConstruction:
         with pytest.raises(ValueError, match="bit_width"):
             _make_engine(bit_width=5)
 
-    def test_dimensions_must_be_multiple_of_8(self):
-        with pytest.raises(ValueError, match="multiple of 8"):
-            TurboVecVectorSearchEngine(
-                num_dimensions=7, similarity_metric=SimilarityMetric.COSINE
-            )
+    def test_unaligned_dimensions_are_accepted(self):
+        TurboVecVectorSearchEngine(
+            num_dimensions=7, similarity_metric=SimilarityMetric.COSINE
+        )
 
 
 # -- Add --
@@ -435,6 +434,52 @@ class TestPersistence:
 
 
 # -- SearchResult types --
+
+
+class TestUnalignedDimensions:
+    @pytest.mark.asyncio
+    async def test_search_at_an_unaligned_width(self):
+        engine = TurboVecVectorSearchEngine(
+            num_dimensions=5, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine.add(
+            {
+                1: [1.0, 0.0, 0.0, 0.0, 0.0],
+                2: [0.0, 1.0, 0.0, 0.0, 0.0],
+            }
+        )
+
+        results = await engine.search([[1.0, 0.0, 0.0, 0.0, 0.0]], limit=2)
+        matches = results[0].matches
+        assert [match.key for match in matches] == [1, 2]
+        assert matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert matches[1].score == pytest.approx(0.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_save_and_load_at_an_unaligned_width(self, tmp_path: Path):
+        def make_engine():
+            return TurboVecVectorSearchEngine(
+                num_dimensions=5, similarity_metric=SimilarityMetric.COSINE
+            )
+
+        engine = make_engine()
+        await engine.add({1: [1.0, 0.0, 0.0, 0.0, 0.0]})
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        loaded = make_engine()
+        await loaded.load(path)
+
+        results = await loaded.search([[1.0, 0.0, 0.0, 0.0, 0.0]], limit=1)
+        assert [match.key for match in results[0].matches] == [1]
+
+    @pytest.mark.asyncio
+    async def test_wrong_width_vector_is_rejected(self):
+        engine = TurboVecVectorSearchEngine(
+            num_dimensions=5, similarity_metric=SimilarityMetric.COSINE
+        )
+        with pytest.raises(ValueError, match="must have 5 dimensions"):
+            await engine.add({1: [1.0, 0.0, 0.0]})
 
 
 class TestScoreRange:

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -355,18 +355,6 @@ class TestSearchFiltered:
         assert [m.key for m in result.matches] == [target]
 
 
-# -- get_vectors --
-
-
-class TestGetVectors:
-    @pytest.mark.asyncio
-    async def test_get_vectors_raises(self):
-        engine = _make_engine()
-        await engine.add({1: _normalize(_one_hot(0))})
-        with pytest.raises(NotImplementedError, match="cannot be retrieved"):
-            await engine.get_vectors([1])
-
-
 # -- Persistence --
 
 

--- a/packages/server/src/memmachine_server/common/vector_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_store/data_types.py
@@ -117,7 +117,8 @@ class Record(BaseModel):
         vector (list[float] | None):
             Vector for similarity search.
             `None` is not allowed on input.
-            `None` on output means the vector was not requested (`return_vector=False`)
+            Always `None` on output: a collection stores vectors to search
+            them, and does not read them back out
             (default: None).
         properties (dict[str, PropertyValue] | None):
             Property key-value pairs.

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -200,16 +200,9 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
     def _parse_record(
         entity: Mapping[str, Any],
         *,
-        return_vector: bool,
         return_properties: bool,
     ) -> Record:
         """Parse a Milvus entity into a vector store record."""
-        vector: list[float] | None = None
-        if return_vector:
-            raw_vector = entity.get(_VECTOR_FIELD)
-            if raw_vector is not None:
-                vector = list(cast(Sequence[float], raw_vector))
-
         properties: dict[str, PropertyValue] | None = None
         if return_properties:
             properties = decode_properties(
@@ -218,16 +211,12 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
 
         return Record(
             uuid=UUID(str(entity[_RECORD_UUID_FIELD])),
-            vector=vector,
             properties=properties,
         )
 
-    def _output_fields(
-        self, *, return_vector: bool, return_properties: bool
-    ) -> list[str]:
-        fields = [_RECORD_UUID_FIELD]
-        if return_vector:
-            fields.append(_VECTOR_FIELD)
+    def _output_fields(self, *, return_properties: bool) -> list[str]:
+        # The vector always comes back: search scores are recomputed from it.
+        fields = [_RECORD_UUID_FIELD, _VECTOR_FIELD]
         if return_properties:
             fields.append(_PROPERTIES_FIELD)
         return fields
@@ -280,7 +269,6 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         limit: int,
         score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         """Query for records matching the criteria by query vectors."""
@@ -308,7 +296,6 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
                 # returns it as similarity. Fetch vectors and compute scores
                 # locally so MemMachine score semantics stay consistent.
                 output_fields=self._output_fields(
-                    return_vector=True,
                     return_properties=return_properties,
                 ),
                 anns_field=_VECTOR_FIELD,
@@ -336,7 +323,6 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
                             score=score,
                             record=self._parse_record(
                                 entity,
-                                return_vector=return_vector,
                                 return_properties=return_properties,
                             ),
                         )
@@ -351,48 +337,59 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
             return results
 
     @override
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        """Get records from the collection by their UUIDs."""
-        async with self._tracker("get"):
-            uuid_list = list(record_uuids)
-            if not uuid_list:
-                return []
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        """Replace the properties of records already in the collection."""
+        async with self._tracker("set_properties"):
+            if not record_properties:
+                return
 
+            uuid_list = list(record_properties)
             primary_ids = [
                 self._primary_id(self._partition_key, uuid) for uuid in uuid_list
             ]
+
+            # Milvus has no partial update: an upsert writes the whole row, so
+            # the vector has to be read back to be written again unchanged. A
+            # row Milvus does not hold is skipped rather than inserted without
+            # a vector.
             raw_records = await asyncio.to_thread(
                 self._client.get,
                 collection_name=self._collection_name,
                 ids=primary_ids,
-                output_fields=self._output_fields(
-                    return_vector=return_vector,
-                    return_properties=return_properties,
-                ),
+                output_fields=[_RECORD_UUID_FIELD, _VECTOR_FIELD],
             )
-
-            records_by_uuid = {
-                record.uuid: record
-                for record in (
-                    self._parse_record(
-                        cast(Mapping[str, Any], raw_record),
-                        return_vector=return_vector,
-                        return_properties=return_properties,
-                    )
-                    for raw_record in raw_records
+            vectors_by_uuid = {
+                UUID(str(raw[_RECORD_UUID_FIELD])): list(
+                    cast(Sequence[float], raw[_VECTOR_FIELD])
                 )
+                for raw in (cast(Mapping[str, Any], r) for r in raw_records)
             }
-            return [
-                records_by_uuid[record_uuid]
+
+            entities = [
+                self._build_entity(
+                    Record(
+                        uuid=record_uuid,
+                        vector=vectors_by_uuid[record_uuid],
+                        properties=dict(record_properties[record_uuid]),
+                    )
+                )
                 for record_uuid in uuid_list
-                if record_uuid in records_by_uuid
+                if record_uuid in vectors_by_uuid
             ]
+            if not entities:
+                return
+
+            def _upsert() -> None:
+                self._client.upsert(
+                    collection_name=self._collection_name,
+                    data=entities,
+                )
+
+            await asyncio.to_thread(_upsert)
 
     @override
     async def delete(

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -340,7 +340,6 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
         limit: int,
         score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         """Query for records matching the criteria by query vectors."""
@@ -369,7 +368,7 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
                     filter=qdrant_filter,
                     score_threshold=score_threshold,
                     limit=limit,
-                    with_vector=return_vector,
+                    with_vector=False,
                     with_payload=return_properties,
                 )
                 for query_vector in query_vectors
@@ -384,10 +383,6 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
             for batch in batch_results:
                 matches: list[QueryMatch] = []
                 for point in batch.points:
-                    vector: list[float] | None = None
-                    if return_vector and point.vector is not None:
-                        vector = cast(list[float], point.vector)
-
                     properties: dict[str, PropertyValue] | None = None
                     if return_properties and point.payload is not None:
                         properties = self._parse_payload(point.payload)
@@ -397,7 +392,6 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
                             score=point.score,
                             record=Record(
                                 uuid=UUID(str(point.id)),
-                                vector=vector,
                                 properties=properties,
                             ),
                         ),
@@ -407,61 +401,34 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
             return query_results
 
     @override
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        """Get records from the collection by their UUIDs."""
-        async with self._tracker("get"):
-            uuid_list = list(record_uuids)
-            if not uuid_list:
-                return []
-
-            # Always get payload so we can check partition_key.
-            points = await self._client.retrieve(
-                collection_name=self._collection_name,
-                ids=list(uuid_list),
-                with_vectors=return_vector,
-                with_payload=True,
-                shard_key_selector=self._shard_key,
-            )
-
-            points_by_uuid: dict[UUID, models.Record] = {
-                UUID(str(point.id)): point
-                for point in points
-                if point.payload
-                and cast(dict[str, Any], point.payload).get(_PAYLOAD_PARTITION_KEY)
-                == self._partition_key
-            }
-
-            records: list[Record] = []
-            for point_uuid in uuid_list:
-                point = points_by_uuid.get(point_uuid)
-                if point is None:
-                    continue
-
-                vector: list[float] | None = None
-                if return_vector and point.vector is not None:
-                    vector = cast(list[float], point.vector)
-
-                properties: dict[str, PropertyValue] | None = None
-                if return_properties and point.payload is not None:
-                    properties = self._parse_payload(
-                        cast(dict[str, Any] | None, point.payload),
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        """Replace the properties of records already in the collection."""
+        async with self._tracker("set_properties"):
+            for record_uuid, properties in record_properties.items():
+                # Select by filter rather than by id: the id alone would reach a
+                # point another logical collection owns in the same native one,
+                # and an id list raises on an id the collection does not hold
+                # where a filter simply matches nothing, which is the contract.
+                selector = models.FilterSelector(
+                    filter=models.Filter(
+                        must=[
+                            _partition_filter(self._partition_key),
+                            models.HasIdCondition(has_id=[record_uuid]),
+                        ]
                     )
-
-                records.append(
-                    Record(
-                        uuid=point_uuid,
-                        vector=vector,
-                        properties=properties,
-                    ),
                 )
-
-            return records
+                # Overwrite rather than merge: the payload carries the partition
+                # key alongside the properties, so `_build_payload` puts it back.
+                await self._client.overwrite_payload(
+                    collection_name=self._collection_name,
+                    payload=cast(dict[str, Any], self._build_payload(dict(properties))),
+                    points=selector,
+                    shard_key_selector=self._shard_key,
+                )
 
     @override
     async def delete(

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -6,7 +6,6 @@ Partition keys are avoided in favor of per-collection tables,
 since sqlite-vec ANN indexes may not support them.
 """
 
-import struct
 from collections.abc import Iterable, Mapping, Sequence
 from typing import ClassVar, override
 from uuid import UUID
@@ -22,10 +21,12 @@ from sqlalchemy import (
     String,
     Table,
     Uuid,
+    bindparam,
     delete,
     event,
     select,
     text,
+    update,
 )
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine.interfaces import DBAPIConnection
@@ -99,11 +100,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
     @staticmethod
     def _serialize_vector(vector: Sequence[float]) -> bytes:
         return sqlite_vec.serialize_float32(list(vector))
-
-    @staticmethod
-    def _deserialize_vector(data: bytes) -> list[float]:
-        count = len(data) // 4
-        return list(struct.unpack(f"={count}f", data))
 
     @staticmethod
     def _distance_to_score(
@@ -200,7 +196,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         limit: int,
         score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         query_vectors = list(query_vectors)
@@ -239,7 +234,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
                     rowid_to_distance=rowid_to_distance,
                     score_threshold=score_threshold,
                     property_filter=property_filter,
-                    return_vector=return_vector,
                     return_properties=return_properties,
                 )
                 results.append(QueryResult(matches=matches))
@@ -252,7 +246,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         rowid_to_distance: Mapping[int, float],
         score_threshold: float | None,
         property_filter: FilterExpr | None,
-        return_vector: bool,
         return_properties: bool,
     ) -> list[QueryMatch]:
         matched_rowids = list(rowid_to_distance.keys())
@@ -277,12 +270,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
 
         matched_rows = (await session.execute(fetch_records)).all()
 
-        rowid_to_vector: dict[int, list[float]] = {}
-        if return_vector:
-            rowid_to_vector = await self._fetch_vectors(
-                session, [row.rowid for row in matched_rows]
-            )
-
         matches: list[QueryMatch] = []
         for row in matched_rows:
             distance = rowid_to_distance.get(row.rowid)
@@ -301,14 +288,10 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
             if return_properties:
                 properties = decode_properties(row.properties)
 
-            vector: list[float] | None = None
-            if return_vector:
-                vector = rowid_to_vector.get(row.rowid)
-
             matches.append(
                 QueryMatch(
                     score=score,
-                    record=Record(uuid=row.uuid, vector=vector, properties=properties),
+                    record=Record(uuid=row.uuid, properties=properties),
                 )
             )
 
@@ -318,75 +301,30 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         )
         return matches
 
-    async def _fetch_vectors(
-        self, session: AsyncSession, rowids: Iterable[int]
-    ) -> dict[int, list[float]]:
-        rowids = list(rowids)
-        if not rowids:
-            return {}
-
-        placeholders = ", ".join(f":r{i}" for i in range(len(rowids)))
-        vector_rows = (
-            await session.execute(
-                text(
-                    f"SELECT rowid, vector FROM [{self._vector_table_name}] "
-                    f"WHERE rowid IN ({placeholders})"
-                ),
-                {f"r{i}": rowid for i, rowid in enumerate(rowids)},
-            )
-        ).all()
-        return {row.rowid: self._deserialize_vector(row.vector) for row in vector_rows}
-
     @override
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        record_uuids = list(record_uuids)
-        if not record_uuids:
-            return []
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        # Properties live in the records table and vectors live in the sqlite-vec
+        # virtual table, so replacing properties never reads a vector back.
+        if not record_properties:
+            return
 
-        selected_columns = [self._records_table.c.uuid, self._records_table.c.rowid]
-        if return_properties:
-            selected_columns.append(self._records_table.c.properties)
-
-        async with self._create_session() as session:
-            fetched_rows = (
-                await session.execute(
-                    select(*selected_columns).where(
-                        self._records_table.c.uuid.in_(record_uuids),
-                    )
-                )
-            ).all()
-
-            rowid_to_vector: dict[int, list[float]] = {}
-            if return_vector:
-                rowid_to_vector = await self._fetch_vectors(
-                    session, [row.rowid for row in fetched_rows]
-                )
-
-        record_map: dict[UUID, Record] = {}
-        for row in fetched_rows:
-            record_uuid = row.uuid
-
-            properties: dict[str, PropertyValue] | None = None
-            if return_properties:
-                properties = decode_properties(row.properties)
-
-            vector: list[float] | None = rowid_to_vector.get(row.rowid)
-
-            record_map[record_uuid] = Record(
-                uuid=record_uuid, vector=vector, properties=properties
+        async with self._create_session() as session, session.begin():
+            await session.execute(
+                update(self._records_table).where(
+                    self._records_table.c.uuid == bindparam("target_uuid")
+                ),
+                [
+                    {
+                        "target_uuid": record_uuid,
+                        "properties": encode_properties(dict(properties)),
+                    }
+                    for record_uuid, properties in record_properties.items()
+                ],
             )
-
-        return [
-            record_map[record_uuid]
-            for record_uuid in record_uuids
-            if record_uuid in record_map
-        ]
 
     @override
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -43,6 +43,7 @@ from sqlalchemy import (
     String,
     Table,
     Uuid,
+    bindparam,
     create_engine,
     delete,
     event,
@@ -402,7 +403,6 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         limit: int,
         score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         query_vectors = list(query_vectors)
@@ -429,7 +429,6 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
             matches = await self._build_matches(
                 row_id_to_score={m.key: m.score for m in search_result.matches},
                 score_threshold=score_threshold,
-                return_vector=return_vector,
                 return_properties=return_properties,
             )
             results.append(QueryResult(matches=matches))
@@ -458,7 +457,6 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         self,
         row_id_to_score: Mapping[int, float],
         score_threshold: float | None,
-        return_vector: bool,
         return_properties: bool,
     ) -> list[QueryMatch]:
         matched_row_ids = list(row_id_to_score.keys())
@@ -473,10 +471,6 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
         async with self._create_session() as session:
             matched_rows = (await session.execute(fetch_records)).all()
-
-        vector_map: dict[int, list[float]] = {}
-        if return_vector:
-            vector_map = await self._search_engine.get_vectors(matched_row_ids)
 
         higher_is_better = self._config.similarity_metric.higher_is_better
         matches: list[QueryMatch] = []
@@ -494,12 +488,10 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
             if return_properties:
                 properties = decode_properties(row.properties)
 
-            vector: list[float] | None = vector_map.get(row.row_id)
-
             matches.append(
                 QueryMatch(
                     score=score,
-                    record=Record(uuid=row.uuid, vector=vector, properties=properties),
+                    record=Record(uuid=row.uuid, properties=properties),
                 )
             )
 
@@ -510,55 +502,30 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         return matches
 
     @override
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        record_uuids = list(record_uuids)
-        if not record_uuids:
-            return []
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        # Properties live in the records table and vectors live in the search
+        # engine, so replacing properties never touches the engine: no pending
+        # operation, no index save, nothing for a crash to lose.
+        if not record_properties:
+            return
 
-        selected_columns = [self._records_table.c.uuid, self._records_table.c.row_id]
-        if return_properties:
-            selected_columns.append(self._records_table.c.properties)
-
-        async with self._create_session() as session:
-            fetched_rows = (
-                await session.execute(
-                    select(*selected_columns).where(
-                        self._records_table.c.uuid.in_(record_uuids),
-                    )
-                )
-            ).all()
-
-        row_id_to_vector: dict[int, list[float]] = {}
-        if return_vector:
-            row_id_to_vector = await self._search_engine.get_vectors(
-                [row.row_id for row in fetched_rows]
+        async with self._create_session() as session, session.begin():
+            await session.execute(
+                update(self._records_table).where(
+                    self._records_table.c.uuid == bindparam("target_uuid")
+                ),
+                [
+                    {
+                        "target_uuid": record_uuid,
+                        "properties": encode_properties(dict(properties)),
+                    }
+                    for record_uuid, properties in record_properties.items()
+                ],
             )
-
-        record_map: dict[UUID, Record] = {}
-        for row in fetched_rows:
-            record_uuid = row.uuid
-
-            properties: dict[str, PropertyValue] | None = None
-            if return_properties:
-                properties = decode_properties(row.properties)
-
-            vector: list[float] | None = row_id_to_vector.get(row.row_id)
-
-            record_map[record_uuid] = Record(
-                uuid=record_uuid, vector=vector, properties=properties
-            )
-
-        return [
-            record_map[record_uuid]
-            for record_uuid in record_uuids
-            if record_uuid in record_map
-        ]
 
     @override
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -284,29 +284,6 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         return best
 
     @override
-    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        async with self._lock.read_lock():
-            return await asyncio.to_thread(self._sync_get_vectors, keys)
-
-    def _sync_get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        keys = list(keys)
-        if not keys:
-            return {}
-
-        try:
-            vectors = self._index.get_items(keys)
-            return {
-                key: list(vector) for key, vector in zip(keys, vectors, strict=True)
-            }
-        except RuntimeError:
-            # Fallback: a deleted key was requested. Fetch one by one.
-            result: dict[int, list[float]] = {}
-            for key in keys:
-                with contextlib.suppress(RuntimeError):
-                    result[key] = list(self._index.get_items([key])[0])
-            return result
-
-    @override
     async def remove(self, keys: Iterable[int]) -> None:
         async with self._lock.write_lock():
             await asyncio.to_thread(self._sync_remove, keys)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -72,7 +72,6 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
         keys = np.array(list(vectors.keys()), dtype=np.uint64)
         array = self._prepare_vectors(list(vectors.values()))
         self._index.add_with_ids(array, keys)
-        self._index.prepare()
 
     @override
     async def search(

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -10,7 +10,6 @@ from turbovec import IdMapIndex
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
-from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -162,8 +161,7 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        with atomic_index_write(path) as temp_path:
-            self._index.write(temp_path)
+        self._index.sync(path)
 
     @override
     async def load(self, path: str) -> None:
@@ -171,5 +169,4 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             self._index = await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> IdMapIndex:
-        clear_stale_index_temp(path)
         return IdMapIndex.load(path)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -1,0 +1,175 @@
+"""turbovec (TurboQuant) implementation of VectorSearchEngine."""
+
+import asyncio
+from collections.abc import Container, Iterable, Mapping, Sequence
+from typing import ClassVar, override
+
+import numpy as np
+from turbovec import IdMapIndex
+
+from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.rw_locks import AsyncRWLock
+
+from .index_persistence import atomic_index_write, clear_stale_index_temp
+from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
+
+
+class TurboVecVectorSearchEngine(VectorSearchEngine):
+    """Vector search engine backed by turbovec."""
+
+    _SUPPORTED_METRICS: ClassVar[frozenset[SimilarityMetric]] = frozenset(
+        {SimilarityMetric.COSINE, SimilarityMetric.DOT}
+    )
+
+    _VALID_BIT_WIDTHS: ClassVar[frozenset[int]] = frozenset({2, 3, 4})
+    _DEFAULT_BIT_WIDTH: ClassVar[int] = 4
+
+    _OVERFETCH_BASE: ClassVar[int] = 4
+
+    def __init__(
+        self,
+        *,
+        num_dimensions: int,
+        similarity_metric: SimilarityMetric,
+        bit_width: int = _DEFAULT_BIT_WIDTH,
+    ) -> None:
+        """Initialize."""
+        if similarity_metric not in self._SUPPORTED_METRICS:
+            supported = ", ".join(metric.value for metric in self._SUPPORTED_METRICS)
+            raise NotImplementedError(
+                f"turbovec does not support {similarity_metric.value!r} "
+                f"(inner-product index only). Supported: {supported}"
+            )
+
+        if bit_width not in self._VALID_BIT_WIDTHS:
+            raise ValueError(
+                f"turbovec bit_width must be one of "
+                f"{sorted(self._VALID_BIT_WIDTHS)}, got {bit_width}"
+            )
+
+        self._similarity_metric = similarity_metric
+        self._index = IdMapIndex(dim=num_dimensions, bit_width=bit_width)
+        self._lock = AsyncRWLock()
+
+    @override
+    async def add(self, vectors: Mapping[int, Sequence[float]]) -> None:
+        if not vectors:
+            return
+        async with self._lock.write_lock():
+            await asyncio.to_thread(self._sync_add, vectors)
+
+    def _sync_add(self, vectors: Mapping[int, Sequence[float]]) -> None:
+        keys = np.array(list(vectors.keys()), dtype=np.uint64)
+        array = self._prepare_vectors(list(vectors.values()))
+        self._index.add_with_ids(array, keys)
+        self._index.prepare()
+
+    @override
+    async def search(
+        self,
+        vectors: Iterable[Sequence[float]],
+        *,
+        limit: int,
+        allowed_keys: Container[int] | None = None,
+    ) -> list[SearchResult]:
+        vectors = list(vectors)
+        if not vectors or limit <= 0:
+            return [SearchResult(matches=[]) for _ in vectors]
+        async with self._lock.read_lock():
+            return await asyncio.to_thread(
+                self._sync_search, vectors, limit, allowed_keys
+            )
+
+    def _sync_search(
+        self,
+        vectors: Sequence[Sequence[float]],
+        limit: int,
+        allowed_keys: Container[int] | None,
+    ) -> list[SearchResult]:
+        query = self._prepare_vectors(vectors)
+
+        if allowed_keys is None:
+            scores, ids = self._index.search(query, limit)
+            return [
+                SearchResult(matches=self._to_matches(scores[i], ids[i], limit, None))
+                for i in range(query.shape[0])
+            ]
+
+        return [
+            self._search_one_filtered(query[i : i + 1], limit, allowed_keys)
+            for i in range(query.shape[0])
+        ]
+
+    def _search_one_filtered(
+        self,
+        query: np.ndarray,
+        limit: int,
+        allowed_keys: Container[int],
+    ) -> SearchResult:
+        fetch_limit = limit * self._OVERFETCH_BASE
+        while True:
+            scores, ids = self._index.search(query, fetch_limit)
+            matches = self._to_matches(scores[0], ids[0], limit, allowed_keys)
+            exhausted = ids.shape[1] < fetch_limit
+            if len(matches) >= limit or exhausted:
+                return SearchResult(matches=matches)
+            fetch_limit *= self._OVERFETCH_BASE
+
+    def _to_matches(
+        self,
+        scores: Iterable[float],
+        keys: Iterable[int],
+        limit: int,
+        allowed_keys: Container[int] | None,
+    ) -> list[SearchMatch]:
+        matches: list[SearchMatch] = []
+        for score, key in zip(scores, keys, strict=True):
+            int_key = int(key)
+            if allowed_keys is not None and int_key not in allowed_keys:
+                continue
+            matches.append(SearchMatch(key=int_key, score=float(score)))
+            if len(matches) >= limit:
+                break
+        return matches
+
+    def _prepare_vectors(self, vectors: Sequence[Sequence[float]]) -> np.ndarray:
+        array = np.array(vectors, dtype=np.float32)
+        if self._similarity_metric is SimilarityMetric.COSINE:
+            norms = np.linalg.norm(array, axis=1, keepdims=True)
+            norms[norms == 0.0] = 1.0
+            array = array / norms
+        return array
+
+    @override
+    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
+        raise NotImplementedError(
+            "turbovec stores only TurboQuant-compressed vectors; "
+            "the original vectors cannot be retrieved"
+        )
+
+    @override
+    async def remove(self, keys: Iterable[int]) -> None:
+        async with self._lock.write_lock():
+            await asyncio.to_thread(self._sync_remove, keys)
+
+    def _sync_remove(self, keys: Iterable[int]) -> None:
+        for key in keys:
+            self._index.remove(key)
+
+    @override
+    async def save(self, path: str) -> None:
+        async with self._lock.write_lock():
+            await asyncio.to_thread(self._sync_save, path)
+
+    def _sync_save(self, path: str) -> None:
+        with atomic_index_write(path) as temp_path:
+            self._index.write(temp_path)
+
+    @override
+    async def load(self, path: str) -> None:
+        async with self._lock.write_lock():
+            self._index = await asyncio.to_thread(self._sync_load, path)
+
+    def _sync_load(self, path: str) -> IdMapIndex:
+        clear_stale_index_temp(path)
+        return IdMapIndex.load(path)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -126,10 +126,16 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             int_key = int(key)
             if allowed_keys is not None and int_key not in allowed_keys:
                 continue
-            matches.append(SearchMatch(key=int_key, score=float(score)))
+            matches.append(SearchMatch(key=int_key, score=self._to_score(score)))
             if len(matches) >= limit:
                 break
         return matches
+
+    def _to_score(self, score: float) -> float:
+        value = float(score)
+        if self._similarity_metric is SimilarityMetric.COSINE:
+            return min(1.0, max(-1.0, value))
+        return value
 
     def _prepare_vectors(self, vectors: Sequence[Sequence[float]]) -> np.ndarray:
         array = np.array(vectors, dtype=np.float32)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -1,6 +1,7 @@
 """turbovec (TurboQuant) implementation of VectorSearchEngine."""
 
 import asyncio
+import math
 from collections.abc import Container, Iterable, Mapping, Sequence
 from typing import ClassVar, override
 
@@ -14,7 +15,15 @@ from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
 class TurboVecVectorSearchEngine(VectorSearchEngine):
-    """Vector search engine backed by turbovec."""
+    """
+    Vector search engine backed by turbovec.
+
+    turbovec indexes a dimensionality that is a multiple of 8, so a vector of
+    any other width is zero-padded up to one. Padding is exact for both metrics
+    this engine serves -- a zero coordinate adds nothing to an inner product
+    and nothing to an L2 norm -- so the padded index answers as the unpadded
+    one would, and any embedding width the other engines accept works here too.
+    """
 
     _SUPPORTED_METRICS: ClassVar[frozenset[SimilarityMetric]] = frozenset(
         {SimilarityMetric.COSINE, SimilarityMetric.DOT}
@@ -47,7 +56,9 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             )
 
         self._similarity_metric = similarity_metric
-        self._index = IdMapIndex(dim=num_dimensions, bit_width=bit_width)
+        self._num_dimensions = num_dimensions
+        self._padded_dimensions = math.ceil(num_dimensions / 8) * 8
+        self._index = IdMapIndex(dim=self._padded_dimensions, bit_width=bit_width)
         self._lock = AsyncRWLock()
 
     @override
@@ -138,7 +149,13 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
         return value
 
     def _prepare_vectors(self, vectors: Sequence[Sequence[float]]) -> np.ndarray:
-        array = np.array(vectors, dtype=np.float32)
+        array = np.zeros((len(vectors), self._padded_dimensions), dtype=np.float32)
+        try:
+            array[:, : self._num_dimensions] = vectors
+        except ValueError as error:
+            raise ValueError(
+                f"vectors must have {self._num_dimensions} dimensions"
+            ) from error
         if self._similarity_metric is SimilarityMetric.COSINE:
             norms = np.linalg.norm(array, axis=1, keepdims=True)
             norms[norms == 0.0] = 1.0

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -162,13 +162,6 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
         return array
 
     @override
-    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        raise NotImplementedError(
-            "turbovec stores only TurboQuant-compressed vectors; "
-            "the original vectors cannot be retrieved"
-        )
-
-    @override
     async def remove(self, keys: Iterable[int]) -> None:
         async with self._lock.write_lock():
             await asyncio.to_thread(self._sync_remove, keys)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
@@ -157,24 +157,6 @@ class USearchVectorSearchEngine(VectorSearchEngine):
         return [r if r is not None else SearchResult(matches=[]) for r in final_results]
 
     @override
-    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        keys = list(keys)
-        if not keys:
-            return {}
-
-        keys_array = np.array(keys, dtype=np.int64)
-        async with self._lock.read_lock():
-            vectors = await asyncio.to_thread(self._index.get, keys_array)
-
-        result: dict[int, list[float]] = {}
-        for i, key in enumerate(keys):
-            vector = vectors[i] if vectors is not None else None
-            if vector is not None:
-                result[key] = list(vector)
-
-        return result
-
-    @override
     async def remove(self, keys: Iterable[int]) -> None:
         async with self._lock.write_lock():
             await asyncio.to_thread(self._sync_remove, keys)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
@@ -93,21 +93,6 @@ class VectorSearchEngine(ABC):
         """
 
     @abstractmethod
-    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        """
-        Retrieve vectors by key.
-
-        Args:
-            keys (Iterable[int]):
-                Keys of vectors to retrieve.
-
-        Returns:
-            dict[int, list[float]]:
-                Mapping of key to vector for keys that exist.
-                Missing keys are omitted.
-        """
-
-    @abstractmethod
     async def remove(self, keys: Iterable[int]) -> None:
         """
         Remove vectors by key.

--- a/packages/server/src/memmachine_server/common/vector_store/vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_store.py
@@ -5,9 +5,10 @@ Defines the interface for adding, querying, and deleting records.
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from uuid import UUID
 
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     FilterExpr,
 )
@@ -68,7 +69,6 @@ class VectorStoreCollection(ABC):
         limit: int,
         score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         """
@@ -86,9 +86,6 @@ class VectorStoreCollection(ABC):
                 Filter expression tree.
                 If None or empty, no property filtering is applied
                 (default: None).
-            return_vector (bool):
-                Whether to include the vector in the returned records
-                (default: False).
             return_properties (bool):
                 Whether to include the properties in the returned records
                 (default: True).
@@ -101,30 +98,25 @@ class VectorStoreCollection(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
         """
-        Get records from the collection by their UUIDs.
+        Replace the properties of records already in the collection.
+
+        Each record keeps the vector it was stored with, so a caller that is
+        only correcting a record's properties does not have to hold the vector
+        to write it back. UUIDs the collection does not hold are ignored, the
+        way `delete` ignores them: whether a backend can tell a missing record
+        from one it just wrote varies, so the contract does not promise to.
 
         Args:
-            record_uuids (Iterable[UUID]):
-                Iterable of UUIDs of the records to retrieve.
-            return_vector (bool):
-                Whether to include the vector in the returned records
-                (default: False).
-            return_properties (bool):
-                Whether to include the properties in the returned records
-                (default: True).
-
-        Returns:
-            list[Record]:
-                Iterable of records with the specified UUIDs,
-                ordered as in the input iterable.
+            record_properties (Mapping[UUID, Mapping[str, PropertyValue]]):
+                Mapping of record UUID to the properties that replace whatever
+                that record currently holds. Properties not in the indexed
+                properties schema are allowed.
         """
         raise NotImplementedError
 

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
@@ -424,7 +424,6 @@ class EventMemory:
             query_vectors=[query_embedding],
             limit=vector_search_limit,
             property_filter=collection_filter,
-            return_vector=False,
             return_properties=True,
         )
         t_vector_query = time.monotonic()

--- a/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
@@ -294,22 +294,49 @@ class VectorStoreSemanticStorage(SemanticStorage):
         if row is None:
             raise ResourceNotFoundError(f"Feature ID not found: {feature_id}")
 
-        if values or embedding is not None:
-            existing_record = await self._get_existing_vector_record(feature_id)
-            await self._upsert_vector_record(
-                feature_id=feature_id,
-                set_id=row.set_id,
-                category_name=row.semantic_category_id,
-                feature=row.feature,
-                value=row.value,
-                tag=row.tag_id,
-                embedding=(
-                    embedding
-                    if embedding is not None
-                    else np.array(existing_record.vector, dtype=float)
-                ),
-                metadata=row.json_metadata,
+        if embedding is not None or values:
+            await self._refresh_vector_record(
+                feature_id=feature_id, row=row, embedding=embedding
             )
+
+    async def _refresh_vector_record(
+        self,
+        *,
+        feature_id: FeatureIdT,
+        row: VectorSemanticFeature,
+        embedding: InstanceOf[np.ndarray] | None,
+    ) -> None:
+        """Bring a feature's vector record back in line with its relational row."""
+        if embedding is None:
+            # The embedding is a function of `value` alone, so a caller that did
+            # not pass one changed nothing the embedding depends on; only the
+            # properties mirroring the relational row need to catch up, and the
+            # stored vector stays where it is rather than being read back out.
+            await self._vector_collection.set_properties(
+                record_properties={
+                    feature_vector_uuid(feature_id): self._vector_properties(
+                        feature_id=feature_id,
+                        set_id=row.set_id,
+                        category_name=row.semantic_category_id,
+                        feature=row.feature,
+                        value=row.value,
+                        tag=row.tag_id,
+                        metadata=row.json_metadata,
+                    )
+                }
+            )
+            return
+
+        await self._upsert_vector_record(
+            feature_id=feature_id,
+            set_id=row.set_id,
+            category_name=row.semantic_category_id,
+            feature=row.feature,
+            value=row.value,
+            tag=row.tag_id,
+            embedding=embedding,
+            metadata=row.json_metadata,
+        )
 
     async def get_feature(
         self,
@@ -620,31 +647,6 @@ class VectorStoreSemanticStorage(SemanticStorage):
             ]
         )
 
-    async def _get_existing_vector_record(self, feature_id: FeatureIdT) -> Record:
-        """Read back a feature's stored embedding.
-
-        A vector store publishes its index atomically but not durably (see
-        `common.vector_store.sqlite_vector_store`), so a power failure can
-        leave a record the store still knows about but whose vector the index
-        no longer holds. The two cases are reported apart because the caller
-        can act on them differently: a missing embedding is repaired by
-        passing a fresh one to `update_feature`, while a missing record is
-        not.
-        """
-        records = await self._vector_collection.get(
-            record_uuids=[feature_vector_uuid(feature_id)],
-            return_vector=True,
-            return_properties=False,
-        )
-        if not records:
-            raise ResourceNotFoundError(f"Vector record not found: {feature_id}")
-        if records[0].vector is None:
-            raise ResourceNotFoundError(
-                f"Vector record {feature_id} has no stored embedding; "
-                "pass an embedding to update this feature"
-            )
-        return records[0]
-
     async def _delete_vector_records(self, feature_ids: Sequence[FeatureIdT]) -> None:
         if not feature_ids:
             return
@@ -670,7 +672,6 @@ class VectorStoreSemanticStorage(SemanticStorage):
             query_vectors=[vector_search_opts.query_embedding.tolist()],
             limit=limit,
             score_threshold=vector_search_opts.min_distance,
-            return_vector=False,
             return_properties=True,
         )
         ordered_ids = [

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'gpu'", specifier = ">=5.1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.43" },
     { name = "sqlite-vec", specifier = ">=0.1.9" },
-    { name = "turbovec", marker = "extra == 'turbovec'", specifier = ">=0.7.0" },
+    { name = "turbovec", marker = "extra == 'turbovec'", specifier = ">=1.0.0" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.1" },
     { name = "usearch", specifier = ">=2.25.1" },
     { name = "uvicorn", specifier = ">=0.35.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2253,6 +2253,9 @@ nebula = [
 qdrant = [
     { name = "qdrant-client" },
 ]
+turbovec = [
+    { name = "turbovec" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2291,11 +2294,12 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'gpu'", specifier = ">=5.1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.43" },
     { name = "sqlite-vec", specifier = ">=0.1.9" },
+    { name = "turbovec", marker = "extra == 'turbovec'", specifier = ">=0.7.0" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.1" },
     { name = "usearch", specifier = ">=2.25.1" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
-provides-extras = ["gpu", "hnswlib", "nebula", "qdrant", "milvus", "litellm"]
+provides-extras = ["gpu", "hnswlib", "nebula", "qdrant", "milvus", "litellm", "turbovec"]
 
 [[package]]
 name = "milvus-lite"
@@ -4629,6 +4633,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
     { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
     { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
+]
+
+[[package]]
+name = "turbovec"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/d2/00c981bd1a6be5b6a875435bf678e627f191e3daf47ea70e1b5ee3109c36/turbovec-1.0.0.tar.gz", hash = "sha256:4ceb3c4ad08e48c6b3483b88aca63d81a06449f90d5fbc1b162dd11df10b8fb2", size = 702952, upload-time = "2026-08-18T20:43:31.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/e0/d759918244236356199b0f4d868ee331d0440a9824f147780aaefa8fe1af/turbovec-1.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:a69e8e2e26ba943f31fba546ab595b60e9b4c25087ed905c3e6ceb0d297ee234", size = 668359, upload-time = "2026-08-18T20:43:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e9/8de1e7d2636a8f5c73d39c64ec6fb4bd20180d8c966962d919356d06e175/turbovec-1.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:09aa495e802701f139820e21700dc947ea21734446112afefb4e480a8f65fa90", size = 700020, upload-time = "2026-08-18T20:43:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/6d/c1acf31a1ef381b588de86ebebb32c3ca7d310cbb84279ac1f65c3a3e854/turbovec-1.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c810f50b967c2163b78d1e27d29e153ab5e8820de23921ad959227acca8bb06a", size = 719275, upload-time = "2026-08-18T20:43:28.402Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/7d/e0c14b09f6dfb7ff156d1f884119daebc5c8bf9f5b8fc72ada26c2674256/turbovec-1.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:cd855e0b318a57dc57c733f9a62ae98de5192f4f6c2c760e305523e8ceb1b090", size = 611788, upload-time = "2026-08-18T20:43:29.854Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Copy of #1499 onto `speedkick`, **stacked on #1588** (the `speedkick` copy of #1460) — its five commits are the first five here, so review only the last six. Cherry-picked cleanly; no conflicts.

Beyond the copy, this carries the change asked for on the port: **`get` is gone from the vector store contract and `get_vectors` from the engine.**

## Taking vector read-back out of the contract

`VectorStoreCollection.get` had exactly one production caller. `VectorStoreSemanticStorage.update_feature` read a feature's stored embedding back so it could write that same embedding again alongside fresh properties, because `upsert` demands a whole record and the vector record's properties mirror the relational row. `return_vector=True` was passed at that one call site and nowhere else, and `VectorSearchEngine.get_vectors` existed to serve it.

It is replaced by `set_properties`, which says what the caller actually wanted — replace a record's properties, leave its vector alone:

- **SQLite / sqlite-vec**: a plain `UPDATE` on the records table. Properties live in SQL and vectors live in the index, so this never touches the index — no pending operation, no index save, nothing for a crash to lose.
- **Qdrant**: `overwrite_payload` selected by *filter*, not by id. An id list raises on an id the collection does not hold, and would reach a point another logical collection owns in the same native collection; the filter form is scoped to the partition and matches nothing when the record is absent.
- **Milvus**: Milvus has no partial update, so the read-back survives — inside the one backend that needs it, rather than in the contract every backend has to satisfy.

With no caller left, `get`, `return_vector` and `get_vectors` all go. Worth noting for this PR in particular: turbovec could not implement `get_vectors` at all — it stores only TurboQuant-compressed vectors, so the method it contributed was `raise NotImplementedError`. Removing it retires the one contract method a conforming engine was allowed to refuse.

## On the semantic memory question: where does the `update_feature` embedding come from?

`SemanticMemory.add_feature` computes it as `embedder.ingest_embed([value])` and `SemanticMemory.update_feature` recomputes it the same way, but only when `value` is not None. So the embedding is a function of `value` alone, on both paths — reusing the stored vector when `value` did not change was already correct, and the other two backends (`sqlalchemy_pgvector_semantic`, `neo4j_semantic_storage`) express it as a partial `UPDATE` that simply leaves the embedding column alone.

What looked weird was not the reuse, it was that this one backend expressed it as a read-modify-write *through the search index* — the least reliable place in the store to route a value that never needed to move. That is what is gone.

## Two consequences worth calling out

1. **A record whose vector the index lost is now invisible through the contract.** `get` was the only read that could still see it; `query` goes through the index. The row survives, and `test_a_reverted_publication_costs_search_not_the_record_row` reads the row directly to say so. This also makes #1460's last commit ("Report a lost embedding as lost, not as a missing feature") moot — the code it added is deleted here, since there is no longer a read-back that can encounter the case.

2. **`get` was load-bearing for tests, not for the server.** About 40 test call sites used it as their read-by-UUID observation point. They now read through `query` via a `_fetch_records` helper per suite, which lists the collection with an arbitrary probe vector and no score threshold. If that trade is not wanted, the alternative is to keep a properties-only `get` in the contract — `get_vectors`, `return_vector` and the read-modify-write all still go, and the tests keep their affordance.

## Verification

- `pytest packages/server/server_tests`: 2013 passed, 3 skipped. The one failure, `test_get_version`, is a git-describe version-string artifact of the local checkout and fails identically on the untouched base branch (`0.3.9.post2.dev10+g4105a720f`).
- `ty check --project packages/server`: 17 diagnostics, the same 17 as the base branch.
- `ruff check` / `ruff format --check` / `uv lock --check`: clean.

---

Below: the original description of #1499.

---

> **Depends on #1460** and is branched from it, so everything here except
> `Add VectorSearchEngine backed by turbovec` and `Update turbovec to 1.0.0 and
> let it publish the index` is either that PR's or a merge of `main` (taken to
> resolve `uv.lock` against the Milvus backend that landed since). Supersedes
> #1448.

### Purpose of the change

`SQLiteVectorStore` backed by turbovec is smaller and faster than
`SQLiteVecVectorStore` backed by sqlite-vec. Both are linear full scans, but
turbovec keeps TurboQuant-compressed vectors in RAM, so its scaling constant is
much smaller and an index is a fraction of the size of the f32 engines'.

### Description

Adds `TurboVecVectorSearchEngine`, a `VectorSearchEngine` backed by turbovec,
behind a new `turbovec` optional extra floored at 1.0.0. turbovec indexes a
dimensionality that is a multiple of 8, so any other width is zero-padded up to
one -- exact for both metrics here, since a zero coordinate adds nothing to an
inner product or to an L2 norm -- and every width the other engines accept
works.

Publication is turbovec's own. 1.0.0 is upstream's first stable release, and
what it commits to is the on-disk format: v7 is the only container turbovec
reads or writes, and a file written by 1.0.0 stays readable by later releases.
v7 is also what makes `sync` possible, and `save` calls it -- a checkpoint
appends what changed since the last one rather than restating the whole index,
and commits it durably, so a crash at any byte leaves the previous commit
intact and the publication survives a power failure. The engine therefore does
not route through the shared `atomic_index_write` helper that the hnswlib and
usearch engines use on #1460: wrapping `sync` would restate the index on every
checkpoint and publish it through the weaker of the two protocols, a rename the
helper's own docstring declines to make durable.

That is what supersedes #1448, which added the same engine against turbovec
0.x, whose `write` had no publication protocol of its own and wrote straight to
the final path -- an interrupted save left a truncated file where the store
expects a loadable index, and because `index_saved` makes a published index a
durable contract, that is a hard `IndexLoadError` rather than a silent rebuild.

Known limitations, both consequences of storing only compressed vectors:

- `get_vectors` raises `NotImplementedError`, since the original vectors are not
  recoverable. That makes the engine usable by EventMemory but not by semantic
  memory, whose feature updates read stored embeddings back.
- Search is approximate. A self-match lands near the exact score rather than on
  it, so the tests assert ranking and membership rather than magnitudes. The
  quantized inner product also overshoots the cosine range -- 40 of 50
  self-matches at 8 dimensions, and every dimension measured at bit width 2 --
  so `SearchMatch` scores are clamped to `[-1, 1]` under a cosine metric, which
  is what its docstring promises and what `score_threshold` compares against.
  A dot product is unbounded by contract and is not clamped.

Removal is a strong point by comparison: turbovec drops the id from its map
rather than tombstoning it, so deletions stay cheap and a removed key cannot
resurface in results.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- [x] Unit Test

`test_turbovec_engine.py` covers construction, add, remove, cosine and dot
search, filtered search, `get_vectors` raising, score range (clamped under
cosine, untouched under dot), unaligned widths (search, save/load, and a
wrong-width vector refused), and persistence -- a save/load
round-trip, a load replacing a live index, a save leaving nothing but the index
behind, and what a later checkpoint carries, reading a bulk removal and an
append back through a fresh engine. The module is `importorskip`-guarded, so the
suite still runs without the extra installed.

**Test Results:** `uv run pytest packages/server/server_tests/memmachine_server/common/vector_store`
-> 346 passed. `ruff check` and `ruff format --check` clean. The `ty` jobs are
red on `main` itself (`nebulagraph_python.client` lost the members the graph
store imports), fixed by #1519 rather than here; nothing `ty` reports is in
this diff.

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (#1460 is still open)
- [x] I have checked my code and corrected any misspellings

### Maintainer Checklist

- [ ] Confirmed all checks passed
- [ ] Contributor has signed the commit(s)
- [ ] Reviewed the code
- [ ] Run, Tested, and Verified the change(s) work as expected



---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKmF9xNph9QH3ozNw3ZnJL
