### PR TITLE
style: reformat an assert ruff 0.15.14 formats differently (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -1350,9 +1350,9 @@ class TestCollectionLifecycleAcrossWorkers:
         await store_a.startup()
         await store_b.startup()
 
-        assert (
-            store_a._client_name_locks is not store_b._client_name_locks
-        ), "separate clients must not share a lock, or this does not test anything"
+        assert store_a._client_name_locks is not store_b._client_name_locks, (
+            "separate clients must not share a lock, or this does not test anything"
+        )
 
         try:
             results = await asyncio.gather(


### PR DESCRIPTION
### Purpose of the change

`ruff format --check` fails on `speedkick` as it stands, so every PR targeting the branch inherits a red format check in a file it does not touch.

### Description

The lint workflow runs `ruff format --check --diff` with `version-file: "pyproject.toml"`, which pins `ruff==0.15.14`. That version moves the message of a multi-line `assert` onto its own line, and one assert in the Qdrant vector store tests predates the change:

```diff
-        assert (
-            store_a._client_name_locks is not store_b._client_name_locks
-        ), "separate clients must not share a lock, or this does not test anything"
+        assert store_a._client_name_locks is not store_b._client_name_locks, (
+            "separate clients must not share a lock, or this does not test anything"
+        )
```

Purely the formatter's output; no behavior change. It is on its own rather than folded into one of the PRs that trips over it, since it belongs to none of them.

### Verification

`ruff check .` and `ruff format --check .` both clean on this branch, against the pinned 0.15.14.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKmF9xNph9QH3ozNw3ZnJL