### PR TITLE
Fix the ty static checks (speedkick)

### DIFF
--- a/packages/client/src/memmachine_client/langgraph.py
+++ b/packages/client/src/memmachine_client/langgraph.py
@@ -306,10 +306,8 @@ class MemMachineTools:
                 if episodes:
                     summary_parts.append(f"Found {len(episodes)} episodic memories:")
                     for i, mem in enumerate(episodes[:3], 1):
-                        content = (
-                            mem.get("content", "")
-                            if isinstance(mem, dict)
-                            else str(mem)
+                        content = str(
+                            mem.get("content", "") if isinstance(mem, dict) else mem
                         )
                         summary_parts.append(f"  {i}. {content[:100]}...")
             elif isinstance(episodic_memories, list) and episodic_memories:
@@ -317,8 +315,8 @@ class MemMachineTools:
                     f"Found {len(episodic_memories)} episodic memories:"
                 )
                 for i, mem in enumerate(episodic_memories[:3], 1):
-                    content = (
-                        mem.get("content", "") if isinstance(mem, dict) else str(mem)
+                    content = str(
+                        mem.get("content", "") if isinstance(mem, dict) else mem
                     )
                     summary_parts.append(f"  {i}. {content[:100]}...")
 

--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -62,7 +62,12 @@ hnswlib = [
     "hnswlib>=0.8.0",
 ]
 nebula = [
-    "nebula5-python>=5.2.1",
+    # 5.3 removed the public async client this backend is written against:
+    # NebulaAsyncClient, SessionConfig and SessionPoolConfig are gone, and the
+    # AsyncNebulaClient that replaces NebulaAsyncClient has no public way to
+    # open a connection -- only the private _init_client(). Until it does, the
+    # async backend cannot move past 5.2.
+    "nebula5-python>=5.2.1,<5.3",
 ]
 qdrant = [
     "qdrant-client>=1.17.0",

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_mixin_confs.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_mixin_confs.py
@@ -200,7 +200,7 @@ def test_password_mixin_without_env():
 
 def test_password_mixin_invalid_type():
     with pytest.raises(ValidationError) as exc:
-        ApiKeyMixin(api_key=12345)  # type: ignore
+        ApiKeyMixin.model_validate({"api_key": 12345})
     assert "should be a valid string" in str(exc.value)
 
 

--- a/packages/server/server_tests/memmachine_server/common/language_model/test_openai_chat_completions_language_model.py
+++ b/packages/server/server_tests/memmachine_server/common/language_model/test_openai_chat_completions_language_model.py
@@ -168,8 +168,8 @@ def test_init_missing_client():
     """Test initialization fails if client is missing."""
     with pytest.raises(ValidationError):
         OpenAIChatCompletionsLanguageModel(
-            OpenAIChatCompletionsLanguageModelParams(
-                model="test-model",
+            OpenAIChatCompletionsLanguageModelParams.model_validate(
+                {"model": "test-model"},
             ),
         )
 
@@ -178,10 +178,8 @@ def test_init_missing_model():
     """Test initialization fails if model is missing."""
     with pytest.raises(ValidationError):
         OpenAIChatCompletionsLanguageModel(
-            OpenAIChatCompletionsLanguageModelParams(
-                client=openai.AsyncOpenAI(
-                    api_key="test_api_key",
-                ),
+            OpenAIChatCompletionsLanguageModelParams.model_validate(
+                {"client": openai.AsyncOpenAI(api_key="test_api_key")},
             ),
         )
 

--- a/packages/server/server_tests/memmachine_server/common/language_model/test_openai_responses_language_model.py
+++ b/packages/server/server_tests/memmachine_server/common/language_model/test_openai_responses_language_model.py
@@ -106,8 +106,8 @@ def test_init_missing_client():
     """Test initialization fails if client is missing."""
     with pytest.raises(ValidationError):
         OpenAIResponsesLanguageModel(
-            OpenAIResponsesLanguageModelParams(
-                model="test-model",
+            OpenAIResponsesLanguageModelParams.model_validate(
+                {"model": "test-model"},
             ),
         )
 
@@ -116,10 +116,8 @@ def test_init_missing_model():
     """Test initialization fails if model is missing."""
     with pytest.raises(ValidationError):
         OpenAIResponsesLanguageModel(
-            OpenAIResponsesLanguageModelParams(
-                client=openai.AsyncOpenAI(
-                    api_key="test_api_key",
-                ),
+            OpenAIResponsesLanguageModelParams.model_validate(
+                {"client": openai.AsyncOpenAI(api_key="test_api_key")},
             ),
         )
 

--- a/packages/server/server_tests/memmachine_server/main/test_memmachine_delete_session.py
+++ b/packages/server/server_tests/memmachine_server/main/test_memmachine_delete_session.py
@@ -114,7 +114,9 @@ async def test_delete_session_clears_semantic_history_and_citations(
 
 
 @pytest.mark.asyncio
-async def test_delete_episode_store_processes_in_batches() -> None:
+async def test_delete_episode_store_processes_in_batches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """_delete_episode_store fetches and deletes episodes in batches until empty."""
 
     @dataclass
@@ -158,7 +160,7 @@ async def test_delete_episode_store_processes_in_batches() -> None:
     resources.get_session_data_manager = AsyncMock(return_value=session_manager)
 
     mm = MemMachine(conf=conf, resources=resources)
-    mm._cleanup_semantic_history = cleanup_mock  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    monkeypatch.setattr(mm, "_cleanup_semantic_history", cleanup_mock)
 
     await mm.start()
     await mm.delete_session(_SD())

--- a/packages/server/src/memmachine_server/common/language_model/openai_responses_language_model.py
+++ b/packages/server/src/memmachine_server/common/language_model/openai_responses_language_model.py
@@ -317,7 +317,7 @@ class OpenAIResponsesLanguageModel(LanguageModel):
                 for output in response.output:
                     if output.type != "function_call":
                         continue
-                    function_call = cast(ResponseFunctionToolCall, output)
+                    function_call: ResponseFunctionToolCall = output
                     function_calls_arguments.append(
                         {
                             "call_id": function_call.call_id,

--- a/uv.lock
+++ b/uv.lock
@@ -2275,7 +2275,7 @@ requires-dist = [
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.63.0,<1.86" },
     { name = "memmachine-common", editable = "packages/common" },
     { name = "milvus-lite", marker = "extra == 'milvus'", specifier = ">=3.0.0" },
-    { name = "nebula5-python", marker = "extra == 'nebula'", specifier = ">=5.2.1" },
+    { name = "nebula5-python", marker = "extra == 'nebula'", specifier = ">=5.2.1,<5.3" },
     { name = "neo4j", specifier = ">=5.28.2" },
     { name = "nltk", specifier = ">=3.9.4" },
     { name = "openai", specifier = ">=2.21.0" },
@@ -2507,20 +2507,18 @@ wheels = [
 
 [[package]]
 name = "nebula5-python"
-version = "5.3.0"
+version = "5.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "grpcio" },
     { name = "minijinja" },
-    { name = "pool" },
     { name = "protobuf" },
-    { name = "pytest" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/ed/3ac50de3a130348a0bd60020d5a8d7871023dcb73d26bda7e21248083eed/nebula5_python-5.3.0.tar.gz", hash = "sha256:c0249068ebb96e3e156d242be24fdd0b4b4c130b87882b10f7b0b345789cbba4", size = 94534, upload-time = "2026-06-26T05:39:32.311Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/66/eee93be1cc050178a631ff30f495d0f1b2b41f046fcee8f47c2219803938/nebula5_python-5.2.2.tar.gz", hash = "sha256:91869f254033e8e526ae82cd8f336116b1177c3a401b3a4dbca3bc9995717dde", size = 82256, upload-time = "2026-04-08T06:42:41.653Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/39/cfa9020ee82b3c3f53b78050a10a10834830c1ee83a1ed5296aaf58fbb7c/nebula5_python-5.3.0-py3-none-any.whl", hash = "sha256:014512d27c41d3097620d0b58da0b0b2f6e1fd385eaa07db32f3d3685391969f", size = 104122, upload-time = "2026-06-26T05:39:31.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/af/9bc05ea38e40ef09d621e30b84e99ad95e748000195097cc0e5746b02ca0/nebula5_python-5.2.2-py3-none-any.whl", hash = "sha256:3904046c5acc587ebf19aca7db8a9e7e9bb034f82b959ef9eeb94a00769caea3", size = 101587, upload-time = "2026-04-08T06:42:40.509Z" },
 ]
 
 [[package]]
@@ -3033,12 +3031,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
-
-[[package]]
-name = "pool"
-version = "0.1.2.dev0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/b4/b7c44381e6e074a01c004ecd6d7b668037821abaf17a787fc01cdf9256a7/pool-0.1.2dev.tar.gz", hash = "sha256:99a3aefa842c5bb87c92a3bbd40cacab212f104268a8fc6e706a2df92002f785", size = 19063, upload-time = "2013-01-05T06:44:34.646Z" }
 
 [[package]]
 name = "portalocker"


### PR DESCRIPTION
The lint workflow's six `ty` jobs (common, client and server, each on the oldest and newest supported Python) fail on every pull request. This makes all six pass.

## The NebulaGraph half

Nine of the eighteen diagnostics are a real breakage rather than a typing nit. nebula5-python 5.3.0 removed `NebulaAsyncClient`, `SessionConfig` and `SessionPoolConfig` — all three in `nebulagraph_python.client.__all__` in 5.2 — so `nebula5-python>=5.2.1` resolves to a release whose import the NebulaGraph backend cannot even complete: `async_get_nebula_client` raises `ImportError` at its use site, and `nebula_graph_vector_graph_store` has no client type to annotate.

Porting forward is not available yet. 5.3's `AsyncNebulaClient` has no public way to open a connection:

- `NebulaAsyncClient.connect(hosts=..., username=..., session_config=..., session_pool_config=...)` is gone.
- `AsyncNebulaClient.__init__` leaves `connection = None` and `session_id = -1`, and its public surface is `close`, `execute`, `execute_with_timeout`, `execute_py`, `ping`, `pq`, `print_query_result`, `is_closed_client` and the `get_*` accessors — no `connect`, `open` or `__aenter__`.
- The only initializer left is the private `_init_client()`, which nothing in the package calls.

Its sync `NebulaClient`, `NebulaPool` and `ClientPoolFactory` are complete, so the ways forward are private API or running blocking gRPC calls off the event loop — a backend rewrite, not a lint fix. This PR caps the extra at `<5.3`, the range the backend actually supports, and documents why at the declaration. Relocking also drops the runtime dependencies on `pytest` and `pool` that 5.3.0 added.

## The rest

- The four `missing-argument` diagnostics were tests that deliberately omit a required field. They now go through `model_validate()` with a dict, so pydantic — not a suppression comment — is what rejects the input.
- `test_delete_episode_store_processes_in_batches` assigned a mock over a bound method behind a `# type: ignore` / `# ty: ignore` pair; it now uses `monkeypatch.setattr`, and both comments are gone.
- `test_password_mixin_invalid_type` loses its blanket `# type: ignore` the same way.
- `cast(ResponseFunctionToolCall, output)` was redundant — ty narrows `output` on the `output.type != "function_call"` guard. It is now an annotation, so the narrowing is proved rather than asserted.
- `_format_search_summary` sliced values pulled out of a `model_dump()`ed dict, which are not necessarily `str`; a non-str value would have raised `TypeError` at runtime. They are stringified before slicing.

No `# type: ignore`, `# ty: ignore`, `Any` or `cast` was added.

## Verification

`ty check` passes for `packages/common` (3.10, 3.14), `packages/client` (3.10, 3.14) and `packages/server` (3.12, 3.14) — the six CI jobs. `ruff check`, `ruff format --check`, `uv lock --check` and the unit suite pass. The touched tests were run directly, including the integration-marked batch-deletion one.

Out of scope: the repository-root `ty check`, which CI does not run, still reports diagnostics under `evaluation/`, `examples/`, `integrations/` and `tools/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcPSoGsQjnVJS8A5NkoGZN