### PR TITLE
Make cosine the only similarity, and add get_cosine_similarity (speedkick)

### DIFF
--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -80,7 +80,7 @@ litellm = [
     "litellm>=1.63.0,<1.86",
 ]
 turbovec = [
-    "turbovec>=0.7.0",
+    "turbovec>=1.0.0",
 ]
 
 [project.scripts]

--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -79,6 +79,9 @@ milvus = [
 litellm = [
     "litellm>=1.63.0,<1.86",
 ]
+turbovec = [
+    "turbovec>=0.7.0",
+]
 
 [project.scripts]
 memmachine-server = "memmachine_server.server.app:main"

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_embedder_conf.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_embedder_conf.py
@@ -9,7 +9,6 @@ from memmachine_server.common.configuration.embedder_conf import (
     AmazonBedrockEmbedderConf,
     OpenAIEmbedderConf,
 )
-from memmachine_server.common.data_types import SimilarityMetric
 
 
 @pytest.fixture
@@ -32,7 +31,6 @@ def aws_embedder_conf() -> dict[str, Any]:
             "aws_access_key_id": "key-id",
             "aws_secret_access_key": "secret-key",
             "model_id": "amazon.titan-embed-text-v2:0",
-            "similarity_metric": "cosine",
         },
     }
 
@@ -77,7 +75,6 @@ def test_valid_aws_bedrock_embedder_config(aws_embedder_conf):
     assert conf.aws_access_key_id == SecretStr("key-id")
     assert conf.aws_secret_access_key == SecretStr("secret-key")
     assert conf.model_id == "amazon.titan-embed-text-v2:0"
-    assert conf.similarity_metric == SimilarityMetric.COSINE
 
 
 def test_valid_ollama_embedder_config(ollama_embedder_conf):

--- a/packages/server/server_tests/memmachine_server/common/embedder/test_embedder.py
+++ b/packages/server/server_tests/memmachine_server/common/embedder/test_embedder.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import pytest
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder.embedder import Embedder
 
 
@@ -42,10 +41,6 @@ class MockEmbedder(Embedder):
     @property
     def dimensions(self) -> int:
         return 2
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        return SimilarityMetric.COSINE
 
 
 @pytest.mark.asyncio

--- a/packages/server/server_tests/memmachine_server/common/reranker/fake_embedder.py
+++ b/packages/server/server_tests/memmachine_server/common/reranker/fake_embedder.py
@@ -1,18 +1,14 @@
 from typing import Any
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder import Embedder
 
 
 class FakeEmbedder(Embedder):
     def __init__(
         self,
-        similarity_metric: SimilarityMetric = SimilarityMetric.COSINE,
         batch_size: int | None = None,
     ) -> None:
         super().__init__(batch_size=batch_size)
-
-        self._similarity_metric = similarity_metric
 
     async def _ingest_embed(
         self,
@@ -35,7 +31,3 @@ class FakeEmbedder(Embedder):
     @property
     def dimensions(self) -> int:
         return 2
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        return self._similarity_metric

--- a/packages/server/server_tests/memmachine_server/common/reranker/test_embedder_reranker.py
+++ b/packages/server/server_tests/memmachine_server/common/reranker/test_embedder_reranker.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.reranker.embedder_reranker import (
     EmbedderReranker,
@@ -11,16 +10,9 @@ from memmachine_server.common.reranker.embedder_reranker import (
 from server_tests.memmachine_server.common.reranker.fake_embedder import FakeEmbedder
 
 
-@pytest.fixture(
-    params=[
-        SimilarityMetric.COSINE,
-        SimilarityMetric.DOT,
-        SimilarityMetric.EUCLIDEAN,
-        SimilarityMetric.MANHATTAN,
-    ],
-)
-def embedder(request):
-    return FakeEmbedder(similarity_metric=request.param)
+@pytest.fixture
+def embedder():
+    return FakeEmbedder()
 
 
 @pytest.fixture
@@ -63,18 +55,5 @@ async def test_score():
     embedder.ingest_embed.return_value = [[1.0, 2.0], [1.5, 1.5]]
     embedder.search_embed.return_value = [[1.0, 1.0]]
 
-    embedder.similarity_metric = SimilarityMetric.COSINE
     scores = await reranker.score("query", ["candidate1", "candidate2"])
     assert scores[0] < scores[1]
-
-    embedder.similarity_metric = SimilarityMetric.DOT
-    scores = await reranker.score("query", ["candidate1", "candidate2"])
-    assert scores[0] == scores[1]
-
-    embedder.similarity_metric = SimilarityMetric.EUCLIDEAN
-    scores = await reranker.score("query", ["candidate1", "candidate2"])
-    assert scores[0] < scores[1]
-
-    embedder.similarity_metric = SimilarityMetric.MANHATTAN
-    scores = await reranker.score("query", ["candidate1", "candidate2"])
-    assert scores[0] == scores[1]

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
@@ -797,10 +797,8 @@ async def test_sqlite_vector_store_default_engine_is_usearch():
 
         # Invoke the factory the manager passed into params and confirm it
         # routes to the USearch engine.
-        from memmachine_server.common.data_types import SimilarityMetric
-
         factory = mock_params_cls.call_args.kwargs["vector_search_engine_factory"]
-        factory(8, SimilarityMetric.COSINE)
+        factory(8)
 
     mock_usearch_cls.assert_called_once()
 

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_reranker_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_reranker_manager.py
@@ -12,7 +12,6 @@ from memmachine_server.common.configuration.reranker_conf import (
     RerankersConf,
     RRFHybridRerankerConf,
 )
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.errors import InvalidRerankerError
 from memmachine_server.common.resource_manager.reranker_manager import (
@@ -78,10 +77,6 @@ class FakeEmbedder(Embedder):
     @property
     def dimensions(self) -> int:
         return 0
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        return SimilarityMetric.COSINE
 
 
 class FakeEmbedderFactory:

--- a/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_nebula_graph_vector_graph_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_nebula_graph_vector_graph_store.py
@@ -9,7 +9,6 @@ import pytest_asyncio
 # Skip all tests if nebulagraph_python is not installed
 pytest.importorskip("nebulagraph_python")
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
     And as FilterAnd,
 )
@@ -178,12 +177,12 @@ async def test_add_nodes(nebula_client, vector_graph_store):
         Node(
             uid=str(uuid4()),
             properties={"name": "Alice", "age": 30},
-            embeddings={"vec": ([1.0, 2.0, 3.0], SimilarityMetric.COSINE)},
+            embeddings={"vec": [1.0, 2.0, 3.0]},
         ),
         Node(
             uid=str(uuid4()),
             properties={"name": "Bob", "age": 25},
-            embeddings={"vec": ([4.0, 5.0, 6.0], SimilarityMetric.COSINE)},
+            embeddings={"vec": [4.0, 5.0, 6.0]},
         ),
     ]
 
@@ -223,12 +222,12 @@ async def test_add_edges(nebula_client, vector_graph_store):
     person = Node(
         uid=str(uuid4()),
         properties={"name": "Alice"},
-        embeddings={"profile": ([1.0, 0.0, 0.0], SimilarityMetric.EUCLIDEAN)},
+        embeddings={"profile": [1.0, 0.0, 0.0]},
     )
     company = Node(
         uid=str(uuid4()),
         properties={"name": "Acme Corp"},
-        embeddings={"profile": ([0.0, 1.0, 0.0], SimilarityMetric.EUCLIDEAN)},
+        embeddings={"profile": [0.0, 1.0, 0.0]},
     )
 
     await vector_graph_store.add_nodes(collection=source_collection, nodes=[person])
@@ -240,7 +239,7 @@ async def test_add_edges(nebula_client, vector_graph_store):
         source_uid=person.uid,
         target_uid=company.uid,
         properties={"since": 2020, "role": "Engineer"},
-        embeddings={"relation_vec": ([0.5, 0.5, 0.0], SimilarityMetric.EUCLIDEAN)},
+        embeddings={"relation_vec": [0.5, 0.5, 0.0]},
     )
 
     await vector_graph_store.add_edges(
@@ -281,17 +280,17 @@ async def test_search_similar_nodes(vector_graph_store):
         Node(
             uid=str(uuid4()),
             properties={"title": "Doc 1"},
-            embeddings={"content": ([1.0, 0.0, 0.0], SimilarityMetric.EUCLIDEAN)},
+            embeddings={"content": [1.0, 0.0, 0.0]},
         ),
         Node(
             uid=str(uuid4()),
             properties={"title": "Doc 2"},
-            embeddings={"content": ([0.0, 1.0, 0.0], SimilarityMetric.EUCLIDEAN)},
+            embeddings={"content": [0.0, 1.0, 0.0]},
         ),
         Node(
             uid=str(uuid4()),
             properties={"title": "Doc 3"},
-            embeddings={"content": ([0.9, 0.1, 0.0], SimilarityMetric.EUCLIDEAN)},
+            embeddings={"content": [0.9, 0.1, 0.0]},
         ),
     ]
 
@@ -304,7 +303,6 @@ async def test_search_similar_nodes(vector_graph_store):
         collection=collection,
         embedding_name="content",
         query_embedding=query_vec,
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
         limit=2,
     )
 
@@ -322,17 +320,17 @@ async def test_search_similar_nodes_with_filter(vector_graph_store):
         Node(
             uid=str(uuid4()),
             properties={"title": "Doc 1", "category": "tech"},
-            embeddings={"content": ([1.0, 0.0, 0.0], SimilarityMetric.EUCLIDEAN)},
+            embeddings={"content": [1.0, 0.0, 0.0]},
         ),
         Node(
             uid=str(uuid4()),
             properties={"title": "Doc 2", "category": "business"},
-            embeddings={"content": ([0.9, 0.1, 0.0], SimilarityMetric.EUCLIDEAN)},
+            embeddings={"content": [0.9, 0.1, 0.0]},
         ),
         Node(
             uid=str(uuid4()),
             properties={"title": "Doc 3", "category": "tech"},
-            embeddings={"content": ([0.8, 0.2, 0.0], SimilarityMetric.EUCLIDEAN)},
+            embeddings={"content": [0.8, 0.2, 0.0]},
         ),
     ]
 
@@ -346,7 +344,6 @@ async def test_search_similar_nodes_with_filter(vector_graph_store):
         collection=collection,
         embedding_name="content",
         query_embedding=query_vec,
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
         limit=10,
         property_filter=filter_expr,
     )
@@ -848,416 +845,6 @@ async def test_complex_filters(vector_graph_store):
 # ---------------------------------------------------------------------------
 
 
-def test_similarity_metric_mappings():
-    """Unit test covering every row of the metric support table.
-
-    | Metric    | _similarity_metric_to_nebula | _get_distance_func_and_order | ANN possible? |
-    |-----------|------------------------------|------------------------------|---------------|
-    | EUCLIDEAN | "L2"                         | euclidean() ASC              | yes           |
-    | DOT       | "IP"                         | inner_product() DESC         | yes           |
-    | COSINE    | None (no index)              | cosine() DESC                | no — KNN only |
-    | MANHATTAN | None (no index)              | raises ValueError            | no            |
-    """
-    # _similarity_metric_to_nebula
-    assert (
-        NebulaGraphVectorGraphStore._similarity_metric_to_nebula(
-            SimilarityMetric.EUCLIDEAN
-        )
-        == "L2"
-    )
-    assert (
-        NebulaGraphVectorGraphStore._similarity_metric_to_nebula(SimilarityMetric.DOT)
-        == "IP"
-    )
-    assert (
-        NebulaGraphVectorGraphStore._similarity_metric_to_nebula(
-            SimilarityMetric.COSINE
-        )
-        is None
-    )
-    assert (
-        NebulaGraphVectorGraphStore._similarity_metric_to_nebula(
-            SimilarityMetric.MANHATTAN
-        )
-        is None
-    )
-
-    # _get_distance_func_and_order
-    assert NebulaGraphVectorGraphStore._get_distance_func_and_order(
-        SimilarityMetric.EUCLIDEAN
-    ) == ("euclidean", "ASC")
-    assert NebulaGraphVectorGraphStore._get_distance_func_and_order(
-        SimilarityMetric.DOT
-    ) == ("inner_product", "DESC")
-    assert NebulaGraphVectorGraphStore._get_distance_func_and_order(
-        SimilarityMetric.COSINE
-    ) == ("cosine", "DESC")
-    with pytest.raises(ValueError, match="manhattan"):
-        NebulaGraphVectorGraphStore._get_distance_func_and_order(
-            SimilarityMetric.MANHATTAN
-        )
-
-
-@pytest.mark.asyncio
-async def test_search_similar_nodes_dot_metric(vector_graph_store):
-    """DOT metric: inner_product() DESC, KNN search."""
-    collection = "dot_docs"
-
-    nodes = [
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 1"},
-            embeddings={"content": ([1.0, 0.0, 0.0], SimilarityMetric.DOT)},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 2"},
-            embeddings={"content": ([0.0, 1.0, 0.0], SimilarityMetric.DOT)},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 3"},
-            embeddings={"content": ([0.9, 0.1, 0.0], SimilarityMetric.DOT)},
-        ),
-    ]
-
-    await vector_graph_store.add_nodes(collection=collection, nodes=nodes)
-
-    # Inner products with query [1,0,0]: Doc1=1.0, Doc3=0.9, Doc2=0.0 → ranked order: Doc1, Doc3
-    query_vec = [1.0, 0.0, 0.0]
-    results = await vector_graph_store.search_similar_nodes(
-        collection=collection,
-        embedding_name="content",
-        query_embedding=query_vec,
-        similarity_metric=SimilarityMetric.DOT,
-        limit=2,
-    )
-
-    assert len(results) == 2
-    assert results[0].properties["title"] == "Doc 1"
-    assert results[1].properties["title"] == "Doc 3"
-
-
-@pytest.mark.asyncio
-async def test_search_similar_nodes_cosine_metric(vector_graph_store):
-    """COSINE metric: cosine() DESC, always KNN (no ANN index)."""
-    collection = "cosine_docs"
-
-    nodes = [
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 1"},
-            embeddings={"content": ([1.0, 0.0, 0.0], SimilarityMetric.COSINE)},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 2"},
-            embeddings={"content": ([0.0, 1.0, 0.0], SimilarityMetric.COSINE)},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 3"},
-            # Slightly off-axis: cosine ≈ 0.993 with [1,0,0]
-            embeddings={"content": ([0.9, 0.1, 0.0], SimilarityMetric.COSINE)},
-        ),
-    ]
-
-    await vector_graph_store.add_nodes(collection=collection, nodes=nodes)
-
-    # Cosine similarities with [1,0,0]: Doc1=1.0, Doc3≈0.993, Doc2=0.0 → ranked: Doc1, Doc3
-    query_vec = [1.0, 0.0, 0.0]
-    results = await vector_graph_store.search_similar_nodes(
-        collection=collection,
-        embedding_name="content",
-        query_embedding=query_vec,
-        similarity_metric=SimilarityMetric.COSINE,
-        limit=2,
-    )
-
-    assert len(results) == 2
-    assert results[0].properties["title"] == "Doc 1"
-    assert results[1].properties["title"] == "Doc 3"
-
-
-@pytest.mark.asyncio
-async def test_search_similar_nodes_manhattan_raises(vector_graph_store):
-    """MANHATTAN metric: not supported by NebulaGraph, raises ValueError."""
-    collection = "manhattan_docs"
-
-    nodes = [
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 1"},
-            embeddings={"content": ([1.0, 0.0, 0.0], SimilarityMetric.EUCLIDEAN)},
-        ),
-    ]
-    await vector_graph_store.add_nodes(collection=collection, nodes=nodes)
-
-    with pytest.raises(ValueError, match="manhattan"):
-        await vector_graph_store.search_similar_nodes(
-            collection=collection,
-            embedding_name="content",
-            query_embedding=[1.0, 0.0, 0.0],
-            similarity_metric=SimilarityMetric.MANHATTAN,
-            limit=1,
-        )
-
-
-# ---------------------------------------------------------------------------
-# Multi-property directional search
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_search_directional_nodes_multiple_by_properties(vector_graph_store):
-    """Test search_directional_nodes with multiple sort properties (timestamp + sequence)."""
-    collection = "seq_events"
-
-    now = datetime.now(UTC)
-    delta = timedelta(hours=1)
-
-    # Two timestamps x two sequence values = 4 nodes
-    nodes = [
-        Node(
-            uid=str(uuid4()),
-            properties={"name": "T1S1", "timestamp": now, "sequence": 1},
-            embeddings={},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"name": "T1S2", "timestamp": now, "sequence": 2},
-            embeddings={},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"name": "T2S1", "timestamp": now + delta, "sequence": 1},
-            embeddings={},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"name": "T2S2", "timestamp": now + delta, "sequence": 2},
-            embeddings={},
-        ),
-    ]
-
-    await vector_graph_store.add_nodes(collection=collection, nodes=nodes)
-
-    # Start at (T1, S2) inclusive, both ascending → T1S2, T2S1, T2S2
-    results = await vector_graph_store.search_directional_nodes(
-        collection=collection,
-        by_properties=["timestamp", "sequence"],
-        starting_at=[now, 2],
-        order_ascending=[True, True],
-        include_equal_start=True,
-        limit=None,
-    )
-    assert len(results) == 3
-    assert results[0].properties["name"] == "T1S2"
-    assert results[1].properties["name"] == "T2S1"
-    assert results[2].properties["name"] == "T2S2"
-
-    # Start at (T2, S1) inclusive, first ascending second descending → T2S1, T2S2 reversed
-    # (same first key, second key descending from S1 means S1 then... S2 > S1 so excluded)
-    # Actually: ascending timestamp, descending sequence from S1 inclusive:
-    # At T2: include S1 (equal, inclusive), nothing below S1 for descending → just T2S1
-    results = await vector_graph_store.search_directional_nodes(
-        collection=collection,
-        by_properties=["timestamp", "sequence"],
-        starting_at=[now + delta, 1],
-        order_ascending=[True, False],
-        include_equal_start=True,
-        limit=None,
-    )
-    assert len(results) == 1
-    assert results[0].properties["name"] == "T2S1"
-
-
-# ---------------------------------------------------------------------------
-# Edge cases
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_add_nodes_empty_list(vector_graph_store):
-    """Adding an empty list of nodes is a no-op."""
-    collection = "empty_test"
-
-    await vector_graph_store.add_nodes(collection=collection, nodes=[])
-
-    results = await vector_graph_store.search_matching_nodes(
-        collection=collection,
-        limit=10,
-    )
-    assert len(results) == 0
-
-
-@pytest.mark.asyncio
-async def test_add_edges_empty_list(vector_graph_store):
-    """Adding an empty list of edges is a no-op."""
-    node = Node(uid=str(uuid4()), properties={"name": "Solo"}, embeddings={})
-    await vector_graph_store.add_nodes(collection="solo", nodes=[node])
-
-    # Should not raise
-    await vector_graph_store.add_edges(
-        relation="knows",
-        source_collection="solo",
-        target_collection="solo",
-        edges=[],
-    )
-
-    # Node still exists, no edges created
-    results = await vector_graph_store.get_nodes(
-        collection="solo", node_uids=[node.uid]
-    )
-    assert len(results) == 1
-
-
-@pytest.mark.asyncio
-async def test_add_nodes_with_none_property(vector_graph_store):
-    """Nodes with None property values are stored and retrieved without error."""
-    collection = "nullable_test"
-
-    node = Node(
-        uid=str(uuid4()),
-        properties={"name": "Alice", "optional_field": None},
-        embeddings={},
-    )
-    await vector_graph_store.add_nodes(collection=collection, nodes=[node])
-
-    results = await vector_graph_store.get_nodes(
-        collection=collection, node_uids=[node.uid]
-    )
-    assert len(results) == 1
-    # None properties may be omitted on retrieval (same behaviour as Neo4j)
-    assert results[0].properties.get("name") == "Alice"
-
-
-@pytest.mark.asyncio
-async def test_add_edges_with_none_property(vector_graph_store):
-    """Edges with None property values are stored without error."""
-    person_collection = "nullable_person"
-    company_collection = "nullable_company"
-    relation = "works_at_nullable"
-
-    alice = Node(uid=str(uuid4()), properties={"name": "Alice"}, embeddings={})
-    acme = Node(uid=str(uuid4()), properties={"name": "Acme"}, embeddings={})
-
-    await vector_graph_store.add_nodes(collection=person_collection, nodes=[alice])
-    await vector_graph_store.add_nodes(collection=company_collection, nodes=[acme])
-
-    edge = Edge(
-        uid=str(uuid4()),
-        source_uid=alice.uid,
-        target_uid=acme.uid,
-        properties={"role": "Engineer", "optional_field": None},
-        embeddings={},
-    )
-    await vector_graph_store.add_edges(
-        relation=relation,
-        source_collection=person_collection,
-        target_collection=company_collection,
-        edges=[edge],
-    )
-
-    # Verify edge was created by searching related nodes
-    results = await vector_graph_store.search_related_nodes(
-        relation=relation,
-        other_collection=company_collection,
-        this_collection=person_collection,
-        this_node_uid=alice.uid,
-        find_targets=True,
-        find_sources=False,
-    )
-    assert len(results) == 1
-    assert results[0].uid == acme.uid
-
-
-@pytest.mark.asyncio
-async def test_get_nodes_with_nonexistent_uids(vector_graph_store):
-    """get_nodes ignores UIDs that do not exist — returns only found nodes."""
-    collection = "partial_get"
-
-    node = Node(uid=str(uuid4()), properties={"name": "Real"}, embeddings={})
-    await vector_graph_store.add_nodes(collection=collection, nodes=[node])
-
-    fake_uid = str(uuid4())
-    results = await vector_graph_store.get_nodes(
-        collection=collection,
-        node_uids=[node.uid, fake_uid],
-    )
-    assert len(results) == 1
-    assert results[0].uid == node.uid
-
-
-@pytest.mark.asyncio
-async def test_delete_nodes_wrong_collection(vector_graph_store):
-    """Deleting from a non-matching collection leaves nodes untouched."""
-    collection = "real_collection"
-    wrong_collection = "wrong_collection"
-
-    node = Node(uid=str(uuid4()), properties={"name": "Keep"}, embeddings={})
-    await vector_graph_store.add_nodes(collection=collection, nodes=[node])
-
-    # Attempt to delete from the wrong collection
-    await vector_graph_store.delete_nodes(
-        collection=wrong_collection, node_uids=[node.uid]
-    )
-
-    results = await vector_graph_store.get_nodes(
-        collection=collection, node_uids=[node.uid]
-    )
-    assert len(results) == 1
-
-
-# ---------------------------------------------------------------------------
-# ANN mode
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_search_similar_nodes_ann(vector_graph_store_ann):
-    """ANN mode: vector index is created immediately (threshold=0) and results are returned."""
-    collection = "ann_docs"
-
-    nodes = [
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 1"},
-            embeddings={"content": ([1.0, 0.0, 0.0], SimilarityMetric.EUCLIDEAN)},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 2"},
-            embeddings={"content": ([0.0, 1.0, 0.0], SimilarityMetric.EUCLIDEAN)},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 3"},
-            embeddings={"content": ([0.9, 0.1, 0.0], SimilarityMetric.EUCLIDEAN)},
-        ),
-    ]
-
-    await vector_graph_store_ann.add_nodes(collection=collection, nodes=nodes)
-
-    results = await vector_graph_store_ann.search_similar_nodes(
-        collection=collection,
-        embedding_name="content",
-        query_embedding=[1.0, 0.0, 0.0],
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
-        limit=3,
-    )
-
-    # ANN may return approximate results but at minimum should return some nodes
-    assert 0 < len(results) <= 3
-    # The closest node (Doc 1) should still appear first in a reasonable ANN implementation
-    assert results[0].properties["title"] == "Doc 1"
-
-
-# ---------------------------------------------------------------------------
-# Extended sanitize/desanitize coverage
-# ---------------------------------------------------------------------------
-
-
 def test_sanitize_name_extended():
     """Comprehensive sanitize/desanitize round-trip for edge-case inputs."""
     names = [
@@ -1370,10 +957,7 @@ async def test_index_creation_with_special_character_names(
             "display name": "Test User",  # space
         },
         embeddings={
-            "content-vector": (
-                [1.0, 0.0, 0.0],
-                SimilarityMetric.EUCLIDEAN,
-            ),  # hyphen in embedding name
+            "content-vector": [1.0, 0.0, 0.0],  # hyphen in embedding name
         },
     )
 
@@ -1395,7 +979,6 @@ async def test_index_creation_with_special_character_names(
         collection=collection,
         embedding_name="content-vector",
         query_embedding=[1.0, 0.0, 0.0],
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
         limit=10,
     )
     assert len(similar) == 1

--- a/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_neo4j_vector_graph_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_neo4j_vector_graph_store.py
@@ -8,7 +8,6 @@ import pytest_asyncio
 from neo4j import AsyncGraphDatabase
 from testcontainers.neo4j import Neo4jContainer
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
     And as FilterAnd,
 )
@@ -163,10 +162,7 @@ async def test_add_nodes(neo4j_driver, vector_graph_store):
                 "none_value": None,
             },
             embeddings={
-                "embedding_name": (
-                    [0.1, 0.2, 0.3],
-                    SimilarityMetric.COSINE,
-                ),
+                "embedding_name": [0.1, 0.2, 0.3],
             },
         ),
     ]
@@ -200,10 +196,7 @@ async def test_add_edges(neo4j_driver, vector_graph_store):
                 "none_value": None,
             },
             embeddings={
-                "embedding_name": (
-                    [0.1, 0.2, 0.3],
-                    SimilarityMetric.COSINE,
-                ),
+                "embedding_name": [0.1, 0.2, 0.3],
             },
         ),
     ]
@@ -243,10 +236,7 @@ async def test_add_edges(neo4j_driver, vector_graph_store):
             target_uid=node3_uid,
             properties={"description": "Node1 to Node3"},
             embeddings={
-                "embedding_name": (
-                    [0.4, 0.5, 0.6],
-                    SimilarityMetric.DOT,
-                ),
+                "embedding_name": [0.4, 0.5, 0.6],
             },
         ),
     ]
@@ -292,14 +282,8 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
                 "name": "Node1",
             },
             embeddings={
-                "embedding1": (
-                    [1000.0, 0.0],
-                    SimilarityMetric.COSINE,
-                ),
-                "embedding2": (
-                    [1000.0, 0.0],
-                    SimilarityMetric.EUCLIDEAN,
-                ),
+                "embedding1": [1000.0, 0.0],
+                "embedding2": [1000.0, 0.0],
             },
         ),
         Node(
@@ -309,14 +293,8 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
                 "include?": "yes",
             },
             embeddings={
-                "embedding1": (
-                    [10.0, 10.0],
-                    SimilarityMetric.COSINE,
-                ),
-                "embedding2": (
-                    [10.0, 10.0],
-                    SimilarityMetric.EUCLIDEAN,
-                ),
+                "embedding1": [10.0, 10.0],
+                "embedding2": [10.0, 10.0],
             },
         ),
         Node(
@@ -326,14 +304,8 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
                 "include?": "no",
             },
             embeddings={
-                "embedding1": (
-                    [-100.0, 0.0],
-                    SimilarityMetric.COSINE,
-                ),
-                "embedding2": (
-                    [-100.0, 0.0],
-                    SimilarityMetric.EUCLIDEAN,
-                ),
+                "embedding1": [-100.0, 0.0],
+                "embedding2": [-100.0, 0.0],
             },
         ),
         Node(
@@ -343,14 +315,8 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
                 "include?": "no",
             },
             embeddings={
-                "embedding1": (
-                    [-100.0, -1.0],
-                    SimilarityMetric.COSINE,
-                ),
-                "embedding2": (
-                    [-100.0, -1.0],
-                    SimilarityMetric.EUCLIDEAN,
-                ),
+                "embedding1": [-100.0, -1.0],
+                "embedding2": [-100.0, -1.0],
             },
         ),
         Node(
@@ -360,14 +326,8 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
                 "include?": "no",
             },
             embeddings={
-                "embedding1": (
-                    [-100.0, -2.0],
-                    SimilarityMetric.COSINE,
-                ),
-                "embedding2": (
-                    [-100.0, -2.0],
-                    SimilarityMetric.EUCLIDEAN,
-                ),
+                "embedding1": [-100.0, -2.0],
+                "embedding2": [-100.0, -2.0],
             },
         ),
         Node(
@@ -377,14 +337,8 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
                 "include?": "no",
             },
             embeddings={
-                "embedding1": (
-                    [-100.0, -3.0],
-                    SimilarityMetric.COSINE,
-                ),
-                "embedding2": (
-                    [-100.0, -3.0],
-                    SimilarityMetric.EUCLIDEAN,
-                ),
+                "embedding1": [-100.0, -3.0],
+                "embedding2": [-100.0, -3.0],
             },
         ),
     ]
@@ -395,7 +349,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding1",
-        similarity_metric=SimilarityMetric.COSINE,
         limit=5,
     )
     assert 0 < len(results) <= 5
@@ -404,7 +357,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding1",
-        similarity_metric=SimilarityMetric.COSINE,
         limit=5,
     )
     assert len(results) == 5
@@ -414,7 +366,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding1",
-        similarity_metric=SimilarityMetric.COSINE,
         limit=5,
         property_filter=FilterComparison(
             field="include?",
@@ -429,7 +380,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding1",
-        similarity_metric=SimilarityMetric.COSINE,
         limit=5,
         property_filter=FilterOr(
             left=FilterComparison(
@@ -449,7 +399,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding2",
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
         limit=5,
     )
     assert len(results) == 5
@@ -459,7 +408,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding2",
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
         limit=5,
         property_filter=FilterComparison(
             field="include?",
@@ -474,7 +422,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding1",
-        similarity_metric=SimilarityMetric.COSINE,
         limit=5,
     )
     assert 0 < len(results) <= 5
@@ -483,7 +430,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding2",
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
         limit=5,
     )
     assert 0 < len(results) <= 5
@@ -1635,60 +1581,51 @@ async def test__create_vector_index_if_not_exists(
                 Neo4jVectorGraphStore._sanitize_name(collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.NODE,
                 Neo4jVectorGraphStore._sanitize_name(collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(other_property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.NODE,
                 Neo4jVectorGraphStore._sanitize_name(other_collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.NODE,
                 Neo4jVectorGraphStore._sanitize_name(other_collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(other_property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.EDGE,
                 Neo4jVectorGraphStore._sanitize_name(collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.EDGE,
                 Neo4jVectorGraphStore._sanitize_name(collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(other_property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.EDGE,
                 Neo4jVectorGraphStore._sanitize_name(other_collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.EDGE,
                 Neo4jVectorGraphStore._sanitize_name(other_collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(other_property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
         ]
         for dimensions in [1, 10]
-        for similarity_metric in [SimilarityMetric.COSINE, SimilarityMetric.EUCLIDEAN]
         for _ in range(2000)
     ]
 
@@ -1805,10 +1742,7 @@ async def test__nodes_from_neo4j_nodes(neo4j_driver, vector_graph_store):
             uid=str(uuid4()),
             properties={"name": "Node3", "time": datetime.now(tz=UTC)},
             embeddings={
-                "embedding_name": (
-                    [0.1, 0.2, 0.3],
-                    SimilarityMetric.COSINE,
-                ),
+                "embedding_name": [0.1, 0.2, 0.3],
             },
         ),
     ]

--- a/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_neo4j_vector_graph_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_neo4j_vector_graph_store.py
@@ -281,9 +281,12 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
             properties={
                 "name": "Node1",
             },
+            # embedding2 deliberately disagrees with embedding1 about which
+            # node the query below is nearest, so searching by name has to
+            # pick the right one to get the right answer.
             embeddings={
                 "embedding1": [1000.0, 0.0],
-                "embedding2": [1000.0, 0.0],
+                "embedding2": [10.0, 10.0],
             },
         ),
         Node(
@@ -294,7 +297,7 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
             },
             embeddings={
                 "embedding1": [10.0, 10.0],
-                "embedding2": [10.0, 10.0],
+                "embedding2": [1000.0, 0.0],
             },
         ),
         Node(

--- a/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_collection.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_collection.py
@@ -5,7 +5,7 @@ import operator
 from collections.abc import Iterable, Mapping, Sequence
 from uuid import UUID
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -79,28 +79,13 @@ def _dot(a: Sequence[float], b: Sequence[float]) -> float:
     return sum(x * y for x, y in zip(a, b, strict=True))
 
 
-def _score(metric: SimilarityMetric, a: Sequence[float], b: Sequence[float]) -> float:
-    """Compute the similarity/distance score for the given metric."""
-    match metric:
-        case SimilarityMetric.COSINE:
-            norm_a = math.sqrt(sum(x * x for x in a))
-            norm_b = math.sqrt(sum(x * x for x in b))
-            if norm_a == 0.0 or norm_b == 0.0:
-                return 0.0
-            return _dot(a, b) / (norm_a * norm_b)
-        case SimilarityMetric.DOT:
-            return _dot(a, b)
-        case SimilarityMetric.EUCLIDEAN:
-            return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b, strict=True)))
-        case SimilarityMetric.MANHATTAN:
-            return sum(abs(x - y) for x, y in zip(a, b, strict=True))
-
-
-def _passes_threshold(score: float, threshold: float, higher_is_better: bool) -> bool:
-    """Check whether a score passes the threshold for the metric direction."""
-    if higher_is_better:
-        return score >= threshold
-    return score <= threshold
+def _cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity between two vectors; 0.0 if either has no magnitude."""
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return _dot(a, b) / (norm_a * norm_b)
 
 
 # ---------------------------------------------------------------------------
@@ -111,8 +96,7 @@ def _passes_threshold(score: float, threshold: float, higher_is_better: bool) ->
 class InMemoryVectorStoreCollection(VectorStoreCollection):
     """In-memory VectorStoreCollection for testing.
 
-    Supports all similarity metrics (cosine, dot, euclidean, manhattan)
-    and full FilterExpr evaluation on record properties.
+    Scores by cosine similarity and evaluates FilterExpr on record properties.
     """
 
     def __init__(self, collection_config: VectorStoreCollectionConfig) -> None:
@@ -135,14 +119,11 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
         self,
         *,
         query_vectors: Iterable[Sequence[float]],
-        score_threshold: float | None = None,
+        min_cosine_similarity: float | None = None,
         limit: int | None = None,
         property_filter: FilterExpr | None = None,
         return_properties: bool = True,
     ) -> list[QueryResult]:
-        metric = self.collection_config.similarity_metric
-        higher_is_better = metric.higher_is_better
-
         results: list[QueryResult] = []
         for query_vector in query_vectors:
             qv = list(query_vector)
@@ -154,22 +135,37 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
                     property_filter, record.properties or {}
                 ):
                     continue
-                score = _score(metric, qv, record.vector)
-                if score_threshold is not None and not _passes_threshold(
-                    score, score_threshold, higher_is_better
+                cosine_similarity = _cosine_similarity(qv, record.vector)
+                if (
+                    min_cosine_similarity is not None
+                    and cosine_similarity < min_cosine_similarity
                 ):
                     continue
                 matches.append(
                     QueryMatch(
-                        score=score,
+                        cosine_similarity=cosine_similarity,
                         record=self._project_record(record, return_properties),
                     )
                 )
-            matches.sort(key=lambda m: m.score, reverse=higher_is_better)
+            matches.sort(key=lambda m: m.cosine_similarity, reverse=True)
             if limit is not None:
                 matches = matches[:limit]
             results.append(QueryResult(matches=matches))
         return results
+
+    async def get_cosine_similarity(
+        self,
+        *,
+        query_vector: Sequence[float],
+        record_uuids: Iterable[UUID],
+    ) -> dict[UUID, float]:
+        similarities: dict[UUID, float] = {}
+        for uid in record_uuids:
+            record = self.records.get(uid)
+            if record is None or record.vector is None:
+                continue
+            similarities[uid] = _cosine_similarity(query_vector, record.vector)
+        return similarities
 
     async def set_properties(
         self,

--- a/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_collection.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_collection.py
@@ -2,7 +2,7 @@
 
 import math
 import operator
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from uuid import UUID
 
 from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
@@ -138,7 +138,6 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
         score_threshold: float | None = None,
         limit: int | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         metric = self.collection_config.similarity_metric
@@ -163,9 +162,7 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
                 matches.append(
                     QueryMatch(
                         score=score,
-                        record=self._project_record(
-                            record, return_vector, return_properties
-                        ),
+                        record=self._project_record(record, return_properties),
                     )
                 )
             matches.sort(key=lambda m: m.score, reverse=higher_is_better)
@@ -174,37 +171,30 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
             results.append(QueryResult(matches=matches))
         return results
 
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        out: list[Record] = []
-        for uid in record_uuids:
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        for uid, properties in record_properties.items():
             record = self.records.get(uid)
             if record is None:
                 continue
-            out.append(self._project_record(record, return_vector, return_properties))
-        return out
+            self.records[uid] = Record(
+                uuid=record.uuid,
+                vector=list(record.vector) if record.vector is not None else None,
+                properties=dict(properties),
+            )
 
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:
         for uid in record_uuids:
             self.records.pop(uid, None)
 
     @staticmethod
-    def _project_record(
-        record: Record, return_vector: bool, return_properties: bool
-    ) -> Record:
+    def _project_record(record: Record, return_properties: bool) -> Record:
         """Return a copy of the record with only the requested fields."""
         return Record(
             uuid=record.uuid,
-            vector=(
-                list(record.vector)
-                if return_vector and record.vector is not None
-                else None
-            ),
             properties=(
                 dict(record.properties)
                 if return_properties and record.properties

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -45,6 +45,26 @@ def _normalize(vector: list[float]) -> list[float]:
     return [x / magnitude for x in vector]
 
 
+_FETCH_LIMIT = 1000
+
+
+async def _fetch_records(collection, record_uuids) -> list[Record]:
+    """Read records back by UUID.
+
+    The collection contract has no read-by-UUID: `query` is the only read, and
+    with no score threshold it returns every record it holds, so a probe vector
+    in any direction lists the collection for a test to pick out of.
+    """
+    record_uuids = list(record_uuids)
+    if not record_uuids:
+        return []
+    dimensions = collection.config.vector_dimensions
+    probe = [1.0] + [0.0] * (dimensions - 1)
+    [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
+    by_uuid = {match.record.uuid: match.record for match in result.matches}
+    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+
+
 def _make_record(
     *,
     uuid: UUID | None = None,
@@ -284,19 +304,15 @@ class TestUpsertAndQuery:
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        no_vector = await collection.query(
-            query_vectors=[v1], limit=10, return_vector=False
-        )
-        assert no_vector[0].matches[0].record.vector is None
-        assert no_vector[0].matches[0].record.properties is not None
+        with_properties = await collection.query(query_vectors=[v1], limit=10)
+        assert with_properties[0].matches[0].record.vector is None
+        assert with_properties[0].matches[0].record.properties is not None
 
         no_properties = await collection.query(
             query_vectors=[v1],
             limit=10,
-            return_vector=True,
             return_properties=False,
         )
-        assert no_properties[0].matches[0].record.vector is not None
         assert no_properties[0].matches[0].record.properties is None
 
     @pytest.mark.asyncio
@@ -356,14 +372,13 @@ class TestUpsertAndQuery:
                 ]
             )
 
-        records = await collection.get(
-            record_uuids=[record.uuid],
-            return_vector=True,
-            return_properties=True,
-        )
+        records = await _fetch_records(collection, [record.uuid])
         assert len(records) == 1
-        assert records[0].vector == old_vector
         assert records[0].properties == {"name": "old"}
+
+        # The old vector is still the indexed one.
+        results = await collection.query(query_vectors=[old_vector], limit=1)
+        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
 
 
 class TestFilters:
@@ -432,8 +447,10 @@ class TestFilters:
         uuids = await self._query(collection, v1, "created_at", "=", dt_filter)
         assert uuids == {r1.uuid}
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        assert results[0].properties["created_at"] == dt_utc
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt_utc
 
     @pytest.mark.asyncio
     async def test_is_null_and_not_null(self, collection):
@@ -491,23 +508,37 @@ class TestFilters:
         assert {m.record.uuid for m in or_results[0].matches} == {r1.uuid, r2.uuid}
 
 
-class TestGetAndDelete:
+class TestSetPropertiesAndDelete:
     @pytest.mark.asyncio
-    async def test_get_by_uuids_preserves_order_and_return_flags(self, collection):
+    async def test_set_properties_replaces_properties_and_keeps_the_vector(
+        self, collection
+    ):
         v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a"})
-        r2 = _make_record(vector=v2, properties={"name": "b"})
-        await collection.upsert(records=[r1, r2])
+        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
+        await collection.upsert(records=[r1])
 
-        results = await collection.get(
-            record_uuids=[r2.uuid, r1.uuid],
-            return_vector=True,
-            return_properties=False,
-        )
-        assert [record.uuid for record in results] == [r2.uuid, r1.uuid]
-        assert results[0].vector is not None
-        assert results[0].properties is None
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "b"}
+
+        # The vector is untouched, so the record still answers its own query.
+        results = await collection.query(query_vectors=[v1], limit=1)
+        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_set_properties_ignores_uuids_the_collection_does_not_hold(
+        self, collection
+    ):
+        v1 = _normalize([1.0, 0.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a"})
+        await collection.upsert(records=[r1])
+
+        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "a"}
 
     @pytest.mark.asyncio
     async def test_delete_records(self, collection):
@@ -519,7 +550,7 @@ class TestGetAndDelete:
 
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = await collection.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
         assert [record.uuid for record in results] == [r2.uuid]
 
 
@@ -547,8 +578,8 @@ class TestPartitionIsolation:
             records=[Record(uuid=record_uuid, vector=v1, properties={"name": "b"})]
         )
 
-        results_a = await coll_a.get(record_uuids=[record_uuid])
-        results_b = await coll_b.get(record_uuids=[record_uuid])
+        results_a = await _fetch_records(coll_a, [record_uuid])
+        results_b = await _fetch_records(coll_b, [record_uuid])
 
         assert results_a[0].properties == {"name": "a"}
         assert results_b[0].properties == {"name": "b"}

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -14,7 +14,7 @@ pymilvus = pytest.importorskip("pymilvus")
 DataType = pymilvus.DataType
 MilvusClient = pymilvus.MilvusClient
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -97,7 +97,6 @@ async def collection(store):
         name=NAME,
         config=VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "name": str,
                 "age": int,
@@ -183,7 +182,6 @@ class TestCollectionLifecycle:
         schema: dict[str, type[PropertyValue]] = {"name": str}
         config = VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema=schema,
         )
         await store.create_collection(namespace=NAMESPACE, name="coll_a", config=config)
@@ -220,18 +218,6 @@ class TestCollectionLifecycle:
         assert fields["properties"]["type"] == DataType.JSON
 
         await store.delete_collection(namespace=NAMESPACE, name="schema")
-
-    @pytest.mark.asyncio
-    async def test_unsupported_metric_raises(self, store):
-        with pytest.raises(ValueError, match="Milvus only supports"):
-            await store.create_collection(
-                namespace=NAMESPACE,
-                name="bad_metric",
-                config=VectorStoreCollectionConfig(
-                    vector_dimensions=VECTOR_DIM,
-                    similarity_metric=SimilarityMetric.MANHATTAN,
-                ),
-            )
 
 
 class TestUpsertAndQuery:
@@ -278,9 +264,13 @@ class TestUpsertAndQuery:
         assert matches[0].record.uuid == r1.uuid
         assert matches[1].record.uuid == r3.uuid
         assert matches[2].record.uuid == r2.uuid
-        assert matches[0].score >= matches[1].score >= matches[2].score
-        assert matches[0].score == pytest.approx(1.0)
-        assert matches[2].score == pytest.approx(0.0)
+        assert (
+            matches[0].cosine_similarity
+            >= matches[1].cosine_similarity
+            >= matches[2].cosine_similarity
+        )
+        assert matches[0].cosine_similarity == pytest.approx(1.0)
+        assert matches[2].cosine_similarity == pytest.approx(0.0)
 
     @pytest.mark.asyncio
     async def test_query_with_similarity_threshold(self, collection):
@@ -292,7 +282,7 @@ class TestUpsertAndQuery:
         await collection.upsert(records=[r1, r2])
 
         query_results = await collection.query(
-            query_vectors=[v1], limit=10, score_threshold=0.9
+            query_vectors=[v1], limit=10, min_cosine_similarity=0.9
         )
         matches = query_results[0].matches
         assert len(matches) == 1
@@ -378,7 +368,7 @@ class TestUpsertAndQuery:
 
         # The old vector is still the indexed one.
         results = await collection.query(query_vectors=[old_vector], limit=1)
-        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
 
 class TestFilters:
@@ -525,7 +515,7 @@ class TestSetPropertiesAndDelete:
         # The vector is untouched, so the record still answers its own query.
         results = await collection.query(query_vectors=[v1], limit=1)
         assert results[0].matches[0].record.uuid == r1.uuid
-        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_set_properties_ignores_uuids_the_collection_does_not_hold(

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -10,7 +10,7 @@ import pytest
 import pytest_asyncio
 from qdrant_client import AsyncQdrantClient, models
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -69,7 +69,6 @@ async def collection(store):
         name=NAME,
         config=VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "name": str,
                 "age": int,
@@ -151,7 +150,6 @@ class TestCollectionLifecycle:
                 name=NAME,
                 config=VectorStoreCollectionConfig(
                     vector_dimensions=VECTOR_DIM,
-                    similarity_metric=SimilarityMetric.COSINE,
                     indexed_properties_schema={
                         "name": str,
                         "age": int,
@@ -208,7 +206,6 @@ class TestCollectionLifecycle:
         schema: dict[str, type[PropertyValue]] = {"name": str}
         config = VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema=schema,
         )
         await store.create_collection(namespace=NAMESPACE, name="coll_a", config=config)
@@ -247,7 +244,11 @@ class TestUpsertAndQuery:
         assert matches[0].record.uuid == r1.uuid
         assert matches[1].record.uuid == r3.uuid
         assert matches[2].record.uuid == r2.uuid
-        assert matches[0].score >= matches[1].score >= matches[2].score
+        assert (
+            matches[0].cosine_similarity
+            >= matches[1].cosine_similarity
+            >= matches[2].cosine_similarity
+        )
 
     @pytest.mark.asyncio
     async def test_query_with_similarity_threshold(self, collection):
@@ -260,7 +261,9 @@ class TestUpsertAndQuery:
         await collection.upsert(records=[r1, r2])
 
         query_results = list(
-            await collection.query(query_vectors=[v1], limit=10, score_threshold=0.9)
+            await collection.query(
+                query_vectors=[v1], limit=10, min_cosine_similarity=0.9
+            )
         )
         matches = query_results[0].matches
 
@@ -960,7 +963,7 @@ class TestSetProperties:
         # The vector is untouched, so the record still answers its own query.
         results = await collection.query(query_vectors=[v1], limit=1)
         assert results[0].matches[0].record.uuid == r1.uuid
-        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_replaced_properties_are_filterable(self, collection):
@@ -1198,7 +1201,6 @@ class TestDistributedSharding:
             name=name,
             config=VectorStoreCollectionConfig(
                 vector_dimensions=VECTOR_DIM,
-                similarity_metric=SimilarityMetric.COSINE,
                 indexed_properties_schema={"name": str},
             ),
         )
@@ -1229,7 +1231,6 @@ class TestDistributedSharding:
         ns = NAMESPACE
         config = VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
         )
 
         await store.create_collection(namespace=ns, name="tenant_a", config=config)
@@ -1287,7 +1288,6 @@ class TestCollectionLifecycleAcrossWorkers:
     def _config() -> VectorStoreCollectionConfig:
         return VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={"name": str},
         )
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -90,6 +90,26 @@ def _normalize(v: list[float]) -> list[float]:
     return [x / mag for x in v]
 
 
+_FETCH_LIMIT = 1000
+
+
+async def _fetch_records(collection, record_uuids) -> list[Record]:
+    """Read records back by UUID.
+
+    The collection contract has no read-by-UUID: `query` is the only read, and
+    with no score threshold it returns every record it holds, so a probe vector
+    in any direction lists the collection for a test to pick out of.
+    """
+    record_uuids = list(record_uuids)
+    if not record_uuids:
+        return []
+    dimensions = collection.config.vector_dimensions
+    probe = [1.0] + [0.0] * (dimensions - 1)
+    [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
+    by_uuid = {match.record.uuid: match.record for match in result.matches}
+    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+
+
 def _make_record(
     *,
     uuid: UUID | None = None,
@@ -259,14 +279,12 @@ class TestUpsertAndQuery:
         assert len(query_results[0].matches) == 2
 
     @pytest.mark.asyncio
-    async def test_query_return_vector_false(self, collection):
+    async def test_query_never_returns_vectors(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        query_results = list(
-            await collection.query(query_vectors=[v1], limit=10, return_vector=False)
-        )
+        query_results = list(await collection.query(query_vectors=[v1], limit=10))
         matches = query_results[0].matches
         assert len(matches) == 1
         assert matches[0].record.vector is None
@@ -282,13 +300,11 @@ class TestUpsertAndQuery:
             await collection.query(
                 query_vectors=[v1],
                 limit=10,
-                return_vector=True,
                 return_properties=False,
             )
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.vector is not None
         assert matches[0].record.properties is None
 
     @pytest.mark.asyncio
@@ -580,8 +596,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "test", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = list(await collection.get(record_uuids=[r1.uuid]))
-        assert results[0].properties["created_at"] == dt
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt
 
     @pytest.mark.asyncio
     async def test_datetime_microseconds_roundtrip(self, collection):
@@ -591,8 +609,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "micro", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = list(await collection.get(record_uuids=[r1.uuid]))
-        assert results[0].properties["created_at"] == dt
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt
 
     @pytest.mark.asyncio
     async def test_eq_datetime(self, collection):
@@ -728,8 +748,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "n", "created_at": naive_dt})
         await collection.upsert(records=[r1])
 
-        results = list(await collection.get(record_uuids=[r1.uuid]))
-        got = results[0].properties["created_at"]
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        got = properties["created_at"]
         assert isinstance(got, datetime)
         assert got.tzinfo is not None
         assert got == datetime(2024, 6, 15, 12, 30, 0, tzinfo=UTC)
@@ -920,72 +942,62 @@ class TestFilters:
         assert len(matches) == 2
 
 
-# ── Get ──
+# ── Set properties ──
 
 
-class TestGet:
+class TestSetProperties:
     @pytest.mark.asyncio
-    async def test_get_by_uuids(self, collection):
+    async def test_replaces_properties_and_keeps_the_vector(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
-        v3 = _normalize([0.0, 0.0, 1.0])
+        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
+        await collection.upsert(records=[r1])
 
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "b"}
+
+        # The vector is untouched, so the record still answers its own query.
+        results = await collection.query(query_vectors=[v1], limit=1)
+        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_replaced_properties_are_filterable(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "a"})
-        r2 = _make_record(vector=v2, properties={"name": "b"})
-        r3 = _make_record(vector=v3, properties={"name": "c"})
-
-        await collection.upsert(records=[r1, r2, r3])
-
-        results = list(await collection.get(record_uuids=[r3.uuid, r1.uuid]))
-        assert len(results) == 2
-        assert results[0].uuid == r3.uuid
-        assert results[1].uuid == r1.uuid
-
-    @pytest.mark.asyncio
-    async def test_get_missing_uuids(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1)
         await collection.upsert(records=[r1])
 
-        missing_uuid = uuid4()
-        results = list(await collection.get(record_uuids=[r1.uuid, missing_uuid]))
-        assert len(results) == 1
-        assert results[0].uuid == r1.uuid
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
 
-    @pytest.mark.asyncio
-    async def test_get_empty_list(self, collection):
-        results = list(await collection.get(record_uuids=[]))
-        assert len(results) == 0
-
-    @pytest.mark.asyncio
-    async def test_get_return_vector_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = list(
-            await collection.get(record_uuids=[r1.uuid], return_vector=False)
+        stale = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="a"),
         )
-        assert len(results) == 1
-        assert results[0].vector is None
-        assert results[0].properties is not None
+        assert stale[0].matches == []
+
+        fresh = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="b"),
+        )
+        assert [match.record.uuid for match in fresh[0].matches] == [r1.uuid]
 
     @pytest.mark.asyncio
-    async def test_get_return_properties_false(self, collection):
+    async def test_ignores_uuids_the_collection_does_not_hold(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
+        r1 = _make_record(vector=v1, properties={"name": "a"})
         await collection.upsert(records=[r1])
 
-        results = list(
-            await collection.get(
-                record_uuids=[r1.uuid],
-                return_vector=True,
-                return_properties=False,
-            )
-        )
-        assert len(results) == 1
-        assert results[0].vector is not None
-        assert results[0].properties is None
+        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "a"}
+
+    @pytest.mark.asyncio
+    async def test_empty_mapping(self, collection):
+        await collection.set_properties(record_properties={})
 
 
 # ── Delete ──
@@ -1003,7 +1015,7 @@ class TestDelete:
         await collection.upsert(records=[r1, r2])
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = list(await collection.get(record_uuids=[r1.uuid, r2.uuid]))
+        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -1071,7 +1083,7 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        results = list(await coll_a.get(record_uuids=[r1.uuid, r2.uuid]))
+        results = await _fetch_records(coll_a, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r1.uuid
 
@@ -1105,7 +1117,7 @@ class TestPartitionIsolation:
         # Attempt to delete r2 using tenant_a's collection — should not work
         await coll_a.delete(record_uuids=[r2.uuid])
 
-        results = list(await coll_b.get(record_uuids=[r2.uuid]))
+        results = await _fetch_records(coll_b, [r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -1201,12 +1213,12 @@ class TestDistributedSharding:
         assert len(results) == 1
         assert results[0].matches[0].record.uuid == r1.uuid
 
-        got = await coll.get(record_uuids=[r1.uuid])
+        got = await _fetch_records(coll, [r1.uuid])
         assert len(got) == 1
         assert got[0].uuid == r1.uuid
 
         await coll.delete(record_uuids=[r1.uuid])
-        got = await coll.get(record_uuids=[r1.uuid])
+        got = await _fetch_records(coll, [r1.uuid])
         assert len(got) == 0
 
         await store.delete_collection(namespace=ns, name=name)
@@ -1239,7 +1251,7 @@ class TestDistributedSharding:
         await store.delete_collection(namespace=ns, name="tenant_a")
 
         # tenant_b data should be untouched.
-        got = await coll_b.get(record_uuids=[r_b.uuid])
+        got = await _fetch_records(coll_b, [r_b.uuid])
         assert len(got) == 1
         assert got[0].uuid == r_b.uuid
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -9,7 +9,6 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -96,7 +95,6 @@ async def collection(store):
         name=NAME,
         config=VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "name": str,
                 "age": int,
@@ -140,7 +138,6 @@ class TestCollectionLifecycle:
                 name=NAME,
                 config=VectorStoreCollectionConfig(
                     vector_dimensions=VECTOR_DIM,
-                    similarity_metric=SimilarityMetric.COSINE,
                     indexed_properties_schema={
                         "name": str,
                         "age": int,
@@ -196,18 +193,6 @@ class TestCollectionLifecycle:
         assert await store.open_collection(namespace=NAMESPACE, name="nope") is None
 
     @pytest.mark.asyncio
-    async def test_unsupported_metric_raises(self, store):
-        with pytest.raises(ValueError, match="sqlite-vec"):
-            await store.create_collection(
-                namespace=NAMESPACE,
-                name="bad_metric",
-                config=VectorStoreCollectionConfig(
-                    vector_dimensions=VECTOR_DIM,
-                    similarity_metric=SimilarityMetric.DOT,
-                ),
-            )
-
-    @pytest.mark.asyncio
     async def test_invalid_namespace_raises(self, store):
         with pytest.raises(ValueError, match="Invalid namespace"):
             await store.create_collection(
@@ -247,7 +232,11 @@ class TestUpsertAndQuery:
 
         assert len(matches) == 3
         assert matches[0].record.uuid == r1.uuid
-        assert matches[0].score >= matches[1].score >= matches[2].score
+        assert (
+            matches[0].cosine_similarity
+            >= matches[1].cosine_similarity
+            >= matches[2].cosine_similarity
+        )
 
     @pytest.mark.asyncio
     async def test_upsert_update(self, collection):
@@ -278,7 +267,7 @@ class TestUpsertAndQuery:
         await collection.upsert(records=[r1, r2])
 
         query_results = await collection.query(
-            query_vectors=[v1], limit=10, score_threshold=0.9
+            query_vectors=[v1], limit=10, min_cosine_similarity=0.9
         )
         matches = query_results[0].matches
 
@@ -651,7 +640,7 @@ class TestSetProperties:
         # The vector is untouched, so the record still answers its own query.
         results = await collection.query(query_vectors=[v1], limit=1)
         assert results[0].matches[0].record.uuid == r1.uuid
-        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_replaced_properties_are_filterable(self, collection):
@@ -876,32 +865,6 @@ class TestPartitionIsolation:
         await store.delete_collection(namespace=NAMESPACE, name="sibling_b")
 
 
-# ── Euclidean metric ──
-
-
-class TestEuclideanMetric:
-    @pytest.mark.asyncio
-    async def test_euclidean_ordering(self, store):
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=2,
-            similarity_metric=SimilarityMetric.EUCLIDEAN,
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean", config=config
-        )
-        r1 = _make_record(vector=[0.0, 0.0])
-        r2 = _make_record(vector=[3.0, 4.0])
-        await coll.upsert(records=[r1, r2])
-
-        results = await coll.query(query_vectors=[[0.0, 0.0]], limit=2)
-        assert results[0].matches[0].score < results[0].matches[1].score
-
-        await store.delete_collection(namespace=NAMESPACE, name="euclidean")
-
-
-# ── No-properties collection ──
-
-
 class TestNoProperties:
     @pytest.mark.asyncio
     async def test_collection_without_properties(self, store):
@@ -951,29 +914,8 @@ class TestScoreSemantics:
         await collection.upsert(records=[r1, r2])
 
         results = await collection.query(query_vectors=[v1], limit=2)
-        scores = [m.score for m in results[0].matches]
+        scores = [m.cosine_similarity for m in results[0].matches]
         assert scores[0] > scores[1]
-
-    @pytest.mark.asyncio
-    async def test_euclidean_lower_is_better(self, store):
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=2,
-            similarity_metric=SimilarityMetric.EUCLIDEAN,
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean_score", config=config
-        )
-        r1 = _make_record(vector=[0.0, 0.0])
-        r2 = _make_record(vector=[3.0, 4.0])
-        await coll.upsert(records=[r1, r2])
-
-        results = await coll.query(query_vectors=[[0.0, 0.0]], limit=2)
-        scores = [m.score for m in results[0].matches]
-        assert scores[0] < scores[1]
-        assert scores[0] == pytest.approx(0.0, abs=0.01)
-        assert scores[1] == pytest.approx(5.0, abs=0.01)
-
-        await store.delete_collection(namespace=NAMESPACE, name="euclidean_score")
 
 
 # ── Upsert behavior ──
@@ -1005,7 +947,7 @@ class TestUpsertBehavior:
 
         results = await collection.query(query_vectors=[v2], limit=1)
         assert results[0].matches[0].record.uuid == record_uuid
-        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
 
 # ── Filter edge cases ──

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -44,6 +44,26 @@ def _normalize(vector: list[float]) -> list[float]:
     return [x / magnitude for x in vector]
 
 
+_FETCH_LIMIT = 1000
+
+
+async def _fetch_records(collection, record_uuids) -> list[Record]:
+    """Read records back by UUID.
+
+    The collection contract has no read-by-UUID: `query` is the only read, and
+    with no score threshold it returns every record it holds, so a probe vector
+    in any direction lists the collection for a test to pick out of.
+    """
+    record_uuids = list(record_uuids)
+    if not record_uuids:
+        return []
+    dimensions = collection.config.vector_dimensions
+    probe = [1.0] + [0.0] * (dimensions - 1)
+    [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
+    by_uuid = {match.record.uuid: match.record for match in result.matches}
+    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+
+
 def _make_record(
     *,
     uuid=None,
@@ -242,8 +262,10 @@ class TestUpsertAndQuery:
         )
         await collection.upsert(records=[updated])
 
-        results = await collection.get(record_uuids=[record.uuid])
-        assert results[0].properties["name"] == "updated"
+        results = await _fetch_records(collection, [record.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["name"] == "updated"
 
     @pytest.mark.asyncio
     async def test_query_with_similarity_threshold(self, collection):
@@ -273,14 +295,12 @@ class TestUpsertAndQuery:
         assert len(query_results[0].matches) == 2
 
     @pytest.mark.asyncio
-    async def test_query_return_vector_false(self, collection):
+    async def test_query_never_returns_vectors(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        query_results = await collection.query(
-            query_vectors=[v1], limit=10, return_vector=False
-        )
+        query_results = await collection.query(query_vectors=[v1], limit=10)
         matches = query_results[0].matches
         assert len(matches) == 1
         assert matches[0].record.vector is None
@@ -295,12 +315,10 @@ class TestUpsertAndQuery:
         query_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            return_vector=True,
             return_properties=False,
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.vector is not None
         assert matches[0].record.properties is None
 
     @pytest.mark.asyncio
@@ -487,8 +505,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "test", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        assert results[0].properties["created_at"] == dt
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt
 
     @pytest.mark.asyncio
     async def test_eq_datetime(self, collection):
@@ -545,8 +565,11 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "tz", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        got = results[0].properties["created_at"]
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        got = properties["created_at"]
+        assert isinstance(got, datetime)
         assert got == dt
         assert got.utcoffset() == timedelta(hours=-5)
 
@@ -610,61 +633,62 @@ class TestFilters:
         assert len(uuids) == 2
 
 
-# ── Get ──
+# ── Set properties ──
 
 
-class TestGet:
+class TestSetProperties:
     @pytest.mark.asyncio
-    async def test_get_by_uuids(self, collection):
+    async def test_replaces_properties_and_keeps_the_vector(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
+        await collection.upsert(records=[r1])
 
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "b"}
+
+        # The vector is untouched, so the record still answers its own query.
+        results = await collection.query(query_vectors=[v1], limit=1)
+        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_replaced_properties_are_filterable(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "a"})
-        r2 = _make_record(vector=v2, properties={"name": "b"})
-        await collection.upsert(records=[r1, r2])
-
-        results = await collection.get(record_uuids=[r2.uuid, r1.uuid])
-        assert len(results) == 2
-        assert results[0].uuid == r2.uuid
-        assert results[1].uuid == r1.uuid
-
-    @pytest.mark.asyncio
-    async def test_get_missing_uuids(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1)
         await collection.upsert(records=[r1])
 
-        missing = uuid4()
-        results = await collection.get(record_uuids=[r1.uuid, missing])
-        assert len(results) == 1
-        assert results[0].uuid == r1.uuid
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
 
-    @pytest.mark.asyncio
-    async def test_get_empty_list(self, collection):
-        results = await collection.get(record_uuids=[])
-        assert len(results) == 0
-
-    @pytest.mark.asyncio
-    async def test_get_return_vector_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = await collection.get(record_uuids=[r1.uuid], return_vector=False)
-        assert results[0].vector is None
-        assert results[0].properties is not None
-
-    @pytest.mark.asyncio
-    async def test_get_return_properties_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = await collection.get(
-            record_uuids=[r1.uuid], return_vector=True, return_properties=False
+        stale = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="a"),
         )
-        assert results[0].vector is not None
-        assert results[0].properties is None
+        assert stale[0].matches == []
+
+        fresh = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="b"),
+        )
+        assert [match.record.uuid for match in fresh[0].matches] == [r1.uuid]
+
+    @pytest.mark.asyncio
+    async def test_ignores_uuids_the_collection_does_not_hold(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a"})
+        await collection.upsert(records=[r1])
+
+        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "a"}
+
+    @pytest.mark.asyncio
+    async def test_empty_mapping(self, collection):
+        await collection.set_properties(record_properties={})
 
 
 # ── Delete ──
@@ -682,7 +706,7 @@ class TestDelete:
         await collection.upsert(records=[r1, r2])
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = await collection.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -762,7 +786,7 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        results = await coll_a.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(coll_a, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r1.uuid
 
@@ -792,7 +816,7 @@ class TestPartitionIsolation:
 
         await coll_a.delete(record_uuids=[r2.uuid])
 
-        results = await coll_b.get(record_uuids=[r2.uuid])
+        results = await _fetch_records(coll_b, [r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -909,9 +933,7 @@ class TestInputValidation:
         v1 = _normalize([1.0, 0.0, 0.0])
         record = _make_record(vector=v1, properties=None)
         await collection.upsert(records=[record])
-        fetched = await collection.get(
-            record_uuids=[record.uuid], return_properties=True
-        )
+        fetched = await _fetch_records(collection, [record.uuid])
         assert len(fetched) == 1
         assert fetched[0].properties == {}
 
@@ -975,11 +997,11 @@ class TestUpsertBehavior:
             ]
         )
 
-        fetched = await collection.get(
-            record_uuids=[record_uuid], return_vector=True, return_properties=True
-        )
+        fetched = await _fetch_records(collection, [record_uuid])
         assert len(fetched) == 1
-        assert fetched[0].properties["name"] == "bob"
+        properties = fetched[0].properties
+        assert properties is not None
+        assert properties["name"] == "bob"
 
         results = await collection.query(query_vectors=[v2], limit=1)
         assert results[0].matches[0].record.uuid == record_uuid

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -45,6 +45,26 @@ def _normalize(vector: list[float]) -> list[float]:
     return [x / magnitude for x in vector]
 
 
+_FETCH_LIMIT = 1000
+
+
+async def _fetch_records(collection, record_uuids) -> list[Record]:
+    """Read records back by UUID.
+
+    The collection contract has no read-by-UUID: `query` is the only read, and
+    with no score threshold it returns every record it holds, so a probe vector
+    in any direction lists the collection for a test to pick out of.
+    """
+    record_uuids = list(record_uuids)
+    if not record_uuids:
+        return []
+    dimensions = collection.config.vector_dimensions
+    probe = [1.0] + [0.0] * (dimensions - 1)
+    [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
+    by_uuid = {match.record.uuid: match.record for match in result.matches}
+    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+
+
 def _make_record(
     *,
     uuid=None,
@@ -248,8 +268,10 @@ class TestUpsertAndQuery:
         )
         await collection.upsert(records=[updated])
 
-        results = await collection.get(record_uuids=[record.uuid])
-        assert results[0].properties["name"] == "updated"
+        results = await _fetch_records(collection, [record.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["name"] == "updated"
 
     @pytest.mark.asyncio
     async def test_query_with_similarity_threshold(self, collection):
@@ -279,14 +301,12 @@ class TestUpsertAndQuery:
         assert len(query_results[0].matches) == 2
 
     @pytest.mark.asyncio
-    async def test_query_return_vector_false(self, collection):
+    async def test_query_never_returns_vectors(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        query_results = await collection.query(
-            query_vectors=[v1], limit=10, return_vector=False
-        )
+        query_results = await collection.query(query_vectors=[v1], limit=10)
         matches = query_results[0].matches
         assert len(matches) == 1
         assert matches[0].record.vector is None
@@ -301,12 +321,10 @@ class TestUpsertAndQuery:
         query_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            return_vector=True,
             return_properties=False,
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.vector is not None
         assert matches[0].record.properties is None
 
     @pytest.mark.asyncio
@@ -493,8 +511,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "test", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        assert results[0].properties["created_at"] == dt
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt
 
     @pytest.mark.asyncio
     async def test_eq_datetime(self, collection):
@@ -551,8 +571,11 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "tz", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        got = results[0].properties["created_at"]
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        got = properties["created_at"]
+        assert isinstance(got, datetime)
         assert got == dt
         assert got.utcoffset() == timedelta(hours=-5)
 
@@ -616,61 +639,62 @@ class TestFilters:
         assert len(uuids) == 2
 
 
-# ── Get ──
+# ── Set properties ──
 
 
-class TestGet:
+class TestSetProperties:
     @pytest.mark.asyncio
-    async def test_get_by_uuids(self, collection):
+    async def test_replaces_properties_and_keeps_the_vector(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
+        await collection.upsert(records=[r1])
 
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "b"}
+
+        # The vector is untouched, so the record still answers its own query.
+        results = await collection.query(query_vectors=[v1], limit=1)
+        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_replaced_properties_are_filterable(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "a"})
-        r2 = _make_record(vector=v2, properties={"name": "b"})
-        await collection.upsert(records=[r1, r2])
-
-        results = await collection.get(record_uuids=[r2.uuid, r1.uuid])
-        assert len(results) == 2
-        assert results[0].uuid == r2.uuid
-        assert results[1].uuid == r1.uuid
-
-    @pytest.mark.asyncio
-    async def test_get_missing_uuids(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1)
         await collection.upsert(records=[r1])
 
-        missing = uuid4()
-        results = await collection.get(record_uuids=[r1.uuid, missing])
-        assert len(results) == 1
-        assert results[0].uuid == r1.uuid
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
 
-    @pytest.mark.asyncio
-    async def test_get_empty_list(self, collection):
-        results = await collection.get(record_uuids=[])
-        assert len(results) == 0
-
-    @pytest.mark.asyncio
-    async def test_get_return_vector_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = await collection.get(record_uuids=[r1.uuid], return_vector=False)
-        assert results[0].vector is None
-        assert results[0].properties is not None
-
-    @pytest.mark.asyncio
-    async def test_get_return_properties_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = await collection.get(
-            record_uuids=[r1.uuid], return_vector=True, return_properties=False
+        stale = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="a"),
         )
-        assert results[0].vector is not None
-        assert results[0].properties is None
+        assert stale[0].matches == []
+
+        fresh = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="b"),
+        )
+        assert [match.record.uuid for match in fresh[0].matches] == [r1.uuid]
+
+    @pytest.mark.asyncio
+    async def test_ignores_uuids_the_collection_does_not_hold(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a"})
+        await collection.upsert(records=[r1])
+
+        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "a"}
+
+    @pytest.mark.asyncio
+    async def test_empty_mapping(self, collection):
+        await collection.set_properties(record_properties={})
 
 
 # ── Delete ──
@@ -688,7 +712,7 @@ class TestDelete:
         await collection.upsert(records=[r1, r2])
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = await collection.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -768,7 +792,7 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        results = await coll_a.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(coll_a, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r1.uuid
 
@@ -798,7 +822,7 @@ class TestPartitionIsolation:
 
         await coll_a.delete(record_uuids=[r2.uuid])
 
-        results = await coll_b.get(record_uuids=[r2.uuid])
+        results = await _fetch_records(coll_b, [r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -942,9 +966,7 @@ class TestInputValidation:
         v1 = _normalize([1.0, 0.0, 0.0])
         record = _make_record(vector=v1, properties=None)
         await collection.upsert(records=[record])
-        fetched = await collection.get(
-            record_uuids=[record.uuid], return_properties=True
-        )
+        fetched = await _fetch_records(collection, [record.uuid])
         assert len(fetched) == 1
         assert fetched[0].properties == {}
 
@@ -1008,11 +1030,11 @@ class TestUpsertBehavior:
             ]
         )
 
-        fetched = await collection.get(
-            record_uuids=[record_uuid], return_vector=True, return_properties=True
-        )
+        fetched = await _fetch_records(collection, [record_uuid])
         assert len(fetched) == 1
-        assert fetched[0].properties["name"] == "bob"
+        properties = fetched[0].properties
+        assert properties is not None
+        assert properties["name"] == "bob"
 
         results = await collection.query(query_vectors=[v2], limit=1)
         assert results[0].matches[0].record.uuid == record_uuid
@@ -1045,7 +1067,7 @@ class TestConcurrentAsync:
         )
 
         # Verify all records were persisted (deterministic, not ANN-dependent).
-        fetched = await collection.get(record_uuids=all_uuids)
+        fetched = await _fetch_records(collection, all_uuids)
         assert len(fetched) == 30
 
     @pytest.mark.asyncio
@@ -1099,6 +1121,19 @@ async def _fresh_store(db_path, tmp_path, *, save_threshold=1000):
     store = SQLiteVectorStore(params)
     await store.startup()
     return store, engine
+
+
+async def _stored_record_uuids(engine, store) -> set[UUID]:
+    """Read a collection's record UUIDs straight out of SQLite.
+
+    The collection contract cannot see a record whose vector the index lost, so
+    a test about surviving that loss has to look past the contract at the row.
+    """
+    records_table = store._records_table(NAMESPACE, NAME)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        rows = (await session.execute(select(records_table.c.uuid))).all()
+    return {row.uuid for row in rows}
 
 
 async def _pending_operation_count(engine) -> int:
@@ -1212,7 +1247,7 @@ class TestCrashRecovery:
         )
         assert len(results[0].matches) == 1
 
-        fetched = await coll2.get(record_uuids=[r1.uuid])
+        fetched = await _fetch_records(coll2, [r1.uuid])
         assert len(fetched) == 0
 
         await store2.shutdown()
@@ -1245,7 +1280,7 @@ class TestCrashRecovery:
         )
         assert len(results[0].matches) == 2
 
-        fetched = await coll2.get(record_uuids=[r1.uuid, r2.uuid, r3.uuid])
+        fetched = await _fetch_records(coll2, [r1.uuid, r2.uuid, r3.uuid])
         fetched_uuids = {r.uuid for r in fetched}
         assert r1.uuid in fetched_uuids
         assert r2.uuid not in fetched_uuids
@@ -1485,15 +1520,19 @@ class TestIndexFileDurability:
         await engine2.dispose()
 
     @pytest.mark.asyncio
-    async def test_a_reverted_publication_costs_search_not_records(self, tmp_path):
+    async def test_a_reverted_publication_costs_search_not_the_record_row(
+        self, tmp_path
+    ):
         """A publication lost to power failure leaves records unsearchable.
 
         The swap is atomic, not durable, so a power failure can revert the last
         publication after the trim behind it has committed. Restoring the
         previous index bytes reconstructs exactly that state, deterministically
         rather than by pulling a plug, and pins the direction it fails in: the
-        record survives and still resolves by uuid, it simply cannot be found
-        by search until it is upserted again.
+        row survives, and only search loses the record, until it is upserted
+        again. The collection contract has no read that can show the survivor --
+        `query` is the only read and it goes through the index that lost it --
+        so this looks at the row directly.
         """
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=1)
@@ -1524,9 +1563,8 @@ class TestIndexFileDurability:
         coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
         assert coll2 is not None
 
-        # The record is still a record.
-        fetched = await coll2.get(record_uuids=[r2.uuid])
-        assert [record.uuid for record in fetched] == [r2.uuid]
+        # The record is still a row.
+        assert await _stored_record_uuids(engine2, store2) == {r1.uuid, r2.uuid}
 
         # The index just cannot find it any more.
         results = await coll2.query(query_vectors=[r2.vector], limit=10)

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -9,7 +9,6 @@ import pytest_asyncio
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -84,8 +83,8 @@ async def store(tmp_path):
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
     params = SQLiteVectorStoreParams(
         sqlalchemy_engine=engine,
-        vector_search_engine_factory=lambda ndim, metric: USearchVectorSearchEngine(
-            num_dimensions=ndim, similarity_metric=metric
+        vector_search_engine_factory=lambda ndim: USearchVectorSearchEngine(
+            num_dimensions=ndim
         ),
     )
     vector_store = SQLiteVectorStore(params)
@@ -102,7 +101,6 @@ async def collection(store):
         name=NAME,
         config=VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "name": str,
                 "age": int,
@@ -146,7 +144,6 @@ class TestCollectionLifecycle:
                 name=NAME,
                 config=VectorStoreCollectionConfig(
                     vector_dimensions=VECTOR_DIM,
-                    similarity_metric=SimilarityMetric.COSINE,
                     indexed_properties_schema={
                         "name": str,
                         "age": int,
@@ -202,18 +199,6 @@ class TestCollectionLifecycle:
         assert await store.open_collection(namespace=NAMESPACE, name="nope") is None
 
     @pytest.mark.asyncio
-    async def test_unsupported_metric_raises(self, store):
-        with pytest.raises(ValueError, match="does not support"):
-            await store.create_collection(
-                namespace=NAMESPACE,
-                name="bad_metric",
-                config=VectorStoreCollectionConfig(
-                    vector_dimensions=VECTOR_DIM,
-                    similarity_metric=SimilarityMetric.MANHATTAN,
-                ),
-            )
-
-    @pytest.mark.asyncio
     async def test_invalid_namespace_raises(self, store):
         with pytest.raises(ValueError, match="Invalid namespace"):
             await store.create_collection(
@@ -253,7 +238,11 @@ class TestUpsertAndQuery:
 
         assert len(matches) == 3
         assert matches[0].record.uuid == r1.uuid
-        assert matches[0].score >= matches[1].score >= matches[2].score
+        assert (
+            matches[0].cosine_similarity
+            >= matches[1].cosine_similarity
+            >= matches[2].cosine_similarity
+        )
 
     @pytest.mark.asyncio
     async def test_upsert_update(self, collection):
@@ -284,7 +273,7 @@ class TestUpsertAndQuery:
         await collection.upsert(records=[r1, r2])
 
         query_results = await collection.query(
-            query_vectors=[v1], limit=10, score_threshold=0.9
+            query_vectors=[v1], limit=10, min_cosine_similarity=0.9
         )
         matches = query_results[0].matches
 
@@ -657,7 +646,7 @@ class TestSetProperties:
         # The vector is untouched, so the record still answers its own query.
         results = await collection.query(query_vectors=[v1], limit=1)
         assert results[0].matches[0].record.uuid == r1.uuid
-        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_replaced_properties_are_filterable(self, collection):
@@ -882,30 +871,6 @@ class TestPartitionIsolation:
         await store.delete_collection(namespace=NAMESPACE, name="sibling_b")
 
 
-# ── Euclidean metric ──
-
-
-class TestEuclideanMetric:
-    @pytest.mark.asyncio
-    async def test_euclidean_ordering(self, store):
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=2,
-            similarity_metric=SimilarityMetric.EUCLIDEAN,
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean", config=config
-        )
-        r1 = _make_record(vector=[0.0, 0.0])
-        r2 = _make_record(vector=[3.0, 4.0])
-        await coll.upsert(records=[r1, r2])
-
-        results = await coll.query(query_vectors=[[0.0, 0.0]], limit=2)
-        # Euclidean: lower distance = better match; best match is first
-        assert results[0].matches[0].score < results[0].matches[1].score
-
-        await store.delete_collection(namespace=NAMESPACE, name="euclidean")
-
-
 # ── No-properties collection ──
 
 
@@ -923,32 +888,6 @@ class TestNoProperties:
         assert len(results[0].matches) == 1
 
         await store.delete_collection(namespace=NAMESPACE, name="no_props")
-
-
-# ── USearch-specific: dot product metric ──
-
-
-class TestDotProductMetric:
-    @pytest.mark.asyncio
-    async def test_dot_product_supported(self, store):
-        """Dot product is supported by USearch but not sqlite-vec."""
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.DOT,
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="dot", config=config
-        )
-        v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
-        r1 = _make_record(vector=v1)
-        r2 = _make_record(vector=v2)
-        await coll.upsert(records=[r1, r2])
-
-        results = await coll.query(query_vectors=[v1], limit=2)
-        assert len(results[0].matches) == 2
-
-        await store.delete_collection(namespace=NAMESPACE, name="dot")
 
 
 # ── Input validation ──
@@ -971,10 +910,10 @@ class TestInputValidation:
         assert fetched[0].properties == {}
 
 
-# ── Score semantics ──
+# ── Cosine similarity semantics ──
 
 
-class TestScoreSemantics:
+class TestCosineSimilaritySemantics:
     @pytest.mark.asyncio
     async def test_cosine_higher_is_better(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
@@ -984,29 +923,8 @@ class TestScoreSemantics:
         await collection.upsert(records=[r1, r2])
 
         results = await collection.query(query_vectors=[v1], limit=2)
-        scores = [m.score for m in results[0].matches]
+        scores = [m.cosine_similarity for m in results[0].matches]
         assert scores[0] > scores[1]
-
-    @pytest.mark.asyncio
-    async def test_euclidean_lower_is_better(self, store):
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=2,
-            similarity_metric=SimilarityMetric.EUCLIDEAN,
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean_score", config=config
-        )
-        r1 = _make_record(vector=[0.0, 0.0])
-        r2 = _make_record(vector=[3.0, 4.0])
-        await coll.upsert(records=[r1, r2])
-
-        results = await coll.query(query_vectors=[[0.0, 0.0]], limit=2)
-        scores = [m.score for m in results[0].matches]
-        assert scores[0] < scores[1]
-        assert scores[0] == pytest.approx(0.0, abs=0.01)
-        assert scores[1] == pytest.approx(5.0, abs=0.01)
-
-        await store.delete_collection(namespace=NAMESPACE, name="euclidean_score")
 
 
 # ── Upsert behavior ──
@@ -1038,7 +956,7 @@ class TestUpsertBehavior:
 
         results = await collection.query(query_vectors=[v2], limit=1)
         assert results[0].matches[0].record.uuid == record_uuid
-        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
 
 # ── Concurrent async behavior ──
@@ -1099,13 +1017,12 @@ class TestConcurrentAsync:
 # ── Crash recovery & pending operations ──
 
 
-def _engine_factory(ndim, metric):
-    return USearchVectorSearchEngine(num_dimensions=ndim, similarity_metric=metric)
+def _engine_factory(ndim):
+    return USearchVectorSearchEngine(num_dimensions=ndim)
 
 
 CONFIG = VectorStoreCollectionConfig(
     vector_dimensions=VECTOR_DIM,
-    similarity_metric=SimilarityMetric.COSINE,
 )
 
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
@@ -17,7 +17,6 @@ if os.getenv("CI") == "true":
         allow_module_level=True,
     )
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.vector_store.vector_search_engine.hnswlib_engine import (
     HnswlibVectorSearchEngine,
 )
@@ -40,19 +39,8 @@ async def _search_one(engine, vector, limit=10, **kwargs):
 
 
 class TestConstruction:
-    def test_supported_metrics(self):
-        for metric in (
-            SimilarityMetric.COSINE,
-            SimilarityMetric.EUCLIDEAN,
-            SimilarityMetric.DOT,
-        ):
-            HnswlibVectorSearchEngine(num_dimensions=NDIM, similarity_metric=metric)
-
-    def test_unsupported_metric_raises(self):
-        with pytest.raises(ValueError, match="does not support"):
-            HnswlibVectorSearchEngine(
-                num_dimensions=NDIM, similarity_metric=SimilarityMetric.MANHATTAN
-            )
+    def test_construction(self):
+        HnswlibVectorSearchEngine(num_dimensions=NDIM)
 
 
 # -- Add --
@@ -61,39 +49,31 @@ class TestConstruction:
 class TestAdd:
     @pytest.mark.asyncio
     async def test_add_single(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1.0, 0.0, 0.0]})
         result = await _search_one(engine, [1.0, 0.0, 0.0], limit=1)
         assert result.matches[0].key == 1
 
     @pytest.mark.asyncio
     async def test_add_batch(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({10: [1, 0, 0], 20: [0, 1, 0], 30: [0, 0, 1]})
         result = await _search_one(engine, [1, 0, 0], limit=3)
         assert {m.key for m in result.matches} == {10, 20, 30}
 
     @pytest.mark.asyncio
     async def test_remove_then_add_replaces_key(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1.0, 0.0, 0.0]})
         await engine.remove([1])
         await engine.add({1: [0.0, 1.0, 0.0]})
         result = await _search_one(engine, _normalize([0, 1, 0]), limit=1)
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_add_empty(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({})
         result = await _search_one(engine, [1, 0, 0], limit=1)
         assert result.matches == []
@@ -102,7 +82,6 @@ class TestAdd:
     async def test_add_beyond_initial_capacity(self):
         engine = HnswlibVectorSearchEngine(
             num_dimensions=NDIM,
-            similarity_metric=SimilarityMetric.COSINE,
             initial_capacity=2,
         )
         await engine.add(
@@ -124,9 +103,7 @@ class TestAdd:
 class TestRemove:
     @pytest.mark.asyncio
     async def test_remove_existing(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0], 2: [0, 1, 0]})
         await engine.remove([1])
         result = await _search_one(engine, [1, 0, 0], limit=2)
@@ -136,9 +113,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_missing_is_ignored(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0]})
         await engine.remove([99, 100])
         result = await _search_one(engine, [1, 0, 0], limit=1)
@@ -146,9 +121,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_all(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0], 2: [0, 1, 0], 3: [0, 0, 1]})
         await engine.remove([1, 2, 3])
         result = await _search_one(engine, [1, 0, 0], limit=3)
@@ -156,9 +129,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_empty_iterable(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0]})
         await engine.remove([])
         result = await _search_one(engine, [1, 0, 0], limit=1)
@@ -166,9 +137,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_excludes_from_search(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
         await engine.remove([1])
         result = await _search_one(engine, _normalize([1, 0, 0]), limit=2)
@@ -181,9 +150,7 @@ class TestRemove:
 class TestSearchCosine:
     @pytest.mark.asyncio
     async def test_basic_knn(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add(
             {
                 1: _normalize([1, 0, 0]),
@@ -194,26 +161,24 @@ class TestSearchCosine:
         result = await _search_one(engine, _normalize([1, 0, 0]), limit=3)
         assert len(result.matches) == 3
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(1.0 / math.sqrt(2), abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+        assert result.matches[1].cosine_similarity == pytest.approx(
+            1.0 / math.sqrt(2), abs=0.01
+        )
 
     @pytest.mark.asyncio
     async def test_scores_are_cosine_similarity(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         v1 = _normalize([1, 0, 0])
         v2 = _normalize([0, 1, 0])
         await engine.add({1: v1, 2: v2})
         result = await _search_one(engine, v1, limit=2)
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(0.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+        assert result.matches[1].cosine_similarity == pytest.approx(0.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_scores_ordered_best_first(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add(
             {
                 1: _normalize([1, 0, 0]),
@@ -223,30 +188,27 @@ class TestSearchCosine:
         )
         result = await _search_one(engine, _normalize([1, 0, 0]), limit=3)
         for i in range(len(result.matches) - 1):
-            assert result.matches[i].score >= result.matches[i + 1].score
+            assert (
+                result.matches[i].cosine_similarity
+                >= result.matches[i + 1].cosine_similarity
+            )
 
     @pytest.mark.asyncio
     async def test_k_larger_than_index(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0]})
         result = await _search_one(engine, [1, 0, 0], limit=10)
         assert len(result.matches) == 1
 
     @pytest.mark.asyncio
     async def test_search_empty_index(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         result = await _search_one(engine, [1, 0, 0], limit=5)
         assert result.matches == []
 
     @pytest.mark.asyncio
     async def test_batched_search(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
         results = await engine.search(
             [_normalize([1, 0, 0]), _normalize([0, 1, 0])], limit=1
@@ -256,92 +218,29 @@ class TestSearchCosine:
         assert results[1].matches[0].key == 2
 
 
-# -- Search: Euclidean --
-
-
-class TestSearchEuclidean:
-    @pytest.mark.asyncio
-    async def test_scores_are_euclidean_distance(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.EUCLIDEAN
-        )
-        await engine.add({1: [0, 0, 0], 2: [3, 4, 0]})
-        result = await _search_one(engine, [0, 0, 0], limit=2)
-        assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(0.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(5.0, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_scores_ordered_best_first(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.EUCLIDEAN
-        )
-        await engine.add({1: [0, 0, 0], 2: [1, 0, 0], 3: [3, 4, 0]})
-        result = await _search_one(engine, [0, 0, 0], limit=3)
-        for i in range(len(result.matches) - 1):
-            assert result.matches[i].score <= result.matches[i + 1].score
-
-
-# -- Search: Dot product --
-
-
-class TestSearchDot:
-    @pytest.mark.asyncio
-    async def test_scores_are_inner_product(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.DOT
-        )
-        v1 = _normalize([1, 0, 0])
-        v2 = _normalize([0, 1, 0])
-        await engine.add({1: v1, 2: v2})
-        result = await _search_one(engine, v1, limit=2)
-        assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(0.0, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_scores_ordered_best_first(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.DOT
-        )
-        v1 = _normalize([1, 0, 0])
-        v2 = _normalize([1, 1, 0])
-        v3 = _normalize([0, 1, 0])
-        await engine.add({1: v1, 2: v2, 3: v3})
-        result = await _search_one(engine, v1, limit=3)
-        for i in range(len(result.matches) - 1):
-            assert result.matches[i].score >= result.matches[i + 1].score
-
-
 # -- Persistence --
 
 
 class TestPersistence:
     @pytest.mark.asyncio
     async def test_save_and_load(self, tmp_path: Path):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
         path = str(tmp_path / "test.hnswlib")
         await engine.save(path)
 
-        engine2 = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine2 = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine2.load(path)
 
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_save_and_load_with_deletions(self, tmp_path: Path):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add(
             {
                 1: _normalize([1, 0, 0]),
@@ -354,9 +253,7 @@ class TestPersistence:
         path = str(tmp_path / "test.hnswlib")
         await engine.save(path)
 
-        engine2 = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine2 = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine2.load(path)
 
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=3)
@@ -364,9 +261,7 @@ class TestPersistence:
 
     @pytest.mark.asyncio
     async def test_save_leaves_no_temp_file(self, tmp_path: Path):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0])})
 
         path = tmp_path / "test.hnswlib"
@@ -377,9 +272,7 @@ class TestPersistence:
 
     @pytest.mark.asyncio
     async def test_load_clears_stale_temp_file(self, tmp_path: Path):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
         path = tmp_path / "test.hnswlib"
@@ -389,9 +282,7 @@ class TestPersistence:
         stale_temp = tmp_path / "test.hnswlib.tmp"
         stale_temp.write_text("STALE")
 
-        engine2 = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine2 = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine2.load(str(path))
 
         assert not stale_temp.exists()
@@ -469,7 +360,6 @@ class TestReplaceDeletedSlotReclamation:
         for allow in (False, True):
             engine = HnswlibVectorSearchEngine(
                 num_dimensions=8,
-                similarity_metric=SimilarityMetric.COSINE,
                 allow_replace_deleted=allow,
             )
             vecs = {i: _rand_unit(rng, 8) for i in range(20)}
@@ -484,7 +374,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(1)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
         )
         v_old = _rand_unit(rng, 8)
@@ -495,7 +384,7 @@ class TestReplaceDeletedSlotReclamation:
 
         result = await _search_one(engine, v_new, limit=1)
         assert result.matches[0].key == 42
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         _no_corruption(engine)
 
     @pytest.mark.asyncio
@@ -508,7 +397,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(2)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=16,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
         )
         vecs = {i: _rand_unit(rng, 16) for i in range(50)}
@@ -522,7 +410,7 @@ class TestReplaceDeletedSlotReclamation:
         for i in range(50):
             result = await _search_one(engine, new_vecs[i], limit=1)
             assert result.matches[0].key == i, f"label {i} missing or wrong"
-            assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+            assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         _no_corruption(engine)
 
     @pytest.mark.asyncio
@@ -535,7 +423,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(3)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=16,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
         )
         vecs = {i: _rand_unit(rng, 16) for i in range(20)}
@@ -560,7 +447,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(4)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
             initial_capacity=200,
         )
@@ -590,7 +476,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(5)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=False,
             initial_capacity=200,
         )
@@ -612,7 +497,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(6)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=16,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
             initial_capacity=500,
         )
@@ -654,7 +538,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(7)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=16,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
             initial_capacity=100,
         )
@@ -667,7 +550,6 @@ class TestReplaceDeletedSlotReclamation:
 
         engine2 = HnswlibVectorSearchEngine(
             num_dimensions=16,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
         )
         await engine2.load(path)
@@ -702,7 +584,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(8)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
         )
         v_orig = _rand_unit(rng, 8)
@@ -713,7 +594,7 @@ class TestReplaceDeletedSlotReclamation:
 
         result = await _search_one(engine, v_reused, limit=1)
         assert result.matches[0].key == 100
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         _no_corruption(engine)
 
 
@@ -737,7 +618,6 @@ class TestAllowReplaceDeletedFalse:
         rng = np.random.default_rng(101)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=False,
         )
         last_v: list[float] | None = None
@@ -749,7 +629,7 @@ class TestAllowReplaceDeletedFalse:
         assert last_v is not None
         result = await _search_one(engine, last_v, limit=1)
         assert result.matches[0].key == 99
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         _no_corruption(engine)
 
     @pytest.mark.asyncio
@@ -764,7 +644,6 @@ class TestAllowReplaceDeletedFalse:
         rng = np.random.default_rng(102)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=False,
         )
         v_old = _rand_unit(rng, 8)
@@ -779,7 +658,7 @@ class TestAllowReplaceDeletedFalse:
         )
         result = await _search_one(engine, v_new, limit=1)
         assert result.matches[0].key == 7
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         _no_corruption(engine)
 
     @pytest.mark.asyncio
@@ -789,7 +668,6 @@ class TestAllowReplaceDeletedFalse:
         rng = np.random.default_rng(103)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=False,
         )
         first = {i: _rand_unit(rng, 8) for i in range(20)}
@@ -810,12 +688,12 @@ class TestAllowReplaceDeletedFalse:
         for k, v in updated.items():
             result = await _search_one(engine, v, limit=1)
             assert result.matches[0].key == k
-            assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+            assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         # Brand-new keys queryable.
         for k, v in added.items():
             result = await _search_one(engine, v, limit=1)
             assert result.matches[0].key == k
-            assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+            assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         # Untouched keys 10-19 still queryable.
         for k in range(10, 20):
             result = await _search_one(engine, first[k], limit=1)
@@ -828,7 +706,6 @@ class TestAllowReplaceDeletedFalse:
         rng = np.random.default_rng(104)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=16,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=False,
             initial_capacity=256,
         )
@@ -863,7 +740,7 @@ class TestAllowReplaceDeletedFalse:
             v = live[k]
             result = await _search_one(engine, v, limit=1)
             assert result.matches[0].key == k, f"label {k} not findable"
-            assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+            assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
 
 # -- SearchResult types --
@@ -872,18 +749,14 @@ class TestAllowReplaceDeletedFalse:
 class TestSearchResultTypes:
     @pytest.mark.asyncio
     async def test_keys_are_ints(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({42: [1, 0, 0]})
         result = await _search_one(engine, [1, 0, 0], limit=1)
         assert isinstance(result.matches[0].key, int)
 
     @pytest.mark.asyncio
     async def test_scores_are_floats(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({42: [1, 0, 0]})
         result = await _search_one(engine, [1, 0, 0], limit=1)
-        assert isinstance(result.matches[0].score, float)
+        assert isinstance(result.matches[0].cosine_similarity, float)

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -1,0 +1,440 @@
+"""Tests for TurboVecVectorSearchEngine.
+
+turbovec stores TurboQuant-compressed vectors, so scores are approximate: a
+self-match lands near (and may slightly exceed) the exact value, and orthogonal
+pairs land near zero rather than exactly zero. Tests therefore assert ranking
+and membership (robust under quantization) and only loosely assert score
+magnitudes.
+"""
+
+import math
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("turbovec")
+
+from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.vector_store.vector_search_engine.turbovec_engine import (
+    TurboVecVectorSearchEngine,
+)
+
+NDIM = 8
+
+QUANT_ABS = 0.05
+
+
+def _normalize(v: list[float]) -> list[float]:
+    magnitude = math.sqrt(sum(x * x for x in v))
+    return [x / magnitude for x in v]
+
+
+def _one_hot(index: int, value: float = 1.0) -> list[float]:
+    """A length-NDIM vector with `value` at `index`, zeros elsewhere."""
+    vector = [0.0] * NDIM
+    vector[index] = value
+    return vector
+
+
+async def _search_one(engine, vector, limit=10, **kwargs):
+    """Helper: search a single vector, return the one SearchResult."""
+    results = await engine.search([vector], limit=limit, **kwargs)
+    return results[0]
+
+
+def _make_engine(metric=SimilarityMetric.COSINE, **kwargs):
+    return TurboVecVectorSearchEngine(
+        num_dimensions=NDIM, similarity_metric=metric, **kwargs
+    )
+
+
+# -- Construction --
+
+
+class TestConstruction:
+    def test_supported_metrics(self):
+        for metric in (SimilarityMetric.COSINE, SimilarityMetric.DOT):
+            _make_engine(metric)
+
+    def test_unsupported_metric_raises(self):
+        for metric in (SimilarityMetric.EUCLIDEAN, SimilarityMetric.MANHATTAN):
+            with pytest.raises(NotImplementedError, match="does not support"):
+                _make_engine(metric)
+
+    def test_valid_bit_widths(self):
+        for bit_width in (2, 3, 4):
+            _make_engine(bit_width=bit_width)
+
+    def test_invalid_bit_width_raises(self):
+        with pytest.raises(ValueError, match="bit_width"):
+            _make_engine(bit_width=5)
+
+    def test_dimensions_must_be_multiple_of_8(self):
+        with pytest.raises(ValueError, match="multiple of 8"):
+            TurboVecVectorSearchEngine(
+                num_dimensions=7, similarity_metric=SimilarityMetric.COSINE
+            )
+
+
+# -- Add --
+
+
+class TestAdd:
+    @pytest.mark.asyncio
+    async def test_add_single(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches[0].key == 1
+
+    @pytest.mark.asyncio
+    async def test_add_batch(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                10: _normalize(_one_hot(0)),
+                20: _normalize(_one_hot(1)),
+                30: _normalize(_one_hot(2)),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        assert {m.key for m in result.matches} == {10, 20, 30}
+
+    @pytest.mark.asyncio
+    async def test_add_empty(self):
+        engine = _make_engine()
+        await engine.add({})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_remove_then_add_replaces_key(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        await engine.remove([1])
+        await engine.add({1: _normalize(_one_hot(1))})
+        result = await _search_one(engine, _normalize(_one_hot(1)), limit=1)
+        assert result.matches[0].key == 1
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_repeated_reupsert_of_same_key(self):
+        engine = _make_engine()
+        for index in range(NDIM):
+            await engine.remove([7])
+            await engine.add({7: _normalize(_one_hot(index))})
+        result = await _search_one(engine, _normalize(_one_hot(NDIM - 1)), limit=1)
+        assert result.matches[0].key == 7
+
+
+# -- Remove --
+
+
+class TestRemove:
+    @pytest.mark.asyncio
+    async def test_remove_existing(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        await engine.remove([1])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=2)
+        keys = {m.key for m in result.matches}
+        assert 1 not in keys
+        assert 2 in keys
+
+    @pytest.mark.asyncio
+    async def test_remove_missing_is_ignored(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        await engine.remove([99, 100])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches[0].key == 1
+
+    @pytest.mark.asyncio
+    async def test_remove_all(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize(_one_hot(2)),
+            }
+        )
+        await engine.remove([1, 2, 3])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_remove_empty_iterable(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        await engine.remove([])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches[0].key == 1
+
+
+# -- Search: Cosine --
+
+
+class TestSearchCosine:
+    @pytest.mark.asyncio
+    async def test_basic_knn(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize([1, 1, 0, 0, 0, 0, 0, 0]),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        assert len(result.matches) == 3
+        assert result.matches[0].key == 1
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[1].key == 3
+        assert result.matches[2].key == 2
+
+    @pytest.mark.asyncio
+    async def test_orthogonal_scores_near_zero(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=2)
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[1].score == pytest.approx(0.0, abs=0.1)
+
+    @pytest.mark.asyncio
+    async def test_scores_ordered_best_first(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize([1, 1, 0, 0, 0, 0, 0, 0]),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        for i in range(len(result.matches) - 1):
+            assert result.matches[i].score >= result.matches[i + 1].score
+
+    @pytest.mark.asyncio
+    async def test_k_larger_than_index(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=10)
+        assert len(result.matches) == 1
+
+    @pytest.mark.asyncio
+    async def test_search_empty_index(self):
+        engine = _make_engine()
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=5)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_limit_zero_returns_empty(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=0)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_empty_query_list(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        results = await engine.search([], limit=3)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_batched_search(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        results = await engine.search(
+            [_normalize(_one_hot(0)), _normalize(_one_hot(1))], limit=1
+        )
+        assert len(results) == 2
+        assert results[0].matches[0].key == 1
+        assert results[1].matches[0].key == 2
+
+
+# -- Search: Dot product --
+
+
+class TestSearchDot:
+    @pytest.mark.asyncio
+    async def test_self_match_highest(self):
+        engine = _make_engine(SimilarityMetric.DOT)
+        v1 = _normalize(_one_hot(0))
+        v2 = _normalize(_one_hot(1))
+        await engine.add({1: v1, 2: v2})
+        result = await _search_one(engine, v1, limit=2)
+        assert result.matches[0].key == 1
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[1].score == pytest.approx(0.0, abs=0.1)
+
+    @pytest.mark.asyncio
+    async def test_scores_ordered_best_first(self):
+        engine = _make_engine(SimilarityMetric.DOT)
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize([1, 1, 0, 0, 0, 0, 0, 0]),
+                3: _normalize(_one_hot(1)),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        for i in range(len(result.matches) - 1):
+            assert result.matches[i].score >= result.matches[i + 1].score
+
+
+# -- Search: allowed_keys filtering --
+
+
+class TestSearchFiltered:
+    @pytest.mark.asyncio
+    async def test_allowed_keys_restricts_results(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize(_one_hot(2)),
+                4: _normalize(_one_hot(3)),
+            }
+        )
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=4, allowed_keys={2, 3}
+        )
+        assert {m.key for m in result.matches} == {2, 3}
+
+    @pytest.mark.asyncio
+    async def test_allowed_keys_excludes_best_match(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize(_one_hot(2)),
+            }
+        )
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=1, allowed_keys={2, 3}
+        )
+        assert len(result.matches) == 1
+        assert result.matches[0].key in {2, 3}
+
+    @pytest.mark.asyncio
+    async def test_allowed_keys_empty_returns_nothing(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=2, allowed_keys=set()
+        )
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_allowed_keys_found_beyond_overfetch_window(self):
+        engine = _make_engine()
+        vectors = {
+            index: _normalize(_one_hot(index % NDIM, value=1.0 + index))
+            for index in range(2 * NDIM)
+        }
+        await engine.add(vectors)
+        target = 2 * NDIM - 1
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=1, allowed_keys={target}
+        )
+        assert [m.key for m in result.matches] == [target]
+
+
+# -- get_vectors --
+
+
+class TestGetVectors:
+    @pytest.mark.asyncio
+    async def test_get_vectors_raises(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        with pytest.raises(NotImplementedError, match="cannot be retrieved"):
+            await engine.get_vectors([1])
+
+
+# -- Persistence --
+
+
+class TestPersistence:
+    @pytest.mark.asyncio
+    async def test_save_and_load(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        engine2 = _make_engine()
+        await engine2.load(path)
+
+        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=2)
+        assert {m.key for m in result.matches} == {1, 2}
+        assert result.matches[0].key == 1
+        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
+
+        assert path.exists()
+        assert not (tmp_path / "test.idx.tmp").exists()
+
+    @pytest.mark.asyncio
+    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
+
+        stale_temp = tmp_path / "test.idx.tmp"
+        stale_temp.write_text("STALE")
+
+        engine2 = _make_engine()
+        await engine2.load(str(path))
+
+        assert not stale_temp.exists()
+        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=2)
+        assert {m.key for m in result.matches} == {1, 2}
+
+    @pytest.mark.asyncio
+    async def test_load_replaces_existing_index(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        engine2 = _make_engine()
+        await engine2.add({2: _normalize(_one_hot(1))})
+        await engine2.load(path)
+
+        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=5)
+        keys = {m.key for m in result.matches}
+        assert keys == {1}
+
+
+# -- SearchResult types --
+
+
+class TestSearchResultTypes:
+    @pytest.mark.asyncio
+    async def test_keys_are_ints(self):
+        engine = _make_engine()
+        await engine.add({42: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert isinstance(result.matches[0].key, int)
+
+    @pytest.mark.asyncio
+    async def test_scores_are_floats(self):
+        engine = _make_engine()
+        await engine.add({42: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert isinstance(result.matches[0].score, float)

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -36,6 +36,18 @@ def _one_hot(index: int, value: float = 1.0) -> list[float]:
     return vector
 
 
+def _entry_names(directory: Path) -> list[str]:
+    """Names of everything in `directory`. Sync: the tests calling it are not."""
+    return [entry.name for entry in directory.iterdir()]
+
+
+def _spread(seed: int) -> list[float]:
+    """A deterministic unit vector, distinct per `seed`."""
+    return _normalize(
+        [math.cos(seed * (axis + 1) * 0.7 + axis) for axis in range(NDIM)]
+    )
+
+
 async def _search_one(engine, vector, limit=10, **kwargs):
     """Helper: search a single vector, return the one SearchResult."""
     results = await engine.search([vector], limit=limit, **kwargs)
@@ -384,26 +396,27 @@ class TestPersistence:
         path = tmp_path / "test.idx"
         await engine.save(str(path))
 
-        assert path.exists()
-        assert not (tmp_path / "test.idx.tmp").exists()
+        assert _entry_names(tmp_path) == ["test.idx"]
 
     @pytest.mark.asyncio
-    async def test_load_clears_stale_temp_file(self, tmp_path: Path):
+    async def test_checkpoint_carries_adds_and_mass_removals(self, tmp_path: Path):
         engine = _make_engine()
-        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        await engine.add({key: _spread(key) for key in range(1, 2001)})
 
-        path = tmp_path / "test.idx"
-        await engine.save(str(path))
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
 
-        stale_temp = tmp_path / "test.idx.tmp"
-        stale_temp.write_text("STALE")
+        doomed = [key for key in range(1, 2001) if key % 4 != 0]
+        await engine.remove(doomed)
+        await engine.add({key: _spread(key) for key in range(10_001, 10_033)})
+        await engine.save(path)
 
         engine2 = _make_engine()
-        await engine2.load(str(path))
+        await engine2.load(path)
 
-        assert not stale_temp.exists()
-        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=2)
-        assert {m.key for m in result.matches} == {1, 2}
+        expected = set(range(4, 2001, 4)) | set(range(10_001, 10_033))
+        result = await _search_one(engine2, _spread(1), limit=len(expected) + 10)
+        assert {match.key for match in result.matches} == expected
 
     @pytest.mark.asyncio
     async def test_load_replaces_existing_index(self, tmp_path: Path):

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -1,10 +1,10 @@
 """Tests for TurboVecVectorSearchEngine.
 
 turbovec stores TurboQuant-compressed vectors, so scores are approximate: a
-self-match lands near (and may slightly exceed) the exact value, and orthogonal
-pairs land near zero rather than exactly zero. Tests therefore assert ranking
-and membership (robust under quantization) and only loosely assert score
-magnitudes.
+self-match lands near the exact value, and orthogonal pairs land near zero
+rather than exactly zero. Tests therefore assert ranking and membership (robust
+under quantization) and only loosely assert score magnitudes. The one exact
+bound is the cosine range, which the engine clamps.
 """
 
 import math
@@ -435,6 +435,27 @@ class TestPersistence:
 
 
 # -- SearchResult types --
+
+
+class TestScoreRange:
+    @pytest.mark.asyncio
+    async def test_cosine_scores_stay_within_range(self):
+        engine = _make_engine()
+        vectors = {key: _spread(key) for key in range(1, 51)}
+        await engine.add(vectors)
+
+        for vector in vectors.values():
+            result = await _search_one(engine, vector, limit=5)
+            for match in result.matches:
+                assert -1.0 <= match.score <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_dot_scores_are_not_clamped(self):
+        engine = _make_engine(SimilarityMetric.DOT)
+        await engine.add({1: [4.0] + [0.0] * (NDIM - 1)})
+
+        result = await _search_one(engine, [4.0] + [0.0] * (NDIM - 1), limit=1)
+        assert result.matches[0].score > 1.0
 
 
 class TestSearchResultTypes:

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -81,11 +81,10 @@ class TestConstruction:
         with pytest.raises(ValueError, match="bit_width"):
             _make_engine(bit_width=5)
 
-    def test_dimensions_must_be_multiple_of_8(self):
-        with pytest.raises(ValueError, match="multiple of 8"):
-            TurboVecVectorSearchEngine(
-                num_dimensions=7, similarity_metric=SimilarityMetric.COSINE
-            )
+    def test_unaligned_dimensions_are_accepted(self):
+        TurboVecVectorSearchEngine(
+            num_dimensions=7, similarity_metric=SimilarityMetric.COSINE
+        )
 
 
 # -- Add --
@@ -435,6 +434,52 @@ class TestPersistence:
 
 
 # -- SearchResult types --
+
+
+class TestUnalignedDimensions:
+    @pytest.mark.asyncio
+    async def test_search_at_an_unaligned_width(self):
+        engine = TurboVecVectorSearchEngine(
+            num_dimensions=5, similarity_metric=SimilarityMetric.COSINE
+        )
+        await engine.add(
+            {
+                1: [1.0, 0.0, 0.0, 0.0, 0.0],
+                2: [0.0, 1.0, 0.0, 0.0, 0.0],
+            }
+        )
+
+        results = await engine.search([[1.0, 0.0, 0.0, 0.0, 0.0]], limit=2)
+        matches = results[0].matches
+        assert [match.key for match in matches] == [1, 2]
+        assert matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert matches[1].score == pytest.approx(0.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_save_and_load_at_an_unaligned_width(self, tmp_path: Path):
+        def make_engine():
+            return TurboVecVectorSearchEngine(
+                num_dimensions=5, similarity_metric=SimilarityMetric.COSINE
+            )
+
+        engine = make_engine()
+        await engine.add({1: [1.0, 0.0, 0.0, 0.0, 0.0]})
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        loaded = make_engine()
+        await loaded.load(path)
+
+        results = await loaded.search([[1.0, 0.0, 0.0, 0.0, 0.0]], limit=1)
+        assert [match.key for match in results[0].matches] == [1]
+
+    @pytest.mark.asyncio
+    async def test_wrong_width_vector_is_rejected(self):
+        engine = TurboVecVectorSearchEngine(
+            num_dimensions=5, similarity_metric=SimilarityMetric.COSINE
+        )
+        with pytest.raises(ValueError, match="must have 5 dimensions"):
+            await engine.add({1: [1.0, 0.0, 0.0]})
 
 
 class TestScoreRange:

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -355,18 +355,6 @@ class TestSearchFiltered:
         assert [m.key for m in result.matches] == [target]
 
 
-# -- get_vectors --
-
-
-class TestGetVectors:
-    @pytest.mark.asyncio
-    async def test_get_vectors_raises(self):
-        engine = _make_engine()
-        await engine.add({1: _normalize(_one_hot(0))})
-        with pytest.raises(NotImplementedError, match="cannot be retrieved"):
-            await engine.get_vectors([1])
-
-
 # -- Persistence --
 
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -14,7 +14,6 @@ import pytest
 
 pytest.importorskip("turbovec")
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.vector_store.vector_search_engine.turbovec_engine import (
     TurboVecVectorSearchEngine,
 )
@@ -54,25 +53,14 @@ async def _search_one(engine, vector, limit=10, **kwargs):
     return results[0]
 
 
-def _make_engine(metric=SimilarityMetric.COSINE, **kwargs):
-    return TurboVecVectorSearchEngine(
-        num_dimensions=NDIM, similarity_metric=metric, **kwargs
-    )
+def _make_engine(**kwargs):
+    return TurboVecVectorSearchEngine(num_dimensions=NDIM, **kwargs)
 
 
 # -- Construction --
 
 
 class TestConstruction:
-    def test_supported_metrics(self):
-        for metric in (SimilarityMetric.COSINE, SimilarityMetric.DOT):
-            _make_engine(metric)
-
-    def test_unsupported_metric_raises(self):
-        for metric in (SimilarityMetric.EUCLIDEAN, SimilarityMetric.MANHATTAN):
-            with pytest.raises(NotImplementedError, match="does not support"):
-                _make_engine(metric)
-
     def test_valid_bit_widths(self):
         for bit_width in (2, 3, 4):
             _make_engine(bit_width=bit_width)
@@ -82,9 +70,7 @@ class TestConstruction:
             _make_engine(bit_width=5)
 
     def test_unaligned_dimensions_are_accepted(self):
-        TurboVecVectorSearchEngine(
-            num_dimensions=7, similarity_metric=SimilarityMetric.COSINE
-        )
+        TurboVecVectorSearchEngine(num_dimensions=7)
 
 
 # -- Add --
@@ -126,7 +112,7 @@ class TestAdd:
         await engine.add({1: _normalize(_one_hot(1))})
         result = await _search_one(engine, _normalize(_one_hot(1)), limit=1)
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=QUANT_ABS)
 
     @pytest.mark.asyncio
     async def test_repeated_reupsert_of_same_key(self):
@@ -200,7 +186,7 @@ class TestSearchCosine:
         result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
         assert len(result.matches) == 3
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=QUANT_ABS)
         assert result.matches[1].key == 3
         assert result.matches[2].key == 2
 
@@ -209,8 +195,8 @@ class TestSearchCosine:
         engine = _make_engine()
         await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
         result = await _search_one(engine, _normalize(_one_hot(0)), limit=2)
-        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
-        assert result.matches[1].score == pytest.approx(0.0, abs=0.1)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[1].cosine_similarity == pytest.approx(0.0, abs=0.1)
 
     @pytest.mark.asyncio
     async def test_scores_ordered_best_first(self):
@@ -224,7 +210,10 @@ class TestSearchCosine:
         )
         result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
         for i in range(len(result.matches) - 1):
-            assert result.matches[i].score >= result.matches[i + 1].score
+            assert (
+                result.matches[i].cosine_similarity
+                >= result.matches[i + 1].cosine_similarity
+            )
 
     @pytest.mark.asyncio
     async def test_k_larger_than_index(self):
@@ -263,36 +252,6 @@ class TestSearchCosine:
         assert len(results) == 2
         assert results[0].matches[0].key == 1
         assert results[1].matches[0].key == 2
-
-
-# -- Search: Dot product --
-
-
-class TestSearchDot:
-    @pytest.mark.asyncio
-    async def test_self_match_highest(self):
-        engine = _make_engine(SimilarityMetric.DOT)
-        v1 = _normalize(_one_hot(0))
-        v2 = _normalize(_one_hot(1))
-        await engine.add({1: v1, 2: v2})
-        result = await _search_one(engine, v1, limit=2)
-        assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
-        assert result.matches[1].score == pytest.approx(0.0, abs=0.1)
-
-    @pytest.mark.asyncio
-    async def test_scores_ordered_best_first(self):
-        engine = _make_engine(SimilarityMetric.DOT)
-        await engine.add(
-            {
-                1: _normalize(_one_hot(0)),
-                2: _normalize([1, 1, 0, 0, 0, 0, 0, 0]),
-                3: _normalize(_one_hot(1)),
-            }
-        )
-        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
-        for i in range(len(result.matches) - 1):
-            assert result.matches[i].score >= result.matches[i + 1].score
 
 
 # -- Search: allowed_keys filtering --
@@ -373,7 +332,7 @@ class TestPersistence:
         result = await _search_one(engine2, _normalize(_one_hot(0)), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=QUANT_ABS)
 
     @pytest.mark.asyncio
     async def test_save_leaves_no_temp_file(self, tmp_path: Path):
@@ -427,9 +386,7 @@ class TestPersistence:
 class TestUnalignedDimensions:
     @pytest.mark.asyncio
     async def test_search_at_an_unaligned_width(self):
-        engine = TurboVecVectorSearchEngine(
-            num_dimensions=5, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = TurboVecVectorSearchEngine(num_dimensions=5)
         await engine.add(
             {
                 1: [1.0, 0.0, 0.0, 0.0, 0.0],
@@ -440,15 +397,13 @@ class TestUnalignedDimensions:
         results = await engine.search([[1.0, 0.0, 0.0, 0.0, 0.0]], limit=2)
         matches = results[0].matches
         assert [match.key for match in matches] == [1, 2]
-        assert matches[0].score == pytest.approx(1.0, abs=QUANT_ABS)
-        assert matches[1].score == pytest.approx(0.0, abs=QUANT_ABS)
+        assert matches[0].cosine_similarity == pytest.approx(1.0, abs=QUANT_ABS)
+        assert matches[1].cosine_similarity == pytest.approx(0.0, abs=QUANT_ABS)
 
     @pytest.mark.asyncio
     async def test_save_and_load_at_an_unaligned_width(self, tmp_path: Path):
         def make_engine():
-            return TurboVecVectorSearchEngine(
-                num_dimensions=5, similarity_metric=SimilarityMetric.COSINE
-            )
+            return TurboVecVectorSearchEngine(num_dimensions=5)
 
         engine = make_engine()
         await engine.add({1: [1.0, 0.0, 0.0, 0.0, 0.0]})
@@ -463,9 +418,7 @@ class TestUnalignedDimensions:
 
     @pytest.mark.asyncio
     async def test_wrong_width_vector_is_rejected(self):
-        engine = TurboVecVectorSearchEngine(
-            num_dimensions=5, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = TurboVecVectorSearchEngine(num_dimensions=5)
         with pytest.raises(ValueError, match="must have 5 dimensions"):
             await engine.add({1: [1.0, 0.0, 0.0]})
 
@@ -480,15 +433,7 @@ class TestScoreRange:
         for vector in vectors.values():
             result = await _search_one(engine, vector, limit=5)
             for match in result.matches:
-                assert -1.0 <= match.score <= 1.0
-
-    @pytest.mark.asyncio
-    async def test_dot_scores_are_not_clamped(self):
-        engine = _make_engine(SimilarityMetric.DOT)
-        await engine.add({1: [4.0] + [0.0] * (NDIM - 1)})
-
-        result = await _search_one(engine, [4.0] + [0.0] * (NDIM - 1), limit=1)
-        assert result.matches[0].score > 1.0
+                assert -1.0 <= match.cosine_similarity <= 1.0
 
 
 class TestSearchResultTypes:
@@ -504,4 +449,4 @@ class TestSearchResultTypes:
         engine = _make_engine()
         await engine.add({42: _normalize(_one_hot(0))})
         result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
-        assert isinstance(result.matches[0].score, float)
+        assert isinstance(result.matches[0].cosine_similarity, float)

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
 )
@@ -28,19 +27,8 @@ async def _search_one(engine, vector, limit=10, **kwargs):
 
 
 class TestConstruction:
-    def test_supported_metrics(self):
-        for metric in (
-            SimilarityMetric.COSINE,
-            SimilarityMetric.EUCLIDEAN,
-            SimilarityMetric.DOT,
-        ):
-            USearchVectorSearchEngine(num_dimensions=NDIM, similarity_metric=metric)
-
-    def test_unsupported_metric_raises(self):
-        with pytest.raises(ValueError, match="does not support"):
-            USearchVectorSearchEngine(
-                num_dimensions=NDIM, similarity_metric=SimilarityMetric.MANHATTAN
-            )
+    def test_construction(self):
+        USearchVectorSearchEngine(num_dimensions=NDIM)
 
 
 # -- Add --
@@ -49,39 +37,31 @@ class TestConstruction:
 class TestAdd:
     @pytest.mark.asyncio
     async def test_add_single(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1.0, 0.0, 0.0]})
         result = await _search_one(engine, [1.0, 0.0, 0.0], limit=1)
         assert result.matches[0].key == 1
 
     @pytest.mark.asyncio
     async def test_add_batch(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({10: [1, 0, 0], 20: [0, 1, 0], 30: [0, 0, 1]})
         result = await _search_one(engine, [1, 0, 0], limit=3)
         assert {m.key for m in result.matches} == {10, 20, 30}
 
     @pytest.mark.asyncio
     async def test_remove_then_add_replaces_key(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1.0, 0.0, 0.0]})
         await engine.remove([1])
         await engine.add({1: [0.0, 1.0, 0.0]})
         result = await _search_one(engine, _normalize([0, 1, 0]), limit=1)
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_add_empty(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({})
         result = await _search_one(engine, [1, 0, 0], limit=1)
         assert result.matches == []
@@ -93,9 +73,7 @@ class TestAdd:
 class TestRemove:
     @pytest.mark.asyncio
     async def test_remove_existing(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0], 2: [0, 1, 0]})
         await engine.remove([1])
         result = await _search_one(engine, [1, 0, 0], limit=2)
@@ -105,9 +83,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_missing_is_ignored(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0]})
         await engine.remove([99, 100])
         result = await _search_one(engine, [1, 0, 0], limit=1)
@@ -115,9 +91,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_all(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0], 2: [0, 1, 0], 3: [0, 0, 1]})
         await engine.remove([1, 2, 3])
         result = await _search_one(engine, [1, 0, 0], limit=3)
@@ -125,9 +99,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_empty_iterable(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0]})
         await engine.remove([])
         result = await _search_one(engine, [1, 0, 0], limit=1)
@@ -140,9 +112,7 @@ class TestRemove:
 class TestSearchCosine:
     @pytest.mark.asyncio
     async def test_basic_knn(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add(
             {
                 1: _normalize([1, 0, 0]),
@@ -153,26 +123,24 @@ class TestSearchCosine:
         result = await _search_one(engine, _normalize([1, 0, 0]), limit=3)
         assert len(result.matches) == 3
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(1.0 / math.sqrt(2), abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+        assert result.matches[1].cosine_similarity == pytest.approx(
+            1.0 / math.sqrt(2), abs=0.01
+        )
 
     @pytest.mark.asyncio
     async def test_scores_are_cosine_similarity(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         v1 = _normalize([1, 0, 0])
         v2 = _normalize([0, 1, 0])
         await engine.add({1: v1, 2: v2})
         result = await _search_one(engine, v1, limit=2)
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(0.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+        assert result.matches[1].cosine_similarity == pytest.approx(0.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_scores_ordered_best_first(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add(
             {
                 1: _normalize([1, 0, 0]),
@@ -182,30 +150,27 @@ class TestSearchCosine:
         )
         result = await _search_one(engine, _normalize([1, 0, 0]), limit=3)
         for i in range(len(result.matches) - 1):
-            assert result.matches[i].score >= result.matches[i + 1].score
+            assert (
+                result.matches[i].cosine_similarity
+                >= result.matches[i + 1].cosine_similarity
+            )
 
     @pytest.mark.asyncio
     async def test_k_larger_than_index(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0]})
         result = await _search_one(engine, [1, 0, 0], limit=10)
         assert len(result.matches) == 1
 
     @pytest.mark.asyncio
     async def test_search_empty_index(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         result = await _search_one(engine, [1, 0, 0], limit=5)
         assert result.matches == []
 
     @pytest.mark.asyncio
     async def test_batched_search(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
         results = await engine.search(
             [_normalize([1, 0, 0]), _normalize([0, 1, 0])], limit=1
@@ -215,92 +180,29 @@ class TestSearchCosine:
         assert results[1].matches[0].key == 2
 
 
-# -- Search: Euclidean --
-
-
-class TestSearchEuclidean:
-    @pytest.mark.asyncio
-    async def test_scores_are_euclidean_distance(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.EUCLIDEAN
-        )
-        await engine.add({1: [0, 0, 0], 2: [3, 4, 0]})
-        result = await _search_one(engine, [0, 0, 0], limit=2)
-        assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(0.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(5.0, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_scores_ordered_best_first(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.EUCLIDEAN
-        )
-        await engine.add({1: [0, 0, 0], 2: [1, 0, 0], 3: [3, 4, 0]})
-        result = await _search_one(engine, [0, 0, 0], limit=3)
-        for i in range(len(result.matches) - 1):
-            assert result.matches[i].score <= result.matches[i + 1].score
-
-
-# -- Search: Dot product --
-
-
-class TestSearchDot:
-    @pytest.mark.asyncio
-    async def test_scores_are_inner_product(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.DOT
-        )
-        v1 = _normalize([1, 0, 0])
-        v2 = _normalize([0, 1, 0])
-        await engine.add({1: v1, 2: v2})
-        result = await _search_one(engine, v1, limit=2)
-        assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(0.0, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_scores_ordered_best_first(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.DOT
-        )
-        v1 = _normalize([1, 0, 0])
-        v2 = _normalize([1, 1, 0])
-        v3 = _normalize([0, 1, 0])
-        await engine.add({1: v1, 2: v2, 3: v3})
-        result = await _search_one(engine, v1, limit=3)
-        for i in range(len(result.matches) - 1):
-            assert result.matches[i].score >= result.matches[i + 1].score
-
-
 # -- Persistence --
 
 
 class TestPersistence:
     @pytest.mark.asyncio
     async def test_save_and_load(self, tmp_path: Path):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
         path = str(tmp_path / "test.idx")
         await engine.save(path)
 
-        engine2 = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine2 = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine2.load(path)
 
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_save_leaves_no_temp_file(self, tmp_path: Path):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0])})
 
         path = tmp_path / "test.idx"
@@ -311,9 +213,7 @@ class TestPersistence:
 
     @pytest.mark.asyncio
     async def test_load_clears_stale_temp_file(self, tmp_path: Path):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
         path = tmp_path / "test.idx"
@@ -323,9 +223,7 @@ class TestPersistence:
         stale_temp = tmp_path / "test.idx.tmp"
         stale_temp.write_text("STALE")
 
-        engine2 = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine2 = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine2.load(str(path))
 
         assert not stale_temp.exists()
@@ -339,18 +237,14 @@ class TestPersistence:
 class TestSearchResultTypes:
     @pytest.mark.asyncio
     async def test_keys_are_ints(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({42: [1, 0, 0]})
         result = await _search_one(engine, [1, 0, 0], limit=1)
         assert isinstance(result.matches[0].key, int)
 
     @pytest.mark.asyncio
     async def test_scores_are_floats(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({42: [1, 0, 0]})
         result = await _search_one(engine, [1, 0, 0], limit=1)
-        assert isinstance(result.matches[0].score, float)
+        assert isinstance(result.matches[0].cosine_similarity, float)

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/conftest.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/conftest.py
@@ -198,7 +198,6 @@ def fake_segment_store_partition():
 def fake_vector_store_collection(fake_embedder):
     config = VectorStoreCollectionConfig(
         vector_dimensions=fake_embedder.dimensions,
-        similarity_metric=fake_embedder.similarity_metric,
         indexed_properties_schema={
             **EventMemory.expected_vector_store_collection_schema(),
             "color": str,

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_event_memory.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_event_memory.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -214,7 +214,6 @@ class TestEncodeEvents:
         # Collection without context fields.
         config = VectorStoreCollectionConfig(
             vector_dimensions=2,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "_segment_uuid": str,
                 "_timestamp": datetime.datetime,
@@ -244,7 +243,6 @@ class TestEncodeEvents:
         # Collection without _timestamp — base field required at init.
         config = VectorStoreCollectionConfig(
             vector_dimensions=2,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "_segment_uuid": str,
             },
@@ -977,7 +975,6 @@ class TestIngestFormatOptions:
     def _build(embedder: FakeEmbedder) -> EventMemory:
         config = VectorStoreCollectionConfig(
             vector_dimensions=embedder.dimensions,
-            similarity_metric=embedder.similarity_metric,
             indexed_properties_schema=(
                 EventMemory.expected_vector_store_collection_schema()
             ),
@@ -1019,7 +1016,6 @@ class TestIngestFormatOptions:
         partition = InMemorySegmentStorePartition()
         config = VectorStoreCollectionConfig(
             vector_dimensions=embedder.dimensions,
-            similarity_metric=embedder.similarity_metric,
             indexed_properties_schema=(
                 EventMemory.expected_vector_store_collection_schema()
             ),

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
@@ -20,7 +20,6 @@ from unittest.mock import create_autospec
 
 import pytest
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.episode_store import (
     Episode,
     EpisodeEntry,
@@ -150,7 +149,6 @@ def vector_store():
 def vector_store_collection(fake_embedder):
     config = VectorStoreCollectionConfig(
         vector_dimensions=fake_embedder.dimensions,
-        similarity_metric=fake_embedder.similarity_metric,
         indexed_properties_schema={
             **EventMemory.expected_vector_store_collection_schema(),
             **EVENT_BACKEND_SYSTEM_FIELDS,
@@ -480,20 +478,15 @@ async def test_timestamp_filter_field_is_accepted(long_term_memory, episodes):
     )
 
 
-def _make_ltm_with_metric(
-    metric: SimilarityMetric,
-    episodes: list[Episode],
-) -> LongTermMemory:
-    """Build a self-contained LongTermMemory whose vector store uses `metric`.
+def _make_ltm(episodes: list[Episode]) -> LongTermMemory:
+    """Build a self-contained LongTermMemory, bypassing the shared fixtures.
 
-    Avoids the shared fixtures so each test can pick its own similarity metric.
-    No reranker is configured — that's the failure mode under euclidean.
+    No reranker is configured, so scores come straight from the vector store.
     """
-    fake_embedder = FakeEmbedder(similarity_metric=metric)
+    fake_embedder = FakeEmbedder()
     vector_store_collection = InMemoryVectorStoreCollection(
         VectorStoreCollectionConfig(
             vector_dimensions=fake_embedder.dimensions,
-            similarity_metric=metric,
             indexed_properties_schema={
                 **EventMemory.expected_vector_store_collection_schema(),
                 **EVENT_BACKEND_SYSTEM_FIELDS,
@@ -526,7 +519,7 @@ async def test_score_threshold_drops_low_scores_under_cosine():
         _episode("near", "abc"),
         _episode("far", "abcdefghij"),
     ]
-    ltm = _make_ltm_with_metric(SimilarityMetric.COSINE, episodes)
+    ltm = _make_ltm(episodes)
     await ltm.add_episodes(episodes)
 
     kept_all = await ltm.search_scored("abc", num_episodes_limit=10)
@@ -536,62 +529,6 @@ async def test_score_threshold_drops_low_scores_under_cosine():
         "abc", num_episodes_limit=10, score_threshold=2.0
     )
     assert kept_none == []
-
-
-async def test_score_threshold_not_inverted_under_euclidean_no_reranker():
-    """Regression: with no reranker the threshold filter must respect
-    similarity_metric.higher_is_better. Under euclidean, scores are distances
-    (lower = better). The filter must DROP scores ABOVE the threshold, not
-    BELOW it.
-
-    Without this fix, `score < threshold` keeps far matches and drops close
-    ones — leaking unrelated content past a "max-distance" gate.
-    """
-    # FakeEmbedder maps text -> [len, -len], so a shorter embedded anchor lands
-    # closer to the short query "abc". "near" (content "abc") is therefore a
-    # closer euclidean match than "far" (content "abcdefghij"). The exact
-    # distances depend on the embedding format (producer prefix, JSON quoting,
-    # date stamp), so we read the actual scores and pick a threshold strictly
-    # between them rather than hard-coding the arithmetic.
-    episodes = [
-        _episode("near", "abc"),
-        _episode("far", "abcdefghij"),
-    ]
-    ltm = _make_ltm_with_metric(SimilarityMetric.EUCLIDEAN, episodes)
-    await ltm.add_episodes(episodes)
-
-    scores_by_uid = {
-        ep.uid: score
-        for score, ep in await ltm.search_scored("abc", num_episodes_limit=10)
-    }
-    assert scores_by_uid["near"] < scores_by_uid["far"], (
-        "FakeEmbedder should make the shorter 'near' anchor a closer "
-        "euclidean match than 'far'."
-    )
-    midpoint_threshold = (scores_by_uid["near"] + scores_by_uid["far"]) / 2
-
-    kept = await ltm.search_scored(
-        "abc", num_episodes_limit=10, score_threshold=midpoint_threshold
-    )
-    uids = {ep.uid for _, ep in kept}
-    assert "near" in uids, (
-        "Close match was dropped — threshold filter is inverted for euclidean."
-    )
-    assert "far" not in uids, (
-        "Far match was kept — threshold filter is inverted for euclidean."
-    )
-
-
-async def test_score_threshold_none_keeps_all_results_under_euclidean():
-    """Regression for the prior `-inf` sentinel: under euclidean (lower=better)
-    the default "no threshold" must NOT drop everything. Default is now
-    `score_threshold=None` which short-circuits the filter."""
-    episodes = [_episode("only", "abc")]
-    ltm = _make_ltm_with_metric(SimilarityMetric.EUCLIDEAN, episodes)
-    await ltm.add_episodes(episodes)
-
-    scored = await ltm.search_scored("abc", num_episodes_limit=10)
-    assert [ep.uid for _, ep in scored] == ["only"]
 
 
 def _timeline_episode(uid: str, content: str, minute: int) -> Episode:

--- a/packages/server/server_tests/memmachine_server/semantic_memory/mock_semantic_memory_objects.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/mock_semantic_memory_objects.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock
 import numpy as np
 from pydantic import InstanceOf
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.episode_store import EpisodeIdT
 from memmachine_server.common.filter.filter_parser import FilterExpr
@@ -216,10 +215,6 @@ class MockEmbedder(Embedder):
     @property
     def dimensions(self) -> int:
         return 2
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        return SimilarityMetric.COSINE
 
 
 class MockResourceRetriever:

--- a/packages/server/server_tests/memmachine_server/semantic_memory/semantic_test_utils.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/semantic_test_utils.py
@@ -1,6 +1,5 @@
 import random
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.episode_store import EpisodeEntry, EpisodeStorage
 
@@ -37,10 +36,6 @@ class SpyEmbedder(Embedder):
     def dimensions(self) -> int:
         return 2
 
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        return SimilarityMetric.COSINE
-
     @staticmethod
     def _vector(text: str) -> list[float]:
         lowered = text.lower()
@@ -76,10 +71,6 @@ class LengthEmbedder(Embedder):
     @property
     def dimensions(self) -> int:
         return self.n
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        return SimilarityMetric.COSINE
 
 
 async def add_history(history_storage: EpisodeStorage, content: str):

--- a/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_vector_store_semantic_storage.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_vector_store_semantic_storage.py
@@ -5,7 +5,6 @@ from datetime import UTC, datetime, timedelta, timezone
 import numpy as np
 import pytest
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.filter.filter_parser import parse_filter
 from memmachine_server.common.vector_store import VectorStoreCollectionConfig
 from memmachine_server.semantic_memory.storage.storage_base import SemanticStorage
@@ -23,7 +22,6 @@ def vector_collection() -> InMemoryVectorStoreCollection:
     return InMemoryVectorStoreCollection(
         VectorStoreCollectionConfig(
             vector_dimensions=2,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "set_id": str,
                 "category": str,

--- a/packages/server/src/memmachine_server/common/configuration/__init__.py
+++ b/packages/server/src/memmachine_server/common/configuration/__init__.py
@@ -27,7 +27,6 @@ from memmachine_server.common.configuration.mixin_confs import (
 )
 from memmachine_server.common.configuration.reranker_conf import RerankersConf
 from memmachine_server.common.configuration.retrieval_config import RetrievalAgentConf
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.errors import (
     DefaultEmbedderNotConfiguredError,
     DefaultLLMModelNotConfiguredError,
@@ -136,10 +135,6 @@ class SemanticMemoryConf(YamlSerializableMixin):
             "vector_store storage, the configured embedder dimensions are used."
         ),
         gt=0,
-    )
-    vector_similarity_metric: SimilarityMetric = Field(
-        default=SimilarityMetric.COSINE,
-        description="Similarity metric for vector_store semantic memory search.",
     )
     config_database: str = Field(
         ...,

--- a/packages/server/src/memmachine_server/common/configuration/embedder_conf.py
+++ b/packages/server/src/memmachine_server/common/configuration/embedder_conf.py
@@ -12,7 +12,6 @@ from memmachine_server.common.configuration.mixin_confs import (
     MetricsFactoryIdMixin,
     YamlSerializableMixin,
 )
-from memmachine_server.common.data_types import SimilarityMetric
 
 
 def _clean_empty_embedder_config(conf: dict) -> dict:
@@ -44,10 +43,6 @@ class AmazonBedrockEmbedderConf(YamlSerializableMixin, AWSCredentialsMixin):
         default=None,
         description="Maximum input length for the model (in Unicode code points).",
         gt=0,
-    )
-    similarity_metric: SimilarityMetric = Field(
-        default=SimilarityMetric.COSINE,
-        description="Similarity metric to use",
     )
     max_retry_interval_seconds: int = Field(
         default=120,

--- a/packages/server/src/memmachine_server/common/configuration/mixin_confs.py
+++ b/packages/server/src/memmachine_server/common/configuration/mixin_confs.py
@@ -206,7 +206,7 @@ class YamlSerializableMixin(BaseModel):
             if isinstance(obj, SecretStr):
                 obj = obj.get_secret_value()
 
-            # Unwrap enums like SimilarityMetric
+            # Unwrap enums to their values
             if isinstance(obj, Enum):
                 obj = obj.value
 

--- a/packages/server/src/memmachine_server/common/data_types.py
+++ b/packages/server/src/memmachine_server/common/data_types.py
@@ -1,7 +1,6 @@
 """Common data types for MemMachine."""
 
 from datetime import datetime
-from enum import Enum
 from typing import Final
 
 PropertyValue = bool | int | float | str | datetime
@@ -24,20 +23,6 @@ FilterValue = bool | int | float | str | datetime | list[int] | list[str]
 
 OrderedValue = int | float | datetime
 """Type for values that can be ordered/sorted."""
-
-
-class SimilarityMetric(Enum):
-    """Similarity metrics supported by embedding operations."""
-
-    COSINE = "cosine"
-    DOT = "dot"
-    EUCLIDEAN = "euclidean"
-    MANHATTAN = "manhattan"
-
-    @property
-    def higher_is_better(self) -> bool:
-        """Whether a higher score indicates a better match."""
-        return self in (SimilarityMetric.COSINE, SimilarityMetric.DOT)
 
 
 class ExternalServiceAPIError(Exception):

--- a/packages/server/src/memmachine_server/common/embedder/amazon_bedrock_embedder.py
+++ b/packages/server/src/memmachine_server/common/embedder/amazon_bedrock_embedder.py
@@ -14,7 +14,6 @@ from pydantic import BaseModel, Field, InstanceOf
 
 from memmachine_server.common.data_types import (
     ExternalServiceAPIError,
-    SimilarityMetric,
 )
 from memmachine_server.common.utils import chunk_text, unflatten_like
 
@@ -42,10 +41,6 @@ class AmazonBedrockEmbedderParams(BaseModel):
         description="Maximum input length for the model (in Unicode code points).",
         gt=0,
     )
-    similarity_metric: SimilarityMetric = Field(
-        default=SimilarityMetric.COSINE,
-        description="Similarity metric to use for comparing embeddings.",
-    )
     max_retry_interval_seconds: int = Field(
         default=120,
         description="Maximal retry interval in seconds (defualt: 120).",
@@ -68,7 +63,6 @@ class AmazonBedrockEmbedder(Embedder):
 
         self._model_id = params.model_id
         self._max_input_length = params.max_input_length
-        self._similarity_metric = params.similarity_metric
         self._max_retry_interval_seconds = params.max_retry_interval_seconds
 
         # Get dimensions by embedding a dummy string.
@@ -233,8 +227,3 @@ class AmazonBedrockEmbedder(Embedder):
     def dimensions(self) -> int:
         """Return the embedding dimensionality."""
         return self._dimensions
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        """Return the similarity metric used by the embedder."""
-        return self._similarity_metric

--- a/packages/server/src/memmachine_server/common/embedder/embedder.py
+++ b/packages/server/src/memmachine_server/common/embedder/embedder.py
@@ -4,8 +4,6 @@ import asyncio
 from abc import ABC, abstractmethod
 from typing import Any
 
-from memmachine_server.common.data_types import SimilarityMetric
-
 
 class Embedder(ABC):
     """Abstract base class for an embedder."""
@@ -84,10 +82,4 @@ class Embedder(ABC):
     @abstractmethod
     def dimensions(self) -> int:
         """Return the embedding dimensionality."""
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def similarity_metric(self) -> SimilarityMetric:
-        """Return the similarity metric used by this embedder."""
         raise NotImplementedError

--- a/packages/server/src/memmachine_server/common/embedder/openai_embedder.py
+++ b/packages/server/src/memmachine_server/common/embedder/openai_embedder.py
@@ -11,7 +11,6 @@ from pydantic import BaseModel, Field, InstanceOf
 
 from memmachine_server.common.data_types import (
     ExternalServiceAPIError,
-    SimilarityMetric,
 )
 from memmachine_server.common.metrics_factory import MetricsFactory, OperationTracker
 from memmachine_server.common.utils import (
@@ -332,9 +331,3 @@ class OpenAIEmbedder(Embedder):
     def dimensions(self) -> int:
         """Return the embedding dimensionality."""
         return self._dimensions
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        """Return the similarity metric used by this embedder."""
-        # https://platform.openai.com/docs/guides/embeddings
-        return SimilarityMetric.COSINE

--- a/packages/server/src/memmachine_server/common/embedder/sentence_transformer_embedder.py
+++ b/packages/server/src/memmachine_server/common/embedder/sentence_transformer_embedder.py
@@ -12,7 +12,6 @@ from sentence_transformers import SentenceTransformer
 
 from memmachine_server.common.data_types import (
     ExternalServiceAPIError,
-    SimilarityMetric,
 )
 from memmachine_server.common.utils import chunk_text, unflatten_like
 
@@ -56,21 +55,13 @@ class SentenceTransformerEmbedder(Embedder):
         self._dimensions = self._sentence_transformer.get_embedding_dimension() or len(
             self._sentence_transformer.encode("")
         )
-        match self._sentence_transformer.similarity_fn_name:
-            case "cosine":
-                self._similarity_metric = SimilarityMetric.COSINE
-            case "dot":
-                self._similarity_metric = SimilarityMetric.DOT
-            case "euclidean":
-                self._similarity_metric = SimilarityMetric.EUCLIDEAN
-            case "manhattan":
-                self._similarity_metric = SimilarityMetric.MANHATTAN
-            case _:
-                logger.warning(
-                    "Unknown similarity function name '%s', defaulting to cosine",
-                    self._sentence_transformer.similarity_fn_name,
-                )
-                self._similarity_metric = SimilarityMetric.COSINE
+        if self._sentence_transformer.similarity_fn_name != "cosine":
+            logger.warning(
+                "Sentence transformer '%s' declares similarity function '%s', "
+                "but embeddings are always compared by cosine similarity",
+                self._model_name,
+                self._sentence_transformer.similarity_fn_name,
+            )
 
         self._max_input_length = params.max_input_length
 
@@ -183,8 +174,3 @@ class SentenceTransformerEmbedder(Embedder):
     def dimensions(self) -> int:
         """Return the embedding dimensionality."""
         return self._dimensions
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        """Return the similarity metric used."""
-        return self._similarity_metric

--- a/packages/server/src/memmachine_server/common/reranker/embedder_reranker.py
+++ b/packages/server/src/memmachine_server/common/reranker/embedder_reranker.py
@@ -1,10 +1,9 @@
 """Embedder-based reranker implementation."""
 
-import numpy as np
 from pydantic import BaseModel, Field, InstanceOf
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder import Embedder
+from memmachine_server.common.utils import compute_cosine_similarity
 
 from .reranker import Reranker
 
@@ -32,42 +31,7 @@ class EmbedderReranker(Reranker):
         if len(candidates) == 0:
             return []
 
-        query_embedding = np.array(await self._embedder.search_embed([query])).flatten()
-        candidate_embeddings = np.array(await self._embedder.ingest_embed(candidates))
+        query_embedding = (await self._embedder.search_embed([query]))[0]
+        candidate_embeddings = await self._embedder.ingest_embed(candidates)
 
-        match self._embedder.similarity_metric:
-            case SimilarityMetric.COSINE:
-                magnitude_products = np.linalg.norm(
-                    candidate_embeddings,
-                    axis=-1,
-                ) * np.linalg.norm(query_embedding)
-                magnitude_products[magnitude_products == 0] = float("inf")
-
-                scores = (
-                    np.dot(candidate_embeddings, query_embedding) / magnitude_products
-                )
-            case SimilarityMetric.DOT:
-                scores = np.dot(candidate_embeddings, query_embedding)
-            case SimilarityMetric.EUCLIDEAN:
-                scores = -np.linalg.norm(
-                    candidate_embeddings - query_embedding,
-                    axis=-1,
-                )
-            case SimilarityMetric.MANHATTAN:
-                scores = -np.sum(
-                    np.abs(candidate_embeddings - query_embedding),
-                    axis=-1,
-                )
-            case _:
-                # Default to cosine similarity.
-                magnitude_products = np.linalg.norm(
-                    candidate_embeddings,
-                    axis=-1,
-                ) * np.linalg.norm(query_embedding)
-                magnitude_products[magnitude_products == 0] = float("inf")
-
-                scores = (
-                    np.dot(candidate_embeddings, query_embedding) / magnitude_products
-                )
-
-        return scores.astype(float).tolist()
+        return compute_cosine_similarity(query_embedding, candidate_embeddings)

--- a/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
@@ -19,7 +19,6 @@ from memmachine_server.common.configuration.database_conf import (
     SQLiteVectorStoreConf,
     SQLiteVectorStoreEngine,
 )
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.errors import (
     MilvusConfigurationError,
     Neo4JConfigurationError,
@@ -752,8 +751,8 @@ class DatabaseManager:
     @staticmethod
     def _make_sqlite_search_engine_factory(
         conf: SQLiteVectorStoreConf,
-    ) -> Callable[[int, SimilarityMetric], VectorSearchEngine]:
-        """Build a (ndim, metric) -> VectorSearchEngine factory from config.
+    ) -> Callable[[int], VectorSearchEngine]:
+        """Build a ndim -> VectorSearchEngine factory from config.
 
         Imports are deferred so the engine packages remain optional unless
         their backend is actually used.
@@ -764,13 +763,8 @@ class DatabaseManager:
                     USearchVectorSearchEngine,
                 )
 
-                def usearch_factory(
-                    num_dimensions: int, similarity_metric: SimilarityMetric
-                ) -> VectorSearchEngine:
-                    return USearchVectorSearchEngine(
-                        num_dimensions=num_dimensions,
-                        similarity_metric=similarity_metric,
-                    )
+                def usearch_factory(num_dimensions: int) -> VectorSearchEngine:
+                    return USearchVectorSearchEngine(num_dimensions=num_dimensions)
 
                 return usearch_factory
             case SQLiteVectorStoreEngine.HNSWLIB:
@@ -778,13 +772,8 @@ class DatabaseManager:
                     HnswlibVectorSearchEngine,
                 )
 
-                def hnswlib_factory(
-                    num_dimensions: int, similarity_metric: SimilarityMetric
-                ) -> VectorSearchEngine:
-                    return HnswlibVectorSearchEngine(
-                        num_dimensions=num_dimensions,
-                        similarity_metric=similarity_metric,
-                    )
+                def hnswlib_factory(num_dimensions: int) -> VectorSearchEngine:
+                    return HnswlibVectorSearchEngine(num_dimensions=num_dimensions)
 
                 return hnswlib_factory
 

--- a/packages/server/src/memmachine_server/common/resource_manager/embedder_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/embedder_manager.py
@@ -184,7 +184,6 @@ class EmbedderManager(BaseResourceManager[Embedder]):
         params = AmazonBedrockEmbedderParams(
             client=client,
             model_id=conf.model_id,
-            similarity_metric=conf.similarity_metric,
             max_input_length=conf.max_input_length,
             max_retry_interval_seconds=conf.max_retry_interval_seconds,
             batch_size=conf.batch_size,

--- a/packages/server/src/memmachine_server/common/resource_manager/semantic_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/semantic_manager.py
@@ -152,7 +152,6 @@ class SemanticResourceManager:
             name=_VECTOR_STORE_COLLECTION_NAME,
             config=VectorStoreCollectionConfig(
                 vector_dimensions=vector_dimensions,
-                similarity_metric=self._conf.vector_similarity_metric,
                 indexed_properties_schema={
                     "feature_id": str,
                     "set_id": str,

--- a/packages/server/src/memmachine_server/common/utils.py
+++ b/packages/server/src/memmachine_server/common/utils.py
@@ -12,8 +12,6 @@ from typing import Any, ParamSpec, TypeVar, cast
 import numpy as np
 from nltk import sent_tokenize
 
-from .data_types import SimilarityMetric
-
 T = TypeVar("T")
 P = ParamSpec("P")
 
@@ -274,21 +272,19 @@ def cluster_texts(
     return clusters
 
 
-def compute_similarity(
+def compute_cosine_similarity(
     query_embedding: list[float],
     candidate_embeddings: list[list[float]],
-    similarity_metric: SimilarityMetric | None = None,
 ) -> list[float]:
     """
-    Compute similarity scores between a query embedding and candidate embeddings.
+    Compute cosine similarities between a query embedding and candidate embeddings.
 
     Args:
         query_embedding (list[float]): The embedding of the query.
         candidate_embeddings (list[list[float]]): A list of candidate embeddings to compare against.
-        similarity_metric (SimilarityMetric | None): The similarity metric to use (default: None).
 
     Returns:
-        list[float]: A list of similarity scores for each candidate embedding.
+        list[float]: A cosine similarity in [-1, 1] for each candidate embedding.
 
     """
     if not candidate_embeddings:
@@ -297,70 +293,14 @@ def compute_similarity(
     query_embedding_np = np.array(query_embedding)
     candidate_embeddings_np = np.array(candidate_embeddings)
 
-    match similarity_metric:
-        case SimilarityMetric.COSINE:
-            magnitude_products = np.linalg.norm(
-                candidate_embeddings_np,
-                axis=-1,
-            ) * np.linalg.norm(query_embedding_np)
-            magnitude_products[magnitude_products == 0] = float("inf")
+    magnitude_products = np.linalg.norm(
+        candidate_embeddings_np,
+        axis=-1,
+    ) * np.linalg.norm(query_embedding_np)
+    magnitude_products[magnitude_products == 0] = float("inf")
 
-            scores = (
-                np.dot(candidate_embeddings_np, query_embedding_np) / magnitude_products
-            )
-        case SimilarityMetric.DOT:
-            scores = np.dot(candidate_embeddings_np, query_embedding_np)
-        case SimilarityMetric.EUCLIDEAN:
-            scores = np.linalg.norm(
-                candidate_embeddings_np - query_embedding_np,
-                axis=-1,
-            )
-        case SimilarityMetric.MANHATTAN:
-            scores = np.sum(
-                np.abs(candidate_embeddings_np - query_embedding_np),
-                axis=-1,
-            )
-        case _:
-            # Default to cosine similarity.
-            magnitude_products = np.linalg.norm(
-                candidate_embeddings_np,
-                axis=-1,
-            ) * np.linalg.norm(query_embedding_np)
-            magnitude_products[magnitude_products == 0] = float("inf")
+    cosine_similarities = (
+        np.dot(candidate_embeddings_np, query_embedding_np) / magnitude_products
+    )
 
-            scores = (
-                np.dot(candidate_embeddings_np, query_embedding_np) / magnitude_products
-            )
-
-    return scores.astype(float).tolist()
-
-
-def similarity_gt(
-    similarity_metric: SimilarityMetric | None = None,
-) -> Callable[[float, float], bool]:
-    """
-    Return a comparator for similarity scores.
-
-    The returned function `gt(a, b)` returns True when score `a`
-    represents greater similarity than score `b` under the given metric.
-
-    For COSINE and DOT, higher scores mean greater similarity (`a > b`).
-    For EUCLIDEAN and MANHATTAN, lower scores mean greater similarity (`a < b`).
-
-    Args:
-        similarity_metric (SimilarityMetric | None):
-            The similarity metric.
-            If None, defaults to greater-than comparison (`a > b`)
-            (default: None).
-
-    Returns:
-        Callable[[float, float], bool]: A comparator for similarity scores.
-
-    """
-    import operator
-
-    match similarity_metric:
-        case SimilarityMetric.EUCLIDEAN | SimilarityMetric.MANHATTAN:
-            return operator.lt
-        case _:
-            return operator.gt
+    return cosine_similarities.astype(float).tolist()

--- a/packages/server/src/memmachine_server/common/vector_graph_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/data_types.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 
-from memmachine_server.common.data_types import SimilarityMetric
-
 # Types that can be used as property values in nodes and edges.
 PropertyValue = (
     bool
@@ -35,9 +33,7 @@ class Node:
 
     uid: str
     properties: dict[str, PropertyValue] = field(default_factory=dict)
-    embeddings: dict[str, tuple[list[float], SimilarityMetric]] = field(
-        default_factory=dict,
-    )
+    embeddings: dict[str, list[float]] = field(default_factory=dict)
 
     def __eq__(self, other: object) -> bool:
         """Compare nodes by UID, properties, and embeddings."""
@@ -62,9 +58,7 @@ class Edge:
     source_uid: str
     target_uid: str
     properties: dict[str, PropertyValue] = field(default_factory=dict)
-    embeddings: dict[str, tuple[list[float], SimilarityMetric]] = field(
-        default_factory=dict,
-    )
+    embeddings: dict[str, list[float]] = field(default_factory=dict)
 
     def __eq__(self, other: object) -> bool:
         """Compare edges by uid, properties, and embeddings."""

--- a/packages/server/src/memmachine_server/common/vector_graph_store/nebula_graph_vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/nebula_graph_vector_graph_store.py
@@ -11,18 +11,17 @@ interface using NebulaGraph Enterprise as the backend. It supports:
 """
 
 import asyncio
-import hashlib
 import logging
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from nebulagraph_python.py_data_types import NVector
 
-from memmachine_server.common.data_types import OrderedValue, SimilarityMetric
+from memmachine_server.common.data_types import OrderedValue
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -115,9 +114,15 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
     with GQL (ISO Graph Query Language) instead of Cypher. Key differences:
     - Schema + Graph model
     - Native VECTOR<N, FLOAT> data type
-    - Vector indexes with IVF/HNSW algorithms
     - SESSION SET SCHEMA and SESSION SET GRAPH for context
+
+    Similarity search is always exact (KNN): NebulaGraph's `cosine()` does not
+    support APPROXIMATE, and its vector indexes only offer L2 and IP metrics,
+    neither of which serves cosine similarity.
     """
+
+    # GQL distance function and ORDER BY direction for cosine similarity.
+    _DISTANCE_FUNC_AND_ORDER: ClassVar[tuple[str, str]] = ("cosine", "DESC")
 
     class CacheIndexState(Enum):
         """Index state tracking for local cache."""
@@ -205,14 +210,14 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
 
         # Collect all properties and embeddings from all nodes to build schema
         all_properties: dict[str, PropertyValue] = {}
-        all_embeddings: dict[str, tuple[list[float], SimilarityMetric]] = {}
+        all_embeddings: dict[str, list[float]] = {}
 
         for node in nodes_list:
             all_properties.update(node.properties)
             # Track embeddings with their dimensions and metrics
-            for emb_name, (emb_vec, metric) in node.embeddings.items():
+            for emb_name, emb_vec in node.embeddings.items():
                 if emb_name not in all_embeddings:
-                    all_embeddings[emb_name] = (emb_vec, metric)
+                    all_embeddings[emb_name] = emb_vec
 
         # Ensure graph type exists with required schema
         await self._ensure_graph_type_for_nodes(
@@ -240,18 +245,11 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 formatted_value = self._format_value(prop_value)
                 prop_assignments.append(f"{sanitized}: {formatted_value}")
 
-            # Add embeddings with companion metric property
-            for emb_name, (emb_vec, metric) in node.embeddings.items():
+            for emb_name, emb_vec in node.embeddings.items():
                 mangled = mangle_embedding_name(emb_name)
                 sanitized = self._sanitize_name(mangled)
                 vec_literal = self._vector_to_gql_literal(emb_vec)
                 prop_assignments.append(f"{sanitized}: {vec_literal}")
-                # Store metric as companion STRING property (mirrors Neo4j pattern)
-                metric_prop = self._similarity_metric_property_name(emb_name)
-                mangled_metric = mangle_property_name(metric_prop)
-                sanitized_metric = self._sanitize_name(mangled_metric)
-                metric_value = self._format_value(metric.value)
-                prop_assignments.append(f"{sanitized_metric}: {metric_value}")
 
             insert_stmt = f"""
             INSERT (n@{sanitized_collection} {{
@@ -264,26 +262,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         current_count = self._collection_node_counts.get(collection, 0)
         new_count = current_count + len(nodes_list)
         self._collection_node_counts[collection] = new_count
-
-        # Check if we should create indexes
-        if (
-            self._vector_index_threshold
-            and new_count >= self._vector_index_threshold
-            and current_count < self._vector_index_threshold
-        ):
-            # Create vector indexes
-            for emb_name, (emb_vec, metric) in all_embeddings.items():
-                task = asyncio.create_task(
-                    self._create_vector_index_if_not_exists(
-                        EntityType.NODE,
-                        collection,
-                        emb_name,
-                        len(emb_vec),
-                        metric,
-                    )
-                )
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
 
         # Create range indexes based on configured hierarchies
         # Note: We don't create a range index on 'uid' because it's declared as PRIMARY KEY
@@ -330,7 +308,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
 
         # Collect all properties and embeddings from all edges
         all_properties: dict[str, PropertyValue] = {}
-        all_embeddings: dict[str, tuple[list[float], SimilarityMetric]] = {}
+        all_embeddings: dict[str, list[float]] = {}
 
         for edge in edges_list:
             all_properties.update(edge.properties)
@@ -363,18 +341,11 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 formatted_value = self._format_value(prop_value)
                 prop_assignments.append(f"{sanitized}: {formatted_value}")
 
-            # Build embedding assignments with companion metric property
-            for emb_name, (emb_vec, metric) in edge.embeddings.items():
+            for emb_name, emb_vec in edge.embeddings.items():
                 mangled = mangle_embedding_name(emb_name)
                 sanitized = self._sanitize_name(mangled)
                 vec_literal = self._vector_to_gql_literal(emb_vec)
                 prop_assignments.append(f"{sanitized}: {vec_literal}")
-                # Store metric as companion STRING property (mirrors Neo4j pattern)
-                metric_prop = self._similarity_metric_property_name(emb_name)
-                mangled_metric = mangle_property_name(metric_prop)
-                sanitized_metric = self._sanitize_name(mangled_metric)
-                metric_value = self._format_value(metric.value)
-                prop_assignments.append(f"{sanitized_metric}: {metric_value}")
 
             # Build INSERT statement with embedded values
             if prop_assignments:
@@ -397,26 +368,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         new_count = current_count + len(edges_list)
         self._relation_edge_counts[relation] = new_count
 
-        # Check if we should create indexes
-        if (
-            self._vector_index_threshold
-            and new_count >= self._vector_index_threshold
-            and current_count < self._vector_index_threshold
-        ):
-            # Create vector indexes for edge embeddings
-            for emb_name, (emb_vec, metric) in all_embeddings.items():
-                task = asyncio.create_task(
-                    self._create_vector_index_if_not_exists(
-                        EntityType.EDGE,
-                        relation,
-                        emb_name,
-                        len(emb_vec),
-                        metric,
-                    )
-                )
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
-
         # Create range indexes based on configured hierarchies when threshold is reached
         if (
             self._range_index_threshold
@@ -438,7 +389,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         collection: str,
         embedding_name: str,
         query_embedding: list[float],
-        similarity_metric: SimilarityMetric = SimilarityMetric.COSINE,
         limit: int | None = 100,
         property_filter: FilterExpr | None = None,
     ) -> list[Node]:
@@ -455,7 +405,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
             collection: Collection name to search
             embedding_name: Name of the embedding vector property
             query_embedding: Query vector
-            similarity_metric: COSINE or EUCLIDEAN
             limit: Maximum results to return
             property_filter: Optional property filter expression
 
@@ -465,121 +414,13 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         """
         await self._discover_existing_indexes()
 
-        sanitized_collection = self._sanitize_name(collection)
-        mangled_embedding = mangle_embedding_name(embedding_name)
-        sanitized_embedding = self._sanitize_name(mangled_embedding)
-
-        # Check if vector index exists
-        # Use mangled and sanitized embedding name to ensure valid identifier
-        index_name = f"idx_{sanitized_collection}_{sanitized_embedding}"
-        has_index = (
-            index_name in self._index_state_cache
-            and self._index_state_cache[index_name] == self.CacheIndexState.ONLINE
-        )
-
-        # Decide on search mode.
-        # ANN requires both a vector index AND a function that supports APPROXIMATE.
-        # cosine() is KNN-only in NebulaGraph, so COSINE must always use exact search.
-        metric_supports_ann = (
-            self._similarity_metric_to_nebula(similarity_metric) is not None
-        )
-        use_ann = (
-            has_index
-            and not self._force_exact_similarity_search
-            and metric_supports_ann
-        )
-
-        # Build WHERE clause from property filter
-        where_clause = ""
-        if property_filter:
-            where_clause = self._render_filter_expr("n", property_filter)
-
-        # Build query based on search mode
-        if use_ann:
-            # ANN search requires a finite limit (default to 1000 like Neo4j)
-            effective_limit = limit if limit is not None else 1000
-
-            # Use fudge factor when filtering to get more candidates
-            if property_filter:
-                search_limit = int(effective_limit * self._fudge_factor)
-            else:
-                search_limit = effective_limit
-
-            # Choose similarity function, order, and index metric
-            distance_func, order_dir = self._get_distance_func_and_order(
-                similarity_metric
-            )
-            metric_name = self._similarity_metric_to_nebula(similarity_metric)
-
-            # Build vector literal
-            vec_literal = self._vector_to_gql_literal(query_embedding)
-
-            # Build OPTIONS clause
-            if self._ann_index_type == "IVF":
-                options = (
-                    f"{{METRIC: {metric_name}, TYPE: IVF, NPROBE: {self._ivf_nprobe}}}"
-                )
-            else:  # HNSW
-                options = f"{{METRIC: {metric_name}, TYPE: HNSW, EFSEARCH: {self._hnsw_ef_search}}}"
-
-            # Build query
-            query_parts = [f"MATCH (n:{sanitized_collection})"]
-            if where_clause:
-                query_parts.append(f"WHERE {where_clause}")
-            query_parts.append(
-                f"ORDER BY {distance_func}(n.{sanitized_embedding}, {vec_literal}) {order_dir}"
-            )
-            query_parts.append("APPROXIMATE")
-            query_parts.append(f"LIMIT {search_limit}")
-            query_parts.append(f"OPTIONS {options}")
-            query_parts.append("RETURN n")
-
-            query = "\n".join(query_parts)
-
-            result = await self._client.execute(query)
-
-            # Convert results
-            nodes = []
-            for row in result:
-                node_data = row["n"]
-                # Unwrap ValueWrapper if needed
-                if hasattr(node_data, "cast_primitive"):
-                    node_data = node_data.cast_primitive()
-                    if "properties" in node_data:
-                        node_data = node_data["properties"]
-                nodes.append(self._nebula_result_to_node(collection, node_data))
-
-            # Check fallback threshold
-            if (
-                property_filter
-                and len(nodes) < (limit or 100) * self._fallback_threshold
-            ):
-                # Fall back to exact search
-                logger.info(
-                    "ANN search returned insufficient results (%s), falling back to exact search",
-                    len(nodes),
-                )
-                return await self._exact_similarity_search(
-                    collection=collection,
-                    embedding_name=embedding_name,
-                    query_embedding=query_embedding,
-                    similarity_metric=similarity_metric,
-                    limit=limit,
-                    property_filter=property_filter,
-                )
-
-            # Trim to requested limit
-            if limit and len(nodes) > limit:
-                nodes = nodes[:limit]
-
-            return nodes
-
-        # Exact search (no index or forced)
+        # NebulaGraph's cosine() is KNN-only -- APPROXIMATE is not supported for
+        # it, and no vector index metric serves it -- so with cosine the only
+        # similarity, search is always exact.
         return await self._exact_similarity_search(
             collection=collection,
             embedding_name=embedding_name,
             query_embedding=query_embedding,
-            similarity_metric=similarity_metric,
             limit=limit,
             property_filter=property_filter,
         )
@@ -590,7 +431,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         collection: str,
         embedding_name: str,
         query_embedding: list[float],
-        similarity_metric: SimilarityMetric,
         limit: int | None,
         property_filter: FilterExpr | None,
     ) -> list[Node]:
@@ -604,7 +444,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
             collection: Collection name
             embedding_name: Embedding property name
             query_embedding: Query vector
-            similarity_metric: COSINE or EUCLIDEAN
             limit: Maximum results
             property_filter: Optional filter
 
@@ -625,7 +464,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         vec_literal = self._vector_to_gql_literal(query_embedding)
 
         # Choose similarity function and order direction
-        distance_func, order_dir = self._get_distance_func_and_order(similarity_metric)
+        distance_func, order_dir = self._DISTANCE_FUNC_AND_ORDER
 
         # Build query (no APPROXIMATE keyword = exact search)
         query_parts = [f"MATCH (n:{sanitized_collection})"]
@@ -1097,21 +936,10 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
             for k, v in node_data.items()
         }
 
-        # Build set of metric companion mangled keys to exclude from regular properties
-        embedding_keys = {k for k in desanitized_data if is_mangled_embedding_name(k)}
-        metric_companion_keys = {
-            mangle_property_name(
-                self._similarity_metric_property_name(demangle_embedding_name(emb_key))
-            )
-            for emb_key in embedding_keys
-        }
-
         for key, value in desanitized_data.items():
             if key == "uid":
                 continue
             if is_mangled_property_name(key):
-                if key in metric_companion_keys:
-                    continue  # Skip metric companions - read alongside embeddings below
                 # Skip NULL values - they represent absent properties from schema evolution
                 # PropertyValue type does not include None, so we filter them out
                 if value is None:
@@ -1120,23 +948,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 properties[prop_name] = value
             elif is_mangled_embedding_name(key):
                 emb_name = demangle_embedding_name(key)
-
-                # Read metric from companion STRING property
-                metric_prop = self._similarity_metric_property_name(emb_name)
-                mangled_metric = mangle_property_name(metric_prop)
-                metric_str = desanitized_data.get(mangled_metric)
-                if metric_str is not None:
-                    try:
-                        sim_metric = SimilarityMetric(metric_str)
-                    except ValueError:
-                        logger.warning(
-                            "Unknown similarity metric '%s' for embedding '%s', defaulting to COSINE",
-                            metric_str,
-                            emb_name,
-                        )
-                        sim_metric = SimilarityMetric.COSINE
-                else:
-                    sim_metric = SimilarityMetric.COSINE  # fallback for legacy data
 
                 # Extract vector value
                 vec = None
@@ -1150,7 +961,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                     logger.warning("Unexpected embedding value type: %s", type(value))
 
                 if vec is not None:
-                    embeddings[emb_name] = (vec, sim_metric)
+                    embeddings[emb_name] = vec
 
         return Node(
             uid=uid,
@@ -1422,86 +1233,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         vec_str = ", ".join(str(v) for v in vec)
         return f"VECTOR<{len(vec)}, FLOAT>([{vec_str}])"
 
-    @staticmethod
-    def _similarity_metric_property_name(embedding_name: str) -> str:
-        """
-        Return the companion property name for storing an embedding's similarity metric.
-
-        Args:
-            embedding_name: Demangled embedding name
-
-        Returns:
-            Property name for the metric companion (e.g., "similarity_metric_for_vec")
-
-        """
-        # Use hash for long embedding names to avoid exceeding NebulaGraph's
-        # 127 character identifier limit after mangling and sanitization
-        if len(embedding_name) > 30:
-            name_hash = hashlib.sha256(embedding_name.encode()).hexdigest()[:16]
-            return f"sim_metric_{name_hash}"
-        return f"similarity_metric_for_{embedding_name}"
-
-    @staticmethod
-    def _similarity_metric_to_nebula(metric: SimilarityMetric) -> str | None:
-        """
-        Convert SimilarityMetric to NebulaGraph vector index METRIC option.
-
-        NebulaGraph vector indexes support only L2 (Euclidean distance) and
-        IP (Inner Product). MANHATTAN has no equivalent index type and returns
-        None, signalling that no vector index can be created for that metric.
-
-        Args:
-            metric: Similarity metric
-
-        Returns:
-            NebulaGraph METRIC string ("L2" or "IP"), or None if not indexable.
-
-        """
-        if metric == SimilarityMetric.EUCLIDEAN:
-            return "L2"
-        if metric == SimilarityMetric.DOT:
-            # Dot product == inner product; IP indexes support ANN for this metric.
-            return "IP"
-        # COSINE: cosine() is KNN-only in NebulaGraph — APPROXIMATE is not supported,
-        # so no vector index can be created for cosine similarity.
-        # MANHATTAN: no NebulaGraph vector index type exists.
-        # Both return None to signal that no vector index should be created.
-        return None
-
-    @staticmethod
-    def _get_distance_func_and_order(metric: SimilarityMetric) -> tuple[str, str]:
-        """
-        Return the GQL distance function name and ORDER BY direction for a metric.
-
-        NebulaGraph supports three distance functions:
-        - euclidean(): KNN and ANN (with L2 index)
-        - inner_product(): KNN and ANN (with IP index)
-        - cosine(): KNN only — APPROXIMATE is not supported for this function
-
-        MANHATTAN has no native NebulaGraph distance function and raises ValueError.
-
-        Args:
-            metric: Similarity metric
-
-        Returns:
-            (distance_function_name, order_direction) e.g. ("euclidean", "ASC")
-
-        Raises:
-            ValueError: If the metric has no native NebulaGraph distance function.
-
-        """
-        if metric == SimilarityMetric.EUCLIDEAN:
-            return "euclidean", "ASC"
-        if metric == SimilarityMetric.DOT:
-            return "inner_product", "DESC"
-        if metric == SimilarityMetric.COSINE:
-            # cosine() is KNN-only; callers must not use APPROXIMATE with this function.
-            return "cosine", "DESC"
-        raise ValueError(
-            f"Similarity metric '{metric.value}' is not supported by NebulaGraph. "
-            "Supported metrics: COSINE, DOT, EUCLIDEAN."
-        )
-
     def _render_filter_expr(
         self,
         node_alias: str,
@@ -1656,7 +1387,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         self,
         collection: str,
         properties: dict[str, PropertyValue],
-        embeddings: dict[str, tuple[list[float], SimilarityMetric]],
+        embeddings: dict[str, list[float]],
     ) -> None:
         """
         Ensure node type exists in graph type for this collection.
@@ -1686,15 +1417,10 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 sanitized = self._sanitize_name(mangled)
                 incoming_schema[sanitized] = self._infer_gql_type(prop_value)
 
-            for emb_name, (vec, _metric) in embeddings.items():
+            for emb_name, vec in embeddings.items():
                 mangled = mangle_embedding_name(emb_name)
                 sanitized = self._sanitize_name(mangled)
                 incoming_schema[sanitized] = f"VECTOR<{len(vec)}, FLOAT>"
-                # Add companion STRING property to persist the similarity metric
-                metric_prop = self._similarity_metric_property_name(emb_name)
-                mangled_metric = mangle_property_name(metric_prop)
-                sanitized_metric = self._sanitize_name(mangled_metric)
-                incoming_schema[sanitized_metric] = "STRING"
 
             # Check if node type already exists in cache
             if collection in self._graph_type_schemas:
@@ -1767,7 +1493,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         source_collection: str,
         target_collection: str,
         properties: dict[str, PropertyValue],
-        embeddings: dict[str, tuple[list[float], SimilarityMetric]],
+        embeddings: dict[str, list[float]],
     ) -> None:
         """
         Ensure edge type exists in graph type for this relation.
@@ -1802,15 +1528,10 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 sanitized = self._sanitize_name(mangled)
                 incoming_schema[sanitized] = self._infer_gql_type(prop_value)
 
-            for emb_name, (vec, _metric) in embeddings.items():
+            for emb_name, vec in embeddings.items():
                 mangled = mangle_embedding_name(emb_name)
                 sanitized = self._sanitize_name(mangled)
                 incoming_schema[sanitized] = f"VECTOR<{len(vec)}, FLOAT>"
-                # Add companion STRING property to persist the similarity metric
-                metric_prop = self._similarity_metric_property_name(emb_name)
-                mangled_metric = mangle_property_name(metric_prop)
-                sanitized_metric = self._sanitize_name(mangled_metric)
-                incoming_schema[sanitized_metric] = "STRING"
 
             # Check if edge type already exists in cache
             if edge_key in self._graph_type_schemas:
@@ -1877,110 +1598,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
 
             # Cache the schema
             self._graph_type_schemas[edge_key] = incoming_schema
-
-    async def _create_vector_index_if_not_exists(
-        self,
-        entity_type: EntityType,
-        node_or_edge_type: str,
-        embedding_name: str,
-        dimensions: int,
-        similarity_metric: SimilarityMetric,
-    ) -> None:
-        """
-        Create vector index if it doesn't exist.
-
-        Args:
-            entity_type: NODE or EDGE
-            node_or_edge_type: Type name
-            embedding_name: Embedding property name
-            dimensions: Vector dimensions
-            similarity_metric: COSINE, DOT, or EUCLIDEAN (MANHATTAN is not supported)
-
-        """
-        # NebulaGraph only supports L2 and IP index metrics.
-        # COSINE (KNN-only) and MANHATTAN have no ANN-capable index; skip creation so search falls back to KNN.
-        nebula_metric = self._similarity_metric_to_nebula(similarity_metric)
-        if nebula_metric is None:
-            logger.warning(
-                "Skipping vector index creation for '%s' on '%s': "
-                "metric '%s' is not supported by NebulaGraph ANN indexes "
-                "(ANN-supported metrics: EUCLIDEAN/L2, DOT/IP). "
-                "Search will use exact KNN instead.",
-                embedding_name,
-                node_or_edge_type,
-                similarity_metric.value,
-            )
-            return
-
-        # Use mangled and sanitized embedding name to ensure valid identifier
-        mangled_embedding = mangle_embedding_name(embedding_name)
-        index_name = f"idx_{self._sanitize_name(node_or_edge_type)}_{self._sanitize_name(mangled_embedding)}"
-
-        # Check cache
-        if index_name in self._index_state_cache:
-            return
-
-        # Acquire lock for this index
-        if index_name not in self._index_locks:
-            self._index_locks[index_name] = asyncio.Lock()
-
-        async with self._index_locks[index_name]:
-            # Double-check after acquiring lock
-            if index_name in self._index_state_cache:
-                return
-
-            # Mark as creating
-            self._index_state_cache[index_name] = self.CacheIndexState.CREATING
-
-            try:
-                sanitized_type = self._sanitize_name(node_or_edge_type)
-                sanitized_embedding = self._sanitize_name(mangled_embedding)
-                metric = nebula_metric
-
-                # Build index options based on type
-                if self._ann_index_type == "IVF":
-                    options = f"""{{
-                        DIM: {dimensions},
-                        METRIC: {metric},
-                        TYPE: IVF,
-                        NLIST: {self._ivf_nlist},
-                        TRAINSIZE: 10000
-                    }}"""
-                else:  # HNSW
-                    options = f"""{{
-                        DIM: {dimensions},
-                        METRIC: {metric},
-                        TYPE: HNSW,
-                        MAXDEGREE: {self._hnsw_max_degree},
-                        EFCONSTRUCTION: {self._hnsw_ef_construction},
-                        CAPACITY: 1000000
-                    }}"""
-
-                # Create index (use sanitized embedding name for valid GQL identifier)
-                if entity_type == EntityType.NODE:
-                    create_stmt = f"""
-                    CREATE VECTOR INDEX IF NOT EXISTS {index_name}
-                    ON NODE {sanitized_type}::{sanitized_embedding}
-                    OPTIONS {options}
-                    """
-                else:  # EDGE
-                    create_stmt = f"""
-                    CREATE VECTOR INDEX IF NOT EXISTS {index_name}
-                    ON EDGE {sanitized_type}::{sanitized_embedding}
-                    OPTIONS {options}
-                    """
-
-                await self._client.execute(create_stmt)
-
-                # Mark as online
-                self._index_state_cache[index_name] = self.CacheIndexState.ONLINE
-                logger.info("Created vector index: %s", index_name)
-
-            except Exception:
-                # Remove from cache on error
-                self._index_state_cache.pop(index_name, None)
-                logger.exception("Failed to create vector index %s", index_name)
-                raise
 
     async def _create_range_index_if_not_exists(
         self,

--- a/packages/server/src/memmachine_server/common/vector_graph_store/neo4j_vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/neo4j_vector_graph_store.py
@@ -20,7 +20,6 @@ from pydantic import BaseModel, Field, InstanceOf
 from memmachine_server.common.data_types import (
     FilterValue,
     OrderedValue,
-    SimilarityMetric,
 )
 from memmachine_server.common.filter.filter_parser import (
     And as FilterAnd,
@@ -234,7 +233,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
             sanitized_collection = Neo4jVectorGraphStore._sanitize_name(collection)
             sanitized_embedding_names = set()
             embedding_dimensions_by_name: dict[str, int] = {}
-            embedding_similarity_by_name: dict[str, SimilarityMetric] = {}
 
             query_nodes = []
             for node in nodes:
@@ -245,33 +243,15 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                     },
                 )
 
-                for embedding_name, (
-                    embedding,
-                    similarity_metric,
-                ) in node.embeddings.items():
+                for embedding_name, embedding in node.embeddings.items():
                     sanitized_embedding_name = Neo4jVectorGraphStore._sanitize_name(
                         mangle_embedding_name(embedding_name),
                     )
-                    sanitized_similarity_metric_name = (
-                        Neo4jVectorGraphStore._sanitize_name(
-                            Neo4jVectorGraphStore._similarity_metric_property_name(
-                                embedding_name,
-                            ),
-                        )
-                    )
-
                     sanitized_embedding_names.add(sanitized_embedding_name)
                     embedding_dimensions_by_name[sanitized_embedding_name] = len(
                         embedding,
                     )
-                    embedding_similarity_by_name[sanitized_embedding_name] = (
-                        similarity_metric
-                    )
-
                     query_node_properties[sanitized_embedding_name] = embedding
-                    query_node_properties[sanitized_similarity_metric_name] = (
-                        similarity_metric.value
-                    )
 
                 query_node: dict[str, PropertyValue | dict[str, PropertyValue]] = {
                     "uid": str(node.uid),
@@ -325,9 +305,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                                     dimensions=embedding_dimensions_by_name[
                                         sanitized_embedding_name
                                     ],
-                                    similarity_metric=embedding_similarity_by_name[
-                                        sanitized_embedding_name
-                                    ],
                                 ),
                             )
                         )
@@ -349,7 +326,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
             sanitized_relation = Neo4jVectorGraphStore._sanitize_name(relation)
             sanitized_embedding_names = set()
             embedding_dimensions_by_name: dict[str, int] = {}
-            embedding_similarity_by_name: dict[str, SimilarityMetric] = {}
 
             query_edges = []
             for edge in edges:
@@ -360,33 +336,15 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                     },
                 )
 
-                for embedding_name, (
-                    embedding,
-                    similarity_metric,
-                ) in edge.embeddings.items():
+                for embedding_name, embedding in edge.embeddings.items():
                     sanitized_embedding_name = Neo4jVectorGraphStore._sanitize_name(
                         mangle_embedding_name(embedding_name),
                     )
-                    sanitized_similarity_metric_name = (
-                        Neo4jVectorGraphStore._sanitize_name(
-                            Neo4jVectorGraphStore._similarity_metric_property_name(
-                                embedding_name,
-                            ),
-                        )
-                    )
-
                     sanitized_embedding_names.add(sanitized_embedding_name)
                     embedding_dimensions_by_name[sanitized_embedding_name] = len(
                         embedding,
                     )
-                    embedding_similarity_by_name[sanitized_embedding_name] = (
-                        similarity_metric
-                    )
-
                     query_edge_properties[sanitized_embedding_name] = embedding
-                    query_edge_properties[sanitized_similarity_metric_name] = (
-                        similarity_metric.value
-                    )
 
                 query_edge = {
                     "uid": str(edge.uid),
@@ -453,9 +411,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                                     dimensions=embedding_dimensions_by_name[
                                         sanitized_embedding_name
                                     ],
-                                    similarity_metric=embedding_similarity_by_name[
-                                        sanitized_embedding_name
-                                    ],
                                 ),
                             )
                         )
@@ -466,7 +421,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
         collection: str,
         embedding_name: str,
         query_embedding: list[float],
-        similarity_metric: SimilarityMetric = SimilarityMetric.COSINE,
         limit: int | None = 100,
         property_filter: FilterExpr | None = None,
     ) -> list[Node]:
@@ -539,13 +493,7 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                     do_exact_similarity_search = True
 
             if do_exact_similarity_search:
-                match similarity_metric:
-                    case SimilarityMetric.COSINE:
-                        vector_similarity_function = "vector.similarity.cosine"
-                    case SimilarityMetric.EUCLIDEAN:
-                        vector_similarity_function = "vector.similarity.euclidean"
-                    case _:
-                        vector_similarity_function = "vector.similarity.cosine"
+                vector_similarity_function = "vector.similarity.cosine"
 
                 query = (
                     f"MATCH (n:{sanitized_collection})\n"
@@ -1067,7 +1015,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
         sanitized_collection_or_relation: str,
         sanitized_embedding_name: str,
         dimensions: int,
-        similarity_metric: SimilarityMetric = SimilarityMetric.COSINE,
     ) -> None:
         """Create a vector index if missing and wait for it to be online."""
         if not (1 <= dimensions <= 4096):
@@ -1100,14 +1047,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                 Neo4jVectorGraphStore.CacheIndexState.CREATING
             )
 
-            match similarity_metric:
-                case SimilarityMetric.COSINE:
-                    similarity_function = "cosine"
-                case SimilarityMetric.EUCLIDEAN:
-                    similarity_function = "euclidean"
-                case _:
-                    similarity_function = "cosine"
-
             match entity_type:
                 case EntityType.NODE:
                     query_index_for_expression = (
@@ -1134,7 +1073,7 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                     "}"
                 ),
                 dimensions=dimensions,
-                similarity_function=similarity_function,
+                similarity_function="cosine",
             )
 
             await self._await_create_index_if_not_exists(
@@ -1219,20 +1158,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
         )
 
     @staticmethod
-    def _similarity_metric_property_name(embedding_name: str) -> str:
-        """
-        Get the similarity metric property name for an embedding.
-
-        Args:
-            embedding_name (str): The name of the embedding.
-
-        Returns:
-            str: The similarity metric property name.
-
-        """
-        return f"similarity_metric_for_{embedding_name}"
-
-    @staticmethod
     def _nodes_from_neo4j_nodes(
         neo4j_nodes: Iterable[Neo4jNode],
     ) -> list[Node]:
@@ -1267,21 +1192,7 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                         list[float],
                         value_from_neo4j(neo4j_property_value),
                     )
-                    similarity_metric = SimilarityMetric(
-                        value_from_neo4j(
-                            neo4j_node[
-                                Neo4jVectorGraphStore._sanitize_name(
-                                    Neo4jVectorGraphStore._similarity_metric_property_name(
-                                        embedding_name,
-                                    ),
-                                )
-                            ],
-                        ),
-                    )
-                    node_embeddings[embedding_name] = (
-                        embedding_value,
-                        similarity_metric,
-                    )
+                    node_embeddings[embedding_name] = embedding_value
 
             nodes.append(
                 Node(

--- a/packages/server/src/memmachine_server/common/vector_graph_store/vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/vector_graph_store.py
@@ -8,7 +8,7 @@ and deleting nodes and edges.
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 
-from memmachine_server.common.data_types import OrderedValue, SimilarityMetric
+from memmachine_server.common.data_types import OrderedValue
 from memmachine_server.common.filter.filter_parser import (
     FilterExpr,
 )
@@ -70,7 +70,6 @@ class VectorGraphStore(ABC):
         collection: str,
         embedding_name: str,
         query_embedding: list[float],
-        similarity_metric: SimilarityMetric = SimilarityMetric.COSINE,
         limit: int | None = 100,
         property_filter: FilterExpr | None = None,
     ) -> list[Node]:
@@ -84,9 +83,6 @@ class VectorGraphStore(ABC):
                 The name of the embedding vector property.
             query_embedding (list[float]):
                 The embedding vector to compare against.
-            similarity_metric (SimilarityMetric):
-                The similarity metric to use
-                (default: SimilarityMetric.COSINE).
             limit (int | None):
                 Maximum number of similar nodes to return.
                 If None, return as many similar nodes as possible

--- a/packages/server/src/memmachine_server/common/vector_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_store/data_types.py
@@ -117,7 +117,8 @@ class Record(BaseModel):
         vector (list[float] | None):
             Vector for similarity search.
             `None` is not allowed on input.
-            `None` on output means the vector was not requested (`return_vector=False`)
+            Always `None` on output: a collection stores vectors to search
+            them, and does not read them back out
             (default: None).
         properties (dict[str, PropertyValue] | None):
             Property key-value pairs.

--- a/packages/server/src/memmachine_server/common/vector_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_store/data_types.py
@@ -9,7 +9,6 @@ from memmachine_server.common.data_types import (
     PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE,
     PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME,
     PropertyValue,
-    SimilarityMetric,
 )
 
 from .utils import validate_identifier
@@ -22,14 +21,11 @@ class VectorStoreCollectionConfig(BaseModel):
     Attributes:
         vector_dimensions (int):
             Dimensionality of vectors stored in the collection.
-        similarity_metric (SimilarityMetric):
-            Metric used to compare vectors.
         indexed_properties_schema (dict[str, type[PropertyValue]]):
             Schema suggesting which properties should be indexed for filtering.
     """
 
     vector_dimensions: int
-    similarity_metric: SimilarityMetric = SimilarityMetric.COSINE
     indexed_properties_schema: dict[str, type[PropertyValue]] = Field(
         default_factory=dict
     )
@@ -154,20 +150,14 @@ class QueryMatch(BaseModel):
     A single vector store query match.
 
     Attributes:
-        score (float):
-            The meaning depends on the collection's `SimilarityMetric`:
-            - *cosine*: cosine similarity in [-1, 1].
-            - *dot*: raw dot product [0, inf).
-            - *euclidean*: Euclidean distance [0, inf).
-            - *manhattan*: Manhattan distance [0, inf).
-
-            Use `SimilarityMetric.higher_is_better` to determine which
-            direction indicates a better match.
+        cosine_similarity (float):
+            Cosine similarity between the query vector and the matched
+            record's vector, in [-1, 1]. Higher is a better match.
         record (Record):
             The matched record.
     """
 
-    score: float
+    cosine_similarity: float
     record: Record
 
 

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field, InstanceOf
 from pymilvus import DataType, MilvusClient
 from pymilvus.exceptions import MilvusException
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     And as FilterAnd,
 )
@@ -41,7 +41,7 @@ from memmachine_server.common.properties_json import (
     decode_properties,
     encode_properties,
 )
-from memmachine_server.common.utils import compute_similarity, ensure_tz_aware
+from memmachine_server.common.utils import compute_cosine_similarity, ensure_tz_aware
 
 from .data_types import (
     QueryMatch,
@@ -136,18 +136,6 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         return f"{field} {operator} {_literal(comparison.value)}"
 
     @staticmethod
-    def _passes_threshold(
-        score: float,
-        threshold: float | None,
-        similarity_metric: SimilarityMetric,
-    ) -> bool:
-        if threshold is None:
-            return True
-        if similarity_metric.higher_is_better:
-            return score >= threshold
-        return score <= threshold
-
-    @staticmethod
     def _primary_id(partition_key: str, record_uuid: UUID) -> str:
         """Build a native primary key unique within a shared native collection."""
         return f"{partition_key}:{record_uuid}"
@@ -222,18 +210,16 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         return fields
 
     @staticmethod
-    def _score_from_entity_vector(
+    def _cosine_similarity_from_entity_vector(
         query_vector: Sequence[float],
         entity: Mapping[str, Any],
-        similarity_metric: SimilarityMetric,
     ) -> float:
         raw_vector = entity.get(_VECTOR_FIELD)
         if raw_vector is None:
             raise ValueError("Milvus search result did not include the vector field")
-        return compute_similarity(
+        return compute_cosine_similarity(
             list(query_vector),
             [list(cast(Sequence[float], raw_vector))],
-            similarity_metric,
         )[0]
 
     def _partition_filter(self) -> str:
@@ -267,7 +253,7 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         *,
         query_vectors: Iterable[Sequence[float]],
         limit: int,
-        score_threshold: float | None = None,
+        min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
         return_properties: bool = True,
     ) -> list[QueryResult]:
@@ -308,19 +294,19 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
                 matches: list[QueryMatch] = []
                 for raw_match in raw_matches:
                     entity = cast(Mapping[str, Any], raw_match["entity"])
-                    score = self._score_from_entity_vector(
+                    cosine_similarity = self._cosine_similarity_from_entity_vector(
                         query_vector,
                         entity,
-                        self._config.similarity_metric,
                     )
-                    if not self._passes_threshold(
-                        score, score_threshold, self._config.similarity_metric
+                    if (
+                        min_cosine_similarity is not None
+                        and cosine_similarity < min_cosine_similarity
                     ):
                         continue
 
                     matches.append(
                         QueryMatch(
-                            score=score,
+                            cosine_similarity=cosine_similarity,
                             record=self._parse_record(
                                 entity,
                                 return_properties=return_properties,
@@ -328,13 +314,43 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
                         )
                     )
 
-                matches.sort(
-                    key=lambda match: match.score,
-                    reverse=self._config.similarity_metric.higher_is_better,
-                )
+                matches.sort(key=lambda match: match.cosine_similarity, reverse=True)
                 results.append(QueryResult(matches=matches))
 
             return results
+
+    @override
+    async def get_cosine_similarity(
+        self,
+        *,
+        query_vector: Sequence[float],
+        record_uuids: Iterable[UUID],
+    ) -> dict[UUID, float]:
+        """Get cosine similarities between a query vector and records' vectors."""
+        async with self._tracker("get_cosine_similarity"):
+            uuid_list = list(record_uuids)
+            if not uuid_list:
+                return {}
+
+            primary_ids = [
+                self._primary_id(self._partition_key, uuid) for uuid in uuid_list
+            ]
+            raw_records = await asyncio.to_thread(
+                self._client.get,
+                collection_name=self._collection_name,
+                ids=primary_ids,
+                output_fields=[_RECORD_UUID_FIELD, _VECTOR_FIELD],
+            )
+
+            query_vector = list(query_vector)
+            return {
+                UUID(str(entity[_RECORD_UUID_FIELD])): (
+                    self._cosine_similarity_from_entity_vector(query_vector, entity)
+                )
+                for entity in (
+                    cast(Mapping[str, Any], raw_record) for raw_record in raw_records
+                )
+            }
 
     @override
     async def set_properties(
@@ -439,15 +455,10 @@ class MilvusVectorStoreParams(BaseModel):
 class MilvusVectorStore(VectorStore):
     """Asynchronous Milvus-based implementation of VectorStore."""
 
-    _SIMILARITY_METRIC_TO_MILVUS_METRIC: ClassVar[dict[SimilarityMetric, str]] = {
-        SimilarityMetric.COSINE: "COSINE",
-        SimilarityMetric.DOT: "IP",
-        SimilarityMetric.EUCLIDEAN: "L2",
-    }
+    _MILVUS_METRIC_TYPE: ClassVar[str] = "COSINE"
 
     _REGISTRY_SUFFIX: ClassVar[str] = "__registry"
     _REGISTRY_VECTOR_DIMENSIONS: ClassVar[str] = "vector_dimensions"
-    _REGISTRY_SIMILARITY_METRIC: ClassVar[str] = "similarity_metric"
     _REGISTRY_INDEXED_PROPERTIES_SCHEMA: ClassVar[str] = "indexed_properties_schema"
     _REGISTRY_CONFIG: ClassVar[str] = "config"
 
@@ -482,21 +493,6 @@ class MilvusVectorStore(VectorStore):
         """Build a deterministic native collection name from namespace and config."""
         digest = hashlib.sha256(config.model_dump_json().encode()).hexdigest()
         return f"memmachine_{namespace}__{digest}"
-
-    @staticmethod
-    def _validate_metric(similarity_metric: SimilarityMetric) -> None:
-        if (
-            similarity_metric
-            not in MilvusVectorStore._SIMILARITY_METRIC_TO_MILVUS_METRIC
-        ):
-            supported = ", ".join(
-                metric.value
-                for metric in MilvusVectorStore._SIMILARITY_METRIC_TO_MILVUS_METRIC
-            )
-            raise ValueError(
-                f"Milvus only supports {supported} similarity metrics, "
-                f"got {similarity_metric.value!r}"
-            )
 
     def __init__(self, params: MilvusVectorStoreParams) -> None:
         """Initialize the vector store with the provided parameters."""
@@ -622,7 +618,6 @@ class MilvusVectorStore(VectorStore):
         """Parse a VectorStoreCollectionConfig from a registry entry."""
         return VectorStoreCollectionConfig(
             vector_dimensions=entry[MilvusVectorStore._REGISTRY_VECTOR_DIMENSIONS],
-            similarity_metric=entry[MilvusVectorStore._REGISTRY_SIMILARITY_METRIC],
             indexed_properties_schema=entry[
                 MilvusVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA
             ],
@@ -646,7 +641,6 @@ class MilvusVectorStore(VectorStore):
         self, namespace: str, config: VectorStoreCollectionConfig
     ) -> None:
         """Idempotently create the native Milvus collection."""
-        self._validate_metric(config.similarity_metric)
         native_collection_name = MilvusVectorStore._build_native_collection_name(
             namespace, config
         )
@@ -689,9 +683,7 @@ class MilvusVectorStore(VectorStore):
             index_params.add_index(
                 field_name=_VECTOR_FIELD,
                 index_type="AUTOINDEX",
-                metric_type=self._SIMILARITY_METRIC_TO_MILVUS_METRIC[
-                    config.similarity_metric
-                ],
+                metric_type=self._MILVUS_METRIC_TYPE,
             )
 
             self._client.create_collection(
@@ -721,7 +713,6 @@ class MilvusVectorStore(VectorStore):
                     _VECTOR_FIELD: [0.0] * _REGISTRY_VECTOR_DIMENSION,
                     self._REGISTRY_CONFIG: {
                         self._REGISTRY_VECTOR_DIMENSIONS: config.vector_dimensions,
-                        self._REGISTRY_SIMILARITY_METRIC: config.similarity_metric.value,
                         self._REGISTRY_INDEXED_PROPERTIES_SCHEMA: config.model_dump(
                             mode="json"
                         )["indexed_properties_schema"],
@@ -747,7 +738,6 @@ class MilvusVectorStore(VectorStore):
             raise ValueError(
                 f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
             )
-        self._validate_metric(config.similarity_metric)
         async with (
             self._client_name_locks[(namespace, name)],
             self._tracker("create_collection"),
@@ -775,7 +765,6 @@ class MilvusVectorStore(VectorStore):
             raise ValueError(
                 f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
             )
-        self._validate_metric(config.similarity_metric)
         async with (
             self._client_name_locks[(namespace, name)],
             self._tracker("open_or_create_collection"),

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -200,16 +200,9 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
     def _parse_record(
         entity: Mapping[str, Any],
         *,
-        return_vector: bool,
         return_properties: bool,
     ) -> Record:
         """Parse a Milvus entity into a vector store record."""
-        vector: list[float] | None = None
-        if return_vector:
-            raw_vector = entity.get(_VECTOR_FIELD)
-            if raw_vector is not None:
-                vector = list(cast(Sequence[float], raw_vector))
-
         properties: dict[str, PropertyValue] | None = None
         if return_properties:
             properties = decode_properties(
@@ -218,16 +211,12 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
 
         return Record(
             uuid=UUID(str(entity[_RECORD_UUID_FIELD])),
-            vector=vector,
             properties=properties,
         )
 
-    def _output_fields(
-        self, *, return_vector: bool, return_properties: bool
-    ) -> list[str]:
-        fields = [_RECORD_UUID_FIELD]
-        if return_vector:
-            fields.append(_VECTOR_FIELD)
+    def _output_fields(self, *, return_properties: bool) -> list[str]:
+        # The vector always comes back: search scores are recomputed from it.
+        fields = [_RECORD_UUID_FIELD, _VECTOR_FIELD]
         if return_properties:
             fields.append(_PROPERTIES_FIELD)
         return fields
@@ -280,7 +269,6 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         limit: int,
         score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         """Query for records matching the criteria by query vectors."""
@@ -308,7 +296,6 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
                 # returns it as similarity. Fetch vectors and compute scores
                 # locally so MemMachine score semantics stay consistent.
                 output_fields=self._output_fields(
-                    return_vector=True,
                     return_properties=return_properties,
                 ),
                 anns_field=_VECTOR_FIELD,
@@ -336,7 +323,6 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
                             score=score,
                             record=self._parse_record(
                                 entity,
-                                return_vector=return_vector,
                                 return_properties=return_properties,
                             ),
                         )
@@ -351,48 +337,59 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
             return results
 
     @override
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        """Get records from the collection by their UUIDs."""
-        async with self._tracker("get"):
-            uuid_list = list(record_uuids)
-            if not uuid_list:
-                return []
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        """Replace the properties of records already in the collection."""
+        async with self._tracker("set_properties"):
+            if not record_properties:
+                return
 
+            uuid_list = list(record_properties)
             primary_ids = [
                 self._primary_id(self._partition_key, uuid) for uuid in uuid_list
             ]
+
+            # Milvus has no partial update: an upsert writes the whole row, so
+            # the vector has to be read back to be written again unchanged. A
+            # row Milvus does not hold is skipped rather than inserted without
+            # a vector.
             raw_records = await asyncio.to_thread(
                 self._client.get,
                 collection_name=self._collection_name,
                 ids=primary_ids,
-                output_fields=self._output_fields(
-                    return_vector=return_vector,
-                    return_properties=return_properties,
-                ),
+                output_fields=[_RECORD_UUID_FIELD, _VECTOR_FIELD],
             )
-
-            records_by_uuid = {
-                record.uuid: record
-                for record in (
-                    self._parse_record(
-                        cast(Mapping[str, Any], raw_record),
-                        return_vector=return_vector,
-                        return_properties=return_properties,
-                    )
-                    for raw_record in raw_records
+            vectors_by_uuid = {
+                UUID(str(raw[_RECORD_UUID_FIELD])): list(
+                    cast(Sequence[float], raw[_VECTOR_FIELD])
                 )
+                for raw in (cast(Mapping[str, Any], r) for r in raw_records)
             }
-            return [
-                records_by_uuid[record_uuid]
+
+            entities = [
+                self._build_entity(
+                    Record(
+                        uuid=record_uuid,
+                        vector=vectors_by_uuid[record_uuid],
+                        properties=dict(record_properties[record_uuid]),
+                    )
+                )
                 for record_uuid in uuid_list
-                if record_uuid in records_by_uuid
+                if record_uuid in vectors_by_uuid
             ]
+            if not entities:
+                return
+
+            def _upsert() -> None:
+                self._client.upsert(
+                    collection_name=self._collection_name,
+                    data=entities,
+                )
+
+            await asyncio.to_thread(_upsert)
 
     @override
     async def delete(

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -340,7 +340,6 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
         limit: int,
         score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         """Query for records matching the criteria by query vectors."""
@@ -369,7 +368,7 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
                     filter=qdrant_filter,
                     score_threshold=score_threshold,
                     limit=limit,
-                    with_vector=return_vector,
+                    with_vector=False,
                     with_payload=return_properties,
                 )
                 for query_vector in query_vectors
@@ -384,10 +383,6 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
             for batch in batch_results:
                 matches: list[QueryMatch] = []
                 for point in batch.points:
-                    vector: list[float] | None = None
-                    if return_vector and point.vector is not None:
-                        vector = cast(list[float], point.vector)
-
                     properties: dict[str, PropertyValue] | None = None
                     if return_properties and point.payload is not None:
                         properties = self._parse_payload(point.payload)
@@ -397,7 +392,6 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
                             score=point.score,
                             record=Record(
                                 uuid=UUID(str(point.id)),
-                                vector=vector,
                                 properties=properties,
                             ),
                         ),
@@ -407,61 +401,34 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
             return query_results
 
     @override
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        """Get records from the collection by their UUIDs."""
-        async with self._tracker("get"):
-            uuid_list = list(record_uuids)
-            if not uuid_list:
-                return []
-
-            # Always get payload so we can check partition_key.
-            points = await self._client.retrieve(
-                collection_name=self._collection_name,
-                ids=list(uuid_list),
-                with_vectors=return_vector,
-                with_payload=True,
-                shard_key_selector=self._shard_key,
-            )
-
-            points_by_uuid: dict[UUID, models.Record] = {
-                UUID(str(point.id)): point
-                for point in points
-                if point.payload
-                and cast(dict[str, Any], point.payload).get(_PAYLOAD_PARTITION_KEY)
-                == self._partition_key
-            }
-
-            records: list[Record] = []
-            for point_uuid in uuid_list:
-                point = points_by_uuid.get(point_uuid)
-                if point is None:
-                    continue
-
-                vector: list[float] | None = None
-                if return_vector and point.vector is not None:
-                    vector = cast(list[float], point.vector)
-
-                properties: dict[str, PropertyValue] | None = None
-                if return_properties and point.payload is not None:
-                    properties = self._parse_payload(
-                        cast(dict[str, Any] | None, point.payload),
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        """Replace the properties of records already in the collection."""
+        async with self._tracker("set_properties"):
+            for record_uuid, properties in record_properties.items():
+                # Select by filter rather than by id: the id alone would reach a
+                # point another logical collection owns in the same native one,
+                # and an id list raises on an id the collection does not hold
+                # where a filter simply matches nothing, which is the contract.
+                selector = models.FilterSelector(
+                    filter=models.Filter(
+                        must=[
+                            _partition_filter(self._partition_key),
+                            models.HasIdCondition(has_id=[record_uuid]),
+                        ]
                     )
-
-                records.append(
-                    Record(
-                        uuid=point_uuid,
-                        vector=vector,
-                        properties=properties,
-                    ),
                 )
-
-            return records
+                # Overwrite rather than merge: the payload carries the partition
+                # key alongside the properties, so `_build_payload` puts it back.
+                await self._client.overwrite_payload(
+                    collection_name=self._collection_name,
+                    payload=cast(dict[str, Any], self._build_payload(dict(properties))),
+                    points=selector,
+                    shard_key_selector=self._shard_key,
+                )
 
     @override
     async def delete(

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -18,7 +18,6 @@ from qdrant_client.http.exceptions import ResponseHandlingException, UnexpectedR
 from memmachine_server.common.data_types import (
     OrderedValue,
     PropertyValue,
-    SimilarityMetric,
 )
 from memmachine_server.common.filter.filter_parser import (
     And as FilterAnd,
@@ -42,7 +41,7 @@ from memmachine_server.common.filter.filter_parser import (
     Or as FilterOr,
 )
 from memmachine_server.common.metrics_factory import MetricsFactory, OperationTracker
-from memmachine_server.common.utils import ensure_tz_aware
+from memmachine_server.common.utils import compute_cosine_similarity, ensure_tz_aware
 
 from .data_types import (
     QueryMatch,
@@ -338,7 +337,7 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
         *,
         query_vectors: Iterable[Sequence[float]],
         limit: int,
-        score_threshold: float | None = None,
+        min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
         return_properties: bool = True,
     ) -> list[QueryResult]:
@@ -366,7 +365,7 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
                     shard_key=self._shard_key,
                     query=query_vector,
                     filter=qdrant_filter,
-                    score_threshold=score_threshold,
+                    score_threshold=min_cosine_similarity,
                     limit=limit,
                     with_vector=False,
                     with_payload=return_properties,
@@ -389,7 +388,7 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
 
                     matches.append(
                         QueryMatch(
-                            score=point.score,
+                            cosine_similarity=point.score,
                             record=Record(
                                 uuid=UUID(str(point.id)),
                                 properties=properties,
@@ -399,6 +398,47 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
                 query_results.append(QueryResult(matches=matches))
 
             return query_results
+
+    @override
+    async def get_cosine_similarity(
+        self,
+        *,
+        query_vector: Sequence[float],
+        record_uuids: Iterable[UUID],
+    ) -> dict[UUID, float]:
+        """Get cosine similarities between a query vector and records' vectors."""
+        async with self._tracker("get_cosine_similarity"):
+            uuid_list = list(record_uuids)
+            if not uuid_list:
+                return {}
+
+            # Retrieval by id is exact; an id-filtered ANN query is not
+            # guaranteed to return every matching point.
+            # Payload is fetched to check partition_key.
+            points = await self._client.retrieve(
+                collection_name=self._collection_name,
+                ids=list(uuid_list),
+                with_vectors=True,
+                with_payload=True,
+                shard_key_selector=self._shard_key,
+            )
+
+            matched_uuids: list[UUID] = []
+            vectors: list[list[float]] = []
+            for point in points:
+                payload = point.payload
+                if (
+                    payload is None
+                    or payload.get(_PAYLOAD_PARTITION_KEY) != self._partition_key
+                ):
+                    continue
+                if point.vector is None:
+                    continue
+                matched_uuids.append(UUID(str(point.id)))
+                vectors.append(cast(list[float], point.vector))
+
+            similarities = compute_cosine_similarity(list(query_vector), vectors)
+            return dict(zip(matched_uuids, similarities, strict=True))
 
     @override
     async def set_properties(
@@ -512,14 +552,7 @@ class QdrantVectorStoreParams(BaseModel):
 class QdrantVectorStore(VectorStore):
     """Asynchronous Qdrant-based implementation of VectorStore."""
 
-    _SIMILARITY_METRIC_TO_QDRANT_DISTANCE: ClassVar[
-        dict[SimilarityMetric, models.Distance]
-    ] = {
-        SimilarityMetric.COSINE: models.Distance.COSINE,
-        SimilarityMetric.DOT: models.Distance.DOT,
-        SimilarityMetric.EUCLIDEAN: models.Distance.EUCLID,
-        SimilarityMetric.MANHATTAN: models.Distance.MANHATTAN,
-    }
+    _QDRANT_DISTANCE: ClassVar[models.Distance] = models.Distance.COSINE
 
     _PROPERTY_TYPE_TO_INDEX_TYPE: ClassVar[
         dict[type[PropertyValue], models.PayloadSchemaType]
@@ -535,7 +568,6 @@ class QdrantVectorStore(VectorStore):
     _REGISTRY_SUFFIX: ClassVar[str] = "__registry"
     _REGISTRY_NAME: ClassVar[str] = "name"
     _REGISTRY_VECTOR_DIMENSIONS: ClassVar[str] = "vector_dimensions"
-    _REGISTRY_SIMILARITY_METRIC: ClassVar[str] = "similarity_metric"
     _REGISTRY_INDEXED_PROPERTIES_SCHEMA: ClassVar[str] = "indexed_properties_schema"
 
     # Fixed UUID namespace for deterministic registry point IDs.
@@ -678,7 +710,6 @@ class QdrantVectorStore(VectorStore):
         """Parse a VectorStoreCollectionConfig from a registry entry."""
         return VectorStoreCollectionConfig(
             vector_dimensions=entry[QdrantVectorStore._REGISTRY_VECTOR_DIMENSIONS],
-            similarity_metric=entry[QdrantVectorStore._REGISTRY_SIMILARITY_METRIC],
             indexed_properties_schema=entry[
                 QdrantVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA
             ],
@@ -706,9 +737,7 @@ class QdrantVectorStore(VectorStore):
         native_collection_name = QdrantVectorStore._build_native_collection_name(
             namespace, config
         )
-        distance = QdrantVectorStore._SIMILARITY_METRIC_TO_QDRANT_DISTANCE[
-            config.similarity_metric
-        ]
+        distance = QdrantVectorStore._QDRANT_DISTANCE
         # The collection and its indexes are created under separate guards. Sharing
         # one meant a collection that already existed - a second worker, or a retry
         # after a crash between the two calls - raised on create_collection, took
@@ -785,7 +814,6 @@ class QdrantVectorStore(VectorStore):
                     payload={
                         QdrantVectorStore._REGISTRY_NAME: name,
                         QdrantVectorStore._REGISTRY_VECTOR_DIMENSIONS: config.vector_dimensions,
-                        QdrantVectorStore._REGISTRY_SIMILARITY_METRIC: config.similarity_metric.value,
                         QdrantVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA: config.model_dump(
                             mode="json"
                         )["indexed_properties_schema"],

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -6,7 +6,6 @@ Partition keys are avoided in favor of per-collection tables,
 since sqlite-vec ANN indexes may not support them.
 """
 
-import struct
 from collections.abc import Iterable, Mapping, Sequence
 from typing import ClassVar, override
 from uuid import UUID
@@ -22,10 +21,12 @@ from sqlalchemy import (
     String,
     Table,
     Uuid,
+    bindparam,
     delete,
     event,
     select,
     text,
+    update,
 )
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine.interfaces import DBAPIConnection
@@ -99,11 +100,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
     @staticmethod
     def _serialize_vector(vector: Sequence[float]) -> bytes:
         return sqlite_vec.serialize_float32(list(vector))
-
-    @staticmethod
-    def _deserialize_vector(data: bytes) -> list[float]:
-        count = len(data) // 4
-        return list(struct.unpack(f"={count}f", data))
 
     @staticmethod
     def _distance_to_score(
@@ -200,7 +196,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         limit: int,
         score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         query_vectors = list(query_vectors)
@@ -239,7 +234,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
                     rowid_to_distance=rowid_to_distance,
                     score_threshold=score_threshold,
                     property_filter=property_filter,
-                    return_vector=return_vector,
                     return_properties=return_properties,
                 )
                 results.append(QueryResult(matches=matches))
@@ -252,7 +246,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         rowid_to_distance: Mapping[int, float],
         score_threshold: float | None,
         property_filter: FilterExpr | None,
-        return_vector: bool,
         return_properties: bool,
     ) -> list[QueryMatch]:
         matched_rowids = list(rowid_to_distance.keys())
@@ -277,12 +270,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
 
         matched_rows = (await session.execute(fetch_records)).all()
 
-        rowid_to_vector: dict[int, list[float]] = {}
-        if return_vector:
-            rowid_to_vector = await self._fetch_vectors(
-                session, [row.rowid for row in matched_rows]
-            )
-
         matches: list[QueryMatch] = []
         for row in matched_rows:
             distance = rowid_to_distance.get(row.rowid)
@@ -301,14 +288,10 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
             if return_properties:
                 properties = decode_properties(row.properties)
 
-            vector: list[float] | None = None
-            if return_vector:
-                vector = rowid_to_vector.get(row.rowid)
-
             matches.append(
                 QueryMatch(
                     score=score,
-                    record=Record(uuid=row.uuid, vector=vector, properties=properties),
+                    record=Record(uuid=row.uuid, properties=properties),
                 )
             )
 
@@ -318,75 +301,30 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         )
         return matches
 
-    async def _fetch_vectors(
-        self, session: AsyncSession, rowids: Iterable[int]
-    ) -> dict[int, list[float]]:
-        rowids = list(rowids)
-        if not rowids:
-            return {}
-
-        placeholders = ", ".join(f":r{i}" for i in range(len(rowids)))
-        vector_rows = (
-            await session.execute(
-                text(
-                    f"SELECT rowid, vector FROM [{self._vector_table_name}] "
-                    f"WHERE rowid IN ({placeholders})"
-                ),
-                {f"r{i}": rowid for i, rowid in enumerate(rowids)},
-            )
-        ).all()
-        return {row.rowid: self._deserialize_vector(row.vector) for row in vector_rows}
-
     @override
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        record_uuids = list(record_uuids)
-        if not record_uuids:
-            return []
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        # Properties live in the records table and vectors live in the sqlite-vec
+        # virtual table, so replacing properties never reads a vector back.
+        if not record_properties:
+            return
 
-        selected_columns = [self._records_table.c.uuid, self._records_table.c.rowid]
-        if return_properties:
-            selected_columns.append(self._records_table.c.properties)
-
-        async with self._create_session() as session:
-            fetched_rows = (
-                await session.execute(
-                    select(*selected_columns).where(
-                        self._records_table.c.uuid.in_(record_uuids),
-                    )
-                )
-            ).all()
-
-            rowid_to_vector: dict[int, list[float]] = {}
-            if return_vector:
-                rowid_to_vector = await self._fetch_vectors(
-                    session, [row.rowid for row in fetched_rows]
-                )
-
-        record_map: dict[UUID, Record] = {}
-        for row in fetched_rows:
-            record_uuid = row.uuid
-
-            properties: dict[str, PropertyValue] | None = None
-            if return_properties:
-                properties = decode_properties(row.properties)
-
-            vector: list[float] | None = rowid_to_vector.get(row.rowid)
-
-            record_map[record_uuid] = Record(
-                uuid=record_uuid, vector=vector, properties=properties
+        async with self._create_session() as session, session.begin():
+            await session.execute(
+                update(self._records_table).where(
+                    self._records_table.c.uuid == bindparam("target_uuid")
+                ),
+                [
+                    {
+                        "target_uuid": record_uuid,
+                        "properties": encode_properties(dict(properties)),
+                    }
+                    for record_uuid, properties in record_properties.items()
+                ],
             )
-
-        return [
-            record_map[record_uuid]
-            for record_uuid in record_uuids
-            if record_uuid in record_map
-        ]
 
     @override
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -34,7 +34,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase, MappedColumn, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
 from memmachine_server.common.properties_json import (
@@ -71,11 +71,6 @@ class _CollectionRow(BaseSQLiteVecVectorStore):
 class SQLiteVecVectorStoreCollection(VectorStoreCollection):
     """A logical collection backed by SQLite + sqlite-vec."""
 
-    _DISTANCE_FUNCTIONS: ClassVar[dict[SimilarityMetric, str]] = {
-        SimilarityMetric.COSINE: "vec_distance_cosine",
-        SimilarityMetric.EUCLIDEAN: "vec_distance_L2",
-    }
-
     def __init__(
         self,
         *,
@@ -90,8 +85,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         self._records_table = records_table
         self._vector_table_name = vector_table_name
 
-        self._similarity_metric = config.similarity_metric
-
     @property
     @override
     def config(self) -> VectorStoreCollectionConfig:
@@ -102,28 +95,9 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         return sqlite_vec.serialize_float32(list(vector))
 
     @staticmethod
-    def _distance_to_score(
-        distance: float, similarity_metric: SimilarityMetric
-    ) -> float:
-        match similarity_metric:
-            case SimilarityMetric.COSINE:
-                return 1.0 - distance
-            case SimilarityMetric.EUCLIDEAN:
-                return distance
-            case _:
-                raise NotImplementedError(similarity_metric)
-
-    @staticmethod
-    def _threshold_to_max_distance(
-        threshold: float, similarity_metric: SimilarityMetric
-    ) -> float:
-        match similarity_metric:
-            case SimilarityMetric.COSINE:
-                return 1.0 - threshold
-            case SimilarityMetric.EUCLIDEAN:
-                return threshold
-            case _:
-                raise NotImplementedError(similarity_metric)
+    def _distance_to_cosine_similarity(distance: float) -> float:
+        """Convert a sqlite-vec cosine distance to a cosine similarity."""
+        return 1.0 - distance
 
     @override
     async def upsert(self, *, records: Iterable[Record]) -> None:
@@ -194,7 +168,7 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         *,
         query_vectors: Iterable[Sequence[float]],
         limit: int,
-        score_threshold: float | None = None,
+        min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
         return_properties: bool = True,
     ) -> list[QueryResult]:
@@ -232,7 +206,7 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
                 matches = await self._build_matches(
                     session=session,
                     rowid_to_distance=rowid_to_distance,
-                    score_threshold=score_threshold,
+                    min_cosine_similarity=min_cosine_similarity,
                     property_filter=property_filter,
                     return_properties=return_properties,
                 )
@@ -244,7 +218,7 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         self,
         session: AsyncSession,
         rowid_to_distance: Mapping[int, float],
-        score_threshold: float | None,
+        min_cosine_similarity: float | None,
         property_filter: FilterExpr | None,
         return_properties: bool,
     ) -> list[QueryMatch]:
@@ -276,11 +250,10 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
             if distance is None:
                 continue
 
-            score = self._distance_to_score(distance, self._similarity_metric)
-            if score_threshold is not None and (
-                score < score_threshold
-                if self._similarity_metric.higher_is_better
-                else score > score_threshold
+            cosine_similarity = self._distance_to_cosine_similarity(distance)
+            if (
+                min_cosine_similarity is not None
+                and cosine_similarity < min_cosine_similarity
             ):
                 continue
 
@@ -290,16 +263,56 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
 
             matches.append(
                 QueryMatch(
-                    score=score,
+                    cosine_similarity=cosine_similarity,
                     record=Record(uuid=row.uuid, properties=properties),
                 )
             )
 
-        matches.sort(
-            key=lambda match: match.score,
-            reverse=self._similarity_metric.higher_is_better,
-        )
+        matches.sort(key=lambda match: match.cosine_similarity, reverse=True)
         return matches
+
+    @override
+    async def get_cosine_similarity(
+        self,
+        *,
+        query_vector: Sequence[float],
+        record_uuids: Iterable[UUID],
+    ) -> dict[UUID, float]:
+        record_uuids = list(record_uuids)
+        if not record_uuids:
+            return {}
+
+        query_blob = self._serialize_vector(query_vector)
+        similarities: dict[UUID, float] = {}
+        async with self._create_session() as session:
+            fetched_rows = (
+                await session.execute(
+                    select(
+                        self._records_table.c.uuid, self._records_table.c.rowid
+                    ).where(
+                        self._records_table.c.uuid.in_(record_uuids),
+                    )
+                )
+            ).all()
+
+            # One point query per rowid: vec0 plans `rowid = ?` as a point
+            # lookup but `rowid IN (...)` as a full scan.
+            for row in fetched_rows:
+                distance = (
+                    await session.execute(
+                        text(
+                            f"SELECT vec_distance_cosine(vector, :query) "
+                            f"FROM [{self._vector_table_name}] "
+                            f"WHERE rowid = :rowid"
+                        ),
+                        {"query": query_blob, "rowid": row.rowid},
+                    )
+                ).scalar()
+                if distance is None:
+                    continue
+                similarities[row.uuid] = self._distance_to_cosine_similarity(distance)
+
+        return similarities
 
     @override
     async def set_properties(
@@ -398,10 +411,7 @@ class SQLiteVecVectorStore(VectorStore):
     Each logical collection gets its own records table and vec0 virtual table.
     """
 
-    _SIMILARITY_METRIC_TO_SQLITE_VEC_DISTANCE: ClassVar[dict[SimilarityMetric, str]] = {
-        SimilarityMetric.COSINE: "cosine",
-        SimilarityMetric.EUCLIDEAN: "L2",
-    }
+    _SQLITE_VEC_DISTANCE_METRIC: ClassVar[str] = "cosine"
 
     def __init__(self, params: SQLiteVecVectorStoreParams) -> None:
         """Initialize the vector store with the provided parameters."""
@@ -442,8 +452,6 @@ class SQLiteVecVectorStore(VectorStore):
     ) -> None:
         if not validate_identifier(namespace) or not validate_identifier(name):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
-        self._validate_metric(config.similarity_metric)
-
         async with self._create_session() as session, session.begin():
             existing_config = await self._get_stored_config(session, namespace, name)
             if existing_config is not None:
@@ -468,8 +476,6 @@ class SQLiteVecVectorStore(VectorStore):
     ) -> VectorStoreCollection:
         if not validate_identifier(namespace) or not validate_identifier(name):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
-        self._validate_metric(config.similarity_metric)
-
         async with self._create_session() as session, session.begin():
             existing_config = await self._get_stored_config(session, namespace, name)
             if existing_config is not None:
@@ -572,21 +578,6 @@ class SQLiteVecVectorStore(VectorStore):
     def _vector_table_name(namespace: str, name: str) -> str:
         return f"{SQLiteVecVectorStore._collection_prefix(namespace, name)}_vc"
 
-    @staticmethod
-    def _validate_metric(similarity_metric: SimilarityMetric) -> None:
-        if (
-            similarity_metric
-            not in SQLiteVecVectorStore._SIMILARITY_METRIC_TO_SQLITE_VEC_DISTANCE
-        ):
-            supported = ", ".join(
-                similarity_metric.value
-                for similarity_metric in SQLiteVecVectorStore._SIMILARITY_METRIC_TO_SQLITE_VEC_DISTANCE
-            )
-            raise ValueError(
-                f"sqlite-vec only supports {supported} similarity metrics, "
-                f"got {similarity_metric.value!r}"
-            )
-
     async def _get_stored_config(
         self, session: AsyncSession, namespace: str, name: str
     ) -> VectorStoreCollectionConfig | None:
@@ -621,9 +612,7 @@ class SQLiteVecVectorStore(VectorStore):
     ) -> tuple[Table, str]:
         records_table = self._records_table(namespace, name)
         vector_table_name = self._vector_table_name(namespace, name)
-        distance_metric_value = self._SIMILARITY_METRIC_TO_SQLITE_VEC_DISTANCE[
-            config.similarity_metric
-        ]
+        distance_metric_value = self._SQLITE_VEC_DISTANCE_METRIC
 
         connection = await session.connection()
         await connection.run_sync(

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -43,6 +43,7 @@ from sqlalchemy import (
     String,
     Table,
     Uuid,
+    bindparam,
     create_engine,
     delete,
     event,
@@ -402,7 +403,6 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         limit: int,
         score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         query_vectors = list(query_vectors)
@@ -429,7 +429,6 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
             matches = await self._build_matches(
                 row_id_to_score={m.key: m.score for m in search_result.matches},
                 score_threshold=score_threshold,
-                return_vector=return_vector,
                 return_properties=return_properties,
             )
             results.append(QueryResult(matches=matches))
@@ -458,7 +457,6 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         self,
         row_id_to_score: Mapping[int, float],
         score_threshold: float | None,
-        return_vector: bool,
         return_properties: bool,
     ) -> list[QueryMatch]:
         matched_row_ids = list(row_id_to_score.keys())
@@ -473,10 +471,6 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
         async with self._create_session() as session:
             matched_rows = (await session.execute(fetch_records)).all()
-
-        vector_map: dict[int, list[float]] = {}
-        if return_vector:
-            vector_map = await self._search_engine.get_vectors(matched_row_ids)
 
         higher_is_better = self._config.similarity_metric.higher_is_better
         matches: list[QueryMatch] = []
@@ -494,12 +488,10 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
             if return_properties:
                 properties = decode_properties(row.properties)
 
-            vector: list[float] | None = vector_map.get(row.row_id)
-
             matches.append(
                 QueryMatch(
                     score=score,
-                    record=Record(uuid=row.uuid, vector=vector, properties=properties),
+                    record=Record(uuid=row.uuid, properties=properties),
                 )
             )
 
@@ -510,55 +502,30 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         return matches
 
     @override
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        record_uuids = list(record_uuids)
-        if not record_uuids:
-            return []
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        # Properties live in the records table and vectors live in the search
+        # engine, so replacing properties never touches the engine: no pending
+        # operation, no index save, nothing for a crash to lose.
+        if not record_properties:
+            return
 
-        selected_columns = [self._records_table.c.uuid, self._records_table.c.row_id]
-        if return_properties:
-            selected_columns.append(self._records_table.c.properties)
-
-        async with self._create_session() as session:
-            fetched_rows = (
-                await session.execute(
-                    select(*selected_columns).where(
-                        self._records_table.c.uuid.in_(record_uuids),
-                    )
-                )
-            ).all()
-
-        row_id_to_vector: dict[int, list[float]] = {}
-        if return_vector:
-            row_id_to_vector = await self._search_engine.get_vectors(
-                [row.row_id for row in fetched_rows]
+        async with self._create_session() as session, session.begin():
+            await session.execute(
+                update(self._records_table).where(
+                    self._records_table.c.uuid == bindparam("target_uuid")
+                ),
+                [
+                    {
+                        "target_uuid": record_uuid,
+                        "properties": encode_properties(dict(properties)),
+                    }
+                    for record_uuid, properties in record_properties.items()
+                ],
             )
-
-        record_map: dict[UUID, Record] = {}
-        for row in fetched_rows:
-            record_uuid = row.uuid
-
-            properties: dict[str, PropertyValue] | None = None
-            if return_properties:
-                properties = decode_properties(row.properties)
-
-            vector: list[float] | None = row_id_to_vector.get(row.row_id)
-
-            record_map[record_uuid] = Record(
-                uuid=record_uuid, vector=vector, properties=properties
-            )
-
-        return [
-            record_map[record_uuid]
-            for record_uuid in record_uuids
-            if record_uuid in record_map
-        ]
 
     @override
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -59,7 +59,7 @@ from sqlalchemy.orm import DeclarativeBase, MappedColumn, Session, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 from sqlalchemy.sql.elements import ColumnElement
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
 from memmachine_server.common.properties_json import (
@@ -401,7 +401,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         *,
         query_vectors: Iterable[Sequence[float]],
         limit: int,
-        score_threshold: float | None = None,
+        min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
         return_properties: bool = True,
     ) -> list[QueryResult]:
@@ -427,8 +427,10 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 results.append(QueryResult(matches=[]))
                 continue
             matches = await self._build_matches(
-                row_id_to_score={m.key: m.score for m in search_result.matches},
-                score_threshold=score_threshold,
+                row_id_to_similarity={
+                    m.key: m.cosine_similarity for m in search_result.matches
+                },
+                min_cosine_similarity=min_cosine_similarity,
                 return_properties=return_properties,
             )
             results.append(QueryResult(matches=matches))
@@ -455,11 +457,11 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
     async def _build_matches(
         self,
-        row_id_to_score: Mapping[int, float],
-        score_threshold: float | None,
+        row_id_to_similarity: Mapping[int, float],
+        min_cosine_similarity: float | None,
         return_properties: bool,
     ) -> list[QueryMatch]:
-        matched_row_ids = list(row_id_to_score.keys())
+        matched_row_ids = list(row_id_to_similarity.keys())
 
         selected_columns = [self._records_table.c.uuid, self._records_table.c.row_id]
         if return_properties:
@@ -472,15 +474,15 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         async with self._create_session() as session:
             matched_rows = (await session.execute(fetch_records)).all()
 
-        higher_is_better = self._config.similarity_metric.higher_is_better
         matches: list[QueryMatch] = []
         for row in matched_rows:
-            score = row_id_to_score.get(row.row_id)
-            if score is None:
+            cosine_similarity = row_id_to_similarity.get(row.row_id)
+            if cosine_similarity is None:
                 continue
 
-            if score_threshold is not None and (
-                score < score_threshold if higher_is_better else score > score_threshold
+            if (
+                min_cosine_similarity is not None
+                and cosine_similarity < min_cosine_similarity
             ):
                 continue
 
@@ -490,16 +492,46 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
             matches.append(
                 QueryMatch(
-                    score=score,
+                    cosine_similarity=cosine_similarity,
                     record=Record(uuid=row.uuid, properties=properties),
                 )
             )
 
-        matches.sort(
-            key=lambda match: match.score,
-            reverse=self._config.similarity_metric.higher_is_better,
-        )
+        matches.sort(key=lambda match: match.cosine_similarity, reverse=True)
         return matches
+
+    @override
+    async def get_cosine_similarity(
+        self,
+        *,
+        query_vector: Sequence[float],
+        record_uuids: Iterable[UUID],
+    ) -> dict[UUID, float]:
+        record_uuids = list(record_uuids)
+        if not record_uuids:
+            return {}
+
+        async with self._create_session() as session:
+            fetched_rows = (
+                await session.execute(
+                    select(
+                        self._records_table.c.uuid, self._records_table.c.row_id
+                    ).where(
+                        self._records_table.c.uuid.in_(record_uuids),
+                    )
+                )
+            ).all()
+        if not fetched_rows:
+            return {}
+
+        row_id_to_uuid = {row.row_id: row.uuid for row in fetched_rows}
+        similarities = await self._search_engine.get_cosine_similarities(
+            query_vector, row_id_to_uuid.keys()
+        )
+        return {
+            row_id_to_uuid[row_id]: similarity
+            for row_id, similarity in similarities.items()
+        }
 
     @override
     async def set_properties(
@@ -590,8 +622,8 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         await self._maybe_save_index()
 
 
-VectorSearchEngineFactory = Callable[[int, SimilarityMetric], VectorSearchEngine]
-"""Callable that creates a VectorSearchEngine given (num_dimensions, similarity_metric)."""
+VectorSearchEngineFactory = Callable[[int], VectorSearchEngine]
+"""Callable that creates a VectorSearchEngine given the number of dimensions."""
 
 
 class SQLiteVectorStoreParams(BaseModel):
@@ -600,7 +632,7 @@ class SQLiteVectorStoreParams(BaseModel):
     Attributes:
         sqlalchemy_engine (AsyncEngine):
             Async SQLAlchemy engine (sqlite+aiosqlite).
-        engine_factory (Callable[[int, SimilarityMetric], VectorSearchEngine]):
+        engine_factory (Callable[[int], VectorSearchEngine]):
             Factory for creating :class:`VectorSearchEngine` instances.
             Receives `(ndim, metric)` and returns a search engine.
         index_directory (str | None):
@@ -1009,9 +1041,7 @@ class SQLiteVectorStore(VectorStore):
         if cache_key in self._search_engines:
             return self._search_engines[cache_key]
 
-        search_engine = self._vector_search_engine_factory(
-            config.vector_dimensions, config.similarity_metric
-        )
+        search_engine = self._vector_search_engine_factory(config.vector_dimensions)
 
         index_path = self._index_path(namespace, name)
         if index_path is not None:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -2,28 +2,24 @@
 
 import asyncio
 import contextlib
-import math
 from collections.abc import Callable, Container, Iterable, Mapping, Sequence
 from typing import ClassVar, override
 
 import hnswlib  # ty: ignore[unresolved-import]  # C extension, no py.typed
 import numpy as np
+import numpy.typing as npt
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
 from .index_persistence import atomic_index_write, clear_stale_index_temp
+from .scoring import cosine_similarities
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
 class HnswlibVectorSearchEngine(VectorSearchEngine):
     """Vector search engine backed by hnswlib HNSW."""
 
-    _SPACE_MAP: ClassVar[dict[SimilarityMetric, str]] = {
-        SimilarityMetric.COSINE: "cosine",
-        SimilarityMetric.EUCLIDEAN: "l2",
-        SimilarityMetric.DOT: "ip",
-    }
+    _SPACE: ClassVar[str] = "cosine"
 
     _DEFAULT_M: ClassVar[int] = 16
     _DEFAULT_EF_CONSTRUCTION: ClassVar[int] = 128
@@ -36,7 +32,6 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         self,
         *,
         num_dimensions: int,
-        similarity_metric: SimilarityMetric,
         m: int = _DEFAULT_M,
         ef_construction: int = _DEFAULT_EF_CONSTRUCTION,
         ef_search: int = _DEFAULT_EF_SEARCH,
@@ -54,23 +49,13 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         see https://github.com/nmslib/hnswlib/blob/v0.8.0/hnswlib/hnswalg.h#L981-L987.
         Set to False if you'd rather pay memory growth than the per-replacement updatePoint cost.
         """
-        hnswlib_space = self._SPACE_MAP.get(similarity_metric)
-        if hnswlib_space is None:
-            supported = ", ".join(
-                similarity_metric.value for similarity_metric in self._SPACE_MAP
-            )
-            raise ValueError(
-                f"hnswlib does not support {similarity_metric.value!r}. Supported: {supported}"
-            )
-
         self._num_dimensions = num_dimensions
-        self._similarity_metric = similarity_metric
 
-        self._space = hnswlib_space
+        self._space = self._SPACE
         self._ef_search = ef_search
         self._allow_replace_deleted = allow_replace_deleted
 
-        self._index = hnswlib.Index(space=hnswlib_space, dim=num_dimensions)
+        self._index = hnswlib.Index(space=self._SPACE, dim=num_dimensions)
         self._index.init_index(
             max_elements=initial_capacity,
             ef_construction=ef_construction,
@@ -89,15 +74,10 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
 
         self._lock = AsyncRWLock()
 
-    def _distance_to_score(self, distance: float) -> float:
-        """Convert an hnswlib distance to a pure metric score."""
-        match self._similarity_metric:
-            case SimilarityMetric.COSINE | SimilarityMetric.DOT:
-                return 1.0 - distance
-            case SimilarityMetric.EUCLIDEAN:
-                return math.sqrt(max(0.0, distance))
-            case _:
-                raise NotImplementedError(self._similarity_metric)
+    @staticmethod
+    def _distance_to_cosine_similarity(distance: float) -> float:
+        """Convert an hnswlib cosine distance to a cosine similarity."""
+        return 1.0 - distance
 
     def _ensure_capacity(self, needed: int) -> None:
         """Grow the index if there isn't room for `needed` more elements."""
@@ -252,7 +232,10 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         results: list[SearchResult] = []
         for labels, distances in zip(all_labels, all_distances, strict=True):
             matches = [
-                SearchMatch(key=int(label), score=self._distance_to_score(float(dist)))
+                SearchMatch(
+                    key=int(label),
+                    cosine_similarity=self._distance_to_cosine_similarity(float(dist)),
+                )
                 for label, dist in zip(labels, distances, strict=True)
                 if int(label) >= 0
             ]
@@ -282,6 +265,54 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
                 high = mid - 1
 
         return best
+
+    @override
+    async def get_cosine_similarities(
+        self,
+        query_vector: Sequence[float],
+        keys: Iterable[int],
+    ) -> dict[int, float]:
+        async with self._lock.read_lock():
+            present_keys, matrix = await asyncio.to_thread(
+                self._sync_gather_vectors, keys
+            )
+        if not present_keys:
+            return {}
+        similarities = cosine_similarities(query_vector, matrix)
+        return {
+            key: float(similarity)
+            for key, similarity in zip(present_keys, similarities, strict=True)
+        }
+
+    def _sync_gather_vectors(
+        self, keys: Iterable[int]
+    ) -> tuple[list[int], npt.NDArray[np.float32]]:
+        """Gather stored vectors by key as a float32 matrix; missing keys drop."""
+        keys = list(dict.fromkeys(int(key) for key in keys))
+        empty = np.empty((0, self._num_dimensions), dtype=np.float32)
+        if not keys:
+            return [], empty
+
+        try:
+            return keys, np.asarray(
+                self._index.get_items(keys, return_type="numpy"), dtype=np.float32
+            )
+        except RuntimeError:
+            # Fallback: a missing key was requested. Fetch one by one.
+            present_keys: list[int] = []
+            rows: list[np.ndarray] = []
+            for key in keys:
+                with contextlib.suppress(RuntimeError):
+                    rows.append(
+                        np.asarray(
+                            self._index.get_items([key], return_type="numpy"),
+                            dtype=np.float32,
+                        )[0]
+                    )
+                    present_keys.append(key)
+            if not present_keys:
+                return [], empty
+            return present_keys, np.vstack(rows)
 
     @override
     async def remove(self, keys: Iterable[int]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -284,29 +284,6 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         return best
 
     @override
-    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        async with self._lock.read_lock():
-            return await asyncio.to_thread(self._sync_get_vectors, keys)
-
-    def _sync_get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        keys = list(keys)
-        if not keys:
-            return {}
-
-        try:
-            vectors = self._index.get_items(keys)
-            return {
-                key: list(vector) for key, vector in zip(keys, vectors, strict=True)
-            }
-        except RuntimeError:
-            # Fallback: a deleted key was requested. Fetch one by one.
-            result: dict[int, list[float]] = {}
-            for key in keys:
-                with contextlib.suppress(RuntimeError):
-                    result[key] = list(self._index.get_items([key])[0])
-            return result
-
-    @override
     async def remove(self, keys: Iterable[int]) -> None:
         async with self._lock.write_lock():
             await asyncio.to_thread(self._sync_remove, keys)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/scoring.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/scoring.py
@@ -1,0 +1,37 @@
+"""Shared numpy scoring helpers for vector search engines."""
+
+from collections.abc import Sequence
+
+import numpy as np
+import numpy.typing as npt
+
+from .vector_search_engine import SearchMatch
+
+
+def cosine_similarities(
+    query_vector: Sequence[float], matrix: npt.NDArray[np.float32]
+) -> npt.NDArray[np.float32]:
+    """Cosine similarity of `query_vector` against each row of `matrix`."""
+    query = np.asarray(query_vector, dtype=np.float32)
+    denominators = np.linalg.norm(matrix, axis=1) * np.linalg.norm(query)
+    denominators[denominators == 0.0] = np.inf
+    return (matrix @ query) / denominators
+
+
+def top_k_matches(
+    query_vector: Sequence[float],
+    keys: Sequence[int],
+    matrix: npt.NDArray[np.float32],
+    limit: int,
+) -> list[SearchMatch]:
+    """The best `limit` rows of `matrix` as matches keyed by `keys`."""
+    similarities = cosine_similarities(query_vector, matrix)
+    k = min(limit, similarities.shape[0])
+    if k <= 0:
+        return []
+    top = np.argpartition(-similarities, k - 1)[:k]
+    top = top[np.argsort(-similarities[top])]
+    return [
+        SearchMatch(key=keys[index], cosine_similarity=float(similarities[index]))
+        for index in top
+    ]

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -72,7 +72,6 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
         keys = np.array(list(vectors.keys()), dtype=np.uint64)
         array = self._prepare_vectors(list(vectors.values()))
         self._index.add_with_ids(array, keys)
-        self._index.prepare()
 
     @override
     async def search(

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -10,7 +10,6 @@ from turbovec import IdMapIndex
 from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
-from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -162,8 +161,7 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
-        with atomic_index_write(path) as temp_path:
-            self._index.write(temp_path)
+        self._index.sync(path)
 
     @override
     async def load(self, path: str) -> None:
@@ -171,5 +169,4 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             self._index = await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> IdMapIndex:
-        clear_stale_index_temp(path)
         return IdMapIndex.load(path)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -1,0 +1,175 @@
+"""turbovec (TurboQuant) implementation of VectorSearchEngine."""
+
+import asyncio
+from collections.abc import Container, Iterable, Mapping, Sequence
+from typing import ClassVar, override
+
+import numpy as np
+from turbovec import IdMapIndex
+
+from memmachine_server.common.data_types import SimilarityMetric
+from memmachine_server.common.rw_locks import AsyncRWLock
+
+from .index_persistence import atomic_index_write, clear_stale_index_temp
+from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
+
+
+class TurboVecVectorSearchEngine(VectorSearchEngine):
+    """Vector search engine backed by turbovec."""
+
+    _SUPPORTED_METRICS: ClassVar[frozenset[SimilarityMetric]] = frozenset(
+        {SimilarityMetric.COSINE, SimilarityMetric.DOT}
+    )
+
+    _VALID_BIT_WIDTHS: ClassVar[frozenset[int]] = frozenset({2, 3, 4})
+    _DEFAULT_BIT_WIDTH: ClassVar[int] = 4
+
+    _OVERFETCH_BASE: ClassVar[int] = 4
+
+    def __init__(
+        self,
+        *,
+        num_dimensions: int,
+        similarity_metric: SimilarityMetric,
+        bit_width: int = _DEFAULT_BIT_WIDTH,
+    ) -> None:
+        """Initialize."""
+        if similarity_metric not in self._SUPPORTED_METRICS:
+            supported = ", ".join(metric.value for metric in self._SUPPORTED_METRICS)
+            raise NotImplementedError(
+                f"turbovec does not support {similarity_metric.value!r} "
+                f"(inner-product index only). Supported: {supported}"
+            )
+
+        if bit_width not in self._VALID_BIT_WIDTHS:
+            raise ValueError(
+                f"turbovec bit_width must be one of "
+                f"{sorted(self._VALID_BIT_WIDTHS)}, got {bit_width}"
+            )
+
+        self._similarity_metric = similarity_metric
+        self._index = IdMapIndex(dim=num_dimensions, bit_width=bit_width)
+        self._lock = AsyncRWLock()
+
+    @override
+    async def add(self, vectors: Mapping[int, Sequence[float]]) -> None:
+        if not vectors:
+            return
+        async with self._lock.write_lock():
+            await asyncio.to_thread(self._sync_add, vectors)
+
+    def _sync_add(self, vectors: Mapping[int, Sequence[float]]) -> None:
+        keys = np.array(list(vectors.keys()), dtype=np.uint64)
+        array = self._prepare_vectors(list(vectors.values()))
+        self._index.add_with_ids(array, keys)
+        self._index.prepare()
+
+    @override
+    async def search(
+        self,
+        vectors: Iterable[Sequence[float]],
+        *,
+        limit: int,
+        allowed_keys: Container[int] | None = None,
+    ) -> list[SearchResult]:
+        vectors = list(vectors)
+        if not vectors or limit <= 0:
+            return [SearchResult(matches=[]) for _ in vectors]
+        async with self._lock.read_lock():
+            return await asyncio.to_thread(
+                self._sync_search, vectors, limit, allowed_keys
+            )
+
+    def _sync_search(
+        self,
+        vectors: Sequence[Sequence[float]],
+        limit: int,
+        allowed_keys: Container[int] | None,
+    ) -> list[SearchResult]:
+        query = self._prepare_vectors(vectors)
+
+        if allowed_keys is None:
+            scores, ids = self._index.search(query, limit)
+            return [
+                SearchResult(matches=self._to_matches(scores[i], ids[i], limit, None))
+                for i in range(query.shape[0])
+            ]
+
+        return [
+            self._search_one_filtered(query[i : i + 1], limit, allowed_keys)
+            for i in range(query.shape[0])
+        ]
+
+    def _search_one_filtered(
+        self,
+        query: np.ndarray,
+        limit: int,
+        allowed_keys: Container[int],
+    ) -> SearchResult:
+        fetch_limit = limit * self._OVERFETCH_BASE
+        while True:
+            scores, ids = self._index.search(query, fetch_limit)
+            matches = self._to_matches(scores[0], ids[0], limit, allowed_keys)
+            exhausted = ids.shape[1] < fetch_limit
+            if len(matches) >= limit or exhausted:
+                return SearchResult(matches=matches)
+            fetch_limit *= self._OVERFETCH_BASE
+
+    def _to_matches(
+        self,
+        scores: Iterable[float],
+        keys: Iterable[int],
+        limit: int,
+        allowed_keys: Container[int] | None,
+    ) -> list[SearchMatch]:
+        matches: list[SearchMatch] = []
+        for score, key in zip(scores, keys, strict=True):
+            int_key = int(key)
+            if allowed_keys is not None and int_key not in allowed_keys:
+                continue
+            matches.append(SearchMatch(key=int_key, score=float(score)))
+            if len(matches) >= limit:
+                break
+        return matches
+
+    def _prepare_vectors(self, vectors: Sequence[Sequence[float]]) -> np.ndarray:
+        array = np.array(vectors, dtype=np.float32)
+        if self._similarity_metric is SimilarityMetric.COSINE:
+            norms = np.linalg.norm(array, axis=1, keepdims=True)
+            norms[norms == 0.0] = 1.0
+            array = array / norms
+        return array
+
+    @override
+    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
+        raise NotImplementedError(
+            "turbovec stores only TurboQuant-compressed vectors; "
+            "the original vectors cannot be retrieved"
+        )
+
+    @override
+    async def remove(self, keys: Iterable[int]) -> None:
+        async with self._lock.write_lock():
+            await asyncio.to_thread(self._sync_remove, keys)
+
+    def _sync_remove(self, keys: Iterable[int]) -> None:
+        for key in keys:
+            self._index.remove(key)
+
+    @override
+    async def save(self, path: str) -> None:
+        async with self._lock.write_lock():
+            await asyncio.to_thread(self._sync_save, path)
+
+    def _sync_save(self, path: str) -> None:
+        with atomic_index_write(path) as temp_path:
+            self._index.write(temp_path)
+
+    @override
+    async def load(self, path: str) -> None:
+        async with self._lock.write_lock():
+            self._index = await asyncio.to_thread(self._sync_load, path)
+
+    def _sync_load(self, path: str) -> IdMapIndex:
+        clear_stale_index_temp(path)
+        return IdMapIndex.load(path)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -126,10 +126,16 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             int_key = int(key)
             if allowed_keys is not None and int_key not in allowed_keys:
                 continue
-            matches.append(SearchMatch(key=int_key, score=float(score)))
+            matches.append(SearchMatch(key=int_key, score=self._to_score(score)))
             if len(matches) >= limit:
                 break
         return matches
+
+    def _to_score(self, score: float) -> float:
+        value = float(score)
+        if self._similarity_metric is SimilarityMetric.COSINE:
+            return min(1.0, max(-1.0, value))
+        return value
 
     def _prepare_vectors(self, vectors: Sequence[Sequence[float]]) -> np.ndarray:
         array = np.array(vectors, dtype=np.float32)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -1,6 +1,7 @@
 """turbovec (TurboQuant) implementation of VectorSearchEngine."""
 
 import asyncio
+import math
 from collections.abc import Container, Iterable, Mapping, Sequence
 from typing import ClassVar, override
 
@@ -14,7 +15,15 @@ from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
 class TurboVecVectorSearchEngine(VectorSearchEngine):
-    """Vector search engine backed by turbovec."""
+    """
+    Vector search engine backed by turbovec.
+
+    turbovec indexes a dimensionality that is a multiple of 8, so a vector of
+    any other width is zero-padded up to one. Padding is exact for both metrics
+    this engine serves -- a zero coordinate adds nothing to an inner product
+    and nothing to an L2 norm -- so the padded index answers as the unpadded
+    one would, and any embedding width the other engines accept works here too.
+    """
 
     _SUPPORTED_METRICS: ClassVar[frozenset[SimilarityMetric]] = frozenset(
         {SimilarityMetric.COSINE, SimilarityMetric.DOT}
@@ -47,7 +56,9 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             )
 
         self._similarity_metric = similarity_metric
-        self._index = IdMapIndex(dim=num_dimensions, bit_width=bit_width)
+        self._num_dimensions = num_dimensions
+        self._padded_dimensions = math.ceil(num_dimensions / 8) * 8
+        self._index = IdMapIndex(dim=self._padded_dimensions, bit_width=bit_width)
         self._lock = AsyncRWLock()
 
     @override
@@ -138,7 +149,13 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
         return value
 
     def _prepare_vectors(self, vectors: Sequence[Sequence[float]]) -> np.ndarray:
-        array = np.array(vectors, dtype=np.float32)
+        array = np.zeros((len(vectors), self._padded_dimensions), dtype=np.float32)
+        try:
+            array[:, : self._num_dimensions] = vectors
+        except ValueError as error:
+            raise ValueError(
+                f"vectors must have {self._num_dimensions} dimensions"
+            ) from error
         if self._similarity_metric is SimilarityMetric.COSINE:
             norms = np.linalg.norm(array, axis=1, keepdims=True)
             norms[norms == 0.0] = 1.0

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -162,13 +162,6 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
         return array
 
     @override
-    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        raise NotImplementedError(
-            "turbovec stores only TurboQuant-compressed vectors; "
-            "the original vectors cannot be retrieved"
-        )
-
-    @override
     async def remove(self, keys: Iterable[int]) -> None:
         async with self._lock.write_lock():
             await asyncio.to_thread(self._sync_remove, keys)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -8,7 +8,6 @@ from typing import ClassVar, override
 import numpy as np
 from turbovec import IdMapIndex
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
@@ -25,10 +24,6 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
     one would, and any embedding width the other engines accept works here too.
     """
 
-    _SUPPORTED_METRICS: ClassVar[frozenset[SimilarityMetric]] = frozenset(
-        {SimilarityMetric.COSINE, SimilarityMetric.DOT}
-    )
-
     _VALID_BIT_WIDTHS: ClassVar[frozenset[int]] = frozenset({2, 3, 4})
     _DEFAULT_BIT_WIDTH: ClassVar[int] = 4
 
@@ -38,24 +33,15 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
         self,
         *,
         num_dimensions: int,
-        similarity_metric: SimilarityMetric,
         bit_width: int = _DEFAULT_BIT_WIDTH,
     ) -> None:
         """Initialize."""
-        if similarity_metric not in self._SUPPORTED_METRICS:
-            supported = ", ".join(metric.value for metric in self._SUPPORTED_METRICS)
-            raise NotImplementedError(
-                f"turbovec does not support {similarity_metric.value!r} "
-                f"(inner-product index only). Supported: {supported}"
-            )
-
         if bit_width not in self._VALID_BIT_WIDTHS:
             raise ValueError(
                 f"turbovec bit_width must be one of "
                 f"{sorted(self._VALID_BIT_WIDTHS)}, got {bit_width}"
             )
 
-        self._similarity_metric = similarity_metric
         self._num_dimensions = num_dimensions
         self._padded_dimensions = math.ceil(num_dimensions / 8) * 8
         self._index = IdMapIndex(dim=self._padded_dimensions, bit_width=bit_width)
@@ -136,16 +122,20 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             int_key = int(key)
             if allowed_keys is not None and int_key not in allowed_keys:
                 continue
-            matches.append(SearchMatch(key=int_key, score=self._to_score(score)))
+            matches.append(
+                SearchMatch(
+                    key=int_key,
+                    cosine_similarity=self._to_cosine_similarity(score),
+                )
+            )
             if len(matches) >= limit:
                 break
         return matches
 
-    def _to_score(self, score: float) -> float:
-        value = float(score)
-        if self._similarity_metric is SimilarityMetric.COSINE:
-            return min(1.0, max(-1.0, value))
-        return value
+    @staticmethod
+    def _to_cosine_similarity(inner_product: float) -> float:
+        """Clamp a quantized inner product onto the cosine range."""
+        return min(1.0, max(-1.0, float(inner_product)))
 
     def _prepare_vectors(self, vectors: Sequence[Sequence[float]]) -> np.ndarray:
         array = np.zeros((len(vectors), self._padded_dimensions), dtype=np.float32)
@@ -155,11 +145,28 @@ class TurboVecVectorSearchEngine(VectorSearchEngine):
             raise ValueError(
                 f"vectors must have {self._num_dimensions} dimensions"
             ) from error
-        if self._similarity_metric is SimilarityMetric.COSINE:
-            norms = np.linalg.norm(array, axis=1, keepdims=True)
-            norms[norms == 0.0] = 1.0
-            array = array / norms
-        return array
+        norms = np.linalg.norm(array, axis=1, keepdims=True)
+        norms[norms == 0.0] = 1.0
+        return array / norms
+
+    @override
+    async def get_cosine_similarities(
+        self,
+        query_vector: Sequence[float],
+        keys: Iterable[int],
+    ) -> dict[int, float]:
+        # turbovec has no keyed vector access, so this leans on the filtered
+        # search instead. That search only stops early once it already holds
+        # `limit` matches, so asking for `limit = len(keys)` returns every key
+        # present -- at the cost of widening the fetch until it finds them.
+        key_set = {int(key) for key in keys}
+        if not key_set:
+            return {}
+        async with self._lock.read_lock():
+            [result] = await asyncio.to_thread(
+                self._sync_search, [query_vector], len(key_set), key_set
+            )
+        return {match.key: match.cosine_similarity for match in result.matches}
 
     @override
     async def remove(self, keys: Iterable[int]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
@@ -157,24 +157,6 @@ class USearchVectorSearchEngine(VectorSearchEngine):
         return [r if r is not None else SearchResult(matches=[]) for r in final_results]
 
     @override
-    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        keys = list(keys)
-        if not keys:
-            return {}
-
-        keys_array = np.array(keys, dtype=np.int64)
-        async with self._lock.read_lock():
-            vectors = await asyncio.to_thread(self._index.get, keys_array)
-
-        result: dict[int, list[float]] = {}
-        for i, key in enumerate(keys):
-            vector = vectors[i] if vectors is not None else None
-            if vector is not None:
-                result[key] = list(vector)
-
-        return result
-
-    @override
     async def remove(self, keys: Iterable[int]) -> None:
         async with self._lock.write_lock():
             await asyncio.to_thread(self._sync_remove, keys)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
@@ -1,28 +1,24 @@
 """USearch HNSW implementation of VectorSearchEngine."""
 
 import asyncio
-import math
 from collections.abc import Container, Iterable, Mapping, Sequence
 from typing import ClassVar, override
 
 import numpy as np
+import numpy.typing as npt
 from usearch.index import Index, MetricKind
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
 from .index_persistence import atomic_index_write, clear_stale_index_temp
+from .scoring import cosine_similarities
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
 class USearchVectorSearchEngine(VectorSearchEngine):
     """Vector search engine backed by USearch HNSW."""
 
-    _METRIC_MAP: ClassVar[dict[SimilarityMetric, MetricKind]] = {
-        SimilarityMetric.COSINE: MetricKind.Cos,
-        SimilarityMetric.EUCLIDEAN: MetricKind.L2sq,
-        SimilarityMetric.DOT: MetricKind.IP,
-    }
+    _METRIC_KIND: ClassVar[MetricKind] = MetricKind.Cos
 
     _DEFAULT_M: ClassVar[int] = 16
     _DEFAULT_EF_CONSTRUCTION: ClassVar[int] = 128
@@ -34,42 +30,26 @@ class USearchVectorSearchEngine(VectorSearchEngine):
         self,
         *,
         num_dimensions: int,
-        similarity_metric: SimilarityMetric,
         m: int = _DEFAULT_M,
         ef_construction: int = _DEFAULT_EF_CONSTRUCTION,
         ef_search: int = _DEFAULT_EF_SEARCH,
     ) -> None:
         """Initialize."""
-        usearch_metric = self._METRIC_MAP.get(similarity_metric)
-        if usearch_metric is None:
-            supported = ", ".join(
-                similarity_metric.value for similarity_metric in self._METRIC_MAP
-            )
-            raise ValueError(
-                f"USearch does not support {similarity_metric.value!r}. Supported: {supported}"
-            )
-
         self._index = Index(
             ndim=num_dimensions,
-            metric=usearch_metric,
+            metric=self._METRIC_KIND,
             dtype="f32",
             connectivity=m,
             expansion_add=ef_construction,
             expansion_search=ef_search,
         )
-        self._similarity_metric = similarity_metric
 
         self._lock = AsyncRWLock()
 
-    def _distance_to_score(self, distance: float) -> float:
-        """Convert a USearch distance to a pure metric score."""
-        match self._similarity_metric:
-            case SimilarityMetric.COSINE | SimilarityMetric.DOT:
-                return 1.0 - distance
-            case SimilarityMetric.EUCLIDEAN:
-                return math.sqrt(max(0.0, distance))
-            case _:
-                raise NotImplementedError(self._similarity_metric)
+    @staticmethod
+    def _distance_to_cosine_similarity(distance: float) -> float:
+        """Convert a USearch cosine distance to a cosine similarity."""
+        return 1.0 - distance
 
     @override
     async def add(self, vectors: Mapping[int, Sequence[float]]) -> None:
@@ -140,7 +120,9 @@ class USearchVectorSearchEngine(VectorSearchEngine):
                     matches.append(
                         SearchMatch(
                             key=int_key,
-                            score=self._distance_to_score(float(dist)),
+                            cosine_similarity=self._distance_to_cosine_similarity(
+                                float(dist)
+                            ),
                         )
                     )
                     if len(matches) >= limit:
@@ -155,6 +137,49 @@ class USearchVectorSearchEngine(VectorSearchEngine):
             overfetch_factor *= USearchVectorSearchEngine._OVERFETCH_BASE
 
         return [r if r is not None else SearchResult(matches=[]) for r in final_results]
+
+    @override
+    async def get_cosine_similarities(
+        self,
+        query_vector: Sequence[float],
+        keys: Iterable[int],
+    ) -> dict[int, float]:
+        async with self._lock.read_lock():
+            present_keys, matrix = await asyncio.to_thread(
+                self._sync_gather_vectors, keys
+            )
+        if not present_keys:
+            return {}
+        similarities = cosine_similarities(query_vector, matrix)
+        return {
+            key: float(similarity)
+            for key, similarity in zip(present_keys, similarities, strict=True)
+        }
+
+    def _sync_gather_vectors(
+        self, keys: Iterable[int]
+    ) -> tuple[list[int], npt.NDArray[np.float32]]:
+        """Gather stored vectors by key as a float32 matrix; missing keys drop."""
+        keys = list(dict.fromkeys(int(key) for key in keys))
+        empty = np.empty((0, self._index.ndim), dtype=np.float32)
+        if not keys:
+            return [], empty
+
+        gathered = self._index.get(np.array(keys, dtype=np.int64))
+        if gathered is None:
+            return [], empty
+        if isinstance(gathered, np.ndarray):
+            return keys, np.asarray(gathered, dtype=np.float32).reshape(len(keys), -1)
+
+        present_keys: list[int] = []
+        rows: list[np.ndarray] = []
+        for key, row in zip(keys, gathered, strict=True):
+            if row is not None:
+                present_keys.append(key)
+                rows.append(np.asarray(row, dtype=np.float32))
+        if not present_keys:
+            return [], empty
+        return present_keys, np.vstack(rows)
 
     @override
     async def remove(self, keys: Iterable[int]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
@@ -93,21 +93,6 @@ class VectorSearchEngine(ABC):
         """
 
     @abstractmethod
-    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        """
-        Retrieve vectors by key.
-
-        Args:
-            keys (Iterable[int]):
-                Keys of vectors to retrieve.
-
-        Returns:
-            dict[int, list[float]]:
-                Mapping of key to vector for keys that exist.
-                Missing keys are omitted.
-        """
-
-    @abstractmethod
     async def remove(self, keys: Iterable[int]) -> None:
         """
         Remove vectors by key.

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
@@ -11,16 +11,13 @@ class SearchMatch:
     A single search match.
 
     Attributes:
-        score (float):
-            The meaning depends on the collection's `SimilarityMetric`:
-            - *cosine*: cosine similarity in [-1, 1].
-            - *dot*: raw dot product [0, inf).
-            - *euclidean*: Euclidean distance [0, inf).
-            - *manhattan*: Manhattan distance [0, inf).
+        cosine_similarity (float):
+            Cosine similarity between the query vector and the matched
+            vector, in [-1, 1]. Higher is a better match.
         key (int): Engine key for the matched vector.
     """
 
-    score: float
+    cosine_similarity: float
     key: int
 
 
@@ -90,6 +87,35 @@ class VectorSearchEngine(ABC):
             list[SearchResult]:
                 Results for each query vector,
                 ordered as in the input iterable.
+        """
+
+    @abstractmethod
+    async def get_cosine_similarities(
+        self,
+        query_vector: Sequence[float],
+        keys: Iterable[int],
+    ) -> dict[int, float]:
+        """
+        Get cosine similarities between a query vector and vectors by key.
+
+        Every key the engine can score is returned; keys it cannot score
+        are omitted. Engines with keyed vector access answer this more
+        cheaply than a search.
+
+        Similarities may be computed from quantized stored vectors,
+        so they may not be faithful to similarities computed
+        with a fresh embedding.
+
+        Args:
+            query_vector (Sequence[float]):
+                The vector to compare against.
+            keys (Iterable[int]):
+                Keys of vectors to compare.
+
+        Returns:
+            dict[int, float]:
+                Mapping of key to cosine similarity in [-1, 1]
+                for keys that exist. Missing keys are omitted.
         """
 
     @abstractmethod

--- a/packages/server/src/memmachine_server/common/vector_store/vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_store.py
@@ -5,9 +5,10 @@ Defines the interface for adding, querying, and deleting records.
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from uuid import UUID
 
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     FilterExpr,
 )
@@ -68,7 +69,6 @@ class VectorStoreCollection(ABC):
         limit: int,
         score_threshold: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         """
@@ -86,9 +86,6 @@ class VectorStoreCollection(ABC):
                 Filter expression tree.
                 If None or empty, no property filtering is applied
                 (default: None).
-            return_vector (bool):
-                Whether to include the vector in the returned records
-                (default: False).
             return_properties (bool):
                 Whether to include the properties in the returned records
                 (default: True).
@@ -101,30 +98,25 @@ class VectorStoreCollection(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
         """
-        Get records from the collection by their UUIDs.
+        Replace the properties of records already in the collection.
+
+        Each record keeps the vector it was stored with, so a caller that is
+        only correcting a record's properties does not have to hold the vector
+        to write it back. UUIDs the collection does not hold are ignored, the
+        way `delete` ignores them: whether a backend can tell a missing record
+        from one it just wrote varies, so the contract does not promise to.
 
         Args:
-            record_uuids (Iterable[UUID]):
-                Iterable of UUIDs of the records to retrieve.
-            return_vector (bool):
-                Whether to include the vector in the returned records
-                (default: False).
-            return_properties (bool):
-                Whether to include the properties in the returned records
-                (default: True).
-
-        Returns:
-            list[Record]:
-                Iterable of records with the specified UUIDs,
-                ordered as in the input iterable.
+            record_properties (Mapping[UUID, Mapping[str, PropertyValue]]):
+                Mapping of record UUID to the properties that replace whatever
+                that record currently holds. Properties not in the indexed
+                properties schema are allowed.
         """
         raise NotImplementedError
 

--- a/packages/server/src/memmachine_server/common/vector_store/vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_store.py
@@ -67,7 +67,7 @@ class VectorStoreCollection(ABC):
         *,
         query_vectors: Iterable[Sequence[float]],
         limit: int,
-        score_threshold: float | None = None,
+        min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
         return_properties: bool = True,
     ) -> list[QueryResult]:
@@ -79,8 +79,9 @@ class VectorStoreCollection(ABC):
                 The vectors to compare against.
             limit (int):
                 Maximum number of matching records to return per query vector.
-            score_threshold (float | None):
-                Score threshold to consider a match
+            min_cosine_similarity (float | None):
+                If provided, only return matches whose cosine similarity
+                is greater than or equal to this value
                 (default: None).
             property_filter (FilterExpr | None):
                 Filter expression tree.
@@ -94,6 +95,33 @@ class VectorStoreCollection(ABC):
             list[QueryResult]:
                 Results for each query vector,
                 ordered as in the input iterable.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_cosine_similarity(
+        self,
+        *,
+        query_vector: Sequence[float],
+        record_uuids: Iterable[UUID],
+    ) -> dict[UUID, float]:
+        """
+        Get cosine similarities between a query vector and records' vectors.
+
+        Similarities may be computed from quantized stored vectors,
+        so they may not be faithful to similarities computed
+        with a fresh embedding.
+
+        Args:
+            query_vector (Sequence[float]):
+                The vector to compare against.
+            record_uuids (Iterable[UUID]):
+                UUIDs of the records to compare.
+
+        Returns:
+            dict[UUID, float]:
+                Mapping of record UUID to cosine similarity in [-1, 1].
+                UUIDs without a stored record are omitted.
         """
         raise NotImplementedError
 

--- a/packages/server/src/memmachine_server/episodic_memory/declarative_memory/declarative_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/declarative_memory/declarative_memory.py
@@ -167,7 +167,7 @@ class DeclarativeMemory:
                     DeclarativeMemory._embedding_name(
                         self._embedder.model_id,
                         self._embedder.dimensions,
-                    ): (embedding, self._embedder.similarity_metric),
+                    ): embedding,
                 },
             )
             for derivative, embedding in zip(
@@ -361,7 +361,6 @@ class DeclarativeMemory:
                 )
             ),
             query_embedding=query_embedding,
-            similarity_metric=self._embedder.similarity_metric,
             limit=min(5 * max_num_episodes, 200),
             property_filter=mangled_property_filter,
         )

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
@@ -424,7 +424,6 @@ class EventMemory:
             query_vectors=[query_embedding],
             limit=vector_search_limit,
             property_filter=collection_filter,
-            return_vector=False,
             return_properties=True,
         )
         t_vector_query = time.monotonic()

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
@@ -442,7 +442,7 @@ class EventMemory:
                 )
             )
             if segment_uuid not in seed_embedding_scores:
-                seed_embedding_scores[segment_uuid] = match.score
+                seed_embedding_scores[segment_uuid] = match.cosine_similarity
 
         seed_segment_uuids = list(seed_embedding_scores)
 
@@ -485,13 +485,6 @@ class EventMemory:
             )
         t_scoring = time.monotonic()
 
-        # Reranker scores are always higher-is-better.
-        # Embedding scores depend on the similarity metric.
-        higher_is_better = (
-            self._reranker is not None
-            or self._vector_store_collection.config.similarity_metric.higher_is_better
-        )
-
         # Return scored contexts ordered by score.
         scored_segment_contexts = [
             ScoredSegmentContext(
@@ -505,7 +498,7 @@ class EventMemory:
                     strict=True,
                 ),
                 key=lambda triple: triple[0],
-                reverse=higher_is_better,
+                reverse=True,
             )
         ]
 

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -192,13 +192,6 @@ class LongTermMemory:
         self._segment_store: SegmentStore | None = None
         self._partition_key: str | None = None
         self._episode_storage: EpisodeStorage | None = None
-        # Event backend only: whether scores from `EventMemory.query` are
-        # higher-is-better. Matches the same derivation inside EventMemory.query
-        # (reranker scores are higher-is-better; raw vector scores depend on the
-        # collection's similarity metric — cosine is higher-is-better, euclidean
-        # is lower-is-better). Used to apply `score_threshold` in the correct
-        # direction so it doesn't invert under euclidean with no reranker.
-        self._score_higher_is_better: bool = True
         # Event backend only: configured user-property names from
         # properties_schema. Empty means "no validation"; non-empty means the
         # set is closed and filter expressions referencing `m.<unknown>` raise
@@ -234,10 +227,6 @@ class LongTermMemory:
                 self._segment_store = params.segment_store
                 self._partition_key = params.partition_key
                 self._episode_storage = params.episode_storage
-                self._score_higher_is_better = (
-                    params.reranker is not None
-                    or params.vector_store_collection.config.similarity_metric.higher_is_better
-                )
                 self._user_property_keys = params.user_property_keys
 
     async def add_episodes(self, episodes: Iterable[Episode]) -> None:
@@ -461,17 +450,13 @@ class LongTermMemory:
     def _score_passes_threshold(
         self, score: float, score_threshold: float | None
     ) -> bool:
-        """Apply `score_threshold` in the correct direction for the metric.
+        """Drop scores below `score_threshold`; None never drops.
 
-        higher-is-better → drop scores BELOW threshold;
-        lower-is-better  → drop scores ABOVE threshold;
-        None             → never drop.
+        Reranker scores and cosine similarities are both higher-is-better.
         """
         if score_threshold is None:
             return True
-        if self._score_higher_is_better:
-            return score >= score_threshold
-        return score <= score_threshold
+        return score >= score_threshold
 
     def _require_event_backend_live(self) -> EventMemory:
         """Return the EventMemory or raise if the instance was dropped."""

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
@@ -115,7 +115,6 @@ async def _event_params(
         user_schema = _resolve_user_properties_schema(config.properties_schema)
         collection_config = VectorStoreCollectionConfig(
             vector_dimensions=embedder.dimensions,
-            similarity_metric=embedder.similarity_metric,
             indexed_properties_schema={
                 **EventMemory.expected_vector_store_collection_schema(),
                 **EVENT_BACKEND_SYSTEM_FIELDS,

--- a/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
@@ -294,22 +294,49 @@ class VectorStoreSemanticStorage(SemanticStorage):
         if row is None:
             raise ResourceNotFoundError(f"Feature ID not found: {feature_id}")
 
-        if values or embedding is not None:
-            existing_record = await self._get_existing_vector_record(feature_id)
-            await self._upsert_vector_record(
-                feature_id=feature_id,
-                set_id=row.set_id,
-                category_name=row.semantic_category_id,
-                feature=row.feature,
-                value=row.value,
-                tag=row.tag_id,
-                embedding=(
-                    embedding
-                    if embedding is not None
-                    else np.array(existing_record.vector, dtype=float)
-                ),
-                metadata=row.json_metadata,
+        if embedding is not None or values:
+            await self._refresh_vector_record(
+                feature_id=feature_id, row=row, embedding=embedding
             )
+
+    async def _refresh_vector_record(
+        self,
+        *,
+        feature_id: FeatureIdT,
+        row: VectorSemanticFeature,
+        embedding: InstanceOf[np.ndarray] | None,
+    ) -> None:
+        """Bring a feature's vector record back in line with its relational row."""
+        if embedding is None:
+            # The embedding is a function of `value` alone, so a caller that did
+            # not pass one changed nothing the embedding depends on; only the
+            # properties mirroring the relational row need to catch up, and the
+            # stored vector stays where it is rather than being read back out.
+            await self._vector_collection.set_properties(
+                record_properties={
+                    feature_vector_uuid(feature_id): self._vector_properties(
+                        feature_id=feature_id,
+                        set_id=row.set_id,
+                        category_name=row.semantic_category_id,
+                        feature=row.feature,
+                        value=row.value,
+                        tag=row.tag_id,
+                        metadata=row.json_metadata,
+                    )
+                }
+            )
+            return
+
+        await self._upsert_vector_record(
+            feature_id=feature_id,
+            set_id=row.set_id,
+            category_name=row.semantic_category_id,
+            feature=row.feature,
+            value=row.value,
+            tag=row.tag_id,
+            embedding=embedding,
+            metadata=row.json_metadata,
+        )
 
     async def get_feature(
         self,
@@ -620,31 +647,6 @@ class VectorStoreSemanticStorage(SemanticStorage):
             ]
         )
 
-    async def _get_existing_vector_record(self, feature_id: FeatureIdT) -> Record:
-        """Read back a feature's stored embedding.
-
-        A vector store publishes its index atomically but not durably (see
-        `common.vector_store.sqlite_vector_store`), so a power failure can
-        leave a record the store still knows about but whose vector the index
-        no longer holds. The two cases are reported apart because the caller
-        can act on them differently: a missing embedding is repaired by
-        passing a fresh one to `update_feature`, while a missing record is
-        not.
-        """
-        records = await self._vector_collection.get(
-            record_uuids=[feature_vector_uuid(feature_id)],
-            return_vector=True,
-            return_properties=False,
-        )
-        if not records:
-            raise ResourceNotFoundError(f"Vector record not found: {feature_id}")
-        if records[0].vector is None:
-            raise ResourceNotFoundError(
-                f"Vector record {feature_id} has no stored embedding; "
-                "pass an embedding to update this feature"
-            )
-        return records[0]
-
     async def _delete_vector_records(self, feature_ids: Sequence[FeatureIdT]) -> None:
         if not feature_ids:
             return
@@ -670,7 +672,6 @@ class VectorStoreSemanticStorage(SemanticStorage):
             query_vectors=[vector_search_opts.query_embedding.tolist()],
             limit=limit,
             score_threshold=vector_search_opts.min_distance,
-            return_vector=False,
             return_properties=True,
         )
         ordered_ids = [

--- a/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
@@ -671,7 +671,7 @@ class VectorStoreSemanticStorage(SemanticStorage):
         [query_result] = await self._vector_collection.query(
             query_vectors=[vector_search_opts.query_embedding.tolist()],
             limit=limit,
-            score_threshold=vector_search_opts.min_distance,
+            min_cosine_similarity=vector_search_opts.min_distance,
             return_properties=True,
         )
         ordered_ids = [

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'gpu'", specifier = ">=5.1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.43" },
     { name = "sqlite-vec", specifier = ">=0.1.9" },
-    { name = "turbovec", marker = "extra == 'turbovec'", specifier = ">=0.7.0" },
+    { name = "turbovec", marker = "extra == 'turbovec'", specifier = ">=1.0.0" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.1" },
     { name = "usearch", specifier = ">=2.25.1" },
     { name = "uvicorn", specifier = ">=0.35.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2253,6 +2253,9 @@ nebula = [
 qdrant = [
     { name = "qdrant-client" },
 ]
+turbovec = [
+    { name = "turbovec" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2291,11 +2294,12 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'gpu'", specifier = ">=5.1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.43" },
     { name = "sqlite-vec", specifier = ">=0.1.9" },
+    { name = "turbovec", marker = "extra == 'turbovec'", specifier = ">=0.7.0" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.1" },
     { name = "usearch", specifier = ">=2.25.1" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
-provides-extras = ["gpu", "hnswlib", "nebula", "qdrant", "milvus", "litellm"]
+provides-extras = ["gpu", "hnswlib", "nebula", "qdrant", "milvus", "litellm", "turbovec"]
 
 [[package]]
 name = "milvus-lite"
@@ -4629,6 +4633,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
     { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
     { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
+]
+
+[[package]]
+name = "turbovec"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/d2/00c981bd1a6be5b6a875435bf678e627f191e3daf47ea70e1b5ee3109c36/turbovec-1.0.0.tar.gz", hash = "sha256:4ceb3c4ad08e48c6b3483b88aca63d81a06449f90d5fbc1b162dd11df10b8fb2", size = 702952, upload-time = "2026-08-18T20:43:31.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/e0/d759918244236356199b0f4d868ee331d0440a9824f147780aaefa8fe1af/turbovec-1.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:a69e8e2e26ba943f31fba546ab595b60e9b4c25087ed905c3e6ceb0d297ee234", size = 668359, upload-time = "2026-08-18T20:43:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e9/8de1e7d2636a8f5c73d39c64ec6fb4bd20180d8c966962d919356d06e175/turbovec-1.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:09aa495e802701f139820e21700dc947ea21734446112afefb4e480a8f65fa90", size = 700020, upload-time = "2026-08-18T20:43:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/6d/c1acf31a1ef381b588de86ebebb32c3ca7d310cbb84279ac1f65c3a3e854/turbovec-1.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c810f50b967c2163b78d1e27d29e153ab5e8820de23921ad959227acca8bb06a", size = 719275, upload-time = "2026-08-18T20:43:28.402Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/7d/e0c14b09f6dfb7ff156d1f884119daebc5c8bf9f5b8fc72ada26c2674256/turbovec-1.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:cd855e0b318a57dc57c733f9a62ae98de5192f4f6c2c760e305523e8ceb1b090", size = 611788, upload-time = "2026-08-18T20:43:29.854Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #1591 (which is itself stacked on #1588) — only the last commit, `Make cosine the only similarity, and read it back per record`, belongs to this PR.

Follows the `default` branch, where this removal has already been made.

### Purpose of the change

Every embedder MemMachine ships produces vectors meant to be compared by cosine similarity. `OpenAIEmbedder` hard-coded `COSINE`; `AmazonBedrockEmbedder` defaulted to it; `SentenceTransformerEmbedder` only reported whatever the model declared. `SimilarityMetric` let the rest of the stack ask which of four metrics was in play, and the answer was cosine everywhere — while every layer that touched a score paid for the other three: direction flags threaded through scoring, thresholds applied in whichever direction the metric implied, and a per-backend table in each store mapping the enum onto native metric names.

### Description

**The enum is gone.** Scores are cosine similarities in `[-1, 1]`, higher is better, and the names say so:

| Before | After |
|---|---|
| `QueryMatch.score` | `QueryMatch.cosine_similarity` |
| `SearchMatch.score` | `SearchMatch.cosine_similarity` |
| `query(score_threshold=…)` | `query(min_cosine_similarity=…)` |
| `compute_similarity(a, b, metric)` | `compute_cosine_similarity(a, b)` |
| `VectorStoreCollectionConfig.similarity_metric` | removed |
| `Embedder.similarity_metric` | removed |
| `similarity_gt(metric)` | removed (no callers) |
| `VectorSearchEngineFactory = (int, SimilarityMetric) -> …` | `(int) -> …` |

`min_cosine_similarity` no longer needs a direction to be meaningful — that is the point of the rename, not just tidier spelling.

**And `get_cosine_similarity` arrives.** With one metric there is finally something worth reading back per record, so this adds `VectorStoreCollection.get_cosine_similarity` and `VectorSearchEngine.get_cosine_similarities`. Every backend can serve it, by one of two routes:

- **Keyed vector access** — hnswlib and usearch gather stored vectors and score locally; sqlite-vec pushes it into SQL (`vec_distance_cosine` per rowid, one point query each because vec0 plans `rowid IN (…)` as a full scan); Qdrant and Milvus retrieve by id, which is *exact* where an id-filtered ANN query is not guaranteed to return every matching point.
- **Comprehensive filtered search** — turbovec cannot hand a vector back at all (it stores only TurboQuant codes), so it leans on its filtered search, which stops early only once it already holds `limit` matches; asking for `limit = len(keys)` therefore returns every key present.

Similarities may be computed from quantized stored vectors, so the contract says plainly that they may not match a similarity computed from a fresh embedding — which covers both turbovec's estimate and hnswlib's normalize-on-insert.

### Two consequences beyond the vector store

`default`'s `packages/core` has no vector graph store, so these two have no counterpart there and are worth reviewing on their own terms.

1. **The vector graph stores carried a metric per stored embedding**, as a companion `similarity_metric_for_<name>` property written beside every vector, in both Neo4j and NebulaGraph. That property is gone, and `Node.embeddings` / `Edge.embeddings` are `dict[str, list[float]]` rather than `dict[str, tuple[list[float], SimilarityMetric]]`. Existing graph data keeps the orphaned companion properties; nothing reads them.

2. **NebulaGraph's similarity search is now always exact KNN.** Its vector indexes offer only L2 and IP, and its `cosine()` does not support `APPROXIMATE` — so with cosine as the only similarity, no index it can build serves a query. `use_ann` could never be true and `_create_vector_index_if_not_exists` could only ever take its skip path, so both are removed rather than left as unreachable code. This is a real behavioral narrowing for NebulaGraph deployments that were relying on an L2 or IP index. The now-unused ANN tuning parameters (`ann_index_type`, `ivf_nprobe`, `hnsw_ef_search`, `force_exact_similarity_search`) are deliberately left in place for a separate change, since they are user-visible configuration.

Tests that existed only to pin multi-metric behavior are removed: euclidean/dot search sections in the engine suites, euclidean ordering and threshold-direction tests in the store suites, the `_similarity_metric_to_nebula` mapping table test, and the euclidean threshold-inversion regressions in the event-backend wiring suite (that inversion is no longer reachable).

### Verification

- `pytest packages/server/server_tests`: **1916 passed, 3 skipped**. The one failure, `test_get_version`, is a git-describe version-string artifact of the local checkout and fails identically on untouched `speedkick` (`0.3.9.post2.dev5+g8dd1c0178`); see #1592's sibling discussion.
- `ty check --project packages/server`: 17 diagnostics, the same 17 as the base branch.
- `ruff check` / `ruff format --check`: clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKmF9xNph9QH3ozNw3ZnJL
