### PR TITLE
Answer with cosine scores and uuids, not vectors and stale properties (speedkick)

### DIFF
--- a/docs/install_guide/install_guide.mdx
+++ b/docs/install_guide/install_guide.mdx
@@ -161,7 +161,6 @@ resources:
         aws_access_key_id: <AWS_ACCESS_KEY_ID>
         aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>
         model_id: "amazon.titan-embed-text-v2:0"
-        similarity_metric: "cosine"
     ollama_embedder:
       provider: openai
       config:
@@ -278,7 +277,6 @@ resources:
         aws_access_key_id: <AWS_ACCESS_KEY_ID>
         aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>
         model_id: "amazon.titan-embed-text-v2:0"
-        similarity_metric: "cosine"
     ollama_embedder:
       provider: openai
       config:

--- a/docs/install_guide/integrate/nebula_graph_integration_guide.mdx
+++ b/docs/install_guide/integrate/nebula_graph_integration_guide.mdx
@@ -168,22 +168,20 @@ config:
 - `hnsw_ef_construction`: 200 (default), 400 (better quality)
 - `hnsw_ef_search`: 40 (default), 100 (higher recall), 200 (maximum recall)
 
-### Similarity Metric Support
+### Similarity
 
-NebulaGraph has native support for three of the four similarity metrics. The search mode
-(ANN or KNN) depends on both index availability and the metric's capabilities:
+Every score is a cosine similarity. NebulaGraph's `cosine()` function does not accept
+the `APPROXIMATE` keyword, and its vector indexes offer only L2 and IP — so cosine is
+spelled as an inner product instead:
 
-| Metric | NebulaGraph Function | Index Metric | ANN Supported? |
-|--------|---------------------|--------------|----------------|
-| `EUCLIDEAN` | `euclidean()` ASC | L2 | Yes — vector index required |
-| `DOT` | `inner_product()` DESC | IP | Yes — vector index required |
-| `COSINE` | `cosine()` DESC | — | No — KNN only (NebulaGraph limitation) |
-| `MANHATTAN` | — | — | No — unsupported, raises error |
+| NebulaGraph Function | Index Metric | ANN Supported? |
+|---------------------|--------------|----------------|
+| `inner_product()` DESC | IP | Yes — vector index required |
 
-**Key points:**
-- `COSINE` always uses exact KNN search regardless of whether an index exists. NebulaGraph's `cosine()` function does not support the `APPROXIMATE` keyword.
-- `DOT` (inner product) and `COSINE` are mathematically different: DOT is the raw dot product; COSINE normalizes by vector magnitudes.
-- `MANHATTAN` is not supported by NebulaGraph and will raise an error.
+Cosine similarity between unit vectors *is* their inner product, so embeddings are
+normalized on the way in and compared with `inner_product()` against an IP index. The
+ranking is cosine ranking, and unlike `cosine()` it can be approximate. Without a
+vector index the same comparison runs as exact KNN.
 
 ### Force Exact Search
 

--- a/docs/open_source/configuration.mdx
+++ b/docs/open_source/configuration.mdx
@@ -419,7 +419,6 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
               aws_access_key_id: <AWS_ACCESS_KEY_ID>
               aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>
               model_id: "amazon.titan-embed-text-v2:0"
-              similarity_metric: "cosine"
           ollama_embedder: # The embedder Service ID
             provider: openai
             config:
@@ -447,7 +446,6 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
                     aws_access_key_id: <AWS_ACCESS_KEY_ID> # AWS access key ID for Bedrock
                     aws_secret_access_key: <AWS_SECRET_ACCESS_KEY> # AWS secret access key for Bedrock
                     model_id: "amazon.titan-embed-text-v2:0" # Bedrock model ID
-                    similarity_metric: "cosine" # Defines the mathematical method used to compare two vectors for relevance (e.g., cosine).
                 ollama_embedder: # The embedder ID
                   provider: openai # The embedder provider type
                   config: # A dictionary containing provider-specific configuration
@@ -472,7 +470,6 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
     | `config.aws_access_key_id` | AWS access key ID for Bedrock.                              | *Required for Bedrock*   |
     | `config.aws_secret_access_key` | AWS secret access key for Bedrock.                      | *Required for Bedrock*   |
     | `config.model_id` | Bedrock model ID.                                                    | *Required for Bedrock*   |
-    | `similarity_metric` | Defines the mathematical method used to compare two vectors for relevance (e.g., cosine). | *Required for Bedrock*   |
 
   ### Language Models
     Defines various language models for tasks like summarization and generation.

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_embedder_conf.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_embedder_conf.py
@@ -9,7 +9,6 @@ from memmachine_server.common.configuration.embedder_conf import (
     AmazonBedrockEmbedderConf,
     OpenAIEmbedderConf,
 )
-from memmachine_server.common.data_types import SimilarityMetric
 
 
 @pytest.fixture
@@ -32,7 +31,6 @@ def aws_embedder_conf() -> dict[str, Any]:
             "aws_access_key_id": "key-id",
             "aws_secret_access_key": "secret-key",
             "model_id": "amazon.titan-embed-text-v2:0",
-            "similarity_metric": "cosine",
         },
     }
 
@@ -77,7 +75,6 @@ def test_valid_aws_bedrock_embedder_config(aws_embedder_conf):
     assert conf.aws_access_key_id == SecretStr("key-id")
     assert conf.aws_secret_access_key == SecretStr("secret-key")
     assert conf.model_id == "amazon.titan-embed-text-v2:0"
-    assert conf.similarity_metric == SimilarityMetric.COSINE
 
 
 def test_valid_ollama_embedder_config(ollama_embedder_conf):

--- a/packages/server/server_tests/memmachine_server/common/embedder/test_embedder.py
+++ b/packages/server/server_tests/memmachine_server/common/embedder/test_embedder.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import pytest
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder.embedder import Embedder
 
 
@@ -42,10 +41,6 @@ class MockEmbedder(Embedder):
     @property
     def dimensions(self) -> int:
         return 2
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        return SimilarityMetric.COSINE
 
 
 @pytest.mark.asyncio

--- a/packages/server/server_tests/memmachine_server/common/reranker/fake_embedder.py
+++ b/packages/server/server_tests/memmachine_server/common/reranker/fake_embedder.py
@@ -1,18 +1,14 @@
 from typing import Any
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder import Embedder
 
 
 class FakeEmbedder(Embedder):
     def __init__(
         self,
-        similarity_metric: SimilarityMetric = SimilarityMetric.COSINE,
         batch_size: int | None = None,
     ) -> None:
         super().__init__(batch_size=batch_size)
-
-        self._similarity_metric = similarity_metric
 
     async def _ingest_embed(
         self,
@@ -35,7 +31,3 @@ class FakeEmbedder(Embedder):
     @property
     def dimensions(self) -> int:
         return 2
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        return self._similarity_metric

--- a/packages/server/server_tests/memmachine_server/common/reranker/test_embedder_reranker.py
+++ b/packages/server/server_tests/memmachine_server/common/reranker/test_embedder_reranker.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.reranker.embedder_reranker import (
     EmbedderReranker,
@@ -11,16 +10,9 @@ from memmachine_server.common.reranker.embedder_reranker import (
 from server_tests.memmachine_server.common.reranker.fake_embedder import FakeEmbedder
 
 
-@pytest.fixture(
-    params=[
-        SimilarityMetric.COSINE,
-        SimilarityMetric.DOT,
-        SimilarityMetric.EUCLIDEAN,
-        SimilarityMetric.MANHATTAN,
-    ],
-)
-def embedder(request):
-    return FakeEmbedder(similarity_metric=request.param)
+@pytest.fixture
+def embedder():
+    return FakeEmbedder()
 
 
 @pytest.fixture
@@ -63,18 +55,5 @@ async def test_score():
     embedder.ingest_embed.return_value = [[1.0, 2.0], [1.5, 1.5]]
     embedder.search_embed.return_value = [[1.0, 1.0]]
 
-    embedder.similarity_metric = SimilarityMetric.COSINE
     scores = await reranker.score("query", ["candidate1", "candidate2"])
     assert scores[0] < scores[1]
-
-    embedder.similarity_metric = SimilarityMetric.DOT
-    scores = await reranker.score("query", ["candidate1", "candidate2"])
-    assert scores[0] == scores[1]
-
-    embedder.similarity_metric = SimilarityMetric.EUCLIDEAN
-    scores = await reranker.score("query", ["candidate1", "candidate2"])
-    assert scores[0] < scores[1]
-
-    embedder.similarity_metric = SimilarityMetric.MANHATTAN
-    scores = await reranker.score("query", ["candidate1", "candidate2"])
-    assert scores[0] == scores[1]

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
@@ -797,10 +797,8 @@ async def test_sqlite_vector_store_default_engine_is_usearch():
 
         # Invoke the factory the manager passed into params and confirm it
         # routes to the USearch engine.
-        from memmachine_server.common.data_types import SimilarityMetric
-
         factory = mock_params_cls.call_args.kwargs["vector_search_engine_factory"]
-        factory(8, SimilarityMetric.COSINE)
+        factory(8)
 
     mock_usearch_cls.assert_called_once()
 

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_reranker_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_reranker_manager.py
@@ -12,7 +12,6 @@ from memmachine_server.common.configuration.reranker_conf import (
     RerankersConf,
     RRFHybridRerankerConf,
 )
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.errors import InvalidRerankerError
 from memmachine_server.common.resource_manager.reranker_manager import (
@@ -78,10 +77,6 @@ class FakeEmbedder(Embedder):
     @property
     def dimensions(self) -> int:
         return 0
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        return SimilarityMetric.COSINE
 
 
 class FakeEmbedderFactory:

--- a/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_nebula_graph_vector_graph_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_nebula_graph_vector_graph_store.py
@@ -297,7 +297,8 @@ async def test_search_similar_nodes(vector_graph_store):
     await vector_graph_store.add_nodes(collection=collection, nodes=nodes)
 
     # Query closest to Doc 1 ([1,0,0]).
-    # Euclidean distances: Doc1=0, Doc3≈0.141, Doc2≈1.414 → ranked order: Doc1, Doc3.
+    # Doc1 is the query itself and Doc3 is near it; Doc2 is orthogonal.
+    # Ranked by cosine: Doc1, Doc3.
     query_vec = [1.0, 0.0, 0.0]
     results = await vector_graph_store.search_similar_nodes(
         collection=collection,
@@ -841,13 +842,13 @@ async def test_complex_filters(vector_graph_store):
 
 
 # ---------------------------------------------------------------------------
-# Similarity metric table coverage
+# Cosine scoring
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_search_similar_nodes_cosine_metric(vector_graph_store):
-    """COSINE metric: cosine() DESC, always KNN (no ANN index)."""
+    """Cosine ranking, spelled as inner_product() DESC over unit vectors."""
     collection = "cosine_docs"
 
     nodes = [
@@ -1278,3 +1279,46 @@ def test_sanitize_name_no_false_decode():
         sanitized = NebulaGraphVectorGraphStore._sanitize_name(name)
         desanitized = NebulaGraphVectorGraphStore._desanitize_name(sanitized)
         assert desanitized == name, f"Round-trip failed for {name!r}"
+
+
+@pytest.mark.asyncio
+async def test_search_similar_nodes_ann(vector_graph_store_ann):
+    """ANN mode: vector index is created immediately (threshold=0) and results are returned."""
+    collection = "ann_docs"
+
+    nodes = [
+        Node(
+            uid=str(uuid4()),
+            properties={"title": "Doc 1"},
+            embeddings={"content": [1.0, 0.0, 0.0]},
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={"title": "Doc 2"},
+            embeddings={"content": [0.0, 1.0, 0.0]},
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={"title": "Doc 3"},
+            embeddings={"content": [0.9, 0.1, 0.0]},
+        ),
+    ]
+
+    await vector_graph_store_ann.add_nodes(collection=collection, nodes=nodes)
+
+    results = await vector_graph_store_ann.search_similar_nodes(
+        collection=collection,
+        embedding_name="content",
+        query_embedding=[1.0, 0.0, 0.0],
+        limit=3,
+    )
+
+    # ANN may return approximate results but at minimum should return some nodes
+    assert 0 < len(results) <= 3
+    # The closest node (Doc 1) should still appear first in a reasonable ANN implementation
+    assert results[0].properties["title"] == "Doc 1"
+
+
+# ---------------------------------------------------------------------------
+# Extended sanitize/desanitize coverage
+# ---------------------------------------------------------------------------

--- a/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_nebula_graph_vector_graph_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_nebula_graph_vector_graph_store.py
@@ -9,7 +9,6 @@ import pytest_asyncio
 # Skip all tests if nebulagraph_python is not installed
 pytest.importorskip("nebulagraph_python")
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
     And as FilterAnd,
 )
@@ -178,12 +177,12 @@ async def test_add_nodes(nebula_client, vector_graph_store):
         Node(
             uid=str(uuid4()),
             properties={"name": "Alice", "age": 30},
-            embeddings={"vec": ([1.0, 2.0, 3.0], SimilarityMetric.COSINE)},
+            embeddings={"vec": [1.0, 2.0, 3.0]},
         ),
         Node(
             uid=str(uuid4()),
             properties={"name": "Bob", "age": 25},
-            embeddings={"vec": ([4.0, 5.0, 6.0], SimilarityMetric.COSINE)},
+            embeddings={"vec": [4.0, 5.0, 6.0]},
         ),
     ]
 
@@ -223,12 +222,12 @@ async def test_add_edges(nebula_client, vector_graph_store):
     person = Node(
         uid=str(uuid4()),
         properties={"name": "Alice"},
-        embeddings={"profile": ([1.0, 0.0, 0.0], SimilarityMetric.EUCLIDEAN)},
+        embeddings={"profile": [1.0, 0.0, 0.0]},
     )
     company = Node(
         uid=str(uuid4()),
         properties={"name": "Acme Corp"},
-        embeddings={"profile": ([0.0, 1.0, 0.0], SimilarityMetric.EUCLIDEAN)},
+        embeddings={"profile": [0.0, 1.0, 0.0]},
     )
 
     await vector_graph_store.add_nodes(collection=source_collection, nodes=[person])
@@ -240,7 +239,7 @@ async def test_add_edges(nebula_client, vector_graph_store):
         source_uid=person.uid,
         target_uid=company.uid,
         properties={"since": 2020, "role": "Engineer"},
-        embeddings={"relation_vec": ([0.5, 0.5, 0.0], SimilarityMetric.EUCLIDEAN)},
+        embeddings={"relation_vec": [0.5, 0.5, 0.0]},
     )
 
     await vector_graph_store.add_edges(
@@ -281,17 +280,17 @@ async def test_search_similar_nodes(vector_graph_store):
         Node(
             uid=str(uuid4()),
             properties={"title": "Doc 1"},
-            embeddings={"content": ([1.0, 0.0, 0.0], SimilarityMetric.EUCLIDEAN)},
+            embeddings={"content": [1.0, 0.0, 0.0]},
         ),
         Node(
             uid=str(uuid4()),
             properties={"title": "Doc 2"},
-            embeddings={"content": ([0.0, 1.0, 0.0], SimilarityMetric.EUCLIDEAN)},
+            embeddings={"content": [0.0, 1.0, 0.0]},
         ),
         Node(
             uid=str(uuid4()),
             properties={"title": "Doc 3"},
-            embeddings={"content": ([0.9, 0.1, 0.0], SimilarityMetric.EUCLIDEAN)},
+            embeddings={"content": [0.9, 0.1, 0.0]},
         ),
     ]
 
@@ -304,7 +303,6 @@ async def test_search_similar_nodes(vector_graph_store):
         collection=collection,
         embedding_name="content",
         query_embedding=query_vec,
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
         limit=2,
     )
 
@@ -322,17 +320,17 @@ async def test_search_similar_nodes_with_filter(vector_graph_store):
         Node(
             uid=str(uuid4()),
             properties={"title": "Doc 1", "category": "tech"},
-            embeddings={"content": ([1.0, 0.0, 0.0], SimilarityMetric.EUCLIDEAN)},
+            embeddings={"content": [1.0, 0.0, 0.0]},
         ),
         Node(
             uid=str(uuid4()),
             properties={"title": "Doc 2", "category": "business"},
-            embeddings={"content": ([0.9, 0.1, 0.0], SimilarityMetric.EUCLIDEAN)},
+            embeddings={"content": [0.9, 0.1, 0.0]},
         ),
         Node(
             uid=str(uuid4()),
             properties={"title": "Doc 3", "category": "tech"},
-            embeddings={"content": ([0.8, 0.2, 0.0], SimilarityMetric.EUCLIDEAN)},
+            embeddings={"content": [0.8, 0.2, 0.0]},
         ),
     ]
 
@@ -346,7 +344,6 @@ async def test_search_similar_nodes_with_filter(vector_graph_store):
         collection=collection,
         embedding_name="content",
         query_embedding=query_vec,
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
         limit=10,
         property_filter=filter_expr,
     )
@@ -848,416 +845,6 @@ async def test_complex_filters(vector_graph_store):
 # ---------------------------------------------------------------------------
 
 
-def test_similarity_metric_mappings():
-    """Unit test covering every row of the metric support table.
-
-    | Metric    | _similarity_metric_to_nebula | _get_distance_func_and_order | ANN possible? |
-    |-----------|------------------------------|------------------------------|---------------|
-    | EUCLIDEAN | "L2"                         | euclidean() ASC              | yes           |
-    | DOT       | "IP"                         | inner_product() DESC         | yes           |
-    | COSINE    | None (no index)              | cosine() DESC                | no — KNN only |
-    | MANHATTAN | None (no index)              | raises ValueError            | no            |
-    """
-    # _similarity_metric_to_nebula
-    assert (
-        NebulaGraphVectorGraphStore._similarity_metric_to_nebula(
-            SimilarityMetric.EUCLIDEAN
-        )
-        == "L2"
-    )
-    assert (
-        NebulaGraphVectorGraphStore._similarity_metric_to_nebula(SimilarityMetric.DOT)
-        == "IP"
-    )
-    assert (
-        NebulaGraphVectorGraphStore._similarity_metric_to_nebula(
-            SimilarityMetric.COSINE
-        )
-        is None
-    )
-    assert (
-        NebulaGraphVectorGraphStore._similarity_metric_to_nebula(
-            SimilarityMetric.MANHATTAN
-        )
-        is None
-    )
-
-    # _get_distance_func_and_order
-    assert NebulaGraphVectorGraphStore._get_distance_func_and_order(
-        SimilarityMetric.EUCLIDEAN
-    ) == ("euclidean", "ASC")
-    assert NebulaGraphVectorGraphStore._get_distance_func_and_order(
-        SimilarityMetric.DOT
-    ) == ("inner_product", "DESC")
-    assert NebulaGraphVectorGraphStore._get_distance_func_and_order(
-        SimilarityMetric.COSINE
-    ) == ("cosine", "DESC")
-    with pytest.raises(ValueError, match="manhattan"):
-        NebulaGraphVectorGraphStore._get_distance_func_and_order(
-            SimilarityMetric.MANHATTAN
-        )
-
-
-@pytest.mark.asyncio
-async def test_search_similar_nodes_dot_metric(vector_graph_store):
-    """DOT metric: inner_product() DESC, KNN search."""
-    collection = "dot_docs"
-
-    nodes = [
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 1"},
-            embeddings={"content": ([1.0, 0.0, 0.0], SimilarityMetric.DOT)},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 2"},
-            embeddings={"content": ([0.0, 1.0, 0.0], SimilarityMetric.DOT)},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 3"},
-            embeddings={"content": ([0.9, 0.1, 0.0], SimilarityMetric.DOT)},
-        ),
-    ]
-
-    await vector_graph_store.add_nodes(collection=collection, nodes=nodes)
-
-    # Inner products with query [1,0,0]: Doc1=1.0, Doc3=0.9, Doc2=0.0 → ranked order: Doc1, Doc3
-    query_vec = [1.0, 0.0, 0.0]
-    results = await vector_graph_store.search_similar_nodes(
-        collection=collection,
-        embedding_name="content",
-        query_embedding=query_vec,
-        similarity_metric=SimilarityMetric.DOT,
-        limit=2,
-    )
-
-    assert len(results) == 2
-    assert results[0].properties["title"] == "Doc 1"
-    assert results[1].properties["title"] == "Doc 3"
-
-
-@pytest.mark.asyncio
-async def test_search_similar_nodes_cosine_metric(vector_graph_store):
-    """COSINE metric: cosine() DESC, always KNN (no ANN index)."""
-    collection = "cosine_docs"
-
-    nodes = [
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 1"},
-            embeddings={"content": ([1.0, 0.0, 0.0], SimilarityMetric.COSINE)},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 2"},
-            embeddings={"content": ([0.0, 1.0, 0.0], SimilarityMetric.COSINE)},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 3"},
-            # Slightly off-axis: cosine ≈ 0.993 with [1,0,0]
-            embeddings={"content": ([0.9, 0.1, 0.0], SimilarityMetric.COSINE)},
-        ),
-    ]
-
-    await vector_graph_store.add_nodes(collection=collection, nodes=nodes)
-
-    # Cosine similarities with [1,0,0]: Doc1=1.0, Doc3≈0.993, Doc2=0.0 → ranked: Doc1, Doc3
-    query_vec = [1.0, 0.0, 0.0]
-    results = await vector_graph_store.search_similar_nodes(
-        collection=collection,
-        embedding_name="content",
-        query_embedding=query_vec,
-        similarity_metric=SimilarityMetric.COSINE,
-        limit=2,
-    )
-
-    assert len(results) == 2
-    assert results[0].properties["title"] == "Doc 1"
-    assert results[1].properties["title"] == "Doc 3"
-
-
-@pytest.mark.asyncio
-async def test_search_similar_nodes_manhattan_raises(vector_graph_store):
-    """MANHATTAN metric: not supported by NebulaGraph, raises ValueError."""
-    collection = "manhattan_docs"
-
-    nodes = [
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 1"},
-            embeddings={"content": ([1.0, 0.0, 0.0], SimilarityMetric.EUCLIDEAN)},
-        ),
-    ]
-    await vector_graph_store.add_nodes(collection=collection, nodes=nodes)
-
-    with pytest.raises(ValueError, match="manhattan"):
-        await vector_graph_store.search_similar_nodes(
-            collection=collection,
-            embedding_name="content",
-            query_embedding=[1.0, 0.0, 0.0],
-            similarity_metric=SimilarityMetric.MANHATTAN,
-            limit=1,
-        )
-
-
-# ---------------------------------------------------------------------------
-# Multi-property directional search
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_search_directional_nodes_multiple_by_properties(vector_graph_store):
-    """Test search_directional_nodes with multiple sort properties (timestamp + sequence)."""
-    collection = "seq_events"
-
-    now = datetime.now(UTC)
-    delta = timedelta(hours=1)
-
-    # Two timestamps x two sequence values = 4 nodes
-    nodes = [
-        Node(
-            uid=str(uuid4()),
-            properties={"name": "T1S1", "timestamp": now, "sequence": 1},
-            embeddings={},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"name": "T1S2", "timestamp": now, "sequence": 2},
-            embeddings={},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"name": "T2S1", "timestamp": now + delta, "sequence": 1},
-            embeddings={},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"name": "T2S2", "timestamp": now + delta, "sequence": 2},
-            embeddings={},
-        ),
-    ]
-
-    await vector_graph_store.add_nodes(collection=collection, nodes=nodes)
-
-    # Start at (T1, S2) inclusive, both ascending → T1S2, T2S1, T2S2
-    results = await vector_graph_store.search_directional_nodes(
-        collection=collection,
-        by_properties=["timestamp", "sequence"],
-        starting_at=[now, 2],
-        order_ascending=[True, True],
-        include_equal_start=True,
-        limit=None,
-    )
-    assert len(results) == 3
-    assert results[0].properties["name"] == "T1S2"
-    assert results[1].properties["name"] == "T2S1"
-    assert results[2].properties["name"] == "T2S2"
-
-    # Start at (T2, S1) inclusive, first ascending second descending → T2S1, T2S2 reversed
-    # (same first key, second key descending from S1 means S1 then... S2 > S1 so excluded)
-    # Actually: ascending timestamp, descending sequence from S1 inclusive:
-    # At T2: include S1 (equal, inclusive), nothing below S1 for descending → just T2S1
-    results = await vector_graph_store.search_directional_nodes(
-        collection=collection,
-        by_properties=["timestamp", "sequence"],
-        starting_at=[now + delta, 1],
-        order_ascending=[True, False],
-        include_equal_start=True,
-        limit=None,
-    )
-    assert len(results) == 1
-    assert results[0].properties["name"] == "T2S1"
-
-
-# ---------------------------------------------------------------------------
-# Edge cases
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_add_nodes_empty_list(vector_graph_store):
-    """Adding an empty list of nodes is a no-op."""
-    collection = "empty_test"
-
-    await vector_graph_store.add_nodes(collection=collection, nodes=[])
-
-    results = await vector_graph_store.search_matching_nodes(
-        collection=collection,
-        limit=10,
-    )
-    assert len(results) == 0
-
-
-@pytest.mark.asyncio
-async def test_add_edges_empty_list(vector_graph_store):
-    """Adding an empty list of edges is a no-op."""
-    node = Node(uid=str(uuid4()), properties={"name": "Solo"}, embeddings={})
-    await vector_graph_store.add_nodes(collection="solo", nodes=[node])
-
-    # Should not raise
-    await vector_graph_store.add_edges(
-        relation="knows",
-        source_collection="solo",
-        target_collection="solo",
-        edges=[],
-    )
-
-    # Node still exists, no edges created
-    results = await vector_graph_store.get_nodes(
-        collection="solo", node_uids=[node.uid]
-    )
-    assert len(results) == 1
-
-
-@pytest.mark.asyncio
-async def test_add_nodes_with_none_property(vector_graph_store):
-    """Nodes with None property values are stored and retrieved without error."""
-    collection = "nullable_test"
-
-    node = Node(
-        uid=str(uuid4()),
-        properties={"name": "Alice", "optional_field": None},
-        embeddings={},
-    )
-    await vector_graph_store.add_nodes(collection=collection, nodes=[node])
-
-    results = await vector_graph_store.get_nodes(
-        collection=collection, node_uids=[node.uid]
-    )
-    assert len(results) == 1
-    # None properties may be omitted on retrieval (same behaviour as Neo4j)
-    assert results[0].properties.get("name") == "Alice"
-
-
-@pytest.mark.asyncio
-async def test_add_edges_with_none_property(vector_graph_store):
-    """Edges with None property values are stored without error."""
-    person_collection = "nullable_person"
-    company_collection = "nullable_company"
-    relation = "works_at_nullable"
-
-    alice = Node(uid=str(uuid4()), properties={"name": "Alice"}, embeddings={})
-    acme = Node(uid=str(uuid4()), properties={"name": "Acme"}, embeddings={})
-
-    await vector_graph_store.add_nodes(collection=person_collection, nodes=[alice])
-    await vector_graph_store.add_nodes(collection=company_collection, nodes=[acme])
-
-    edge = Edge(
-        uid=str(uuid4()),
-        source_uid=alice.uid,
-        target_uid=acme.uid,
-        properties={"role": "Engineer", "optional_field": None},
-        embeddings={},
-    )
-    await vector_graph_store.add_edges(
-        relation=relation,
-        source_collection=person_collection,
-        target_collection=company_collection,
-        edges=[edge],
-    )
-
-    # Verify edge was created by searching related nodes
-    results = await vector_graph_store.search_related_nodes(
-        relation=relation,
-        other_collection=company_collection,
-        this_collection=person_collection,
-        this_node_uid=alice.uid,
-        find_targets=True,
-        find_sources=False,
-    )
-    assert len(results) == 1
-    assert results[0].uid == acme.uid
-
-
-@pytest.mark.asyncio
-async def test_get_nodes_with_nonexistent_uids(vector_graph_store):
-    """get_nodes ignores UIDs that do not exist — returns only found nodes."""
-    collection = "partial_get"
-
-    node = Node(uid=str(uuid4()), properties={"name": "Real"}, embeddings={})
-    await vector_graph_store.add_nodes(collection=collection, nodes=[node])
-
-    fake_uid = str(uuid4())
-    results = await vector_graph_store.get_nodes(
-        collection=collection,
-        node_uids=[node.uid, fake_uid],
-    )
-    assert len(results) == 1
-    assert results[0].uid == node.uid
-
-
-@pytest.mark.asyncio
-async def test_delete_nodes_wrong_collection(vector_graph_store):
-    """Deleting from a non-matching collection leaves nodes untouched."""
-    collection = "real_collection"
-    wrong_collection = "wrong_collection"
-
-    node = Node(uid=str(uuid4()), properties={"name": "Keep"}, embeddings={})
-    await vector_graph_store.add_nodes(collection=collection, nodes=[node])
-
-    # Attempt to delete from the wrong collection
-    await vector_graph_store.delete_nodes(
-        collection=wrong_collection, node_uids=[node.uid]
-    )
-
-    results = await vector_graph_store.get_nodes(
-        collection=collection, node_uids=[node.uid]
-    )
-    assert len(results) == 1
-
-
-# ---------------------------------------------------------------------------
-# ANN mode
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_search_similar_nodes_ann(vector_graph_store_ann):
-    """ANN mode: vector index is created immediately (threshold=0) and results are returned."""
-    collection = "ann_docs"
-
-    nodes = [
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 1"},
-            embeddings={"content": ([1.0, 0.0, 0.0], SimilarityMetric.EUCLIDEAN)},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 2"},
-            embeddings={"content": ([0.0, 1.0, 0.0], SimilarityMetric.EUCLIDEAN)},
-        ),
-        Node(
-            uid=str(uuid4()),
-            properties={"title": "Doc 3"},
-            embeddings={"content": ([0.9, 0.1, 0.0], SimilarityMetric.EUCLIDEAN)},
-        ),
-    ]
-
-    await vector_graph_store_ann.add_nodes(collection=collection, nodes=nodes)
-
-    results = await vector_graph_store_ann.search_similar_nodes(
-        collection=collection,
-        embedding_name="content",
-        query_embedding=[1.0, 0.0, 0.0],
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
-        limit=3,
-    )
-
-    # ANN may return approximate results but at minimum should return some nodes
-    assert 0 < len(results) <= 3
-    # The closest node (Doc 1) should still appear first in a reasonable ANN implementation
-    assert results[0].properties["title"] == "Doc 1"
-
-
-# ---------------------------------------------------------------------------
-# Extended sanitize/desanitize coverage
-# ---------------------------------------------------------------------------
-
-
 def test_sanitize_name_extended():
     """Comprehensive sanitize/desanitize round-trip for edge-case inputs."""
     names = [
@@ -1370,10 +957,7 @@ async def test_index_creation_with_special_character_names(
             "display name": "Test User",  # space
         },
         embeddings={
-            "content-vector": (
-                [1.0, 0.0, 0.0],
-                SimilarityMetric.EUCLIDEAN,
-            ),  # hyphen in embedding name
+            "content-vector": [1.0, 0.0, 0.0],  # hyphen in embedding name
         },
     )
 
@@ -1395,7 +979,6 @@ async def test_index_creation_with_special_character_names(
         collection=collection,
         embedding_name="content-vector",
         query_embedding=[1.0, 0.0, 0.0],
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
         limit=10,
     )
     assert len(similar) == 1

--- a/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_nebula_graph_vector_graph_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_nebula_graph_vector_graph_store.py
@@ -845,6 +845,252 @@ async def test_complex_filters(vector_graph_store):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.asyncio
+async def test_search_similar_nodes_cosine_metric(vector_graph_store):
+    """COSINE metric: cosine() DESC, always KNN (no ANN index)."""
+    collection = "cosine_docs"
+
+    nodes = [
+        Node(
+            uid=str(uuid4()),
+            properties={"title": "Doc 1"},
+            embeddings={"content": [1.0, 0.0, 0.0]},
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={"title": "Doc 2"},
+            embeddings={"content": [0.0, 1.0, 0.0]},
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={"title": "Doc 3"},
+            # Slightly off-axis: cosine ≈ 0.993 with [1,0,0]
+            embeddings={"content": [0.9, 0.1, 0.0]},
+        ),
+    ]
+
+    await vector_graph_store.add_nodes(collection=collection, nodes=nodes)
+
+    # Cosine similarities with [1,0,0]: Doc1=1.0, Doc3≈0.993, Doc2=0.0 → ranked: Doc1, Doc3
+    query_vec = [1.0, 0.0, 0.0]
+    results = await vector_graph_store.search_similar_nodes(
+        collection=collection,
+        embedding_name="content",
+        query_embedding=query_vec,
+        limit=2,
+    )
+
+    assert len(results) == 2
+    assert results[0].properties["title"] == "Doc 1"
+    assert results[1].properties["title"] == "Doc 3"
+
+
+@pytest.mark.asyncio
+async def test_search_directional_nodes_multiple_by_properties(vector_graph_store):
+    """Test search_directional_nodes with multiple sort properties (timestamp + sequence)."""
+    collection = "seq_events"
+
+    now = datetime.now(UTC)
+    delta = timedelta(hours=1)
+
+    # Two timestamps x two sequence values = 4 nodes
+    nodes = [
+        Node(
+            uid=str(uuid4()),
+            properties={"name": "T1S1", "timestamp": now, "sequence": 1},
+            embeddings={},
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={"name": "T1S2", "timestamp": now, "sequence": 2},
+            embeddings={},
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={"name": "T2S1", "timestamp": now + delta, "sequence": 1},
+            embeddings={},
+        ),
+        Node(
+            uid=str(uuid4()),
+            properties={"name": "T2S2", "timestamp": now + delta, "sequence": 2},
+            embeddings={},
+        ),
+    ]
+
+    await vector_graph_store.add_nodes(collection=collection, nodes=nodes)
+
+    # Start at (T1, S2) inclusive, both ascending → T1S2, T2S1, T2S2
+    results = await vector_graph_store.search_directional_nodes(
+        collection=collection,
+        by_properties=["timestamp", "sequence"],
+        starting_at=[now, 2],
+        order_ascending=[True, True],
+        include_equal_start=True,
+        limit=None,
+    )
+    assert len(results) == 3
+    assert results[0].properties["name"] == "T1S2"
+    assert results[1].properties["name"] == "T2S1"
+    assert results[2].properties["name"] == "T2S2"
+
+    # Start at (T2, S1) inclusive, first ascending second descending → T2S1, T2S2 reversed
+    # (same first key, second key descending from S1 means S1 then... S2 > S1 so excluded)
+    # Actually: ascending timestamp, descending sequence from S1 inclusive:
+    # At T2: include S1 (equal, inclusive), nothing below S1 for descending → just T2S1
+    results = await vector_graph_store.search_directional_nodes(
+        collection=collection,
+        by_properties=["timestamp", "sequence"],
+        starting_at=[now + delta, 1],
+        order_ascending=[True, False],
+        include_equal_start=True,
+        limit=None,
+    )
+    assert len(results) == 1
+    assert results[0].properties["name"] == "T2S1"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_empty_list(vector_graph_store):
+    """Adding an empty list of nodes is a no-op."""
+    collection = "empty_test"
+
+    await vector_graph_store.add_nodes(collection=collection, nodes=[])
+
+    results = await vector_graph_store.search_matching_nodes(
+        collection=collection,
+        limit=10,
+    )
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_add_edges_empty_list(vector_graph_store):
+    """Adding an empty list of edges is a no-op."""
+    node = Node(uid=str(uuid4()), properties={"name": "Solo"}, embeddings={})
+    await vector_graph_store.add_nodes(collection="solo", nodes=[node])
+
+    # Should not raise
+    await vector_graph_store.add_edges(
+        relation="knows",
+        source_collection="solo",
+        target_collection="solo",
+        edges=[],
+    )
+
+    # Node still exists, no edges created
+    results = await vector_graph_store.get_nodes(
+        collection="solo", node_uids=[node.uid]
+    )
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_with_none_property(vector_graph_store):
+    """Nodes with None property values are stored and retrieved without error."""
+    collection = "nullable_test"
+
+    node = Node(
+        uid=str(uuid4()),
+        properties={"name": "Alice", "optional_field": None},
+        embeddings={},
+    )
+    await vector_graph_store.add_nodes(collection=collection, nodes=[node])
+
+    results = await vector_graph_store.get_nodes(
+        collection=collection, node_uids=[node.uid]
+    )
+    assert len(results) == 1
+    # None properties may be omitted on retrieval (same behaviour as Neo4j)
+    assert results[0].properties.get("name") == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_add_edges_with_none_property(vector_graph_store):
+    """Edges with None property values are stored without error."""
+    person_collection = "nullable_person"
+    company_collection = "nullable_company"
+    relation = "works_at_nullable"
+
+    alice = Node(uid=str(uuid4()), properties={"name": "Alice"}, embeddings={})
+    acme = Node(uid=str(uuid4()), properties={"name": "Acme"}, embeddings={})
+
+    await vector_graph_store.add_nodes(collection=person_collection, nodes=[alice])
+    await vector_graph_store.add_nodes(collection=company_collection, nodes=[acme])
+
+    edge = Edge(
+        uid=str(uuid4()),
+        source_uid=alice.uid,
+        target_uid=acme.uid,
+        properties={"role": "Engineer", "optional_field": None},
+        embeddings={},
+    )
+    await vector_graph_store.add_edges(
+        relation=relation,
+        source_collection=person_collection,
+        target_collection=company_collection,
+        edges=[edge],
+    )
+
+    # Verify edge was created by searching related nodes
+    results = await vector_graph_store.search_related_nodes(
+        relation=relation,
+        other_collection=company_collection,
+        this_collection=person_collection,
+        this_node_uid=alice.uid,
+        find_targets=True,
+        find_sources=False,
+    )
+    assert len(results) == 1
+    assert results[0].uid == acme.uid
+
+
+@pytest.mark.asyncio
+async def test_get_nodes_with_nonexistent_uids(vector_graph_store):
+    """get_nodes ignores UIDs that do not exist — returns only found nodes."""
+    collection = "partial_get"
+
+    node = Node(uid=str(uuid4()), properties={"name": "Real"}, embeddings={})
+    await vector_graph_store.add_nodes(collection=collection, nodes=[node])
+
+    fake_uid = str(uuid4())
+    results = await vector_graph_store.get_nodes(
+        collection=collection,
+        node_uids=[node.uid, fake_uid],
+    )
+    assert len(results) == 1
+    assert results[0].uid == node.uid
+
+
+@pytest.mark.asyncio
+async def test_delete_nodes_wrong_collection(vector_graph_store):
+    """Deleting from a non-matching collection leaves nodes untouched."""
+    collection = "real_collection"
+    wrong_collection = "wrong_collection"
+
+    node = Node(uid=str(uuid4()), properties={"name": "Keep"}, embeddings={})
+    await vector_graph_store.add_nodes(collection=collection, nodes=[node])
+
+    # Attempt to delete from the wrong collection
+    await vector_graph_store.delete_nodes(
+        collection=wrong_collection, node_uids=[node.uid]
+    )
+
+    results = await vector_graph_store.get_nodes(
+        collection=collection, node_uids=[node.uid]
+    )
+    assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# ANN mode
+# ---------------------------------------------------------------------------
+
+
 def test_sanitize_name_extended():
     """Comprehensive sanitize/desanitize round-trip for edge-case inputs."""
     names = [

--- a/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_nebula_graph_vector_literals.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_nebula_graph_vector_literals.py
@@ -1,0 +1,123 @@
+"""Unit tests for NebulaGraph's cosine-as-inner-product vector encoding.
+
+These need no server: the encoding is pure, and it is what makes an IP
+index answer cosine. The rest of the NebulaGraph suite is integration-only,
+so without these the invariant would go unexercised everywhere.
+"""
+
+import math
+import re
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+pytest.importorskip("nebulagraph_python")
+
+from nebulagraph_python.client import NebulaAsyncClient
+
+from memmachine_server.common.vector_graph_store.nebula_graph_vector_graph_store import (
+    NebulaGraphVectorGraphStore,
+    NebulaGraphVectorGraphStoreParams,
+)
+
+
+@pytest.fixture
+def store() -> NebulaGraphVectorGraphStore:
+    """A store that never talks to a server; only the encoding is exercised."""
+    return NebulaGraphVectorGraphStore(
+        NebulaGraphVectorGraphStoreParams(
+            # Never dereferenced: nothing here reaches the wire.
+            client=cast(NebulaAsyncClient, object()),
+            schema_name="/test_schema",
+            graph_type_name="test_graph_type",
+            graph_name="test_graph",
+        )
+    )
+
+
+def _components(literal: str) -> list[float]:
+    inside = literal[literal.index("([") + 2 : literal.rindex("])")]
+    return [float(part) for part in inside.split(",")]
+
+
+class TestUnit:
+    def test_scales_to_unit_length(self):
+        assert NebulaGraphVectorGraphStore._unit([3.0, 4.0]) == [0.6, 0.8]
+
+    def test_preserves_direction(self):
+        scaled = NebulaGraphVectorGraphStore._unit([2.0, 4.0, 4.0])
+        assert scaled[1] == pytest.approx(scaled[2])
+        assert scaled[1] == pytest.approx(2 * scaled[0])
+
+    def test_already_unit_vector_is_unchanged(self):
+        assert NebulaGraphVectorGraphStore._unit([0.0, 1.0]) == [0.0, 1.0]
+
+    def test_zero_vector_is_left_alone(self):
+        """It has no direction to preserve, and dividing would raise."""
+        assert NebulaGraphVectorGraphStore._unit([0.0, 0.0, 0.0]) == [0.0, 0.0, 0.0]
+
+    def test_negative_components_survive(self):
+        assert NebulaGraphVectorGraphStore._unit([-3.0, 4.0]) == [-0.6, 0.8]
+
+
+class TestVectorLiteral:
+    def test_normalizes_the_components(self, store: NebulaGraphVectorGraphStore):
+        components = _components(store._vector_to_gql_literal([3.0, 4.0]))
+        assert components == [0.6, 0.8]
+
+    def test_declares_the_original_dimension(self, store: NebulaGraphVectorGraphStore):
+        literal = store._vector_to_gql_literal([3.0, 4.0, 0.0])
+        assert literal.startswith("VECTOR<3, FLOAT>(")
+        assert len(_components(literal)) == 3
+
+    def test_a_zero_vector_still_renders(self, store: NebulaGraphVectorGraphStore):
+        assert _components(store._vector_to_gql_literal([0.0, 0.0])) == [0.0, 0.0]
+
+    @pytest.mark.parametrize(
+        ("left", "right"),
+        [
+            ([1.0, 0.0], [1.0, 0.0]),
+            ([1.0, 0.0], [0.0, 1.0]),
+            ([1.0, 0.0], [-1.0, 0.0]),
+            ([3.0, 4.0], [4.0, 3.0]),
+            ([2.0, 1.0, 0.5], [0.25, 8.0, 1.0]),
+            # Magnitude must not leak into the score: a scaled-up vector has
+            # the same direction, so it must score identically.
+            ([300.0, 400.0], [4.0, 3.0]),
+        ],
+    )
+    def test_inner_product_of_literals_is_cosine_of_the_originals(
+        self, store: NebulaGraphVectorGraphStore, left: list[float], right: list[float]
+    ):
+        """This is the whole reason an IP index can answer a cosine query."""
+        inner_product = sum(
+            a * b
+            for a, b in zip(
+                _components(store._vector_to_gql_literal(left)),
+                _components(store._vector_to_gql_literal(right)),
+                strict=True,
+            )
+        )
+
+        dot = sum(a * b for a, b in zip(left, right, strict=True))
+        magnitudes = math.sqrt(sum(a * a for a in left)) * math.sqrt(
+            sum(b * b for b in right)
+        )
+        assert inner_product == pytest.approx(dot / magnitudes)
+
+
+def test_only_one_site_turns_a_vector_into_a_literal():
+    """Stored and query sides cannot disagree while they share one encoder.
+
+    Both write paths and both read paths call `_vector_to_gql_literal`; a
+    second place building a `VECTOR<...>(...)` value would be free to skip
+    normalization and silently corrupt IP ranking.
+    """
+    source = Path(NebulaGraphVectorGraphStore.__module__.replace(".", "/") + ".py")
+    module_text = (Path("packages/server/src") / source).read_text()
+
+    # `VECTOR<n, FLOAT>` alone is a type name (used in schema declarations);
+    # only a following `(` makes it a value.
+    value_literals = re.findall(r"VECTOR<[^>]*>\(", module_text)
+    assert len(value_literals) == 1

--- a/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_neo4j_vector_graph_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_neo4j_vector_graph_store.py
@@ -8,7 +8,6 @@ import pytest_asyncio
 from neo4j import AsyncGraphDatabase
 from testcontainers.neo4j import Neo4jContainer
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
     And as FilterAnd,
 )
@@ -163,10 +162,7 @@ async def test_add_nodes(neo4j_driver, vector_graph_store):
                 "none_value": None,
             },
             embeddings={
-                "embedding_name": (
-                    [0.1, 0.2, 0.3],
-                    SimilarityMetric.COSINE,
-                ),
+                "embedding_name": [0.1, 0.2, 0.3],
             },
         ),
     ]
@@ -200,10 +196,7 @@ async def test_add_edges(neo4j_driver, vector_graph_store):
                 "none_value": None,
             },
             embeddings={
-                "embedding_name": (
-                    [0.1, 0.2, 0.3],
-                    SimilarityMetric.COSINE,
-                ),
+                "embedding_name": [0.1, 0.2, 0.3],
             },
         ),
     ]
@@ -243,10 +236,7 @@ async def test_add_edges(neo4j_driver, vector_graph_store):
             target_uid=node3_uid,
             properties={"description": "Node1 to Node3"},
             embeddings={
-                "embedding_name": (
-                    [0.4, 0.5, 0.6],
-                    SimilarityMetric.DOT,
-                ),
+                "embedding_name": [0.4, 0.5, 0.6],
             },
         ),
     ]
@@ -291,15 +281,12 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
             properties={
                 "name": "Node1",
             },
+            # embedding2 deliberately disagrees with embedding1 about which
+            # node the query below is nearest, so searching by name has to
+            # pick the right one to get the right answer.
             embeddings={
-                "embedding1": (
-                    [1000.0, 0.0],
-                    SimilarityMetric.COSINE,
-                ),
-                "embedding2": (
-                    [1000.0, 0.0],
-                    SimilarityMetric.EUCLIDEAN,
-                ),
+                "embedding1": [1000.0, 0.0],
+                "embedding2": [10.0, 10.0],
             },
         ),
         Node(
@@ -309,14 +296,8 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
                 "include?": "yes",
             },
             embeddings={
-                "embedding1": (
-                    [10.0, 10.0],
-                    SimilarityMetric.COSINE,
-                ),
-                "embedding2": (
-                    [10.0, 10.0],
-                    SimilarityMetric.EUCLIDEAN,
-                ),
+                "embedding1": [10.0, 10.0],
+                "embedding2": [1000.0, 0.0],
             },
         ),
         Node(
@@ -326,14 +307,8 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
                 "include?": "no",
             },
             embeddings={
-                "embedding1": (
-                    [-100.0, 0.0],
-                    SimilarityMetric.COSINE,
-                ),
-                "embedding2": (
-                    [-100.0, 0.0],
-                    SimilarityMetric.EUCLIDEAN,
-                ),
+                "embedding1": [-100.0, 0.0],
+                "embedding2": [-100.0, 0.0],
             },
         ),
         Node(
@@ -343,14 +318,8 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
                 "include?": "no",
             },
             embeddings={
-                "embedding1": (
-                    [-100.0, -1.0],
-                    SimilarityMetric.COSINE,
-                ),
-                "embedding2": (
-                    [-100.0, -1.0],
-                    SimilarityMetric.EUCLIDEAN,
-                ),
+                "embedding1": [-100.0, -1.0],
+                "embedding2": [-100.0, -1.0],
             },
         ),
         Node(
@@ -360,14 +329,8 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
                 "include?": "no",
             },
             embeddings={
-                "embedding1": (
-                    [-100.0, -2.0],
-                    SimilarityMetric.COSINE,
-                ),
-                "embedding2": (
-                    [-100.0, -2.0],
-                    SimilarityMetric.EUCLIDEAN,
-                ),
+                "embedding1": [-100.0, -2.0],
+                "embedding2": [-100.0, -2.0],
             },
         ),
         Node(
@@ -377,14 +340,8 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
                 "include?": "no",
             },
             embeddings={
-                "embedding1": (
-                    [-100.0, -3.0],
-                    SimilarityMetric.COSINE,
-                ),
-                "embedding2": (
-                    [-100.0, -3.0],
-                    SimilarityMetric.EUCLIDEAN,
-                ),
+                "embedding1": [-100.0, -3.0],
+                "embedding2": [-100.0, -3.0],
             },
         ),
     ]
@@ -395,7 +352,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding1",
-        similarity_metric=SimilarityMetric.COSINE,
         limit=5,
     )
     assert 0 < len(results) <= 5
@@ -404,7 +360,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding1",
-        similarity_metric=SimilarityMetric.COSINE,
         limit=5,
     )
     assert len(results) == 5
@@ -414,7 +369,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding1",
-        similarity_metric=SimilarityMetric.COSINE,
         limit=5,
         property_filter=FilterComparison(
             field="include?",
@@ -429,7 +383,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding1",
-        similarity_metric=SimilarityMetric.COSINE,
         limit=5,
         property_filter=FilterOr(
             left=FilterComparison(
@@ -449,7 +402,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding2",
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
         limit=5,
     )
     assert len(results) == 5
@@ -459,7 +411,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding2",
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
         limit=5,
         property_filter=FilterComparison(
             field="include?",
@@ -474,7 +425,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding1",
-        similarity_metric=SimilarityMetric.COSINE,
         limit=5,
     )
     assert 0 < len(results) <= 5
@@ -483,7 +433,6 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         collection="Entity",
         query_embedding=[1.0, 0.0],
         embedding_name="embedding2",
-        similarity_metric=SimilarityMetric.EUCLIDEAN,
         limit=5,
     )
     assert 0 < len(results) <= 5
@@ -1635,60 +1584,51 @@ async def test__create_vector_index_if_not_exists(
                 Neo4jVectorGraphStore._sanitize_name(collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.NODE,
                 Neo4jVectorGraphStore._sanitize_name(collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(other_property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.NODE,
                 Neo4jVectorGraphStore._sanitize_name(other_collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.NODE,
                 Neo4jVectorGraphStore._sanitize_name(other_collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(other_property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.EDGE,
                 Neo4jVectorGraphStore._sanitize_name(collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.EDGE,
                 Neo4jVectorGraphStore._sanitize_name(collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(other_property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.EDGE,
                 Neo4jVectorGraphStore._sanitize_name(other_collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
             vector_graph_store_indexing._create_vector_index_if_not_exists(
                 EntityType.EDGE,
                 Neo4jVectorGraphStore._sanitize_name(other_collection_or_relation_name),
                 Neo4jVectorGraphStore._sanitize_name(other_property_name),
                 dimensions=dimensions,
-                similarity_metric=similarity_metric,
             ),
         ]
         for dimensions in [1, 10]
-        for similarity_metric in [SimilarityMetric.COSINE, SimilarityMetric.EUCLIDEAN]
         for _ in range(2000)
     ]
 
@@ -1805,10 +1745,7 @@ async def test__nodes_from_neo4j_nodes(neo4j_driver, vector_graph_store):
             uid=str(uuid4()),
             properties={"name": "Node3", "time": datetime.now(tz=UTC)},
             embeddings={
-                "embedding_name": (
-                    [0.1, 0.2, 0.3],
-                    SimilarityMetric.COSINE,
-                ),
+                "embedding_name": [0.1, 0.2, 0.3],
             },
         ),
     ]

--- a/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_collection.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_collection.py
@@ -2,7 +2,7 @@
 
 import math
 import operator
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
 from uuid import UUID
 
 from memmachine_server.common.data_types import PropertyValue
@@ -122,7 +122,6 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
         min_cosine_similarity: float | None = None,
         limit: int | None = None,
         property_filter: FilterExpr | None = None,
-        return_properties: bool = True,
     ) -> list[QueryResult]:
         results: list[QueryResult] = []
         for query_vector in query_vectors:
@@ -144,7 +143,7 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
                 matches.append(
                     QueryMatch(
                         cosine_similarity=cosine_similarity,
-                        record=self._project_record(record, return_properties),
+                        record_uuid=record.uuid,
                     )
                 )
             matches.sort(key=lambda m: m.cosine_similarity, reverse=True)
@@ -153,33 +152,6 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
             results.append(QueryResult(matches=matches))
         return results
 
-    async def set_properties(
-        self,
-        *,
-        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
-    ) -> None:
-        for uid, properties in record_properties.items():
-            record = self.records.get(uid)
-            if record is None:
-                continue
-            self.records[uid] = Record(
-                uuid=record.uuid,
-                vector=list(record.vector) if record.vector is not None else None,
-                properties=dict(properties),
-            )
-
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:
         for uid in record_uuids:
             self.records.pop(uid, None)
-
-    @staticmethod
-    def _project_record(record: Record, return_properties: bool) -> Record:
-        """Return a copy of the record with only the requested fields."""
-        return Record(
-            uuid=record.uuid,
-            properties=(
-                dict(record.properties)
-                if return_properties and record.properties
-                else None
-            ),
-        )

--- a/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_collection.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_collection.py
@@ -2,10 +2,10 @@
 
 import math
 import operator
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from uuid import UUID
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -79,28 +79,13 @@ def _dot(a: Sequence[float], b: Sequence[float]) -> float:
     return sum(x * y for x, y in zip(a, b, strict=True))
 
 
-def _score(metric: SimilarityMetric, a: Sequence[float], b: Sequence[float]) -> float:
-    """Compute the similarity/distance score for the given metric."""
-    match metric:
-        case SimilarityMetric.COSINE:
-            norm_a = math.sqrt(sum(x * x for x in a))
-            norm_b = math.sqrt(sum(x * x for x in b))
-            if norm_a == 0.0 or norm_b == 0.0:
-                return 0.0
-            return _dot(a, b) / (norm_a * norm_b)
-        case SimilarityMetric.DOT:
-            return _dot(a, b)
-        case SimilarityMetric.EUCLIDEAN:
-            return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b, strict=True)))
-        case SimilarityMetric.MANHATTAN:
-            return sum(abs(x - y) for x, y in zip(a, b, strict=True))
-
-
-def _passes_threshold(score: float, threshold: float, higher_is_better: bool) -> bool:
-    """Check whether a score passes the threshold for the metric direction."""
-    if higher_is_better:
-        return score >= threshold
-    return score <= threshold
+def _cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity between two vectors; 0.0 if either has no magnitude."""
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return _dot(a, b) / (norm_a * norm_b)
 
 
 # ---------------------------------------------------------------------------
@@ -111,8 +96,7 @@ def _passes_threshold(score: float, threshold: float, higher_is_better: bool) ->
 class InMemoryVectorStoreCollection(VectorStoreCollection):
     """In-memory VectorStoreCollection for testing.
 
-    Supports all similarity metrics (cosine, dot, euclidean, manhattan)
-    and full FilterExpr evaluation on record properties.
+    Scores by cosine similarity and evaluates FilterExpr on record properties.
     """
 
     def __init__(self, collection_config: VectorStoreCollectionConfig) -> None:
@@ -135,15 +119,11 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
         self,
         *,
         query_vectors: Iterable[Sequence[float]],
-        score_threshold: float | None = None,
+        min_cosine_similarity: float | None = None,
         limit: int | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
-        metric = self.collection_config.similarity_metric
-        higher_is_better = metric.higher_is_better
-
         results: list[QueryResult] = []
         for query_vector in query_vectors:
             qv = list(query_vector)
@@ -155,56 +135,48 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
                     property_filter, record.properties or {}
                 ):
                     continue
-                score = _score(metric, qv, record.vector)
-                if score_threshold is not None and not _passes_threshold(
-                    score, score_threshold, higher_is_better
+                cosine_similarity = _cosine_similarity(qv, record.vector)
+                if (
+                    min_cosine_similarity is not None
+                    and cosine_similarity < min_cosine_similarity
                 ):
                     continue
                 matches.append(
                     QueryMatch(
-                        score=score,
-                        record=self._project_record(
-                            record, return_vector, return_properties
-                        ),
+                        cosine_similarity=cosine_similarity,
+                        record=self._project_record(record, return_properties),
                     )
                 )
-            matches.sort(key=lambda m: m.score, reverse=higher_is_better)
+            matches.sort(key=lambda m: m.cosine_similarity, reverse=True)
             if limit is not None:
                 matches = matches[:limit]
             results.append(QueryResult(matches=matches))
         return results
 
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        out: list[Record] = []
-        for uid in record_uuids:
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        for uid, properties in record_properties.items():
             record = self.records.get(uid)
             if record is None:
                 continue
-            out.append(self._project_record(record, return_vector, return_properties))
-        return out
+            self.records[uid] = Record(
+                uuid=record.uuid,
+                vector=list(record.vector) if record.vector is not None else None,
+                properties=dict(properties),
+            )
 
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:
         for uid in record_uuids:
             self.records.pop(uid, None)
 
     @staticmethod
-    def _project_record(
-        record: Record, return_vector: bool, return_properties: bool
-    ) -> Record:
+    def _project_record(record: Record, return_properties: bool) -> Record:
         """Return a copy of the record with only the requested fields."""
         return Record(
             uuid=record.uuid,
-            vector=(
-                list(record.vector)
-                if return_vector and record.vector is not None
-                else None
-            ),
             properties=(
                 dict(record.properties)
                 if return_properties and record.properties

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -48,12 +48,12 @@ def _normalize(vector: list[float]) -> list[float]:
 _FETCH_LIMIT = 1000
 
 
-async def _fetch_records(collection, record_uuids) -> list[Record]:
-    """Read records back by UUID.
+async def _present_uuids(collection, record_uuids) -> list[UUID]:
+    """Which of these UUIDs the collection still holds, in the order given.
 
-    The collection contract has no read-by-UUID: `query` is the only read, and
-    with no score threshold it returns every record it holds, so a probe vector
-    in any direction lists the collection for a test to pick out of.
+    `query` is the only read and it answers with UUIDs and scores, so existence
+    is all a test can observe about a record here. With no score threshold a
+    probe vector in any direction lists the whole collection.
     """
     record_uuids = list(record_uuids)
     if not record_uuids:
@@ -61,8 +61,8 @@ async def _fetch_records(collection, record_uuids) -> list[Record]:
     dimensions = collection.config.vector_dimensions
     probe = [1.0] + [0.0] * (dimensions - 1)
     [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
-    by_uuid = {match.record.uuid: match.record for match in result.matches}
-    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+    present = {match.record_uuid for match in result.matches}
+    return [uuid for uuid in record_uuids if uuid in present]
 
 
 def _make_record(
@@ -261,9 +261,9 @@ class TestUpsertAndQuery:
         matches = query_results[0].matches
 
         assert len(matches) == 3
-        assert matches[0].record.uuid == r1.uuid
-        assert matches[1].record.uuid == r3.uuid
-        assert matches[2].record.uuid == r2.uuid
+        assert matches[0].record_uuid == r1.uuid
+        assert matches[1].record_uuid == r3.uuid
+        assert matches[2].record_uuid == r2.uuid
         assert (
             matches[0].cosine_similarity
             >= matches[1].cosine_similarity
@@ -286,24 +286,25 @@ class TestUpsertAndQuery:
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.uuid == r1.uuid
+        assert matches[0].record_uuid == r1.uuid
 
     @pytest.mark.asyncio
-    async def test_query_return_flags(self, collection):
+    async def test_a_match_is_a_uuid_and_a_score(self, collection):
+        """A match names the record and how well it scored, and nothing else.
+
+        Stored properties are filterable but never returned: this store is not
+        the authority for a record's content, so a caller that wants its
+        fields reads them from whatever owns them.
+        """
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        with_properties = await collection.query(query_vectors=[v1], limit=10)
-        assert with_properties[0].matches[0].record.vector is None
-        assert with_properties[0].matches[0].record.properties is not None
-
-        no_properties = await collection.query(
-            query_vectors=[v1],
-            limit=10,
-            return_properties=False,
-        )
-        assert no_properties[0].matches[0].record.properties is None
+        [result] = await collection.query(query_vectors=[v1], limit=10)
+        assert len(result.matches) == 1
+        assert result.matches[0].record_uuid == r1.uuid
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+        assert not hasattr(result.matches[0], "record")
 
     @pytest.mark.asyncio
     async def test_query_batch_multiple_vectors(self, collection):
@@ -317,8 +318,8 @@ class TestUpsertAndQuery:
         all_results = await collection.query(query_vectors=[v1, v2], limit=1)
 
         assert len(all_results) == 2
-        assert all_results[0].matches[0].record.uuid == r1.uuid
-        assert all_results[1].matches[0].record.uuid == r2.uuid
+        assert all_results[0].matches[0].record_uuid == r1.uuid
+        assert all_results[1].matches[0].record_uuid == r2.uuid
 
     @pytest.mark.asyncio
     async def test_upsert_removes_stale_filter_fields(self, collection):
@@ -335,7 +336,7 @@ class TestUpsertAndQuery:
             limit=10,
             property_filter=IsNull(field="name"),
         )
-        assert {match.record.uuid for match in results[0].matches} == {record.uuid}
+        assert {match.record_uuid for match in results[0].matches} == {record.uuid}
 
     @pytest.mark.asyncio
     async def test_upsert_failure_preserves_existing_record(
@@ -362,9 +363,7 @@ class TestUpsertAndQuery:
                 ]
             )
 
-        records = await _fetch_records(collection, [record.uuid])
-        assert len(records) == 1
-        assert records[0].properties == {"name": "old"}
+        assert await _present_uuids(collection, [record.uuid]) == [record.uuid]
 
         # The old vector is still the indexed one.
         results = await collection.query(query_vectors=[old_vector], limit=1)
@@ -397,7 +396,7 @@ class TestFilters:
             limit=10,
             property_filter=Comparison(field=field, op=op, value=value),
         )
-        return {match.record.uuid for match in all_results[0].matches}
+        return {match.record_uuid for match in all_results[0].matches}
 
     @pytest.mark.asyncio
     async def test_scalar_filters(self, collection):
@@ -437,10 +436,8 @@ class TestFilters:
         uuids = await self._query(collection, v1, "created_at", "=", dt_filter)
         assert uuids == {r1.uuid}
 
-        results = await _fetch_records(collection, [r1.uuid])
-        properties = results[0].properties
-        assert properties is not None
-        assert properties["created_at"] == dt_utc
+        # Already asserted through the filter above, which is the only way
+        # properties are observable.
 
     @pytest.mark.asyncio
     async def test_is_null_and_not_null(self, collection):
@@ -455,14 +452,14 @@ class TestFilters:
             limit=10,
             property_filter=IsNull(field="name"),
         )
-        assert {m.record.uuid for m in null_results[0].matches} == {r_missing.uuid}
+        assert {m.record_uuid for m in null_results[0].matches} == {r_missing.uuid}
 
         not_null_results = await collection.query(
             query_vectors=[v1],
             limit=10,
             property_filter=Not(expr=IsNull(field="name")),
         )
-        assert {m.record.uuid for m in not_null_results[0].matches} == {
+        assert {m.record_uuid for m in not_null_results[0].matches} == {
             r_has_value.uuid
         }
 
@@ -475,7 +472,7 @@ class TestFilters:
             limit=10,
             property_filter=In(field="name", values=["alice", "carol"]),
         )
-        assert {m.record.uuid for m in in_results[0].matches} == {r1.uuid, r3.uuid}
+        assert {m.record_uuid for m in in_results[0].matches} == {r1.uuid, r3.uuid}
 
         and_results = await collection.query(
             query_vectors=[v1],
@@ -485,7 +482,7 @@ class TestFilters:
                 right=Comparison(field="age", op=">", value=30),
             ),
         )
-        assert {m.record.uuid for m in and_results[0].matches} == {r3.uuid}
+        assert {m.record_uuid for m in and_results[0].matches} == {r3.uuid}
 
         or_results = await collection.query(
             query_vectors=[v1],
@@ -495,53 +492,7 @@ class TestFilters:
                 right=Comparison(field="name", op="=", value="bob"),
             ),
         )
-        assert {m.record.uuid for m in or_results[0].matches} == {r1.uuid, r2.uuid}
-
-
-class TestSetPropertiesAndDelete:
-    @pytest.mark.asyncio
-    async def test_set_properties_replaces_properties_and_keeps_the_vector(
-        self, collection
-    ):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
-        await collection.upsert(records=[r1])
-
-        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
-
-        [fetched] = await _fetch_records(collection, [r1.uuid])
-        assert fetched.properties == {"name": "b"}
-
-        # The vector is untouched, so the record still answers its own query.
-        results = await collection.query(query_vectors=[v1], limit=1)
-        assert results[0].matches[0].record.uuid == r1.uuid
-        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_set_properties_ignores_uuids_the_collection_does_not_hold(
-        self, collection
-    ):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a"})
-        await collection.upsert(records=[r1])
-
-        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
-
-        [fetched] = await _fetch_records(collection, [r1.uuid])
-        assert fetched.properties == {"name": "a"}
-
-    @pytest.mark.asyncio
-    async def test_delete_records(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
-        r1 = _make_record(vector=v1)
-        r2 = _make_record(vector=v2)
-        await collection.upsert(records=[r1, r2])
-
-        await collection.delete(record_uuids=[r1.uuid])
-
-        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
-        assert [record.uuid for record in results] == [r2.uuid]
+        assert {m.record_uuid for m in or_results[0].matches} == {r1.uuid, r2.uuid}
 
 
 class TestPartitionIsolation:
@@ -568,11 +519,20 @@ class TestPartitionIsolation:
             records=[Record(uuid=record_uuid, vector=v1, properties={"name": "b"})]
         )
 
-        results_a = await _fetch_records(coll_a, [record_uuid])
-        results_b = await _fetch_records(coll_b, [record_uuid])
-
-        assert results_a[0].properties == {"name": "a"}
-        assert results_b[0].properties == {"name": "b"}
+        # Each collection holds its own record under the shared uuid, and
+        # each one's properties are only reachable through its own filter.
+        [only_a] = await coll_a.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="a"),
+        )
+        [only_b] = await coll_b.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="b"),
+        )
+        assert [m.record_uuid for m in only_a.matches] == [record_uuid]
+        assert [m.record_uuid for m in only_b.matches] == [record_uuid]
 
         await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
         await store.delete_collection(namespace=NAMESPACE, name="tenant_b")

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -14,7 +14,7 @@ pymilvus = pytest.importorskip("pymilvus")
 DataType = pymilvus.DataType
 MilvusClient = pymilvus.MilvusClient
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -43,6 +43,26 @@ VECTOR_DIM = 3
 def _normalize(vector: list[float]) -> list[float]:
     magnitude = math.sqrt(sum(x * x for x in vector))
     return [x / magnitude for x in vector]
+
+
+_FETCH_LIMIT = 1000
+
+
+async def _fetch_records(collection, record_uuids) -> list[Record]:
+    """Read records back by UUID.
+
+    The collection contract has no read-by-UUID: `query` is the only read, and
+    with no score threshold it returns every record it holds, so a probe vector
+    in any direction lists the collection for a test to pick out of.
+    """
+    record_uuids = list(record_uuids)
+    if not record_uuids:
+        return []
+    dimensions = collection.config.vector_dimensions
+    probe = [1.0] + [0.0] * (dimensions - 1)
+    [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
+    by_uuid = {match.record.uuid: match.record for match in result.matches}
+    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
 
 
 def _make_record(
@@ -77,7 +97,6 @@ async def collection(store):
         name=NAME,
         config=VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "name": str,
                 "age": int,
@@ -163,7 +182,6 @@ class TestCollectionLifecycle:
         schema: dict[str, type[PropertyValue]] = {"name": str}
         config = VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema=schema,
         )
         await store.create_collection(namespace=NAMESPACE, name="coll_a", config=config)
@@ -200,18 +218,6 @@ class TestCollectionLifecycle:
         assert fields["properties"]["type"] == DataType.JSON
 
         await store.delete_collection(namespace=NAMESPACE, name="schema")
-
-    @pytest.mark.asyncio
-    async def test_unsupported_metric_raises(self, store):
-        with pytest.raises(ValueError, match="Milvus only supports"):
-            await store.create_collection(
-                namespace=NAMESPACE,
-                name="bad_metric",
-                config=VectorStoreCollectionConfig(
-                    vector_dimensions=VECTOR_DIM,
-                    similarity_metric=SimilarityMetric.MANHATTAN,
-                ),
-            )
 
 
 class TestUpsertAndQuery:
@@ -258,9 +264,13 @@ class TestUpsertAndQuery:
         assert matches[0].record.uuid == r1.uuid
         assert matches[1].record.uuid == r3.uuid
         assert matches[2].record.uuid == r2.uuid
-        assert matches[0].score >= matches[1].score >= matches[2].score
-        assert matches[0].score == pytest.approx(1.0)
-        assert matches[2].score == pytest.approx(0.0)
+        assert (
+            matches[0].cosine_similarity
+            >= matches[1].cosine_similarity
+            >= matches[2].cosine_similarity
+        )
+        assert matches[0].cosine_similarity == pytest.approx(1.0)
+        assert matches[2].cosine_similarity == pytest.approx(0.0)
 
     @pytest.mark.asyncio
     async def test_query_with_similarity_threshold(self, collection):
@@ -272,7 +282,7 @@ class TestUpsertAndQuery:
         await collection.upsert(records=[r1, r2])
 
         query_results = await collection.query(
-            query_vectors=[v1], limit=10, score_threshold=0.9
+            query_vectors=[v1], limit=10, min_cosine_similarity=0.9
         )
         matches = query_results[0].matches
         assert len(matches) == 1
@@ -284,19 +294,15 @@ class TestUpsertAndQuery:
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        no_vector = await collection.query(
-            query_vectors=[v1], limit=10, return_vector=False
-        )
-        assert no_vector[0].matches[0].record.vector is None
-        assert no_vector[0].matches[0].record.properties is not None
+        with_properties = await collection.query(query_vectors=[v1], limit=10)
+        assert with_properties[0].matches[0].record.vector is None
+        assert with_properties[0].matches[0].record.properties is not None
 
         no_properties = await collection.query(
             query_vectors=[v1],
             limit=10,
-            return_vector=True,
             return_properties=False,
         )
-        assert no_properties[0].matches[0].record.vector is not None
         assert no_properties[0].matches[0].record.properties is None
 
     @pytest.mark.asyncio
@@ -356,14 +362,13 @@ class TestUpsertAndQuery:
                 ]
             )
 
-        records = await collection.get(
-            record_uuids=[record.uuid],
-            return_vector=True,
-            return_properties=True,
-        )
+        records = await _fetch_records(collection, [record.uuid])
         assert len(records) == 1
-        assert records[0].vector == old_vector
         assert records[0].properties == {"name": "old"}
+
+        # The old vector is still the indexed one.
+        results = await collection.query(query_vectors=[old_vector], limit=1)
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
 
 class TestFilters:
@@ -432,8 +437,10 @@ class TestFilters:
         uuids = await self._query(collection, v1, "created_at", "=", dt_filter)
         assert uuids == {r1.uuid}
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        assert results[0].properties["created_at"] == dt_utc
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt_utc
 
     @pytest.mark.asyncio
     async def test_is_null_and_not_null(self, collection):
@@ -491,23 +498,37 @@ class TestFilters:
         assert {m.record.uuid for m in or_results[0].matches} == {r1.uuid, r2.uuid}
 
 
-class TestGetAndDelete:
+class TestSetPropertiesAndDelete:
     @pytest.mark.asyncio
-    async def test_get_by_uuids_preserves_order_and_return_flags(self, collection):
+    async def test_set_properties_replaces_properties_and_keeps_the_vector(
+        self, collection
+    ):
         v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a"})
-        r2 = _make_record(vector=v2, properties={"name": "b"})
-        await collection.upsert(records=[r1, r2])
+        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
+        await collection.upsert(records=[r1])
 
-        results = await collection.get(
-            record_uuids=[r2.uuid, r1.uuid],
-            return_vector=True,
-            return_properties=False,
-        )
-        assert [record.uuid for record in results] == [r2.uuid, r1.uuid]
-        assert results[0].vector is not None
-        assert results[0].properties is None
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "b"}
+
+        # The vector is untouched, so the record still answers its own query.
+        results = await collection.query(query_vectors=[v1], limit=1)
+        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_set_properties_ignores_uuids_the_collection_does_not_hold(
+        self, collection
+    ):
+        v1 = _normalize([1.0, 0.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a"})
+        await collection.upsert(records=[r1])
+
+        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "a"}
 
     @pytest.mark.asyncio
     async def test_delete_records(self, collection):
@@ -519,7 +540,7 @@ class TestGetAndDelete:
 
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = await collection.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
         assert [record.uuid for record in results] == [r2.uuid]
 
 
@@ -547,8 +568,8 @@ class TestPartitionIsolation:
             records=[Record(uuid=record_uuid, vector=v1, properties={"name": "b"})]
         )
 
-        results_a = await coll_a.get(record_uuids=[record_uuid])
-        results_b = await coll_b.get(record_uuids=[record_uuid])
+        results_a = await _fetch_records(coll_a, [record_uuid])
+        results_b = await _fetch_records(coll_b, [record_uuid])
 
         assert results_a[0].properties == {"name": "a"}
         assert results_b[0].properties == {"name": "b"}

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -10,7 +10,7 @@ import pytest
 import pytest_asyncio
 from qdrant_client import AsyncQdrantClient, models
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -69,7 +69,6 @@ async def collection(store):
         name=NAME,
         config=VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "name": str,
                 "age": int,
@@ -88,6 +87,26 @@ async def collection(store):
 def _normalize(v: list[float]) -> list[float]:
     mag = math.sqrt(sum(x * x for x in v))
     return [x / mag for x in v]
+
+
+_FETCH_LIMIT = 1000
+
+
+async def _fetch_records(collection, record_uuids) -> list[Record]:
+    """Read records back by UUID.
+
+    The collection contract has no read-by-UUID: `query` is the only read, and
+    with no score threshold it returns every record it holds, so a probe vector
+    in any direction lists the collection for a test to pick out of.
+    """
+    record_uuids = list(record_uuids)
+    if not record_uuids:
+        return []
+    dimensions = collection.config.vector_dimensions
+    probe = [1.0] + [0.0] * (dimensions - 1)
+    [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
+    by_uuid = {match.record.uuid: match.record for match in result.matches}
+    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
 
 
 def _make_record(
@@ -131,7 +150,6 @@ class TestCollectionLifecycle:
                 name=NAME,
                 config=VectorStoreCollectionConfig(
                     vector_dimensions=VECTOR_DIM,
-                    similarity_metric=SimilarityMetric.COSINE,
                     indexed_properties_schema={
                         "name": str,
                         "age": int,
@@ -188,7 +206,6 @@ class TestCollectionLifecycle:
         schema: dict[str, type[PropertyValue]] = {"name": str}
         config = VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema=schema,
         )
         await store.create_collection(namespace=NAMESPACE, name="coll_a", config=config)
@@ -227,7 +244,11 @@ class TestUpsertAndQuery:
         assert matches[0].record.uuid == r1.uuid
         assert matches[1].record.uuid == r3.uuid
         assert matches[2].record.uuid == r2.uuid
-        assert matches[0].score >= matches[1].score >= matches[2].score
+        assert (
+            matches[0].cosine_similarity
+            >= matches[1].cosine_similarity
+            >= matches[2].cosine_similarity
+        )
 
     @pytest.mark.asyncio
     async def test_query_with_similarity_threshold(self, collection):
@@ -240,7 +261,9 @@ class TestUpsertAndQuery:
         await collection.upsert(records=[r1, r2])
 
         query_results = list(
-            await collection.query(query_vectors=[v1], limit=10, score_threshold=0.9)
+            await collection.query(
+                query_vectors=[v1], limit=10, min_cosine_similarity=0.9
+            )
         )
         matches = query_results[0].matches
 
@@ -259,14 +282,12 @@ class TestUpsertAndQuery:
         assert len(query_results[0].matches) == 2
 
     @pytest.mark.asyncio
-    async def test_query_return_vector_false(self, collection):
+    async def test_query_never_returns_vectors(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        query_results = list(
-            await collection.query(query_vectors=[v1], limit=10, return_vector=False)
-        )
+        query_results = list(await collection.query(query_vectors=[v1], limit=10))
         matches = query_results[0].matches
         assert len(matches) == 1
         assert matches[0].record.vector is None
@@ -282,13 +303,11 @@ class TestUpsertAndQuery:
             await collection.query(
                 query_vectors=[v1],
                 limit=10,
-                return_vector=True,
                 return_properties=False,
             )
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.vector is not None
         assert matches[0].record.properties is None
 
     @pytest.mark.asyncio
@@ -580,8 +599,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "test", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = list(await collection.get(record_uuids=[r1.uuid]))
-        assert results[0].properties["created_at"] == dt
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt
 
     @pytest.mark.asyncio
     async def test_datetime_microseconds_roundtrip(self, collection):
@@ -591,8 +612,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "micro", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = list(await collection.get(record_uuids=[r1.uuid]))
-        assert results[0].properties["created_at"] == dt
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt
 
     @pytest.mark.asyncio
     async def test_eq_datetime(self, collection):
@@ -728,8 +751,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "n", "created_at": naive_dt})
         await collection.upsert(records=[r1])
 
-        results = list(await collection.get(record_uuids=[r1.uuid]))
-        got = results[0].properties["created_at"]
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        got = properties["created_at"]
         assert isinstance(got, datetime)
         assert got.tzinfo is not None
         assert got == datetime(2024, 6, 15, 12, 30, 0, tzinfo=UTC)
@@ -920,72 +945,62 @@ class TestFilters:
         assert len(matches) == 2
 
 
-# ── Get ──
+# ── Set properties ──
 
 
-class TestGet:
+class TestSetProperties:
     @pytest.mark.asyncio
-    async def test_get_by_uuids(self, collection):
+    async def test_replaces_properties_and_keeps_the_vector(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
-        v3 = _normalize([0.0, 0.0, 1.0])
+        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
+        await collection.upsert(records=[r1])
 
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "b"}
+
+        # The vector is untouched, so the record still answers its own query.
+        results = await collection.query(query_vectors=[v1], limit=1)
+        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_replaced_properties_are_filterable(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "a"})
-        r2 = _make_record(vector=v2, properties={"name": "b"})
-        r3 = _make_record(vector=v3, properties={"name": "c"})
-
-        await collection.upsert(records=[r1, r2, r3])
-
-        results = list(await collection.get(record_uuids=[r3.uuid, r1.uuid]))
-        assert len(results) == 2
-        assert results[0].uuid == r3.uuid
-        assert results[1].uuid == r1.uuid
-
-    @pytest.mark.asyncio
-    async def test_get_missing_uuids(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1)
         await collection.upsert(records=[r1])
 
-        missing_uuid = uuid4()
-        results = list(await collection.get(record_uuids=[r1.uuid, missing_uuid]))
-        assert len(results) == 1
-        assert results[0].uuid == r1.uuid
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
 
-    @pytest.mark.asyncio
-    async def test_get_empty_list(self, collection):
-        results = list(await collection.get(record_uuids=[]))
-        assert len(results) == 0
-
-    @pytest.mark.asyncio
-    async def test_get_return_vector_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = list(
-            await collection.get(record_uuids=[r1.uuid], return_vector=False)
+        stale = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="a"),
         )
-        assert len(results) == 1
-        assert results[0].vector is None
-        assert results[0].properties is not None
+        assert stale[0].matches == []
+
+        fresh = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="b"),
+        )
+        assert [match.record.uuid for match in fresh[0].matches] == [r1.uuid]
 
     @pytest.mark.asyncio
-    async def test_get_return_properties_false(self, collection):
+    async def test_ignores_uuids_the_collection_does_not_hold(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
+        r1 = _make_record(vector=v1, properties={"name": "a"})
         await collection.upsert(records=[r1])
 
-        results = list(
-            await collection.get(
-                record_uuids=[r1.uuid],
-                return_vector=True,
-                return_properties=False,
-            )
-        )
-        assert len(results) == 1
-        assert results[0].vector is not None
-        assert results[0].properties is None
+        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "a"}
+
+    @pytest.mark.asyncio
+    async def test_empty_mapping(self, collection):
+        await collection.set_properties(record_properties={})
 
 
 # ── Delete ──
@@ -1003,7 +1018,7 @@ class TestDelete:
         await collection.upsert(records=[r1, r2])
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = list(await collection.get(record_uuids=[r1.uuid, r2.uuid]))
+        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -1071,7 +1086,7 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        results = list(await coll_a.get(record_uuids=[r1.uuid, r2.uuid]))
+        results = await _fetch_records(coll_a, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r1.uuid
 
@@ -1105,7 +1120,7 @@ class TestPartitionIsolation:
         # Attempt to delete r2 using tenant_a's collection — should not work
         await coll_a.delete(record_uuids=[r2.uuid])
 
-        results = list(await coll_b.get(record_uuids=[r2.uuid]))
+        results = await _fetch_records(coll_b, [r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -1186,7 +1201,6 @@ class TestDistributedSharding:
             name=name,
             config=VectorStoreCollectionConfig(
                 vector_dimensions=VECTOR_DIM,
-                similarity_metric=SimilarityMetric.COSINE,
                 indexed_properties_schema={"name": str},
             ),
         )
@@ -1201,12 +1215,12 @@ class TestDistributedSharding:
         assert len(results) == 1
         assert results[0].matches[0].record.uuid == r1.uuid
 
-        got = await coll.get(record_uuids=[r1.uuid])
+        got = await _fetch_records(coll, [r1.uuid])
         assert len(got) == 1
         assert got[0].uuid == r1.uuid
 
         await coll.delete(record_uuids=[r1.uuid])
-        got = await coll.get(record_uuids=[r1.uuid])
+        got = await _fetch_records(coll, [r1.uuid])
         assert len(got) == 0
 
         await store.delete_collection(namespace=ns, name=name)
@@ -1217,7 +1231,6 @@ class TestDistributedSharding:
         ns = NAMESPACE
         config = VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
         )
 
         await store.create_collection(namespace=ns, name="tenant_a", config=config)
@@ -1239,7 +1252,7 @@ class TestDistributedSharding:
         await store.delete_collection(namespace=ns, name="tenant_a")
 
         # tenant_b data should be untouched.
-        got = await coll_b.get(record_uuids=[r_b.uuid])
+        got = await _fetch_records(coll_b, [r_b.uuid])
         assert len(got) == 1
         assert got[0].uuid == r_b.uuid
 
@@ -1275,7 +1288,6 @@ class TestCollectionLifecycleAcrossWorkers:
     def _config() -> VectorStoreCollectionConfig:
         return VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={"name": str},
         )
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -92,12 +92,12 @@ def _normalize(v: list[float]) -> list[float]:
 _FETCH_LIMIT = 1000
 
 
-async def _fetch_records(collection, record_uuids) -> list[Record]:
-    """Read records back by UUID.
+async def _present_uuids(collection, record_uuids) -> list[UUID]:
+    """Which of these UUIDs the collection still holds, in the order given.
 
-    The collection contract has no read-by-UUID: `query` is the only read, and
-    with no score threshold it returns every record it holds, so a probe vector
-    in any direction lists the collection for a test to pick out of.
+    `query` is the only read and it answers with UUIDs and scores, so existence
+    is all a test can observe about a record here. With no score threshold a
+    probe vector in any direction lists the whole collection.
     """
     record_uuids = list(record_uuids)
     if not record_uuids:
@@ -105,8 +105,8 @@ async def _fetch_records(collection, record_uuids) -> list[Record]:
     dimensions = collection.config.vector_dimensions
     probe = [1.0] + [0.0] * (dimensions - 1)
     [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
-    by_uuid = {match.record.uuid: match.record for match in result.matches}
-    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+    present = {match.record_uuid for match in result.matches}
+    return [uuid for uuid in record_uuids if uuid in present]
 
 
 def _make_record(
@@ -241,9 +241,9 @@ class TestUpsertAndQuery:
         matches = query_results[0].matches
 
         assert len(matches) == 3
-        assert matches[0].record.uuid == r1.uuid
-        assert matches[1].record.uuid == r3.uuid
-        assert matches[2].record.uuid == r2.uuid
+        assert matches[0].record_uuid == r1.uuid
+        assert matches[1].record_uuid == r3.uuid
+        assert matches[2].record_uuid == r2.uuid
         assert (
             matches[0].cosine_similarity
             >= matches[1].cosine_similarity
@@ -268,7 +268,7 @@ class TestUpsertAndQuery:
         matches = query_results[0].matches
 
         assert len(matches) == 1
-        assert matches[0].record.uuid == r1.uuid
+        assert matches[0].record_uuid == r1.uuid
 
     @pytest.mark.asyncio
     async def test_query_with_limit(self, collection):
@@ -282,33 +282,22 @@ class TestUpsertAndQuery:
         assert len(query_results[0].matches) == 2
 
     @pytest.mark.asyncio
-    async def test_query_never_returns_vectors(self, collection):
+    async def test_a_match_is_a_uuid_and_a_score(self, collection):
+        """A match names the record and how well it scored, and nothing else.
+
+        Stored properties are filterable but never returned: this store is not
+        the authority for a record's content, so a caller that wants its
+        fields reads them from whatever owns them.
+        """
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        query_results = list(await collection.query(query_vectors=[v1], limit=10))
-        matches = query_results[0].matches
-        assert len(matches) == 1
-        assert matches[0].record.vector is None
-        assert matches[0].record.properties is not None
-
-    @pytest.mark.asyncio
-    async def test_query_return_properties_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        query_results = list(
-            await collection.query(
-                query_vectors=[v1],
-                limit=10,
-                return_properties=False,
-            )
-        )
-        matches = query_results[0].matches
-        assert len(matches) == 1
-        assert matches[0].record.properties is None
+        [result] = await collection.query(query_vectors=[v1], limit=10)
+        assert len(result.matches) == 1
+        assert result.matches[0].record_uuid == r1.uuid
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+        assert not hasattr(result.matches[0], "record")
 
     @pytest.mark.asyncio
     async def test_query_batch_multiple_vectors(self, collection):
@@ -322,8 +311,8 @@ class TestUpsertAndQuery:
         all_results = list(await collection.query(query_vectors=[v1, v2], limit=1))
 
         assert len(all_results) == 2
-        assert all_results[0].matches[0].record.uuid == r1.uuid
-        assert all_results[1].matches[0].record.uuid == r2.uuid
+        assert all_results[0].matches[0].record_uuid == r1.uuid
+        assert all_results[1].matches[0].record_uuid == r2.uuid
 
     @pytest.mark.asyncio
     async def test_query_empty_vectors(self, collection):
@@ -391,7 +380,7 @@ class TestFilters:
                 property_filter=Comparison(field=field, op=op, value=value),
             )
         )
-        return {m.record.uuid for m in all_results[0].matches}
+        return {m.record_uuid for m in all_results[0].matches}
 
     # ── String / int ──
 
@@ -407,7 +396,7 @@ class TestFilters:
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.uuid == r1.uuid
+        assert matches[0].record_uuid == r1.uuid
 
     @pytest.mark.asyncio
     async def test_ne_str(self, collection):
@@ -429,7 +418,7 @@ class TestFilters:
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.uuid == r3.uuid
+        assert matches[0].record_uuid == r3.uuid
 
     @pytest.mark.asyncio
     async def test_gte_int(self, collection):
@@ -451,7 +440,7 @@ class TestFilters:
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.uuid == r2.uuid
+        assert matches[0].record_uuid == r2.uuid
 
     @pytest.mark.asyncio
     async def test_lte_int(self, collection):
@@ -599,10 +588,14 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "test", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await _fetch_records(collection, [r1.uuid])
-        properties = results[0].properties
-        assert properties is not None
-        assert properties["created_at"] == dt
+        # Properties are filterable but never returned, so a filter is what
+        # observes them.
+        [result] = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="created_at", op="=", value=dt),
+        )
+        assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
     @pytest.mark.asyncio
     async def test_datetime_microseconds_roundtrip(self, collection):
@@ -612,10 +605,14 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "micro", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await _fetch_records(collection, [r1.uuid])
-        properties = results[0].properties
-        assert properties is not None
-        assert properties["created_at"] == dt
+        # Properties are filterable but never returned, so a filter is what
+        # observes them.
+        [result] = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="created_at", op="=", value=dt),
+        )
+        assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
     @pytest.mark.asyncio
     async def test_eq_datetime(self, collection):
@@ -751,13 +748,19 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "n", "created_at": naive_dt})
         await collection.upsert(records=[r1])
 
-        results = await _fetch_records(collection, [r1.uuid])
-        properties = results[0].properties
-        assert properties is not None
-        got = properties["created_at"]
-        assert isinstance(got, datetime)
-        assert got.tzinfo is not None
-        assert got == datetime(2024, 6, 15, 12, 30, 0, tzinfo=UTC)
+        # Properties are filterable but never returned, so a filter is what
+        # observes them.
+        # A naive value is stored as the same instant in UTC.
+        [result] = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(
+                field="created_at",
+                op="=",
+                value=datetime(2024, 6, 15, 12, 30, 0, tzinfo=UTC),
+            ),
+        )
+        assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
     @pytest.mark.asyncio
     async def test_eq_naive_datetime(self, collection):
@@ -841,7 +844,7 @@ class TestFilters:
                 property_filter=IsNull(field="name"),
             )
         )
-        uuids = {m.record.uuid for m in query_results[0].matches}
+        uuids = {m.record_uuid for m in query_results[0].matches}
         assert r_has_value.uuid not in uuids
         assert r_explicit_none.uuid in uuids
         assert r_key_missing.uuid in uuids
@@ -868,7 +871,7 @@ class TestFilters:
                 property_filter=Not(expr=IsNull(field="name")),
             )
         )
-        uuids = {m.record.uuid for m in query_results[0].matches}
+        uuids = {m.record_uuid for m in query_results[0].matches}
         assert r_has_value.uuid in uuids
         assert r_explicit_none.uuid not in uuids
         assert r_key_missing.uuid not in uuids
@@ -887,7 +890,7 @@ class TestFilters:
             )
         )
         matches = query_results[0].matches
-        uuids = {m.record.uuid for m in matches}
+        uuids = {m.record_uuid for m in matches}
         assert r1.uuid in uuids
         assert r3.uuid in uuids
         assert len(matches) == 2
@@ -907,7 +910,7 @@ class TestFilters:
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.uuid == r3.uuid
+        assert matches[0].record_uuid == r3.uuid
 
     @pytest.mark.asyncio
     async def test_or(self, collection):
@@ -923,7 +926,7 @@ class TestFilters:
             )
         )
         matches = query_results[0].matches
-        uuids = {m.record.uuid for m in matches}
+        uuids = {m.record_uuid for m in matches}
         assert r1.uuid in uuids
         assert r3.uuid in uuids
         assert len(matches) == 2
@@ -939,68 +942,10 @@ class TestFilters:
             )
         )
         matches = query_results[0].matches
-        uuids = {m.record.uuid for m in matches}
+        uuids = {m.record_uuid for m in matches}
         assert r1.uuid in uuids
         assert r2.uuid in uuids
         assert len(matches) == 2
-
-
-# ── Set properties ──
-
-
-class TestSetProperties:
-    @pytest.mark.asyncio
-    async def test_replaces_properties_and_keeps_the_vector(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
-        await collection.upsert(records=[r1])
-
-        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
-
-        [fetched] = await _fetch_records(collection, [r1.uuid])
-        assert fetched.properties == {"name": "b"}
-
-        # The vector is untouched, so the record still answers its own query.
-        results = await collection.query(query_vectors=[v1], limit=1)
-        assert results[0].matches[0].record.uuid == r1.uuid
-        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_replaced_properties_are_filterable(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a"})
-        await collection.upsert(records=[r1])
-
-        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
-
-        stale = await collection.query(
-            query_vectors=[v1],
-            limit=10,
-            property_filter=Comparison(field="name", op="=", value="a"),
-        )
-        assert stale[0].matches == []
-
-        fresh = await collection.query(
-            query_vectors=[v1],
-            limit=10,
-            property_filter=Comparison(field="name", op="=", value="b"),
-        )
-        assert [match.record.uuid for match in fresh[0].matches] == [r1.uuid]
-
-    @pytest.mark.asyncio
-    async def test_ignores_uuids_the_collection_does_not_hold(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a"})
-        await collection.upsert(records=[r1])
-
-        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
-
-        [fetched] = await _fetch_records(collection, [r1.uuid])
-        assert fetched.properties == {"name": "a"}
-
-    @pytest.mark.asyncio
-    async def test_empty_mapping(self, collection):
-        await collection.set_properties(record_properties={})
 
 
 # ── Delete ──
@@ -1018,9 +963,9 @@ class TestDelete:
         await collection.upsert(records=[r1, r2])
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
+        results = await _present_uuids(collection, [r1.uuid, r2.uuid])
         assert len(results) == 1
-        assert results[0].uuid == r2.uuid
+        assert results[0] == r2.uuid
 
 
 # ── Partition isolation (via separate logical collections) ──
@@ -1054,8 +999,8 @@ class TestPartitionIsolation:
         results_a = list(await coll_a.query(query_vectors=[v1], limit=10))
         results_b = list(await coll_b.query(query_vectors=[v1], limit=10))
 
-        uuids_a = {m.record.uuid for m in results_a[0].matches}
-        uuids_b = {m.record.uuid for m in results_b[0].matches}
+        uuids_a = {m.record_uuid for m in results_a[0].matches}
+        uuids_b = {m.record_uuid for m in results_b[0].matches}
         assert uuids_a == {r1.uuid}
         assert uuids_b == {r2.uuid}
 
@@ -1086,9 +1031,9 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        results = await _fetch_records(coll_a, [r1.uuid, r2.uuid])
+        results = await _present_uuids(coll_a, [r1.uuid, r2.uuid])
         assert len(results) == 1
-        assert results[0].uuid == r1.uuid
+        assert results[0] == r1.uuid
 
         await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
         await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
@@ -1120,9 +1065,9 @@ class TestPartitionIsolation:
         # Attempt to delete r2 using tenant_a's collection — should not work
         await coll_a.delete(record_uuids=[r2.uuid])
 
-        results = await _fetch_records(coll_b, [r2.uuid])
+        results = await _present_uuids(coll_b, [r2.uuid])
         assert len(results) == 1
-        assert results[0].uuid == r2.uuid
+        assert results[0] == r2.uuid
 
         await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
         await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
@@ -1213,14 +1158,12 @@ class TestDistributedSharding:
 
         results = await coll.query(query_vectors=[v1], limit=1)
         assert len(results) == 1
-        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].record_uuid == r1.uuid
 
-        got = await _fetch_records(coll, [r1.uuid])
-        assert len(got) == 1
-        assert got[0].uuid == r1.uuid
+        assert await _present_uuids(coll, [r1.uuid]) == [r1.uuid]
 
         await coll.delete(record_uuids=[r1.uuid])
-        got = await _fetch_records(coll, [r1.uuid])
+        got = await _present_uuids(coll, [r1.uuid])
         assert len(got) == 0
 
         await store.delete_collection(namespace=ns, name=name)
@@ -1252,9 +1195,7 @@ class TestDistributedSharding:
         await store.delete_collection(namespace=ns, name="tenant_a")
 
         # tenant_b data should be untouched.
-        got = await _fetch_records(coll_b, [r_b.uuid])
-        assert len(got) == 1
-        assert got[0].uuid == r_b.uuid
+        assert await _present_uuids(coll_b, [r_b.uuid]) == [r_b.uuid]
 
         await store.delete_collection(namespace=ns, name="tenant_b")
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -3,7 +3,7 @@
 import math
 import sqlite3
 from datetime import UTC, datetime, timedelta, timezone
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 import pytest_asyncio
@@ -46,12 +46,12 @@ def _normalize(vector: list[float]) -> list[float]:
 _FETCH_LIMIT = 1000
 
 
-async def _fetch_records(collection, record_uuids) -> list[Record]:
-    """Read records back by UUID.
+async def _present_uuids(collection, record_uuids) -> list[UUID]:
+    """Which of these UUIDs the collection still holds, in the order given.
 
-    The collection contract has no read-by-UUID: `query` is the only read, and
-    with no score threshold it returns every record it holds, so a probe vector
-    in any direction lists the collection for a test to pick out of.
+    `query` is the only read and it answers with UUIDs and scores, so existence
+    is all a test can observe about a record here. With no score threshold a
+    probe vector in any direction lists the whole collection.
     """
     record_uuids = list(record_uuids)
     if not record_uuids:
@@ -59,8 +59,8 @@ async def _fetch_records(collection, record_uuids) -> list[Record]:
     dimensions = collection.config.vector_dimensions
     probe = [1.0] + [0.0] * (dimensions - 1)
     [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
-    by_uuid = {match.record.uuid: match.record for match in result.matches}
-    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+    present = {match.record_uuid for match in result.matches}
+    return [uuid for uuid in record_uuids if uuid in present]
 
 
 def _make_record(
@@ -231,7 +231,7 @@ class TestUpsertAndQuery:
         matches = query_results[0].matches
 
         assert len(matches) == 3
-        assert matches[0].record.uuid == r1.uuid
+        assert matches[0].record_uuid == r1.uuid
         assert (
             matches[0].cosine_similarity
             >= matches[1].cosine_similarity
@@ -251,10 +251,14 @@ class TestUpsertAndQuery:
         )
         await collection.upsert(records=[updated])
 
-        results = await _fetch_records(collection, [record.uuid])
-        properties = results[0].properties
-        assert properties is not None
-        assert properties["name"] == "updated"
+        # Properties are filterable but never returned, so a filter is what
+        # observes them.
+        [result] = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="updated"),
+        )
+        assert [m.record_uuid for m in result.matches] == [record.uuid]
 
     @pytest.mark.asyncio
     async def test_query_with_similarity_threshold(self, collection):
@@ -272,7 +276,7 @@ class TestUpsertAndQuery:
         matches = query_results[0].matches
 
         assert len(matches) == 1
-        assert matches[0].record.uuid == r1.uuid
+        assert matches[0].record_uuid == r1.uuid
 
     @pytest.mark.asyncio
     async def test_query_with_limit(self, collection):
@@ -284,31 +288,22 @@ class TestUpsertAndQuery:
         assert len(query_results[0].matches) == 2
 
     @pytest.mark.asyncio
-    async def test_query_never_returns_vectors(self, collection):
+    async def test_a_match_is_a_uuid_and_a_score(self, collection):
+        """A match names the record and how well it scored, and nothing else.
+
+        Stored properties are filterable but never returned: this store is not
+        the authority for a record's content, so a caller that wants its
+        fields reads them from whatever owns them.
+        """
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        query_results = await collection.query(query_vectors=[v1], limit=10)
-        matches = query_results[0].matches
-        assert len(matches) == 1
-        assert matches[0].record.vector is None
-        assert matches[0].record.properties is not None
-
-    @pytest.mark.asyncio
-    async def test_query_return_properties_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        query_results = await collection.query(
-            query_vectors=[v1],
-            limit=10,
-            return_properties=False,
-        )
-        matches = query_results[0].matches
-        assert len(matches) == 1
-        assert matches[0].record.properties is None
+        [result] = await collection.query(query_vectors=[v1], limit=10)
+        assert len(result.matches) == 1
+        assert result.matches[0].record_uuid == r1.uuid
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+        assert not hasattr(result.matches[0], "record")
 
     @pytest.mark.asyncio
     async def test_query_batch_multiple_vectors(self, collection):
@@ -322,8 +317,8 @@ class TestUpsertAndQuery:
         all_results = await collection.query(query_vectors=[v1, v2], limit=1)
 
         assert len(all_results) == 2
-        assert all_results[0].matches[0].record.uuid == r1.uuid
-        assert all_results[1].matches[0].record.uuid == r2.uuid
+        assert all_results[0].matches[0].record_uuid == r1.uuid
+        assert all_results[1].matches[0].record_uuid == r2.uuid
 
     @pytest.mark.asyncio
     async def test_query_empty_vectors(self, collection):
@@ -393,7 +388,7 @@ class TestFilters:
             limit=10,
             property_filter=Comparison(field=field, op=op, value=value),
         )
-        return {match.record.uuid for match in all_results[0].matches}
+        return {match.record_uuid for match in all_results[0].matches}
 
     # ── String / int ──
 
@@ -494,10 +489,14 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "test", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await _fetch_records(collection, [r1.uuid])
-        properties = results[0].properties
-        assert properties is not None
-        assert properties["created_at"] == dt
+        # Properties are filterable but never returned, so a filter is what
+        # observes them.
+        [result] = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="created_at", op="=", value=dt),
+        )
+        assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
     @pytest.mark.asyncio
     async def test_eq_datetime(self, collection):
@@ -554,13 +553,17 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "tz", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await _fetch_records(collection, [r1.uuid])
-        properties = results[0].properties
-        assert properties is not None
-        got = properties["created_at"]
-        assert isinstance(got, datetime)
-        assert got == dt
-        assert got.utcoffset() == timedelta(hours=-5)
+        # Properties are filterable but never returned, so a filter is what
+        # observes them.
+        # The instant survives the round trip whichever zone it is named in.
+        [result] = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(
+                field="created_at", op="=", value=dt.astimezone(UTC)
+            ),
+        )
+        assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
     # ── In / And / Or / Not ──
 
@@ -572,7 +575,7 @@ class TestFilters:
             limit=10,
             property_filter=In(field="name", values=["alice", "carol"]),
         )
-        uuids = {match.record.uuid for match in query_results[0].matches}
+        uuids = {match.record_uuid for match in query_results[0].matches}
         assert r1.uuid in uuids
         assert r3.uuid in uuids
         assert len(uuids) == 2
@@ -590,7 +593,7 @@ class TestFilters:
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.uuid == r3.uuid
+        assert matches[0].record_uuid == r3.uuid
 
     @pytest.mark.asyncio
     async def test_or(self, collection):
@@ -603,7 +606,7 @@ class TestFilters:
                 right=Comparison(field="name", op="=", value="carol"),
             ),
         )
-        uuids = {match.record.uuid for match in query_results[0].matches}
+        uuids = {match.record_uuid for match in query_results[0].matches}
         assert r1.uuid in uuids
         assert r3.uuid in uuids
         assert len(uuids) == 2
@@ -616,68 +619,10 @@ class TestFilters:
             limit=10,
             property_filter=Not(expr=Comparison(field="age", op=">", value=30)),
         )
-        uuids = {match.record.uuid for match in query_results[0].matches}
+        uuids = {match.record_uuid for match in query_results[0].matches}
         assert r1.uuid in uuids
         assert r2.uuid in uuids
         assert len(uuids) == 2
-
-
-# ── Set properties ──
-
-
-class TestSetProperties:
-    @pytest.mark.asyncio
-    async def test_replaces_properties_and_keeps_the_vector(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
-        await collection.upsert(records=[r1])
-
-        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
-
-        [fetched] = await _fetch_records(collection, [r1.uuid])
-        assert fetched.properties == {"name": "b"}
-
-        # The vector is untouched, so the record still answers its own query.
-        results = await collection.query(query_vectors=[v1], limit=1)
-        assert results[0].matches[0].record.uuid == r1.uuid
-        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_replaced_properties_are_filterable(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a"})
-        await collection.upsert(records=[r1])
-
-        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
-
-        stale = await collection.query(
-            query_vectors=[v1],
-            limit=10,
-            property_filter=Comparison(field="name", op="=", value="a"),
-        )
-        assert stale[0].matches == []
-
-        fresh = await collection.query(
-            query_vectors=[v1],
-            limit=10,
-            property_filter=Comparison(field="name", op="=", value="b"),
-        )
-        assert [match.record.uuid for match in fresh[0].matches] == [r1.uuid]
-
-    @pytest.mark.asyncio
-    async def test_ignores_uuids_the_collection_does_not_hold(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a"})
-        await collection.upsert(records=[r1])
-
-        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
-
-        [fetched] = await _fetch_records(collection, [r1.uuid])
-        assert fetched.properties == {"name": "a"}
-
-    @pytest.mark.asyncio
-    async def test_empty_mapping(self, collection):
-        await collection.set_properties(record_properties={})
 
 
 # ── Delete ──
@@ -695,9 +640,9 @@ class TestDelete:
         await collection.upsert(records=[r1, r2])
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
+        results = await _present_uuids(collection, [r1.uuid, r2.uuid])
         assert len(results) == 1
-        assert results[0].uuid == r2.uuid
+        assert results[0] == r2.uuid
 
     @pytest.mark.asyncio
     async def test_delete_empty_list(self, collection):
@@ -746,8 +691,8 @@ class TestPartitionIsolation:
         results_a = await coll_a.query(query_vectors=[v1], limit=10)
         results_b = await coll_b.query(query_vectors=[v1], limit=10)
 
-        uuids_a = {match.record.uuid for match in results_a[0].matches}
-        uuids_b = {match.record.uuid for match in results_b[0].matches}
+        uuids_a = {match.record_uuid for match in results_a[0].matches}
+        uuids_b = {match.record_uuid for match in results_b[0].matches}
         assert uuids_a == {r1.uuid}
         assert uuids_b == {r2.uuid}
 
@@ -775,9 +720,9 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        results = await _fetch_records(coll_a, [r1.uuid, r2.uuid])
+        results = await _present_uuids(coll_a, [r1.uuid, r2.uuid])
         assert len(results) == 1
-        assert results[0].uuid == r1.uuid
+        assert results[0] == r1.uuid
 
         await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
         await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
@@ -805,9 +750,9 @@ class TestPartitionIsolation:
 
         await coll_a.delete(record_uuids=[r2.uuid])
 
-        results = await _fetch_records(coll_b, [r2.uuid])
+        results = await _present_uuids(coll_b, [r2.uuid])
         assert len(results) == 1
-        assert results[0].uuid == r2.uuid
+        assert results[0] == r2.uuid
 
         await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
         await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
@@ -834,7 +779,7 @@ class TestPartitionIsolation:
         await coll_b.upsert(records=[r2])
 
         results_a = await coll_a.query(query_vectors=[v1], limit=10)
-        assert {match.record.uuid for match in results_a[0].matches} == {r1.uuid}
+        assert {match.record_uuid for match in results_a[0].matches} == {r1.uuid}
 
         await store.delete_collection(namespace="namespace_a", name="coll")
         await store.delete_collection(namespace="namespace_b", name="coll")
@@ -860,7 +805,7 @@ class TestPartitionIsolation:
 
         results = await coll_b.query(query_vectors=[v1], limit=10)
         assert len(results[0].matches) == 1
-        assert results[0].matches[0].record.uuid == r2.uuid
+        assert results[0].matches[0].record_uuid == r2.uuid
 
         await store.delete_collection(namespace=NAMESPACE, name="sibling_b")
 
@@ -896,9 +841,7 @@ class TestInputValidation:
         v1 = _normalize([1.0, 0.0, 0.0])
         record = _make_record(vector=v1, properties=None)
         await collection.upsert(records=[record])
-        fetched = await _fetch_records(collection, [record.uuid])
-        assert len(fetched) == 1
-        assert fetched[0].properties == {}
+        assert await _present_uuids(collection, [record.uuid]) == [record.uuid]
 
 
 # ── Score semantics ──
@@ -939,14 +882,17 @@ class TestUpsertBehavior:
             ]
         )
 
-        fetched = await _fetch_records(collection, [record_uuid])
-        assert len(fetched) == 1
-        properties = fetched[0].properties
-        assert properties is not None
-        assert properties["name"] == "bob"
+        # Properties are filterable but never returned, so a filter is what
+        # observes them.
+        [named_bob] = await collection.query(
+            query_vectors=[v2],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="bob"),
+        )
+        assert [m.record_uuid for m in named_bob.matches] == [record_uuid]
 
         results = await collection.query(query_vectors=[v2], limit=1)
-        assert results[0].matches[0].record.uuid == record_uuid
+        assert results[0].matches[0].record_uuid == record_uuid
         assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
 
@@ -971,7 +917,7 @@ class TestFilterEdgeCases:
                 right=Comparison(field="name", op="=", value="carol"),
             ),
         )
-        uuids = {m.record.uuid for m in results[0].matches}
+        uuids = {m.record_uuid for m in results[0].matches}
         assert r1.uuid in uuids
         assert r3.uuid in uuids
         assert r2.uuid not in uuids

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -9,7 +9,6 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -44,6 +43,26 @@ def _normalize(vector: list[float]) -> list[float]:
     return [x / magnitude for x in vector]
 
 
+_FETCH_LIMIT = 1000
+
+
+async def _fetch_records(collection, record_uuids) -> list[Record]:
+    """Read records back by UUID.
+
+    The collection contract has no read-by-UUID: `query` is the only read, and
+    with no score threshold it returns every record it holds, so a probe vector
+    in any direction lists the collection for a test to pick out of.
+    """
+    record_uuids = list(record_uuids)
+    if not record_uuids:
+        return []
+    dimensions = collection.config.vector_dimensions
+    probe = [1.0] + [0.0] * (dimensions - 1)
+    [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
+    by_uuid = {match.record.uuid: match.record for match in result.matches}
+    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+
+
 def _make_record(
     *,
     uuid=None,
@@ -76,7 +95,6 @@ async def collection(store):
         name=NAME,
         config=VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "name": str,
                 "age": int,
@@ -120,7 +138,6 @@ class TestCollectionLifecycle:
                 name=NAME,
                 config=VectorStoreCollectionConfig(
                     vector_dimensions=VECTOR_DIM,
-                    similarity_metric=SimilarityMetric.COSINE,
                     indexed_properties_schema={
                         "name": str,
                         "age": int,
@@ -176,18 +193,6 @@ class TestCollectionLifecycle:
         assert await store.open_collection(namespace=NAMESPACE, name="nope") is None
 
     @pytest.mark.asyncio
-    async def test_unsupported_metric_raises(self, store):
-        with pytest.raises(ValueError, match="sqlite-vec"):
-            await store.create_collection(
-                namespace=NAMESPACE,
-                name="bad_metric",
-                config=VectorStoreCollectionConfig(
-                    vector_dimensions=VECTOR_DIM,
-                    similarity_metric=SimilarityMetric.DOT,
-                ),
-            )
-
-    @pytest.mark.asyncio
     async def test_invalid_namespace_raises(self, store):
         with pytest.raises(ValueError, match="Invalid namespace"):
             await store.create_collection(
@@ -227,7 +232,11 @@ class TestUpsertAndQuery:
 
         assert len(matches) == 3
         assert matches[0].record.uuid == r1.uuid
-        assert matches[0].score >= matches[1].score >= matches[2].score
+        assert (
+            matches[0].cosine_similarity
+            >= matches[1].cosine_similarity
+            >= matches[2].cosine_similarity
+        )
 
     @pytest.mark.asyncio
     async def test_upsert_update(self, collection):
@@ -242,8 +251,10 @@ class TestUpsertAndQuery:
         )
         await collection.upsert(records=[updated])
 
-        results = await collection.get(record_uuids=[record.uuid])
-        assert results[0].properties["name"] == "updated"
+        results = await _fetch_records(collection, [record.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["name"] == "updated"
 
     @pytest.mark.asyncio
     async def test_query_with_similarity_threshold(self, collection):
@@ -256,7 +267,7 @@ class TestUpsertAndQuery:
         await collection.upsert(records=[r1, r2])
 
         query_results = await collection.query(
-            query_vectors=[v1], limit=10, score_threshold=0.9
+            query_vectors=[v1], limit=10, min_cosine_similarity=0.9
         )
         matches = query_results[0].matches
 
@@ -273,14 +284,12 @@ class TestUpsertAndQuery:
         assert len(query_results[0].matches) == 2
 
     @pytest.mark.asyncio
-    async def test_query_return_vector_false(self, collection):
+    async def test_query_never_returns_vectors(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        query_results = await collection.query(
-            query_vectors=[v1], limit=10, return_vector=False
-        )
+        query_results = await collection.query(query_vectors=[v1], limit=10)
         matches = query_results[0].matches
         assert len(matches) == 1
         assert matches[0].record.vector is None
@@ -295,12 +304,10 @@ class TestUpsertAndQuery:
         query_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            return_vector=True,
             return_properties=False,
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.vector is not None
         assert matches[0].record.properties is None
 
     @pytest.mark.asyncio
@@ -487,8 +494,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "test", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        assert results[0].properties["created_at"] == dt
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt
 
     @pytest.mark.asyncio
     async def test_eq_datetime(self, collection):
@@ -545,8 +554,11 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "tz", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        got = results[0].properties["created_at"]
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        got = properties["created_at"]
+        assert isinstance(got, datetime)
         assert got == dt
         assert got.utcoffset() == timedelta(hours=-5)
 
@@ -610,61 +622,62 @@ class TestFilters:
         assert len(uuids) == 2
 
 
-# ── Get ──
+# ── Set properties ──
 
 
-class TestGet:
+class TestSetProperties:
     @pytest.mark.asyncio
-    async def test_get_by_uuids(self, collection):
+    async def test_replaces_properties_and_keeps_the_vector(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
+        await collection.upsert(records=[r1])
 
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "b"}
+
+        # The vector is untouched, so the record still answers its own query.
+        results = await collection.query(query_vectors=[v1], limit=1)
+        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_replaced_properties_are_filterable(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "a"})
-        r2 = _make_record(vector=v2, properties={"name": "b"})
-        await collection.upsert(records=[r1, r2])
-
-        results = await collection.get(record_uuids=[r2.uuid, r1.uuid])
-        assert len(results) == 2
-        assert results[0].uuid == r2.uuid
-        assert results[1].uuid == r1.uuid
-
-    @pytest.mark.asyncio
-    async def test_get_missing_uuids(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1)
         await collection.upsert(records=[r1])
 
-        missing = uuid4()
-        results = await collection.get(record_uuids=[r1.uuid, missing])
-        assert len(results) == 1
-        assert results[0].uuid == r1.uuid
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
 
-    @pytest.mark.asyncio
-    async def test_get_empty_list(self, collection):
-        results = await collection.get(record_uuids=[])
-        assert len(results) == 0
-
-    @pytest.mark.asyncio
-    async def test_get_return_vector_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = await collection.get(record_uuids=[r1.uuid], return_vector=False)
-        assert results[0].vector is None
-        assert results[0].properties is not None
-
-    @pytest.mark.asyncio
-    async def test_get_return_properties_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = await collection.get(
-            record_uuids=[r1.uuid], return_vector=True, return_properties=False
+        stale = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="a"),
         )
-        assert results[0].vector is not None
-        assert results[0].properties is None
+        assert stale[0].matches == []
+
+        fresh = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="b"),
+        )
+        assert [match.record.uuid for match in fresh[0].matches] == [r1.uuid]
+
+    @pytest.mark.asyncio
+    async def test_ignores_uuids_the_collection_does_not_hold(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a"})
+        await collection.upsert(records=[r1])
+
+        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "a"}
+
+    @pytest.mark.asyncio
+    async def test_empty_mapping(self, collection):
+        await collection.set_properties(record_properties={})
 
 
 # ── Delete ──
@@ -682,7 +695,7 @@ class TestDelete:
         await collection.upsert(records=[r1, r2])
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = await collection.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -762,7 +775,7 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        results = await coll_a.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(coll_a, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r1.uuid
 
@@ -792,7 +805,7 @@ class TestPartitionIsolation:
 
         await coll_a.delete(record_uuids=[r2.uuid])
 
-        results = await coll_b.get(record_uuids=[r2.uuid])
+        results = await _fetch_records(coll_b, [r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -852,32 +865,6 @@ class TestPartitionIsolation:
         await store.delete_collection(namespace=NAMESPACE, name="sibling_b")
 
 
-# ── Euclidean metric ──
-
-
-class TestEuclideanMetric:
-    @pytest.mark.asyncio
-    async def test_euclidean_ordering(self, store):
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=2,
-            similarity_metric=SimilarityMetric.EUCLIDEAN,
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean", config=config
-        )
-        r1 = _make_record(vector=[0.0, 0.0])
-        r2 = _make_record(vector=[3.0, 4.0])
-        await coll.upsert(records=[r1, r2])
-
-        results = await coll.query(query_vectors=[[0.0, 0.0]], limit=2)
-        assert results[0].matches[0].score < results[0].matches[1].score
-
-        await store.delete_collection(namespace=NAMESPACE, name="euclidean")
-
-
-# ── No-properties collection ──
-
-
 class TestNoProperties:
     @pytest.mark.asyncio
     async def test_collection_without_properties(self, store):
@@ -909,9 +896,7 @@ class TestInputValidation:
         v1 = _normalize([1.0, 0.0, 0.0])
         record = _make_record(vector=v1, properties=None)
         await collection.upsert(records=[record])
-        fetched = await collection.get(
-            record_uuids=[record.uuid], return_properties=True
-        )
+        fetched = await _fetch_records(collection, [record.uuid])
         assert len(fetched) == 1
         assert fetched[0].properties == {}
 
@@ -929,29 +914,8 @@ class TestScoreSemantics:
         await collection.upsert(records=[r1, r2])
 
         results = await collection.query(query_vectors=[v1], limit=2)
-        scores = [m.score for m in results[0].matches]
+        scores = [m.cosine_similarity for m in results[0].matches]
         assert scores[0] > scores[1]
-
-    @pytest.mark.asyncio
-    async def test_euclidean_lower_is_better(self, store):
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=2,
-            similarity_metric=SimilarityMetric.EUCLIDEAN,
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean_score", config=config
-        )
-        r1 = _make_record(vector=[0.0, 0.0])
-        r2 = _make_record(vector=[3.0, 4.0])
-        await coll.upsert(records=[r1, r2])
-
-        results = await coll.query(query_vectors=[[0.0, 0.0]], limit=2)
-        scores = [m.score for m in results[0].matches]
-        assert scores[0] < scores[1]
-        assert scores[0] == pytest.approx(0.0, abs=0.01)
-        assert scores[1] == pytest.approx(5.0, abs=0.01)
-
-        await store.delete_collection(namespace=NAMESPACE, name="euclidean_score")
 
 
 # ── Upsert behavior ──
@@ -975,15 +939,15 @@ class TestUpsertBehavior:
             ]
         )
 
-        fetched = await collection.get(
-            record_uuids=[record_uuid], return_vector=True, return_properties=True
-        )
+        fetched = await _fetch_records(collection, [record_uuid])
         assert len(fetched) == 1
-        assert fetched[0].properties["name"] == "bob"
+        properties = fetched[0].properties
+        assert properties is not None
+        assert properties["name"] == "bob"
 
         results = await collection.query(query_vectors=[v2], limit=1)
         assert results[0].matches[0].record.uuid == record_uuid
-        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
 
 # ── Filter edge cases ──

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -47,12 +47,12 @@ def _normalize(vector: list[float]) -> list[float]:
 _FETCH_LIMIT = 1000
 
 
-async def _fetch_records(collection, record_uuids) -> list[Record]:
-    """Read records back by UUID.
+async def _present_uuids(collection, record_uuids) -> list[UUID]:
+    """Which of these UUIDs the collection still holds, in the order given.
 
-    The collection contract has no read-by-UUID: `query` is the only read, and
-    with no score threshold it returns every record it holds, so a probe vector
-    in any direction lists the collection for a test to pick out of.
+    `query` is the only read and it answers with UUIDs and scores, so existence
+    is all a test can observe about a record here. With no score threshold a
+    probe vector in any direction lists the whole collection.
     """
     record_uuids = list(record_uuids)
     if not record_uuids:
@@ -60,8 +60,8 @@ async def _fetch_records(collection, record_uuids) -> list[Record]:
     dimensions = collection.config.vector_dimensions
     probe = [1.0] + [0.0] * (dimensions - 1)
     [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
-    by_uuid = {match.record.uuid: match.record for match in result.matches}
-    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+    present = {match.record_uuid for match in result.matches}
+    return [uuid for uuid in record_uuids if uuid in present]
 
 
 def _make_record(
@@ -237,7 +237,7 @@ class TestUpsertAndQuery:
         matches = query_results[0].matches
 
         assert len(matches) == 3
-        assert matches[0].record.uuid == r1.uuid
+        assert matches[0].record_uuid == r1.uuid
         assert (
             matches[0].cosine_similarity
             >= matches[1].cosine_similarity
@@ -257,10 +257,14 @@ class TestUpsertAndQuery:
         )
         await collection.upsert(records=[updated])
 
-        results = await _fetch_records(collection, [record.uuid])
-        properties = results[0].properties
-        assert properties is not None
-        assert properties["name"] == "updated"
+        # Properties are filterable but never returned, so a filter is what
+        # observes them.
+        [result] = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="updated"),
+        )
+        assert [m.record_uuid for m in result.matches] == [record.uuid]
 
     @pytest.mark.asyncio
     async def test_query_with_similarity_threshold(self, collection):
@@ -278,7 +282,7 @@ class TestUpsertAndQuery:
         matches = query_results[0].matches
 
         assert len(matches) == 1
-        assert matches[0].record.uuid == r1.uuid
+        assert matches[0].record_uuid == r1.uuid
 
     @pytest.mark.asyncio
     async def test_query_with_limit(self, collection):
@@ -290,31 +294,22 @@ class TestUpsertAndQuery:
         assert len(query_results[0].matches) == 2
 
     @pytest.mark.asyncio
-    async def test_query_never_returns_vectors(self, collection):
+    async def test_a_match_is_a_uuid_and_a_score(self, collection):
+        """A match names the record and how well it scored, and nothing else.
+
+        Stored properties are filterable but never returned: this store is not
+        the authority for a record's content, so a caller that wants its
+        fields reads them from whatever owns them.
+        """
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        query_results = await collection.query(query_vectors=[v1], limit=10)
-        matches = query_results[0].matches
-        assert len(matches) == 1
-        assert matches[0].record.vector is None
-        assert matches[0].record.properties is not None
-
-    @pytest.mark.asyncio
-    async def test_query_return_properties_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        query_results = await collection.query(
-            query_vectors=[v1],
-            limit=10,
-            return_properties=False,
-        )
-        matches = query_results[0].matches
-        assert len(matches) == 1
-        assert matches[0].record.properties is None
+        [result] = await collection.query(query_vectors=[v1], limit=10)
+        assert len(result.matches) == 1
+        assert result.matches[0].record_uuid == r1.uuid
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+        assert not hasattr(result.matches[0], "record")
 
     @pytest.mark.asyncio
     async def test_query_batch_multiple_vectors(self, collection):
@@ -328,8 +323,8 @@ class TestUpsertAndQuery:
         all_results = await collection.query(query_vectors=[v1, v2], limit=1)
 
         assert len(all_results) == 2
-        assert all_results[0].matches[0].record.uuid == r1.uuid
-        assert all_results[1].matches[0].record.uuid == r2.uuid
+        assert all_results[0].matches[0].record_uuid == r1.uuid
+        assert all_results[1].matches[0].record_uuid == r2.uuid
 
     @pytest.mark.asyncio
     async def test_query_empty_vectors(self, collection):
@@ -399,7 +394,7 @@ class TestFilters:
             limit=10,
             property_filter=Comparison(field=field, op=op, value=value),
         )
-        return {match.record.uuid for match in all_results[0].matches}
+        return {match.record_uuid for match in all_results[0].matches}
 
     # ── String / int ──
 
@@ -500,10 +495,14 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "test", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await _fetch_records(collection, [r1.uuid])
-        properties = results[0].properties
-        assert properties is not None
-        assert properties["created_at"] == dt
+        # Properties are filterable but never returned, so a filter is what
+        # observes them.
+        [result] = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="created_at", op="=", value=dt),
+        )
+        assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
     @pytest.mark.asyncio
     async def test_eq_datetime(self, collection):
@@ -560,13 +559,17 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "tz", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await _fetch_records(collection, [r1.uuid])
-        properties = results[0].properties
-        assert properties is not None
-        got = properties["created_at"]
-        assert isinstance(got, datetime)
-        assert got == dt
-        assert got.utcoffset() == timedelta(hours=-5)
+        # Properties are filterable but never returned, so a filter is what
+        # observes them.
+        # The instant survives the round trip whichever zone it is named in.
+        [result] = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(
+                field="created_at", op="=", value=dt.astimezone(UTC)
+            ),
+        )
+        assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
     # ── In / And / Or / Not ──
 
@@ -578,7 +581,7 @@ class TestFilters:
             limit=10,
             property_filter=In(field="name", values=["alice", "carol"]),
         )
-        uuids = {match.record.uuid for match in query_results[0].matches}
+        uuids = {match.record_uuid for match in query_results[0].matches}
         assert r1.uuid in uuids
         assert r3.uuid in uuids
         assert len(uuids) == 2
@@ -596,7 +599,7 @@ class TestFilters:
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.uuid == r3.uuid
+        assert matches[0].record_uuid == r3.uuid
 
     @pytest.mark.asyncio
     async def test_or(self, collection):
@@ -609,7 +612,7 @@ class TestFilters:
                 right=Comparison(field="name", op="=", value="carol"),
             ),
         )
-        uuids = {match.record.uuid for match in query_results[0].matches}
+        uuids = {match.record_uuid for match in query_results[0].matches}
         assert r1.uuid in uuids
         assert r3.uuid in uuids
         assert len(uuids) == 2
@@ -622,68 +625,10 @@ class TestFilters:
             limit=10,
             property_filter=Not(expr=Comparison(field="age", op=">", value=30)),
         )
-        uuids = {match.record.uuid for match in query_results[0].matches}
+        uuids = {match.record_uuid for match in query_results[0].matches}
         assert r1.uuid in uuids
         assert r2.uuid in uuids
         assert len(uuids) == 2
-
-
-# ── Set properties ──
-
-
-class TestSetProperties:
-    @pytest.mark.asyncio
-    async def test_replaces_properties_and_keeps_the_vector(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
-        await collection.upsert(records=[r1])
-
-        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
-
-        [fetched] = await _fetch_records(collection, [r1.uuid])
-        assert fetched.properties == {"name": "b"}
-
-        # The vector is untouched, so the record still answers its own query.
-        results = await collection.query(query_vectors=[v1], limit=1)
-        assert results[0].matches[0].record.uuid == r1.uuid
-        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_replaced_properties_are_filterable(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a"})
-        await collection.upsert(records=[r1])
-
-        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
-
-        stale = await collection.query(
-            query_vectors=[v1],
-            limit=10,
-            property_filter=Comparison(field="name", op="=", value="a"),
-        )
-        assert stale[0].matches == []
-
-        fresh = await collection.query(
-            query_vectors=[v1],
-            limit=10,
-            property_filter=Comparison(field="name", op="=", value="b"),
-        )
-        assert [match.record.uuid for match in fresh[0].matches] == [r1.uuid]
-
-    @pytest.mark.asyncio
-    async def test_ignores_uuids_the_collection_does_not_hold(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "a"})
-        await collection.upsert(records=[r1])
-
-        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
-
-        [fetched] = await _fetch_records(collection, [r1.uuid])
-        assert fetched.properties == {"name": "a"}
-
-    @pytest.mark.asyncio
-    async def test_empty_mapping(self, collection):
-        await collection.set_properties(record_properties={})
 
 
 # ── Delete ──
@@ -701,9 +646,9 @@ class TestDelete:
         await collection.upsert(records=[r1, r2])
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
+        results = await _present_uuids(collection, [r1.uuid, r2.uuid])
         assert len(results) == 1
-        assert results[0].uuid == r2.uuid
+        assert results[0] == r2.uuid
 
     @pytest.mark.asyncio
     async def test_delete_empty_list(self, collection):
@@ -752,8 +697,8 @@ class TestPartitionIsolation:
         results_a = await coll_a.query(query_vectors=[v1], limit=10)
         results_b = await coll_b.query(query_vectors=[v1], limit=10)
 
-        uuids_a = {match.record.uuid for match in results_a[0].matches}
-        uuids_b = {match.record.uuid for match in results_b[0].matches}
+        uuids_a = {match.record_uuid for match in results_a[0].matches}
+        uuids_b = {match.record_uuid for match in results_b[0].matches}
         assert uuids_a == {r1.uuid}
         assert uuids_b == {r2.uuid}
 
@@ -781,9 +726,9 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        results = await _fetch_records(coll_a, [r1.uuid, r2.uuid])
+        results = await _present_uuids(coll_a, [r1.uuid, r2.uuid])
         assert len(results) == 1
-        assert results[0].uuid == r1.uuid
+        assert results[0] == r1.uuid
 
         await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
         await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
@@ -811,9 +756,9 @@ class TestPartitionIsolation:
 
         await coll_a.delete(record_uuids=[r2.uuid])
 
-        results = await _fetch_records(coll_b, [r2.uuid])
+        results = await _present_uuids(coll_b, [r2.uuid])
         assert len(results) == 1
-        assert results[0].uuid == r2.uuid
+        assert results[0] == r2.uuid
 
         await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
         await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
@@ -840,7 +785,7 @@ class TestPartitionIsolation:
         await coll_b.upsert(records=[r2])
 
         results_a = await coll_a.query(query_vectors=[v1], limit=10)
-        assert {match.record.uuid for match in results_a[0].matches} == {r1.uuid}
+        assert {match.record_uuid for match in results_a[0].matches} == {r1.uuid}
 
         await store.delete_collection(namespace="namespace_a", name="coll")
         await store.delete_collection(namespace="namespace_b", name="coll")
@@ -866,7 +811,7 @@ class TestPartitionIsolation:
 
         results = await coll_b.query(query_vectors=[v1], limit=10)
         assert len(results[0].matches) == 1
-        assert results[0].matches[0].record.uuid == r2.uuid
+        assert results[0].matches[0].record_uuid == r2.uuid
 
         await store.delete_collection(namespace=NAMESPACE, name="sibling_b")
 
@@ -905,9 +850,7 @@ class TestInputValidation:
         v1 = _normalize([1.0, 0.0, 0.0])
         record = _make_record(vector=v1, properties=None)
         await collection.upsert(records=[record])
-        fetched = await _fetch_records(collection, [record.uuid])
-        assert len(fetched) == 1
-        assert fetched[0].properties == {}
+        assert await _present_uuids(collection, [record.uuid]) == [record.uuid]
 
 
 # ── Cosine similarity semantics ──
@@ -948,14 +891,17 @@ class TestUpsertBehavior:
             ]
         )
 
-        fetched = await _fetch_records(collection, [record_uuid])
-        assert len(fetched) == 1
-        properties = fetched[0].properties
-        assert properties is not None
-        assert properties["name"] == "bob"
+        # Properties are filterable but never returned, so a filter is what
+        # observes them.
+        [named_bob] = await collection.query(
+            query_vectors=[v2],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="bob"),
+        )
+        assert [m.record_uuid for m in named_bob.matches] == [record_uuid]
 
         results = await collection.query(query_vectors=[v2], limit=1)
-        assert results[0].matches[0].record.uuid == record_uuid
+        assert results[0].matches[0].record_uuid == record_uuid
         assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
 
@@ -985,7 +931,7 @@ class TestConcurrentAsync:
         )
 
         # Verify all records were persisted (deterministic, not ANN-dependent).
-        fetched = await _fetch_records(collection, all_uuids)
+        fetched = await _present_uuids(collection, all_uuids)
         assert len(fetched) == 30
 
     @pytest.mark.asyncio
@@ -1164,7 +1110,7 @@ class TestCrashRecovery:
         )
         assert len(results[0].matches) == 1
 
-        fetched = await _fetch_records(coll2, [r1.uuid])
+        fetched = await _present_uuids(coll2, [r1.uuid])
         assert len(fetched) == 0
 
         await store2.shutdown()
@@ -1197,8 +1143,8 @@ class TestCrashRecovery:
         )
         assert len(results[0].matches) == 2
 
-        fetched = await _fetch_records(coll2, [r1.uuid, r2.uuid, r3.uuid])
-        fetched_uuids = {r.uuid for r in fetched}
+        fetched = await _present_uuids(coll2, [r1.uuid, r2.uuid, r3.uuid])
+        fetched_uuids = set(fetched)
         assert r1.uuid in fetched_uuids
         assert r2.uuid not in fetched_uuids
         assert r3.uuid in fetched_uuids
@@ -1485,7 +1431,7 @@ class TestIndexFileDurability:
 
         # The index just cannot find it any more.
         results = await coll2.query(query_vectors=[r2.vector], limit=10)
-        assert [match.record.uuid for match in results[0].matches] == [r1.uuid]
+        assert [match.record_uuid for match in results[0].matches] == [r1.uuid]
 
         await store2.shutdown()
         await engine2.dispose()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -9,7 +9,6 @@ import pytest_asyncio
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -45,6 +44,26 @@ def _normalize(vector: list[float]) -> list[float]:
     return [x / magnitude for x in vector]
 
 
+_FETCH_LIMIT = 1000
+
+
+async def _fetch_records(collection, record_uuids) -> list[Record]:
+    """Read records back by UUID.
+
+    The collection contract has no read-by-UUID: `query` is the only read, and
+    with no score threshold it returns every record it holds, so a probe vector
+    in any direction lists the collection for a test to pick out of.
+    """
+    record_uuids = list(record_uuids)
+    if not record_uuids:
+        return []
+    dimensions = collection.config.vector_dimensions
+    probe = [1.0] + [0.0] * (dimensions - 1)
+    [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
+    by_uuid = {match.record.uuid: match.record for match in result.matches}
+    return [by_uuid[uuid] for uuid in record_uuids if uuid in by_uuid]
+
+
 def _make_record(
     *,
     uuid=None,
@@ -64,8 +83,8 @@ async def store(tmp_path):
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
     params = SQLiteVectorStoreParams(
         sqlalchemy_engine=engine,
-        vector_search_engine_factory=lambda ndim, metric: USearchVectorSearchEngine(
-            num_dimensions=ndim, similarity_metric=metric
+        vector_search_engine_factory=lambda ndim: USearchVectorSearchEngine(
+            num_dimensions=ndim
         ),
     )
     vector_store = SQLiteVectorStore(params)
@@ -82,7 +101,6 @@ async def collection(store):
         name=NAME,
         config=VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "name": str,
                 "age": int,
@@ -126,7 +144,6 @@ class TestCollectionLifecycle:
                 name=NAME,
                 config=VectorStoreCollectionConfig(
                     vector_dimensions=VECTOR_DIM,
-                    similarity_metric=SimilarityMetric.COSINE,
                     indexed_properties_schema={
                         "name": str,
                         "age": int,
@@ -182,18 +199,6 @@ class TestCollectionLifecycle:
         assert await store.open_collection(namespace=NAMESPACE, name="nope") is None
 
     @pytest.mark.asyncio
-    async def test_unsupported_metric_raises(self, store):
-        with pytest.raises(ValueError, match="does not support"):
-            await store.create_collection(
-                namespace=NAMESPACE,
-                name="bad_metric",
-                config=VectorStoreCollectionConfig(
-                    vector_dimensions=VECTOR_DIM,
-                    similarity_metric=SimilarityMetric.MANHATTAN,
-                ),
-            )
-
-    @pytest.mark.asyncio
     async def test_invalid_namespace_raises(self, store):
         with pytest.raises(ValueError, match="Invalid namespace"):
             await store.create_collection(
@@ -233,7 +238,11 @@ class TestUpsertAndQuery:
 
         assert len(matches) == 3
         assert matches[0].record.uuid == r1.uuid
-        assert matches[0].score >= matches[1].score >= matches[2].score
+        assert (
+            matches[0].cosine_similarity
+            >= matches[1].cosine_similarity
+            >= matches[2].cosine_similarity
+        )
 
     @pytest.mark.asyncio
     async def test_upsert_update(self, collection):
@@ -248,8 +257,10 @@ class TestUpsertAndQuery:
         )
         await collection.upsert(records=[updated])
 
-        results = await collection.get(record_uuids=[record.uuid])
-        assert results[0].properties["name"] == "updated"
+        results = await _fetch_records(collection, [record.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["name"] == "updated"
 
     @pytest.mark.asyncio
     async def test_query_with_similarity_threshold(self, collection):
@@ -262,7 +273,7 @@ class TestUpsertAndQuery:
         await collection.upsert(records=[r1, r2])
 
         query_results = await collection.query(
-            query_vectors=[v1], limit=10, score_threshold=0.9
+            query_vectors=[v1], limit=10, min_cosine_similarity=0.9
         )
         matches = query_results[0].matches
 
@@ -279,14 +290,12 @@ class TestUpsertAndQuery:
         assert len(query_results[0].matches) == 2
 
     @pytest.mark.asyncio
-    async def test_query_return_vector_false(self, collection):
+    async def test_query_never_returns_vectors(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "test"})
         await collection.upsert(records=[r1])
 
-        query_results = await collection.query(
-            query_vectors=[v1], limit=10, return_vector=False
-        )
+        query_results = await collection.query(query_vectors=[v1], limit=10)
         matches = query_results[0].matches
         assert len(matches) == 1
         assert matches[0].record.vector is None
@@ -301,12 +310,10 @@ class TestUpsertAndQuery:
         query_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            return_vector=True,
             return_properties=False,
         )
         matches = query_results[0].matches
         assert len(matches) == 1
-        assert matches[0].record.vector is not None
         assert matches[0].record.properties is None
 
     @pytest.mark.asyncio
@@ -493,8 +500,10 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "test", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        assert results[0].properties["created_at"] == dt
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        assert properties["created_at"] == dt
 
     @pytest.mark.asyncio
     async def test_eq_datetime(self, collection):
@@ -551,8 +560,11 @@ class TestFilters:
         r1 = _make_record(vector=v1, properties={"name": "tz", "created_at": dt})
         await collection.upsert(records=[r1])
 
-        results = await collection.get(record_uuids=[r1.uuid])
-        got = results[0].properties["created_at"]
+        results = await _fetch_records(collection, [r1.uuid])
+        properties = results[0].properties
+        assert properties is not None
+        got = properties["created_at"]
+        assert isinstance(got, datetime)
         assert got == dt
         assert got.utcoffset() == timedelta(hours=-5)
 
@@ -616,61 +628,62 @@ class TestFilters:
         assert len(uuids) == 2
 
 
-# ── Get ──
+# ── Set properties ──
 
 
-class TestGet:
+class TestSetProperties:
     @pytest.mark.asyncio
-    async def test_get_by_uuids(self, collection):
+    async def test_replaces_properties_and_keeps_the_vector(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a", "rank": 1})
+        await collection.upsert(records=[r1])
 
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "b"}
+
+        # The vector is untouched, so the record still answers its own query.
+        results = await collection.query(query_vectors=[v1], limit=1)
+        assert results[0].matches[0].record.uuid == r1.uuid
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_replaced_properties_are_filterable(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1, properties={"name": "a"})
-        r2 = _make_record(vector=v2, properties={"name": "b"})
-        await collection.upsert(records=[r1, r2])
-
-        results = await collection.get(record_uuids=[r2.uuid, r1.uuid])
-        assert len(results) == 2
-        assert results[0].uuid == r2.uuid
-        assert results[1].uuid == r1.uuid
-
-    @pytest.mark.asyncio
-    async def test_get_missing_uuids(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1)
         await collection.upsert(records=[r1])
 
-        missing = uuid4()
-        results = await collection.get(record_uuids=[r1.uuid, missing])
-        assert len(results) == 1
-        assert results[0].uuid == r1.uuid
+        await collection.set_properties(record_properties={r1.uuid: {"name": "b"}})
 
-    @pytest.mark.asyncio
-    async def test_get_empty_list(self, collection):
-        results = await collection.get(record_uuids=[])
-        assert len(results) == 0
-
-    @pytest.mark.asyncio
-    async def test_get_return_vector_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = await collection.get(record_uuids=[r1.uuid], return_vector=False)
-        assert results[0].vector is None
-        assert results[0].properties is not None
-
-    @pytest.mark.asyncio
-    async def test_get_return_properties_false(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        r1 = _make_record(vector=v1, properties={"name": "test"})
-        await collection.upsert(records=[r1])
-
-        results = await collection.get(
-            record_uuids=[r1.uuid], return_vector=True, return_properties=False
+        stale = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="a"),
         )
-        assert results[0].vector is not None
-        assert results[0].properties is None
+        assert stale[0].matches == []
+
+        fresh = await collection.query(
+            query_vectors=[v1],
+            limit=10,
+            property_filter=Comparison(field="name", op="=", value="b"),
+        )
+        assert [match.record.uuid for match in fresh[0].matches] == [r1.uuid]
+
+    @pytest.mark.asyncio
+    async def test_ignores_uuids_the_collection_does_not_hold(self, collection):
+        v1 = _normalize([1.0, 0.0, 0.0])
+        r1 = _make_record(vector=v1, properties={"name": "a"})
+        await collection.upsert(records=[r1])
+
+        await collection.set_properties(record_properties={uuid4(): {"name": "ghost"}})
+
+        [fetched] = await _fetch_records(collection, [r1.uuid])
+        assert fetched.properties == {"name": "a"}
+
+    @pytest.mark.asyncio
+    async def test_empty_mapping(self, collection):
+        await collection.set_properties(record_properties={})
 
 
 # ── Delete ──
@@ -688,7 +701,7 @@ class TestDelete:
         await collection.upsert(records=[r1, r2])
         await collection.delete(record_uuids=[r1.uuid])
 
-        results = await collection.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(collection, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -768,7 +781,7 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        results = await coll_a.get(record_uuids=[r1.uuid, r2.uuid])
+        results = await _fetch_records(coll_a, [r1.uuid, r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r1.uuid
 
@@ -798,7 +811,7 @@ class TestPartitionIsolation:
 
         await coll_a.delete(record_uuids=[r2.uuid])
 
-        results = await coll_b.get(record_uuids=[r2.uuid])
+        results = await _fetch_records(coll_b, [r2.uuid])
         assert len(results) == 1
         assert results[0].uuid == r2.uuid
 
@@ -858,30 +871,6 @@ class TestPartitionIsolation:
         await store.delete_collection(namespace=NAMESPACE, name="sibling_b")
 
 
-# ── Euclidean metric ──
-
-
-class TestEuclideanMetric:
-    @pytest.mark.asyncio
-    async def test_euclidean_ordering(self, store):
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=2,
-            similarity_metric=SimilarityMetric.EUCLIDEAN,
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean", config=config
-        )
-        r1 = _make_record(vector=[0.0, 0.0])
-        r2 = _make_record(vector=[3.0, 4.0])
-        await coll.upsert(records=[r1, r2])
-
-        results = await coll.query(query_vectors=[[0.0, 0.0]], limit=2)
-        # Euclidean: lower distance = better match; best match is first
-        assert results[0].matches[0].score < results[0].matches[1].score
-
-        await store.delete_collection(namespace=NAMESPACE, name="euclidean")
-
-
 # ── No-properties collection ──
 
 
@@ -901,32 +890,6 @@ class TestNoProperties:
         await store.delete_collection(namespace=NAMESPACE, name="no_props")
 
 
-# ── USearch-specific: dot product metric ──
-
-
-class TestDotProductMetric:
-    @pytest.mark.asyncio
-    async def test_dot_product_supported(self, store):
-        """Dot product is supported by USearch but not sqlite-vec."""
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=VECTOR_DIM,
-            similarity_metric=SimilarityMetric.DOT,
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="dot", config=config
-        )
-        v1 = _normalize([1.0, 0.0, 0.0])
-        v2 = _normalize([0.0, 1.0, 0.0])
-        r1 = _make_record(vector=v1)
-        r2 = _make_record(vector=v2)
-        await coll.upsert(records=[r1, r2])
-
-        results = await coll.query(query_vectors=[v1], limit=2)
-        assert len(results[0].matches) == 2
-
-        await store.delete_collection(namespace=NAMESPACE, name="dot")
-
-
 # ── Input validation ──
 
 
@@ -942,17 +905,15 @@ class TestInputValidation:
         v1 = _normalize([1.0, 0.0, 0.0])
         record = _make_record(vector=v1, properties=None)
         await collection.upsert(records=[record])
-        fetched = await collection.get(
-            record_uuids=[record.uuid], return_properties=True
-        )
+        fetched = await _fetch_records(collection, [record.uuid])
         assert len(fetched) == 1
         assert fetched[0].properties == {}
 
 
-# ── Score semantics ──
+# ── Cosine similarity semantics ──
 
 
-class TestScoreSemantics:
+class TestCosineSimilaritySemantics:
     @pytest.mark.asyncio
     async def test_cosine_higher_is_better(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
@@ -962,29 +923,8 @@ class TestScoreSemantics:
         await collection.upsert(records=[r1, r2])
 
         results = await collection.query(query_vectors=[v1], limit=2)
-        scores = [m.score for m in results[0].matches]
+        scores = [m.cosine_similarity for m in results[0].matches]
         assert scores[0] > scores[1]
-
-    @pytest.mark.asyncio
-    async def test_euclidean_lower_is_better(self, store):
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=2,
-            similarity_metric=SimilarityMetric.EUCLIDEAN,
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="euclidean_score", config=config
-        )
-        r1 = _make_record(vector=[0.0, 0.0])
-        r2 = _make_record(vector=[3.0, 4.0])
-        await coll.upsert(records=[r1, r2])
-
-        results = await coll.query(query_vectors=[[0.0, 0.0]], limit=2)
-        scores = [m.score for m in results[0].matches]
-        assert scores[0] < scores[1]
-        assert scores[0] == pytest.approx(0.0, abs=0.01)
-        assert scores[1] == pytest.approx(5.0, abs=0.01)
-
-        await store.delete_collection(namespace=NAMESPACE, name="euclidean_score")
 
 
 # ── Upsert behavior ──
@@ -1008,15 +948,15 @@ class TestUpsertBehavior:
             ]
         )
 
-        fetched = await collection.get(
-            record_uuids=[record_uuid], return_vector=True, return_properties=True
-        )
+        fetched = await _fetch_records(collection, [record_uuid])
         assert len(fetched) == 1
-        assert fetched[0].properties["name"] == "bob"
+        properties = fetched[0].properties
+        assert properties is not None
+        assert properties["name"] == "bob"
 
         results = await collection.query(query_vectors=[v2], limit=1)
         assert results[0].matches[0].record.uuid == record_uuid
-        assert results[0].matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
 
 # ── Concurrent async behavior ──
@@ -1045,7 +985,7 @@ class TestConcurrentAsync:
         )
 
         # Verify all records were persisted (deterministic, not ANN-dependent).
-        fetched = await collection.get(record_uuids=all_uuids)
+        fetched = await _fetch_records(collection, all_uuids)
         assert len(fetched) == 30
 
     @pytest.mark.asyncio
@@ -1077,13 +1017,12 @@ class TestConcurrentAsync:
 # ── Crash recovery & pending operations ──
 
 
-def _engine_factory(ndim, metric):
-    return USearchVectorSearchEngine(num_dimensions=ndim, similarity_metric=metric)
+def _engine_factory(ndim):
+    return USearchVectorSearchEngine(num_dimensions=ndim)
 
 
 CONFIG = VectorStoreCollectionConfig(
     vector_dimensions=VECTOR_DIM,
-    similarity_metric=SimilarityMetric.COSINE,
 )
 
 
@@ -1099,6 +1038,19 @@ async def _fresh_store(db_path, tmp_path, *, save_threshold=1000):
     store = SQLiteVectorStore(params)
     await store.startup()
     return store, engine
+
+
+async def _stored_record_uuids(engine, store) -> set[UUID]:
+    """Read a collection's record UUIDs straight out of SQLite.
+
+    The collection contract cannot see a record whose vector the index lost, so
+    a test about surviving that loss has to look past the contract at the row.
+    """
+    records_table = store._records_table(NAMESPACE, NAME)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        rows = (await session.execute(select(records_table.c.uuid))).all()
+    return {row.uuid for row in rows}
 
 
 async def _pending_operation_count(engine) -> int:
@@ -1212,7 +1164,7 @@ class TestCrashRecovery:
         )
         assert len(results[0].matches) == 1
 
-        fetched = await coll2.get(record_uuids=[r1.uuid])
+        fetched = await _fetch_records(coll2, [r1.uuid])
         assert len(fetched) == 0
 
         await store2.shutdown()
@@ -1245,7 +1197,7 @@ class TestCrashRecovery:
         )
         assert len(results[0].matches) == 2
 
-        fetched = await coll2.get(record_uuids=[r1.uuid, r2.uuid, r3.uuid])
+        fetched = await _fetch_records(coll2, [r1.uuid, r2.uuid, r3.uuid])
         fetched_uuids = {r.uuid for r in fetched}
         assert r1.uuid in fetched_uuids
         assert r2.uuid not in fetched_uuids
@@ -1485,15 +1437,19 @@ class TestIndexFileDurability:
         await engine2.dispose()
 
     @pytest.mark.asyncio
-    async def test_a_reverted_publication_costs_search_not_records(self, tmp_path):
+    async def test_a_reverted_publication_costs_search_not_the_record_row(
+        self, tmp_path
+    ):
         """A publication lost to power failure leaves records unsearchable.
 
         The swap is atomic, not durable, so a power failure can revert the last
         publication after the trim behind it has committed. Restoring the
         previous index bytes reconstructs exactly that state, deterministically
         rather than by pulling a plug, and pins the direction it fails in: the
-        record survives and still resolves by uuid, it simply cannot be found
-        by search until it is upserted again.
+        row survives, and only search loses the record, until it is upserted
+        again. The collection contract has no read that can show the survivor --
+        `query` is the only read and it goes through the index that lost it --
+        so this looks at the row directly.
         """
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=1)
@@ -1524,9 +1480,8 @@ class TestIndexFileDurability:
         coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
         assert coll2 is not None
 
-        # The record is still a record.
-        fetched = await coll2.get(record_uuids=[r2.uuid])
-        assert [record.uuid for record in fetched] == [r2.uuid]
+        # The record is still a row.
+        assert await _stored_record_uuids(engine2, store2) == {r1.uuid, r2.uuid}
 
         # The index just cannot find it any more.
         results = await coll2.query(query_vectors=[r2.vector], limit=10)

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
@@ -17,7 +17,6 @@ if os.getenv("CI") == "true":
         allow_module_level=True,
     )
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.vector_store.vector_search_engine.hnswlib_engine import (
     HnswlibVectorSearchEngine,
 )
@@ -40,19 +39,8 @@ async def _search_one(engine, vector, limit=10, **kwargs):
 
 
 class TestConstruction:
-    def test_supported_metrics(self):
-        for metric in (
-            SimilarityMetric.COSINE,
-            SimilarityMetric.EUCLIDEAN,
-            SimilarityMetric.DOT,
-        ):
-            HnswlibVectorSearchEngine(num_dimensions=NDIM, similarity_metric=metric)
-
-    def test_unsupported_metric_raises(self):
-        with pytest.raises(ValueError, match="does not support"):
-            HnswlibVectorSearchEngine(
-                num_dimensions=NDIM, similarity_metric=SimilarityMetric.MANHATTAN
-            )
+    def test_construction(self):
+        HnswlibVectorSearchEngine(num_dimensions=NDIM)
 
 
 # -- Add --
@@ -61,39 +49,31 @@ class TestConstruction:
 class TestAdd:
     @pytest.mark.asyncio
     async def test_add_single(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1.0, 0.0, 0.0]})
         result = await _search_one(engine, [1.0, 0.0, 0.0], limit=1)
         assert result.matches[0].key == 1
 
     @pytest.mark.asyncio
     async def test_add_batch(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({10: [1, 0, 0], 20: [0, 1, 0], 30: [0, 0, 1]})
         result = await _search_one(engine, [1, 0, 0], limit=3)
         assert {m.key for m in result.matches} == {10, 20, 30}
 
     @pytest.mark.asyncio
     async def test_remove_then_add_replaces_key(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1.0, 0.0, 0.0]})
         await engine.remove([1])
         await engine.add({1: [0.0, 1.0, 0.0]})
         result = await _search_one(engine, _normalize([0, 1, 0]), limit=1)
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_add_empty(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({})
         result = await _search_one(engine, [1, 0, 0], limit=1)
         assert result.matches == []
@@ -102,7 +82,6 @@ class TestAdd:
     async def test_add_beyond_initial_capacity(self):
         engine = HnswlibVectorSearchEngine(
             num_dimensions=NDIM,
-            similarity_metric=SimilarityMetric.COSINE,
             initial_capacity=2,
         )
         await engine.add(
@@ -124,9 +103,7 @@ class TestAdd:
 class TestRemove:
     @pytest.mark.asyncio
     async def test_remove_existing(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0], 2: [0, 1, 0]})
         await engine.remove([1])
         result = await _search_one(engine, [1, 0, 0], limit=2)
@@ -136,9 +113,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_missing_is_ignored(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0]})
         await engine.remove([99, 100])
         result = await _search_one(engine, [1, 0, 0], limit=1)
@@ -146,9 +121,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_all(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0], 2: [0, 1, 0], 3: [0, 0, 1]})
         await engine.remove([1, 2, 3])
         result = await _search_one(engine, [1, 0, 0], limit=3)
@@ -156,9 +129,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_empty_iterable(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0]})
         await engine.remove([])
         result = await _search_one(engine, [1, 0, 0], limit=1)
@@ -166,9 +137,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_excludes_from_search(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
         await engine.remove([1])
         result = await _search_one(engine, _normalize([1, 0, 0]), limit=2)
@@ -181,9 +150,7 @@ class TestRemove:
 class TestSearchCosine:
     @pytest.mark.asyncio
     async def test_basic_knn(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add(
             {
                 1: _normalize([1, 0, 0]),
@@ -194,26 +161,24 @@ class TestSearchCosine:
         result = await _search_one(engine, _normalize([1, 0, 0]), limit=3)
         assert len(result.matches) == 3
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(1.0 / math.sqrt(2), abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+        assert result.matches[1].cosine_similarity == pytest.approx(
+            1.0 / math.sqrt(2), abs=0.01
+        )
 
     @pytest.mark.asyncio
     async def test_scores_are_cosine_similarity(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         v1 = _normalize([1, 0, 0])
         v2 = _normalize([0, 1, 0])
         await engine.add({1: v1, 2: v2})
         result = await _search_one(engine, v1, limit=2)
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(0.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+        assert result.matches[1].cosine_similarity == pytest.approx(0.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_scores_ordered_best_first(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add(
             {
                 1: _normalize([1, 0, 0]),
@@ -223,30 +188,27 @@ class TestSearchCosine:
         )
         result = await _search_one(engine, _normalize([1, 0, 0]), limit=3)
         for i in range(len(result.matches) - 1):
-            assert result.matches[i].score >= result.matches[i + 1].score
+            assert (
+                result.matches[i].cosine_similarity
+                >= result.matches[i + 1].cosine_similarity
+            )
 
     @pytest.mark.asyncio
     async def test_k_larger_than_index(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0]})
         result = await _search_one(engine, [1, 0, 0], limit=10)
         assert len(result.matches) == 1
 
     @pytest.mark.asyncio
     async def test_search_empty_index(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         result = await _search_one(engine, [1, 0, 0], limit=5)
         assert result.matches == []
 
     @pytest.mark.asyncio
     async def test_batched_search(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
         results = await engine.search(
             [_normalize([1, 0, 0]), _normalize([0, 1, 0])], limit=1
@@ -256,92 +218,29 @@ class TestSearchCosine:
         assert results[1].matches[0].key == 2
 
 
-# -- Search: Euclidean --
-
-
-class TestSearchEuclidean:
-    @pytest.mark.asyncio
-    async def test_scores_are_euclidean_distance(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.EUCLIDEAN
-        )
-        await engine.add({1: [0, 0, 0], 2: [3, 4, 0]})
-        result = await _search_one(engine, [0, 0, 0], limit=2)
-        assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(0.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(5.0, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_scores_ordered_best_first(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.EUCLIDEAN
-        )
-        await engine.add({1: [0, 0, 0], 2: [1, 0, 0], 3: [3, 4, 0]})
-        result = await _search_one(engine, [0, 0, 0], limit=3)
-        for i in range(len(result.matches) - 1):
-            assert result.matches[i].score <= result.matches[i + 1].score
-
-
-# -- Search: Dot product --
-
-
-class TestSearchDot:
-    @pytest.mark.asyncio
-    async def test_scores_are_inner_product(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.DOT
-        )
-        v1 = _normalize([1, 0, 0])
-        v2 = _normalize([0, 1, 0])
-        await engine.add({1: v1, 2: v2})
-        result = await _search_one(engine, v1, limit=2)
-        assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(0.0, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_scores_ordered_best_first(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.DOT
-        )
-        v1 = _normalize([1, 0, 0])
-        v2 = _normalize([1, 1, 0])
-        v3 = _normalize([0, 1, 0])
-        await engine.add({1: v1, 2: v2, 3: v3})
-        result = await _search_one(engine, v1, limit=3)
-        for i in range(len(result.matches) - 1):
-            assert result.matches[i].score >= result.matches[i + 1].score
-
-
 # -- Persistence --
 
 
 class TestPersistence:
     @pytest.mark.asyncio
     async def test_save_and_load(self, tmp_path: Path):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
         path = str(tmp_path / "test.hnswlib")
         await engine.save(path)
 
-        engine2 = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine2 = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine2.load(path)
 
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_save_and_load_with_deletions(self, tmp_path: Path):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add(
             {
                 1: _normalize([1, 0, 0]),
@@ -354,9 +253,7 @@ class TestPersistence:
         path = str(tmp_path / "test.hnswlib")
         await engine.save(path)
 
-        engine2 = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine2 = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine2.load(path)
 
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=3)
@@ -364,9 +261,7 @@ class TestPersistence:
 
     @pytest.mark.asyncio
     async def test_save_leaves_no_temp_file(self, tmp_path: Path):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0])})
 
         path = tmp_path / "test.hnswlib"
@@ -377,9 +272,7 @@ class TestPersistence:
 
     @pytest.mark.asyncio
     async def test_load_clears_stale_temp_file(self, tmp_path: Path):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
         path = tmp_path / "test.hnswlib"
@@ -389,9 +282,7 @@ class TestPersistence:
         stale_temp = tmp_path / "test.hnswlib.tmp"
         stale_temp.write_text("STALE")
 
-        engine2 = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine2 = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine2.load(str(path))
 
         assert not stale_temp.exists()
@@ -469,7 +360,6 @@ class TestReplaceDeletedSlotReclamation:
         for allow in (False, True):
             engine = HnswlibVectorSearchEngine(
                 num_dimensions=8,
-                similarity_metric=SimilarityMetric.COSINE,
                 allow_replace_deleted=allow,
             )
             vecs = {i: _rand_unit(rng, 8) for i in range(20)}
@@ -484,7 +374,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(1)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
         )
         v_old = _rand_unit(rng, 8)
@@ -495,7 +384,7 @@ class TestReplaceDeletedSlotReclamation:
 
         result = await _search_one(engine, v_new, limit=1)
         assert result.matches[0].key == 42
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         _no_corruption(engine)
 
     @pytest.mark.asyncio
@@ -508,7 +397,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(2)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=16,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
         )
         vecs = {i: _rand_unit(rng, 16) for i in range(50)}
@@ -522,7 +410,7 @@ class TestReplaceDeletedSlotReclamation:
         for i in range(50):
             result = await _search_one(engine, new_vecs[i], limit=1)
             assert result.matches[0].key == i, f"label {i} missing or wrong"
-            assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+            assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         _no_corruption(engine)
 
     @pytest.mark.asyncio
@@ -535,7 +423,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(3)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=16,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
         )
         vecs = {i: _rand_unit(rng, 16) for i in range(20)}
@@ -560,7 +447,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(4)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
             initial_capacity=200,
         )
@@ -590,7 +476,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(5)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=False,
             initial_capacity=200,
         )
@@ -612,7 +497,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(6)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=16,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
             initial_capacity=500,
         )
@@ -654,7 +538,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(7)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=16,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
             initial_capacity=100,
         )
@@ -667,7 +550,6 @@ class TestReplaceDeletedSlotReclamation:
 
         engine2 = HnswlibVectorSearchEngine(
             num_dimensions=16,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
         )
         await engine2.load(path)
@@ -702,7 +584,6 @@ class TestReplaceDeletedSlotReclamation:
         rng = np.random.default_rng(8)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=True,
         )
         v_orig = _rand_unit(rng, 8)
@@ -713,7 +594,7 @@ class TestReplaceDeletedSlotReclamation:
 
         result = await _search_one(engine, v_reused, limit=1)
         assert result.matches[0].key == 100
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         _no_corruption(engine)
 
 
@@ -737,7 +618,6 @@ class TestAllowReplaceDeletedFalse:
         rng = np.random.default_rng(101)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=False,
         )
         last_v: list[float] | None = None
@@ -749,7 +629,7 @@ class TestAllowReplaceDeletedFalse:
         assert last_v is not None
         result = await _search_one(engine, last_v, limit=1)
         assert result.matches[0].key == 99
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         _no_corruption(engine)
 
     @pytest.mark.asyncio
@@ -764,7 +644,6 @@ class TestAllowReplaceDeletedFalse:
         rng = np.random.default_rng(102)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=False,
         )
         v_old = _rand_unit(rng, 8)
@@ -779,7 +658,7 @@ class TestAllowReplaceDeletedFalse:
         )
         result = await _search_one(engine, v_new, limit=1)
         assert result.matches[0].key == 7
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         _no_corruption(engine)
 
     @pytest.mark.asyncio
@@ -789,7 +668,6 @@ class TestAllowReplaceDeletedFalse:
         rng = np.random.default_rng(103)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=8,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=False,
         )
         first = {i: _rand_unit(rng, 8) for i in range(20)}
@@ -810,12 +688,12 @@ class TestAllowReplaceDeletedFalse:
         for k, v in updated.items():
             result = await _search_one(engine, v, limit=1)
             assert result.matches[0].key == k
-            assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+            assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         # Brand-new keys queryable.
         for k, v in added.items():
             result = await _search_one(engine, v, limit=1)
             assert result.matches[0].key == k
-            assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+            assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
         # Untouched keys 10-19 still queryable.
         for k in range(10, 20):
             result = await _search_one(engine, first[k], limit=1)
@@ -828,7 +706,6 @@ class TestAllowReplaceDeletedFalse:
         rng = np.random.default_rng(104)
         engine = HnswlibVectorSearchEngine(
             num_dimensions=16,
-            similarity_metric=SimilarityMetric.COSINE,
             allow_replace_deleted=False,
             initial_capacity=256,
         )
@@ -863,7 +740,7 @@ class TestAllowReplaceDeletedFalse:
             v = live[k]
             result = await _search_one(engine, v, limit=1)
             assert result.matches[0].key == k, f"label {k} not findable"
-            assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+            assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
 
 # -- SearchResult types --
@@ -872,18 +749,14 @@ class TestAllowReplaceDeletedFalse:
 class TestSearchResultTypes:
     @pytest.mark.asyncio
     async def test_keys_are_ints(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({42: [1, 0, 0]})
         result = await _search_one(engine, [1, 0, 0], limit=1)
         assert isinstance(result.matches[0].key, int)
 
     @pytest.mark.asyncio
     async def test_scores_are_floats(self):
-        engine = HnswlibVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({42: [1, 0, 0]})
         result = await _search_one(engine, [1, 0, 0], limit=1)
-        assert isinstance(result.matches[0].score, float)
+        assert isinstance(result.matches[0].cosine_similarity, float)

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
 )
@@ -28,19 +27,8 @@ async def _search_one(engine, vector, limit=10, **kwargs):
 
 
 class TestConstruction:
-    def test_supported_metrics(self):
-        for metric in (
-            SimilarityMetric.COSINE,
-            SimilarityMetric.EUCLIDEAN,
-            SimilarityMetric.DOT,
-        ):
-            USearchVectorSearchEngine(num_dimensions=NDIM, similarity_metric=metric)
-
-    def test_unsupported_metric_raises(self):
-        with pytest.raises(ValueError, match="does not support"):
-            USearchVectorSearchEngine(
-                num_dimensions=NDIM, similarity_metric=SimilarityMetric.MANHATTAN
-            )
+    def test_construction(self):
+        USearchVectorSearchEngine(num_dimensions=NDIM)
 
 
 # -- Add --
@@ -49,39 +37,31 @@ class TestConstruction:
 class TestAdd:
     @pytest.mark.asyncio
     async def test_add_single(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1.0, 0.0, 0.0]})
         result = await _search_one(engine, [1.0, 0.0, 0.0], limit=1)
         assert result.matches[0].key == 1
 
     @pytest.mark.asyncio
     async def test_add_batch(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({10: [1, 0, 0], 20: [0, 1, 0], 30: [0, 0, 1]})
         result = await _search_one(engine, [1, 0, 0], limit=3)
         assert {m.key for m in result.matches} == {10, 20, 30}
 
     @pytest.mark.asyncio
     async def test_remove_then_add_replaces_key(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1.0, 0.0, 0.0]})
         await engine.remove([1])
         await engine.add({1: [0.0, 1.0, 0.0]})
         result = await _search_one(engine, _normalize([0, 1, 0]), limit=1)
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_add_empty(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({})
         result = await _search_one(engine, [1, 0, 0], limit=1)
         assert result.matches == []
@@ -93,9 +73,7 @@ class TestAdd:
 class TestRemove:
     @pytest.mark.asyncio
     async def test_remove_existing(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0], 2: [0, 1, 0]})
         await engine.remove([1])
         result = await _search_one(engine, [1, 0, 0], limit=2)
@@ -105,9 +83,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_missing_is_ignored(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0]})
         await engine.remove([99, 100])
         result = await _search_one(engine, [1, 0, 0], limit=1)
@@ -115,9 +91,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_all(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0], 2: [0, 1, 0], 3: [0, 0, 1]})
         await engine.remove([1, 2, 3])
         result = await _search_one(engine, [1, 0, 0], limit=3)
@@ -125,9 +99,7 @@ class TestRemove:
 
     @pytest.mark.asyncio
     async def test_remove_empty_iterable(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0]})
         await engine.remove([])
         result = await _search_one(engine, [1, 0, 0], limit=1)
@@ -140,9 +112,7 @@ class TestRemove:
 class TestSearchCosine:
     @pytest.mark.asyncio
     async def test_basic_knn(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add(
             {
                 1: _normalize([1, 0, 0]),
@@ -153,26 +123,24 @@ class TestSearchCosine:
         result = await _search_one(engine, _normalize([1, 0, 0]), limit=3)
         assert len(result.matches) == 3
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(1.0 / math.sqrt(2), abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+        assert result.matches[1].cosine_similarity == pytest.approx(
+            1.0 / math.sqrt(2), abs=0.01
+        )
 
     @pytest.mark.asyncio
     async def test_scores_are_cosine_similarity(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         v1 = _normalize([1, 0, 0])
         v2 = _normalize([0, 1, 0])
         await engine.add({1: v1, 2: v2})
         result = await _search_one(engine, v1, limit=2)
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(0.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+        assert result.matches[1].cosine_similarity == pytest.approx(0.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_scores_ordered_best_first(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add(
             {
                 1: _normalize([1, 0, 0]),
@@ -182,30 +150,27 @@ class TestSearchCosine:
         )
         result = await _search_one(engine, _normalize([1, 0, 0]), limit=3)
         for i in range(len(result.matches) - 1):
-            assert result.matches[i].score >= result.matches[i + 1].score
+            assert (
+                result.matches[i].cosine_similarity
+                >= result.matches[i + 1].cosine_similarity
+            )
 
     @pytest.mark.asyncio
     async def test_k_larger_than_index(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: [1, 0, 0]})
         result = await _search_one(engine, [1, 0, 0], limit=10)
         assert len(result.matches) == 1
 
     @pytest.mark.asyncio
     async def test_search_empty_index(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         result = await _search_one(engine, [1, 0, 0], limit=5)
         assert result.matches == []
 
     @pytest.mark.asyncio
     async def test_batched_search(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
         results = await engine.search(
             [_normalize([1, 0, 0]), _normalize([0, 1, 0])], limit=1
@@ -215,92 +180,29 @@ class TestSearchCosine:
         assert results[1].matches[0].key == 2
 
 
-# -- Search: Euclidean --
-
-
-class TestSearchEuclidean:
-    @pytest.mark.asyncio
-    async def test_scores_are_euclidean_distance(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.EUCLIDEAN
-        )
-        await engine.add({1: [0, 0, 0], 2: [3, 4, 0]})
-        result = await _search_one(engine, [0, 0, 0], limit=2)
-        assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(0.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(5.0, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_scores_ordered_best_first(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.EUCLIDEAN
-        )
-        await engine.add({1: [0, 0, 0], 2: [1, 0, 0], 3: [3, 4, 0]})
-        result = await _search_one(engine, [0, 0, 0], limit=3)
-        for i in range(len(result.matches) - 1):
-            assert result.matches[i].score <= result.matches[i + 1].score
-
-
-# -- Search: Dot product --
-
-
-class TestSearchDot:
-    @pytest.mark.asyncio
-    async def test_scores_are_inner_product(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.DOT
-        )
-        v1 = _normalize([1, 0, 0])
-        v2 = _normalize([0, 1, 0])
-        await engine.add({1: v1, 2: v2})
-        result = await _search_one(engine, v1, limit=2)
-        assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
-        assert result.matches[1].score == pytest.approx(0.0, abs=0.01)
-
-    @pytest.mark.asyncio
-    async def test_scores_ordered_best_first(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.DOT
-        )
-        v1 = _normalize([1, 0, 0])
-        v2 = _normalize([1, 1, 0])
-        v3 = _normalize([0, 1, 0])
-        await engine.add({1: v1, 2: v2, 3: v3})
-        result = await _search_one(engine, v1, limit=3)
-        for i in range(len(result.matches) - 1):
-            assert result.matches[i].score >= result.matches[i + 1].score
-
-
 # -- Persistence --
 
 
 class TestPersistence:
     @pytest.mark.asyncio
     async def test_save_and_load(self, tmp_path: Path):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
         path = str(tmp_path / "test.idx")
         await engine.save(path)
 
-        engine2 = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine2 = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine2.load(path)
 
         result = await _search_one(engine2, _normalize([1, 0, 0]), limit=2)
         assert {m.key for m in result.matches} == {1, 2}
         assert result.matches[0].key == 1
-        assert result.matches[0].score == pytest.approx(1.0, abs=0.01)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
     async def test_save_leaves_no_temp_file(self, tmp_path: Path):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0])})
 
         path = tmp_path / "test.idx"
@@ -311,9 +213,7 @@ class TestPersistence:
 
     @pytest.mark.asyncio
     async def test_load_clears_stale_temp_file(self, tmp_path: Path):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({1: _normalize([1, 0, 0]), 2: _normalize([0, 1, 0])})
 
         path = tmp_path / "test.idx"
@@ -323,9 +223,7 @@ class TestPersistence:
         stale_temp = tmp_path / "test.idx.tmp"
         stale_temp.write_text("STALE")
 
-        engine2 = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine2 = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine2.load(str(path))
 
         assert not stale_temp.exists()
@@ -339,18 +237,14 @@ class TestPersistence:
 class TestSearchResultTypes:
     @pytest.mark.asyncio
     async def test_keys_are_ints(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({42: [1, 0, 0]})
         result = await _search_one(engine, [1, 0, 0], limit=1)
         assert isinstance(result.matches[0].key, int)
 
     @pytest.mark.asyncio
     async def test_scores_are_floats(self):
-        engine = USearchVectorSearchEngine(
-            num_dimensions=NDIM, similarity_metric=SimilarityMetric.COSINE
-        )
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
         await engine.add({42: [1, 0, 0]})
         result = await _search_one(engine, [1, 0, 0], limit=1)
-        assert isinstance(result.matches[0].score, float)
+        assert isinstance(result.matches[0].cosine_similarity, float)

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/conftest.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/conftest.py
@@ -153,6 +153,19 @@ class InMemorySegmentStorePartition(SegmentStorePartition):
         return result
 
     @override
+    async def get_segment_uuids_by_derivative_uuids(
+        self,
+        derivative_uuids: Iterable[UUID],
+    ) -> dict[UUID, UUID]:
+        wanted = set(derivative_uuids)
+        return {
+            derivative_uuid: segment_uuid
+            for segment_uuid, owned in self.segment_to_derivatives.items()
+            for derivative_uuid in owned
+            if derivative_uuid in wanted
+        }
+
+    @override
     async def delete_segments(
         self,
         segment_uuids: Iterable[UUID],

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/conftest.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/conftest.py
@@ -198,7 +198,6 @@ def fake_segment_store_partition():
 def fake_vector_store_collection(fake_embedder):
     config = VectorStoreCollectionConfig(
         vector_dimensions=fake_embedder.dimensions,
-        similarity_metric=fake_embedder.similarity_metric,
         indexed_properties_schema={
             **EventMemory.expected_vector_store_collection_schema(),
             "color": str,

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
@@ -754,6 +754,119 @@ async def test_get_derivative_uuids_by_segment_uuids_unknown(
 
 
 # ===================================================================
+# get_segment_uuids_by_derivative_uuids
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_segment_uuids_by_derivative_uuids(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    seg = _seg()
+    d1, d2 = uuid4(), uuid4()
+    await partition.add_segments({seg: [d1, d2]})
+
+    result = await partition.get_segment_uuids_by_derivative_uuids([d1, d2])
+    assert result == {d1: seg.uuid, d2: seg.uuid}
+
+
+@pytest.mark.asyncio
+async def test_get_segment_uuids_by_derivative_uuids_inverts_the_forward_lookup(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    """Every derivative belongs to exactly one segment, so the two agree."""
+    segments = [_seg(offset=i, ts_offset_seconds=i) for i in range(3)]
+    links = {seg: [uuid4(), uuid4()] for seg in segments}
+    await partition.add_segments(links)
+
+    forward = await partition.get_derivative_uuids_by_segment_uuids(
+        [seg.uuid for seg in segments]
+    )
+    all_derivative_uuids = [
+        derivative_uuid
+        for derivative_uuids in forward.values()
+        for derivative_uuid in derivative_uuids
+    ]
+    backward = await partition.get_segment_uuids_by_derivative_uuids(
+        all_derivative_uuids
+    )
+
+    assert backward == {
+        derivative_uuid: segment_uuid
+        for segment_uuid, derivative_uuids in forward.items()
+        for derivative_uuid in derivative_uuids
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_segment_uuids_by_derivative_uuids_empty(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    result = await partition.get_segment_uuids_by_derivative_uuids([])
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_get_segment_uuids_by_derivative_uuids_omits_unknown(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    """UUIDs the partition does not hold are omitted, not raised on."""
+    seg = _seg()
+    known = uuid4()
+    await partition.add_segments({seg: [known]})
+
+    unknown = uuid4()
+    result = await partition.get_segment_uuids_by_derivative_uuids([known, unknown])
+    assert result == {known: seg.uuid}
+
+
+@pytest.mark.asyncio
+async def test_get_segment_uuids_by_derivative_uuids_session_isolation(
+    store: SQLAlchemySegmentStore,
+) -> None:
+    """A derivative another partition owns is invisible here."""
+    other_partition = await store.open_or_create_partition(
+        "other_derivatives",
+        _plaintext_partition_config(),
+    )
+    other_seg = _seg()
+    other_derivative = uuid4()
+    await other_partition.add_segments({other_seg: [other_derivative]})
+
+    partition = await store.open_or_create_partition(
+        PARTITION_KEY,
+        _plaintext_partition_config(),
+    )
+    seg = _seg()
+    derivative = uuid4()
+    await partition.add_segments({seg: [derivative]})
+
+    result = await partition.get_segment_uuids_by_derivative_uuids(
+        [derivative, other_derivative]
+    )
+    assert result == {derivative: seg.uuid}
+
+
+@pytest.mark.asyncio
+async def test_get_segment_uuids_by_derivative_uuids_after_delete_segments(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    """Deleting a segment takes its derivatives' mapping with it."""
+    kept, dropped = _seg(offset=0), _seg(offset=1)
+    kept_derivative, dropped_derivative = uuid4(), uuid4()
+    await partition.add_segments(
+        {kept: [kept_derivative], dropped: [dropped_derivative]}
+    )
+
+    await partition.delete_segments([dropped.uuid])
+
+    result = await partition.get_segment_uuids_by_derivative_uuids(
+        [kept_derivative, dropped_derivative]
+    )
+    assert result == {kept_derivative: kept.uuid}
+
+
+# ===================================================================
 # delete_segments
 # ===================================================================
 
@@ -1224,6 +1337,8 @@ async def test_stale_handle_raises_after_delete(
         await partition.get_segment_uuids_by_event_uuids([seg.event_uuid])
     with pytest.raises(SegmentStorePartitionHandleStaleError):
         await partition.get_derivative_uuids_by_segment_uuids([seg.uuid])
+    with pytest.raises(SegmentStorePartitionHandleStaleError):
+        await partition.get_segment_uuids_by_derivative_uuids([uuid4()])
 
 
 @pytest.mark.integration
@@ -1241,13 +1356,15 @@ async def test_reads_check_liveness_inside_the_data_statement(
         "folded", _plaintext_partition_config()
     )
     seg = _seg()
-    await partition.add_segments(_links(seg))
+    derivative_uuids = [uuid4()]
+    await partition.add_segments({seg: derivative_uuids})
     recorded_statements.clear()
 
     await partition.get_segment_contexts([seg.uuid])
     await partition.get_segment_uuids_by_event_uuids([seg.event_uuid])
     await partition.get_derivative_uuids_by_segment_uuids([seg.uuid])
-    assert len(recorded_statements) == 3
+    await partition.get_segment_uuids_by_derivative_uuids(derivative_uuids)
+    assert len(recorded_statements) == 4
     assert all(
         "EXISTS (SELECT" in s and "segment_store_pt" in s for s in recorded_statements
     )

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_event_memory.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_event_memory.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -214,7 +214,6 @@ class TestEncodeEvents:
         # Collection without context fields.
         config = VectorStoreCollectionConfig(
             vector_dimensions=2,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "_segment_uuid": str,
                 "_timestamp": datetime.datetime,
@@ -244,7 +243,6 @@ class TestEncodeEvents:
         # Collection without _timestamp — base field required at init.
         config = VectorStoreCollectionConfig(
             vector_dimensions=2,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "_segment_uuid": str,
             },
@@ -977,7 +975,6 @@ class TestIngestFormatOptions:
     def _build(embedder: FakeEmbedder) -> EventMemory:
         config = VectorStoreCollectionConfig(
             vector_dimensions=embedder.dimensions,
-            similarity_metric=embedder.similarity_metric,
             indexed_properties_schema=(
                 EventMemory.expected_vector_store_collection_schema()
             ),
@@ -1019,7 +1016,6 @@ class TestIngestFormatOptions:
         partition = InMemorySegmentStorePartition()
         config = VectorStoreCollectionConfig(
             vector_dimensions=embedder.dimensions,
-            similarity_metric=embedder.similarity_metric,
             indexed_properties_schema=(
                 EventMemory.expected_vector_store_collection_schema()
             ),

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_event_memory.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_event_memory.py
@@ -94,7 +94,6 @@ def _ts(minutes: int) -> datetime.datetime:
 class TestSchema:
     def test_expected_vector_store_collection_schema_only_has_base_fields(self):
         assert EventMemory.expected_vector_store_collection_schema() == {
-            "_segment_uuid": str,
             "_timestamp": datetime.datetime,
         }
 
@@ -127,8 +126,13 @@ class TestEncodeEvents:
         assert len(fake_vector_store_collection.records) == 1
         record = next(iter(fake_vector_store_collection.records.values()))
         props = _record_properties(record)
-        assert props["_segment_uuid"] == str(segment.uuid)
         assert props["_timestamp"] == event.timestamp
+        # The derivative's segment is not copied here; the segment store owns
+        # that mapping and answers it from the derivative's own row.
+        assert "_segment_uuid" not in props
+        assert await fake_segment_store_partition.get_segment_uuids_by_derivative_uuids(
+            [record.uuid]
+        ) == {record.uuid: segment.uuid}
 
     async def test_producer_context(
         self,

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
@@ -20,7 +20,6 @@ from unittest.mock import create_autospec
 
 import pytest
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.episode_store import (
     Episode,
     EpisodeEntry,
@@ -150,7 +149,6 @@ def vector_store():
 def vector_store_collection(fake_embedder):
     config = VectorStoreCollectionConfig(
         vector_dimensions=fake_embedder.dimensions,
-        similarity_metric=fake_embedder.similarity_metric,
         indexed_properties_schema={
             **EventMemory.expected_vector_store_collection_schema(),
             **EVENT_BACKEND_SYSTEM_FIELDS,
@@ -480,20 +478,15 @@ async def test_timestamp_filter_field_is_accepted(long_term_memory, episodes):
     )
 
 
-def _make_ltm_with_metric(
-    metric: SimilarityMetric,
-    episodes: list[Episode],
-) -> LongTermMemory:
-    """Build a self-contained LongTermMemory whose vector store uses `metric`.
+def _make_ltm(episodes: list[Episode]) -> LongTermMemory:
+    """Build a self-contained LongTermMemory, bypassing the shared fixtures.
 
-    Avoids the shared fixtures so each test can pick its own similarity metric.
-    No reranker is configured — that's the failure mode under euclidean.
+    No reranker is configured, so scores come straight from the vector store.
     """
-    fake_embedder = FakeEmbedder(similarity_metric=metric)
+    fake_embedder = FakeEmbedder()
     vector_store_collection = InMemoryVectorStoreCollection(
         VectorStoreCollectionConfig(
             vector_dimensions=fake_embedder.dimensions,
-            similarity_metric=metric,
             indexed_properties_schema={
                 **EventMemory.expected_vector_store_collection_schema(),
                 **EVENT_BACKEND_SYSTEM_FIELDS,
@@ -526,7 +519,7 @@ async def test_score_threshold_drops_low_scores_under_cosine():
         _episode("near", "abc"),
         _episode("far", "abcdefghij"),
     ]
-    ltm = _make_ltm_with_metric(SimilarityMetric.COSINE, episodes)
+    ltm = _make_ltm(episodes)
     await ltm.add_episodes(episodes)
 
     kept_all = await ltm.search_scored("abc", num_episodes_limit=10)
@@ -536,62 +529,6 @@ async def test_score_threshold_drops_low_scores_under_cosine():
         "abc", num_episodes_limit=10, score_threshold=2.0
     )
     assert kept_none == []
-
-
-async def test_score_threshold_not_inverted_under_euclidean_no_reranker():
-    """Regression: with no reranker the threshold filter must respect
-    similarity_metric.higher_is_better. Under euclidean, scores are distances
-    (lower = better). The filter must DROP scores ABOVE the threshold, not
-    BELOW it.
-
-    Without this fix, `score < threshold` keeps far matches and drops close
-    ones — leaking unrelated content past a "max-distance" gate.
-    """
-    # FakeEmbedder maps text -> [len, -len], so a shorter embedded anchor lands
-    # closer to the short query "abc". "near" (content "abc") is therefore a
-    # closer euclidean match than "far" (content "abcdefghij"). The exact
-    # distances depend on the embedding format (producer prefix, JSON quoting,
-    # date stamp), so we read the actual scores and pick a threshold strictly
-    # between them rather than hard-coding the arithmetic.
-    episodes = [
-        _episode("near", "abc"),
-        _episode("far", "abcdefghij"),
-    ]
-    ltm = _make_ltm_with_metric(SimilarityMetric.EUCLIDEAN, episodes)
-    await ltm.add_episodes(episodes)
-
-    scores_by_uid = {
-        ep.uid: score
-        for score, ep in await ltm.search_scored("abc", num_episodes_limit=10)
-    }
-    assert scores_by_uid["near"] < scores_by_uid["far"], (
-        "FakeEmbedder should make the shorter 'near' anchor a closer "
-        "euclidean match than 'far'."
-    )
-    midpoint_threshold = (scores_by_uid["near"] + scores_by_uid["far"]) / 2
-
-    kept = await ltm.search_scored(
-        "abc", num_episodes_limit=10, score_threshold=midpoint_threshold
-    )
-    uids = {ep.uid for _, ep in kept}
-    assert "near" in uids, (
-        "Close match was dropped — threshold filter is inverted for euclidean."
-    )
-    assert "far" not in uids, (
-        "Far match was kept — threshold filter is inverted for euclidean."
-    )
-
-
-async def test_score_threshold_none_keeps_all_results_under_euclidean():
-    """Regression for the prior `-inf` sentinel: under euclidean (lower=better)
-    the default "no threshold" must NOT drop everything. Default is now
-    `score_threshold=None` which short-circuits the filter."""
-    episodes = [_episode("only", "abc")]
-    ltm = _make_ltm_with_metric(SimilarityMetric.EUCLIDEAN, episodes)
-    await ltm.add_episodes(episodes)
-
-    scored = await ltm.search_scored("abc", num_episodes_limit=10)
-    assert [ep.uid for _, ep in scored] == ["only"]
 
 
 def _timeline_episode(uid: str, content: str, minute: int) -> Episode:
@@ -695,8 +632,8 @@ def timeline_long_term_memory(
     segment_store_partition,
     timeline_storage,
 ) -> LongTermMemory:
-    # `RankedEmbedder` shares FakeEmbedder's dimensions and similarity metric,
-    # so the shared `vector_store_collection` config still applies.
+    # `RankedEmbedder` shares FakeEmbedder's dimensions, so the shared
+    # `vector_store_collection` config still applies.
     return LongTermMemory(
         EventBackendParams(
             session_id="sess1",

--- a/packages/server/server_tests/memmachine_server/semantic_memory/mock_semantic_memory_objects.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/mock_semantic_memory_objects.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock
 import numpy as np
 from pydantic import InstanceOf
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.episode_store import EpisodeIdT
 from memmachine_server.common.filter.filter_parser import FilterExpr
@@ -216,10 +215,6 @@ class MockEmbedder(Embedder):
     @property
     def dimensions(self) -> int:
         return 2
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        return SimilarityMetric.COSINE
 
 
 class MockResourceRetriever:

--- a/packages/server/server_tests/memmachine_server/semantic_memory/semantic_test_utils.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/semantic_test_utils.py
@@ -1,6 +1,5 @@
 import random
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.episode_store import EpisodeEntry, EpisodeStorage
 
@@ -37,10 +36,6 @@ class SpyEmbedder(Embedder):
     def dimensions(self) -> int:
         return 2
 
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        return SimilarityMetric.COSINE
-
     @staticmethod
     def _vector(text: str) -> list[float]:
         lowered = text.lower()
@@ -76,10 +71,6 @@ class LengthEmbedder(Embedder):
     @property
     def dimensions(self) -> int:
         return self.n
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        return SimilarityMetric.COSINE
 
 
 async def add_history(history_storage: EpisodeStorage, content: str):

--- a/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_vector_store_semantic_storage.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_vector_store_semantic_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta, timezone
+from uuid import UUID
 
 import numpy as np
 import pytest
@@ -9,8 +10,8 @@ from memmachine_server.common.filter.filter_parser import parse_filter
 from memmachine_server.common.vector_store import VectorStoreCollectionConfig
 from memmachine_server.semantic_memory.storage.storage_base import SemanticStorage
 from memmachine_server.semantic_memory.storage.vector_store_semantic_storage import (
+    VectorSemanticFeature,
     VectorStoreSemanticStorage,
-    feature_vector_uuid,
 )
 from server_tests.memmachine_server.common.vector_store.in_memory_vector_store_collection import (
     InMemoryVectorStoreCollection,
@@ -30,6 +31,14 @@ def vector_collection() -> InMemoryVectorStoreCollection:
             },
         )
     )
+
+
+async def _vector_uuid(storage: VectorStoreSemanticStorage, feature_id) -> UUID:
+    """The uuid of the vector record a feature owns, read off its own row."""
+    async with storage._create_session() as session:
+        row = await session.get(VectorSemanticFeature, int(feature_id))
+    assert row is not None
+    return row.vector_uuid
 
 
 @pytest.mark.asyncio
@@ -75,7 +84,11 @@ async def test_add_update_delete_feature_keeps_vector_collection_in_sync(
             embedding=np.array([1.0, 0.0], dtype=float),
         )
 
-        record_uuid = feature_vector_uuid(feature_id)
+        # The feature row owns the mapping to its vector record.
+        async with storage._create_session() as session:
+            row = await session.get(VectorSemanticFeature, int(feature_id))
+        assert row is not None
+        record_uuid = row.vector_uuid
         assert record_uuid in vector_collection.records
         assert vector_collection.records[record_uuid].vector == [1.0, 0.0]
 
@@ -95,6 +108,139 @@ async def test_add_update_delete_feature_keeps_vector_collection_in_sync(
         assert await storage.get_feature(feature_id) is None
     finally:
         await storage.delete_all()
+        await storage.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_each_feature_owns_a_distinct_vector_record(
+    sqlalchemy_sqlite_engine,
+    vector_collection: InMemoryVectorStoreCollection,
+):
+    """`vector_uuid` is minted per feature, so no two features can collide."""
+    storage = VectorStoreSemanticStorage(sqlalchemy_sqlite_engine, vector_collection)
+    await storage.startup()
+    try:
+        feature_ids = [
+            await storage.add_feature(
+                set_id="user",
+                category_name="default",
+                feature="likes",
+                value=value,
+                tag="food",
+                embedding=np.array([1.0, 0.0], dtype=float),
+            )
+            # Same set, category, feature name, tag and embedding: only the
+            # value differs, so anything derived from the others would collide.
+            for value in ("pizza", "sushi")
+        ]
+
+        vector_uuids = [
+            await _vector_uuid(storage, feature_id) for feature_id in feature_ids
+        ]
+
+        assert len(set(vector_uuids)) == 2
+        assert all(
+            vector_uuid in vector_collection.records for vector_uuid in vector_uuids
+        )
+    finally:
+        await storage.delete_all()
+        await storage.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_vector_records_carry_no_properties(
+    sqlalchemy_sqlite_engine,
+    vector_collection: InMemoryVectorStoreCollection,
+):
+    """The feature row is the authority; the vector record holds only a vector."""
+    storage = VectorStoreSemanticStorage(sqlalchemy_sqlite_engine, vector_collection)
+    await storage.startup()
+    try:
+        feature_id = await storage.add_feature(
+            set_id="user",
+            category_name="default",
+            feature="likes",
+            value="pizza",
+            tag="food",
+            embedding=np.array([1.0, 0.0], dtype=float),
+        )
+        vector_uuid = await _vector_uuid(storage, feature_id)
+        assert not vector_collection.records[vector_uuid].properties
+
+        # An update rewrites the vector and still writes no properties.
+        await storage.update_feature(
+            feature_id,
+            value="sushi",
+            embedding=np.array([0.0, 1.0], dtype=float),
+        )
+        assert not vector_collection.records[vector_uuid].properties
+    finally:
+        await storage.delete_all()
+        await storage.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_delete_feature_set_removes_the_vector_records(
+    sqlalchemy_sqlite_engine,
+    vector_collection: InMemoryVectorStoreCollection,
+):
+    """The uuids must be read before the rows go, or the vectors are orphaned."""
+    storage = VectorStoreSemanticStorage(sqlalchemy_sqlite_engine, vector_collection)
+    await storage.startup()
+    try:
+        dropped_id = await storage.add_feature(
+            set_id="dropped",
+            category_name="default",
+            feature="likes",
+            value="pizza",
+            tag="food",
+            embedding=np.array([1.0, 0.0], dtype=float),
+        )
+        kept_id = await storage.add_feature(
+            set_id="kept",
+            category_name="default",
+            feature="likes",
+            value="sushi",
+            tag="food",
+            embedding=np.array([0.0, 1.0], dtype=float),
+        )
+        dropped_uuid = await _vector_uuid(storage, dropped_id)
+        kept_uuid = await _vector_uuid(storage, kept_id)
+
+        await storage.delete_feature_set(
+            filter_expr=parse_filter("set_id IN (dropped)")
+        )
+
+        assert dropped_uuid not in vector_collection.records
+        assert kept_uuid in vector_collection.records
+    finally:
+        await storage.delete_all()
+        await storage.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_delete_all_removes_the_vector_records(
+    sqlalchemy_sqlite_engine,
+    vector_collection: InMemoryVectorStoreCollection,
+):
+    storage = VectorStoreSemanticStorage(sqlalchemy_sqlite_engine, vector_collection)
+    await storage.startup()
+    try:
+        for value in ("pizza", "sushi"):
+            await storage.add_feature(
+                set_id="user",
+                category_name="default",
+                feature="likes",
+                value=value,
+                tag="food",
+                embedding=np.array([1.0, 0.0], dtype=float),
+            )
+        assert len(vector_collection.records) == 2
+
+        await storage.delete_all()
+
+        assert vector_collection.records == {}
+    finally:
         await storage.cleanup()
 
 

--- a/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_vector_store_semantic_storage.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_vector_store_semantic_storage.py
@@ -5,7 +5,6 @@ from datetime import UTC, datetime, timedelta, timezone
 import numpy as np
 import pytest
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.filter.filter_parser import parse_filter
 from memmachine_server.common.vector_store import VectorStoreCollectionConfig
 from memmachine_server.semantic_memory.storage.storage_base import SemanticStorage
@@ -23,7 +22,6 @@ def vector_collection() -> InMemoryVectorStoreCollection:
     return InMemoryVectorStoreCollection(
         VectorStoreCollectionConfig(
             vector_dimensions=2,
-            similarity_metric=SimilarityMetric.COSINE,
             indexed_properties_schema={
                 "set_id": str,
                 "category": str,

--- a/packages/server/src/memmachine_server/common/configuration/__init__.py
+++ b/packages/server/src/memmachine_server/common/configuration/__init__.py
@@ -27,7 +27,6 @@ from memmachine_server.common.configuration.mixin_confs import (
 )
 from memmachine_server.common.configuration.reranker_conf import RerankersConf
 from memmachine_server.common.configuration.retrieval_config import RetrievalAgentConf
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.errors import (
     DefaultEmbedderNotConfiguredError,
     DefaultLLMModelNotConfiguredError,
@@ -136,10 +135,6 @@ class SemanticMemoryConf(YamlSerializableMixin):
             "vector_store storage, the configured embedder dimensions are used."
         ),
         gt=0,
-    )
-    vector_similarity_metric: SimilarityMetric = Field(
-        default=SimilarityMetric.COSINE,
-        description="Similarity metric for vector_store semantic memory search.",
     )
     config_database: str = Field(
         ...,

--- a/packages/server/src/memmachine_server/common/configuration/embedder_conf.py
+++ b/packages/server/src/memmachine_server/common/configuration/embedder_conf.py
@@ -12,7 +12,6 @@ from memmachine_server.common.configuration.mixin_confs import (
     MetricsFactoryIdMixin,
     YamlSerializableMixin,
 )
-from memmachine_server.common.data_types import SimilarityMetric
 
 
 def _clean_empty_embedder_config(conf: dict) -> dict:
@@ -44,10 +43,6 @@ class AmazonBedrockEmbedderConf(YamlSerializableMixin, AWSCredentialsMixin):
         default=None,
         description="Maximum input length for the model (in Unicode code points).",
         gt=0,
-    )
-    similarity_metric: SimilarityMetric = Field(
-        default=SimilarityMetric.COSINE,
-        description="Similarity metric to use",
     )
     max_retry_interval_seconds: int = Field(
         default=120,

--- a/packages/server/src/memmachine_server/common/configuration/mixin_confs.py
+++ b/packages/server/src/memmachine_server/common/configuration/mixin_confs.py
@@ -206,7 +206,7 @@ class YamlSerializableMixin(BaseModel):
             if isinstance(obj, SecretStr):
                 obj = obj.get_secret_value()
 
-            # Unwrap enums like SimilarityMetric
+            # Unwrap enums to their values
             if isinstance(obj, Enum):
                 obj = obj.value
 

--- a/packages/server/src/memmachine_server/common/data_types.py
+++ b/packages/server/src/memmachine_server/common/data_types.py
@@ -1,7 +1,6 @@
 """Common data types for MemMachine."""
 
 from datetime import datetime
-from enum import Enum
 from typing import Final
 
 PropertyValue = bool | int | float | str | datetime
@@ -24,20 +23,6 @@ FilterValue = bool | int | float | str | datetime | list[int] | list[str]
 
 OrderedValue = int | float | datetime
 """Type for values that can be ordered/sorted."""
-
-
-class SimilarityMetric(Enum):
-    """Similarity metrics supported by embedding operations."""
-
-    COSINE = "cosine"
-    DOT = "dot"
-    EUCLIDEAN = "euclidean"
-    MANHATTAN = "manhattan"
-
-    @property
-    def higher_is_better(self) -> bool:
-        """Whether a higher score indicates a better match."""
-        return self in (SimilarityMetric.COSINE, SimilarityMetric.DOT)
 
 
 class ExternalServiceAPIError(Exception):

--- a/packages/server/src/memmachine_server/common/embedder/amazon_bedrock_embedder.py
+++ b/packages/server/src/memmachine_server/common/embedder/amazon_bedrock_embedder.py
@@ -14,7 +14,6 @@ from pydantic import BaseModel, Field, InstanceOf
 
 from memmachine_server.common.data_types import (
     ExternalServiceAPIError,
-    SimilarityMetric,
 )
 from memmachine_server.common.utils import chunk_text, unflatten_like
 
@@ -42,10 +41,6 @@ class AmazonBedrockEmbedderParams(BaseModel):
         description="Maximum input length for the model (in Unicode code points).",
         gt=0,
     )
-    similarity_metric: SimilarityMetric = Field(
-        default=SimilarityMetric.COSINE,
-        description="Similarity metric to use for comparing embeddings.",
-    )
     max_retry_interval_seconds: int = Field(
         default=120,
         description="Maximal retry interval in seconds (defualt: 120).",
@@ -68,7 +63,6 @@ class AmazonBedrockEmbedder(Embedder):
 
         self._model_id = params.model_id
         self._max_input_length = params.max_input_length
-        self._similarity_metric = params.similarity_metric
         self._max_retry_interval_seconds = params.max_retry_interval_seconds
 
         # Get dimensions by embedding a dummy string.
@@ -233,8 +227,3 @@ class AmazonBedrockEmbedder(Embedder):
     def dimensions(self) -> int:
         """Return the embedding dimensionality."""
         return self._dimensions
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        """Return the similarity metric used by the embedder."""
-        return self._similarity_metric

--- a/packages/server/src/memmachine_server/common/embedder/embedder.py
+++ b/packages/server/src/memmachine_server/common/embedder/embedder.py
@@ -4,8 +4,6 @@ import asyncio
 from abc import ABC, abstractmethod
 from typing import Any
 
-from memmachine_server.common.data_types import SimilarityMetric
-
 
 class Embedder(ABC):
     """Abstract base class for an embedder."""
@@ -84,10 +82,4 @@ class Embedder(ABC):
     @abstractmethod
     def dimensions(self) -> int:
         """Return the embedding dimensionality."""
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def similarity_metric(self) -> SimilarityMetric:
-        """Return the similarity metric used by this embedder."""
         raise NotImplementedError

--- a/packages/server/src/memmachine_server/common/embedder/openai_embedder.py
+++ b/packages/server/src/memmachine_server/common/embedder/openai_embedder.py
@@ -11,7 +11,6 @@ from pydantic import BaseModel, Field, InstanceOf
 
 from memmachine_server.common.data_types import (
     ExternalServiceAPIError,
-    SimilarityMetric,
 )
 from memmachine_server.common.metrics_factory import MetricsFactory, OperationTracker
 from memmachine_server.common.utils import (
@@ -332,9 +331,3 @@ class OpenAIEmbedder(Embedder):
     def dimensions(self) -> int:
         """Return the embedding dimensionality."""
         return self._dimensions
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        """Return the similarity metric used by this embedder."""
-        # https://platform.openai.com/docs/guides/embeddings
-        return SimilarityMetric.COSINE

--- a/packages/server/src/memmachine_server/common/embedder/sentence_transformer_embedder.py
+++ b/packages/server/src/memmachine_server/common/embedder/sentence_transformer_embedder.py
@@ -12,7 +12,6 @@ from sentence_transformers import SentenceTransformer
 
 from memmachine_server.common.data_types import (
     ExternalServiceAPIError,
-    SimilarityMetric,
 )
 from memmachine_server.common.utils import chunk_text, unflatten_like
 
@@ -56,21 +55,13 @@ class SentenceTransformerEmbedder(Embedder):
         self._dimensions = self._sentence_transformer.get_embedding_dimension() or len(
             self._sentence_transformer.encode("")
         )
-        match self._sentence_transformer.similarity_fn_name:
-            case "cosine":
-                self._similarity_metric = SimilarityMetric.COSINE
-            case "dot":
-                self._similarity_metric = SimilarityMetric.DOT
-            case "euclidean":
-                self._similarity_metric = SimilarityMetric.EUCLIDEAN
-            case "manhattan":
-                self._similarity_metric = SimilarityMetric.MANHATTAN
-            case _:
-                logger.warning(
-                    "Unknown similarity function name '%s', defaulting to cosine",
-                    self._sentence_transformer.similarity_fn_name,
-                )
-                self._similarity_metric = SimilarityMetric.COSINE
+        if self._sentence_transformer.similarity_fn_name != "cosine":
+            logger.warning(
+                "Sentence transformer '%s' declares similarity function '%s', "
+                "but embeddings are always compared by cosine similarity",
+                self._model_name,
+                self._sentence_transformer.similarity_fn_name,
+            )
 
         self._max_input_length = params.max_input_length
 
@@ -183,8 +174,3 @@ class SentenceTransformerEmbedder(Embedder):
     def dimensions(self) -> int:
         """Return the embedding dimensionality."""
         return self._dimensions
-
-    @property
-    def similarity_metric(self) -> SimilarityMetric:
-        """Return the similarity metric used."""
-        return self._similarity_metric

--- a/packages/server/src/memmachine_server/common/reranker/embedder_reranker.py
+++ b/packages/server/src/memmachine_server/common/reranker/embedder_reranker.py
@@ -1,10 +1,9 @@
 """Embedder-based reranker implementation."""
 
-import numpy as np
 from pydantic import BaseModel, Field, InstanceOf
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.embedder import Embedder
+from memmachine_server.common.utils import compute_cosine_similarity
 
 from .reranker import Reranker
 
@@ -32,42 +31,7 @@ class EmbedderReranker(Reranker):
         if len(candidates) == 0:
             return []
 
-        query_embedding = np.array(await self._embedder.search_embed([query])).flatten()
-        candidate_embeddings = np.array(await self._embedder.ingest_embed(candidates))
+        query_embedding = (await self._embedder.search_embed([query]))[0]
+        candidate_embeddings = await self._embedder.ingest_embed(candidates)
 
-        match self._embedder.similarity_metric:
-            case SimilarityMetric.COSINE:
-                magnitude_products = np.linalg.norm(
-                    candidate_embeddings,
-                    axis=-1,
-                ) * np.linalg.norm(query_embedding)
-                magnitude_products[magnitude_products == 0] = float("inf")
-
-                scores = (
-                    np.dot(candidate_embeddings, query_embedding) / magnitude_products
-                )
-            case SimilarityMetric.DOT:
-                scores = np.dot(candidate_embeddings, query_embedding)
-            case SimilarityMetric.EUCLIDEAN:
-                scores = -np.linalg.norm(
-                    candidate_embeddings - query_embedding,
-                    axis=-1,
-                )
-            case SimilarityMetric.MANHATTAN:
-                scores = -np.sum(
-                    np.abs(candidate_embeddings - query_embedding),
-                    axis=-1,
-                )
-            case _:
-                # Default to cosine similarity.
-                magnitude_products = np.linalg.norm(
-                    candidate_embeddings,
-                    axis=-1,
-                ) * np.linalg.norm(query_embedding)
-                magnitude_products[magnitude_products == 0] = float("inf")
-
-                scores = (
-                    np.dot(candidate_embeddings, query_embedding) / magnitude_products
-                )
-
-        return scores.astype(float).tolist()
+        return compute_cosine_similarity(query_embedding, candidate_embeddings)

--- a/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
@@ -19,7 +19,6 @@ from memmachine_server.common.configuration.database_conf import (
     SQLiteVectorStoreConf,
     SQLiteVectorStoreEngine,
 )
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.errors import (
     MilvusConfigurationError,
     Neo4JConfigurationError,
@@ -752,8 +751,8 @@ class DatabaseManager:
     @staticmethod
     def _make_sqlite_search_engine_factory(
         conf: SQLiteVectorStoreConf,
-    ) -> Callable[[int, SimilarityMetric], VectorSearchEngine]:
-        """Build a (ndim, metric) -> VectorSearchEngine factory from config.
+    ) -> Callable[[int], VectorSearchEngine]:
+        """Build a ndim -> VectorSearchEngine factory from config.
 
         Imports are deferred so the engine packages remain optional unless
         their backend is actually used.
@@ -764,13 +763,8 @@ class DatabaseManager:
                     USearchVectorSearchEngine,
                 )
 
-                def usearch_factory(
-                    num_dimensions: int, similarity_metric: SimilarityMetric
-                ) -> VectorSearchEngine:
-                    return USearchVectorSearchEngine(
-                        num_dimensions=num_dimensions,
-                        similarity_metric=similarity_metric,
-                    )
+                def usearch_factory(num_dimensions: int) -> VectorSearchEngine:
+                    return USearchVectorSearchEngine(num_dimensions=num_dimensions)
 
                 return usearch_factory
             case SQLiteVectorStoreEngine.HNSWLIB:
@@ -778,13 +772,8 @@ class DatabaseManager:
                     HnswlibVectorSearchEngine,
                 )
 
-                def hnswlib_factory(
-                    num_dimensions: int, similarity_metric: SimilarityMetric
-                ) -> VectorSearchEngine:
-                    return HnswlibVectorSearchEngine(
-                        num_dimensions=num_dimensions,
-                        similarity_metric=similarity_metric,
-                    )
+                def hnswlib_factory(num_dimensions: int) -> VectorSearchEngine:
+                    return HnswlibVectorSearchEngine(num_dimensions=num_dimensions)
 
                 return hnswlib_factory
 

--- a/packages/server/src/memmachine_server/common/resource_manager/embedder_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/embedder_manager.py
@@ -184,7 +184,6 @@ class EmbedderManager(BaseResourceManager[Embedder]):
         params = AmazonBedrockEmbedderParams(
             client=client,
             model_id=conf.model_id,
-            similarity_metric=conf.similarity_metric,
             max_input_length=conf.max_input_length,
             max_retry_interval_seconds=conf.max_retry_interval_seconds,
             batch_size=conf.batch_size,

--- a/packages/server/src/memmachine_server/common/resource_manager/semantic_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/semantic_manager.py
@@ -152,7 +152,6 @@ class SemanticResourceManager:
             name=_VECTOR_STORE_COLLECTION_NAME,
             config=VectorStoreCollectionConfig(
                 vector_dimensions=vector_dimensions,
-                similarity_metric=self._conf.vector_similarity_metric,
                 indexed_properties_schema={
                     "feature_id": str,
                     "set_id": str,

--- a/packages/server/src/memmachine_server/common/utils.py
+++ b/packages/server/src/memmachine_server/common/utils.py
@@ -12,8 +12,6 @@ from typing import Any, ParamSpec, TypeVar, cast
 import numpy as np
 from nltk import sent_tokenize
 
-from .data_types import SimilarityMetric
-
 T = TypeVar("T")
 P = ParamSpec("P")
 
@@ -274,21 +272,19 @@ def cluster_texts(
     return clusters
 
 
-def compute_similarity(
+def compute_cosine_similarity(
     query_embedding: list[float],
     candidate_embeddings: list[list[float]],
-    similarity_metric: SimilarityMetric | None = None,
 ) -> list[float]:
     """
-    Compute similarity scores between a query embedding and candidate embeddings.
+    Compute cosine similarities between a query embedding and candidate embeddings.
 
     Args:
         query_embedding (list[float]): The embedding of the query.
         candidate_embeddings (list[list[float]]): A list of candidate embeddings to compare against.
-        similarity_metric (SimilarityMetric | None): The similarity metric to use (default: None).
 
     Returns:
-        list[float]: A list of similarity scores for each candidate embedding.
+        list[float]: A cosine similarity in [-1, 1] for each candidate embedding.
 
     """
     if not candidate_embeddings:
@@ -297,70 +293,14 @@ def compute_similarity(
     query_embedding_np = np.array(query_embedding)
     candidate_embeddings_np = np.array(candidate_embeddings)
 
-    match similarity_metric:
-        case SimilarityMetric.COSINE:
-            magnitude_products = np.linalg.norm(
-                candidate_embeddings_np,
-                axis=-1,
-            ) * np.linalg.norm(query_embedding_np)
-            magnitude_products[magnitude_products == 0] = float("inf")
+    magnitude_products = np.linalg.norm(
+        candidate_embeddings_np,
+        axis=-1,
+    ) * np.linalg.norm(query_embedding_np)
+    magnitude_products[magnitude_products == 0] = float("inf")
 
-            scores = (
-                np.dot(candidate_embeddings_np, query_embedding_np) / magnitude_products
-            )
-        case SimilarityMetric.DOT:
-            scores = np.dot(candidate_embeddings_np, query_embedding_np)
-        case SimilarityMetric.EUCLIDEAN:
-            scores = np.linalg.norm(
-                candidate_embeddings_np - query_embedding_np,
-                axis=-1,
-            )
-        case SimilarityMetric.MANHATTAN:
-            scores = np.sum(
-                np.abs(candidate_embeddings_np - query_embedding_np),
-                axis=-1,
-            )
-        case _:
-            # Default to cosine similarity.
-            magnitude_products = np.linalg.norm(
-                candidate_embeddings_np,
-                axis=-1,
-            ) * np.linalg.norm(query_embedding_np)
-            magnitude_products[magnitude_products == 0] = float("inf")
+    cosine_similarities = (
+        np.dot(candidate_embeddings_np, query_embedding_np) / magnitude_products
+    )
 
-            scores = (
-                np.dot(candidate_embeddings_np, query_embedding_np) / magnitude_products
-            )
-
-    return scores.astype(float).tolist()
-
-
-def similarity_gt(
-    similarity_metric: SimilarityMetric | None = None,
-) -> Callable[[float, float], bool]:
-    """
-    Return a comparator for similarity scores.
-
-    The returned function `gt(a, b)` returns True when score `a`
-    represents greater similarity than score `b` under the given metric.
-
-    For COSINE and DOT, higher scores mean greater similarity (`a > b`).
-    For EUCLIDEAN and MANHATTAN, lower scores mean greater similarity (`a < b`).
-
-    Args:
-        similarity_metric (SimilarityMetric | None):
-            The similarity metric.
-            If None, defaults to greater-than comparison (`a > b`)
-            (default: None).
-
-    Returns:
-        Callable[[float, float], bool]: A comparator for similarity scores.
-
-    """
-    import operator
-
-    match similarity_metric:
-        case SimilarityMetric.EUCLIDEAN | SimilarityMetric.MANHATTAN:
-            return operator.lt
-        case _:
-            return operator.gt
+    return cosine_similarities.astype(float).tolist()

--- a/packages/server/src/memmachine_server/common/vector_graph_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/data_types.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 
-from memmachine_server.common.data_types import SimilarityMetric
-
 # Types that can be used as property values in nodes and edges.
 PropertyValue = (
     bool
@@ -35,9 +33,7 @@ class Node:
 
     uid: str
     properties: dict[str, PropertyValue] = field(default_factory=dict)
-    embeddings: dict[str, tuple[list[float], SimilarityMetric]] = field(
-        default_factory=dict,
-    )
+    embeddings: dict[str, list[float]] = field(default_factory=dict)
 
     def __eq__(self, other: object) -> bool:
         """Compare nodes by UID, properties, and embeddings."""
@@ -62,9 +58,7 @@ class Edge:
     source_uid: str
     target_uid: str
     properties: dict[str, PropertyValue] = field(default_factory=dict)
-    embeddings: dict[str, tuple[list[float], SimilarityMetric]] = field(
-        default_factory=dict,
-    )
+    embeddings: dict[str, list[float]] = field(default_factory=dict)
 
     def __eq__(self, other: object) -> bool:
         """Compare edges by uid, properties, and embeddings."""

--- a/packages/server/src/memmachine_server/common/vector_graph_store/nebula_graph_vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/nebula_graph_vector_graph_store.py
@@ -18,7 +18,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 from nebulagraph_python.py_data_types import NVector
 
@@ -107,6 +107,15 @@ class NebulaGraphVectorGraphStoreParams:
     user_metrics_labels: dict[str, str] = field(default_factory=dict)
 
 
+# NebulaGraph's `cosine()` is KNN-only -- it cannot take APPROXIMATE -- and its
+# vector indexes offer only L2 and IP. Cosine similarity between unit vectors
+# *is* their inner product, so embeddings are normalized on the way in and
+# compared with `inner_product()` against an IP index. That is cosine ranking,
+# and unlike `cosine()` it can be approximate.
+_INDEX_METRIC = "IP"
+_DISTANCE_FUNCTION = "inner_product"
+
+
 class NebulaGraphVectorGraphStore(VectorGraphStore):
     """
     NebulaGraph Enterprise implementation of VectorGraphStore.
@@ -118,14 +127,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
     - Vector indexes with IVF/HNSW algorithms
     - SESSION SET SCHEMA and SESSION SET GRAPH for context
     """
-
-    # NebulaGraph's `cosine()` is KNN-only -- it cannot take APPROXIMATE -- and
-    # its vector indexes offer only L2 and IP. Cosine similarity between unit
-    # vectors *is* their inner product, so embeddings are normalized on the way
-    # in and compared with `inner_product()` against an IP index. That is
-    # cosine ranking, and unlike `cosine()` it can be approximate.
-    _INDEX_METRIC: ClassVar[str] = "IP"
-    _DISTANCE_FUNC_AND_ORDER: ClassVar[tuple[str, str]] = ("inner_product", "DESC")
 
     class CacheIndexState(Enum):
         """Index state tracking for local cache."""
@@ -490,26 +491,21 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
             else:
                 search_limit = effective_limit
 
-            distance_func, order_dir = self._DISTANCE_FUNC_AND_ORDER
-            metric_name = self._INDEX_METRIC
-
             # Build vector literal
             vec_literal = self._vector_to_gql_literal(query_embedding)
 
             # Build OPTIONS clause
             if self._ann_index_type == "IVF":
-                options = (
-                    f"{{METRIC: {metric_name}, TYPE: IVF, NPROBE: {self._ivf_nprobe}}}"
-                )
+                options = f"{{METRIC: {_INDEX_METRIC}, TYPE: IVF, NPROBE: {self._ivf_nprobe}}}"
             else:  # HNSW
-                options = f"{{METRIC: {metric_name}, TYPE: HNSW, EFSEARCH: {self._hnsw_ef_search}}}"
+                options = f"{{METRIC: {_INDEX_METRIC}, TYPE: HNSW, EFSEARCH: {self._hnsw_ef_search}}}"
 
             # Build query
             query_parts = [f"MATCH (n:{sanitized_collection})"]
             if where_clause:
                 query_parts.append(f"WHERE {where_clause}")
             query_parts.append(
-                f"ORDER BY {distance_func}(n.{sanitized_embedding}, {vec_literal}) {order_dir}"
+                f"ORDER BY {_DISTANCE_FUNCTION}(n.{sanitized_embedding}, {vec_literal}) DESC"
             )
             query_parts.append("APPROXIMATE")
             query_parts.append(f"LIMIT {search_limit}")
@@ -602,16 +598,13 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         # Build vector literal
         vec_literal = self._vector_to_gql_literal(query_embedding)
 
-        # Choose similarity function and order direction
-        distance_func, order_dir = self._DISTANCE_FUNC_AND_ORDER
-
         # Build query (no APPROXIMATE keyword = exact search)
         query_parts = [f"MATCH (n:{sanitized_collection})"]
         if where_clause:
             query_parts.append(f"WHERE {where_clause}")
         query_parts.append("RETURN n")
         query_parts.append(
-            f"ORDER BY {distance_func}(n.{sanitized_embedding}, {vec_literal}) {order_dir}"
+            f"ORDER BY {_DISTANCE_FUNCTION}(n.{sanitized_embedding}, {vec_literal}) DESC"
         )
         if limit:
             query_parts.append(f"LIMIT {limit}")
@@ -1767,8 +1760,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
             dimensions: Vector dimensions
 
         """
-        nebula_metric = self._INDEX_METRIC
-
         # Use mangled and sanitized embedding name to ensure valid identifier
         mangled_embedding = mangle_embedding_name(embedding_name)
         index_name = f"idx_{self._sanitize_name(node_or_edge_type)}_{self._sanitize_name(mangled_embedding)}"
@@ -1792,13 +1783,12 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
             try:
                 sanitized_type = self._sanitize_name(node_or_edge_type)
                 sanitized_embedding = self._sanitize_name(mangled_embedding)
-                metric = nebula_metric
 
                 # Build index options based on type
                 if self._ann_index_type == "IVF":
                     options = f"""{{
                         DIM: {dimensions},
-                        METRIC: {metric},
+                        METRIC: {_INDEX_METRIC},
                         TYPE: IVF,
                         NLIST: {self._ivf_nlist},
                         TRAINSIZE: 10000
@@ -1806,7 +1796,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 else:  # HNSW
                     options = f"""{{
                         DIM: {dimensions},
-                        METRIC: {metric},
+                        METRIC: {_INDEX_METRIC},
                         TYPE: HNSW,
                         MAXDEGREE: {self._hnsw_max_degree},
                         EFCONSTRUCTION: {self._hnsw_ef_construction},

--- a/packages/server/src/memmachine_server/common/vector_graph_store/nebula_graph_vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/nebula_graph_vector_graph_store.py
@@ -12,6 +12,7 @@ interface using NebulaGraph Enterprise as the backend. It supports:
 
 import asyncio
 import logging
+import math
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -114,15 +115,17 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
     with GQL (ISO Graph Query Language) instead of Cypher. Key differences:
     - Schema + Graph model
     - Native VECTOR<N, FLOAT> data type
+    - Vector indexes with IVF/HNSW algorithms
     - SESSION SET SCHEMA and SESSION SET GRAPH for context
-
-    Similarity search is always exact (KNN): NebulaGraph's `cosine()` does not
-    support APPROXIMATE, and its vector indexes only offer L2 and IP metrics,
-    neither of which serves cosine similarity.
     """
 
-    # GQL distance function and ORDER BY direction for cosine similarity.
-    _DISTANCE_FUNC_AND_ORDER: ClassVar[tuple[str, str]] = ("cosine", "DESC")
+    # NebulaGraph's `cosine()` is KNN-only -- it cannot take APPROXIMATE -- and
+    # its vector indexes offer only L2 and IP. Cosine similarity between unit
+    # vectors *is* their inner product, so embeddings are normalized on the way
+    # in and compared with `inner_product()` against an IP index. That is
+    # cosine ranking, and unlike `cosine()` it can be approximate.
+    _INDEX_METRIC: ClassVar[str] = "IP"
+    _DISTANCE_FUNC_AND_ORDER: ClassVar[tuple[str, str]] = ("inner_product", "DESC")
 
     class CacheIndexState(Enum):
         """Index state tracking for local cache."""
@@ -245,6 +248,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 formatted_value = self._format_value(prop_value)
                 prop_assignments.append(f"{sanitized}: {formatted_value}")
 
+            # Add embeddings with companion metric property
             for emb_name, emb_vec in node.embeddings.items():
                 mangled = mangle_embedding_name(emb_name)
                 sanitized = self._sanitize_name(mangled)
@@ -262,6 +266,25 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         current_count = self._collection_node_counts.get(collection, 0)
         new_count = current_count + len(nodes_list)
         self._collection_node_counts[collection] = new_count
+
+        # Check if we should create indexes
+        if (
+            self._vector_index_threshold
+            and new_count >= self._vector_index_threshold
+            and current_count < self._vector_index_threshold
+        ):
+            # Create vector indexes
+            for emb_name, emb_vec in all_embeddings.items():
+                task = asyncio.create_task(
+                    self._create_vector_index_if_not_exists(
+                        EntityType.NODE,
+                        collection,
+                        emb_name,
+                        len(emb_vec),
+                    )
+                )
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
 
         # Create range indexes based on configured hierarchies
         # Note: We don't create a range index on 'uid' because it's declared as PRIMARY KEY
@@ -341,6 +364,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 formatted_value = self._format_value(prop_value)
                 prop_assignments.append(f"{sanitized}: {formatted_value}")
 
+            # Build embedding assignments with companion metric property
             for emb_name, emb_vec in edge.embeddings.items():
                 mangled = mangle_embedding_name(emb_name)
                 sanitized = self._sanitize_name(mangled)
@@ -367,6 +391,25 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         current_count = self._relation_edge_counts.get(relation, 0)
         new_count = current_count + len(edges_list)
         self._relation_edge_counts[relation] = new_count
+
+        # Check if we should create indexes
+        if (
+            self._vector_index_threshold
+            and new_count >= self._vector_index_threshold
+            and current_count < self._vector_index_threshold
+        ):
+            # Create vector indexes for edge embeddings
+            for emb_name, emb_vec in all_embeddings.items():
+                task = asyncio.create_task(
+                    self._create_vector_index_if_not_exists(
+                        EntityType.EDGE,
+                        relation,
+                        emb_name,
+                        len(emb_vec),
+                    )
+                )
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
 
         # Create range indexes based on configured hierarchies when threshold is reached
         if (
@@ -414,9 +457,105 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         """
         await self._discover_existing_indexes()
 
-        # NebulaGraph's cosine() is KNN-only -- APPROXIMATE is not supported for
-        # it, and no vector index metric serves it -- so with cosine the only
-        # similarity, search is always exact.
+        sanitized_collection = self._sanitize_name(collection)
+        mangled_embedding = mangle_embedding_name(embedding_name)
+        sanitized_embedding = self._sanitize_name(mangled_embedding)
+
+        # Check if vector index exists
+        # Use mangled and sanitized embedding name to ensure valid identifier
+        index_name = f"idx_{sanitized_collection}_{sanitized_embedding}"
+        has_index = (
+            index_name in self._index_state_cache
+            and self._index_state_cache[index_name] == self.CacheIndexState.ONLINE
+        )
+
+        # Decide on search mode.
+        # ANN requires both a vector index AND a function that supports APPROXIMATE.
+        # cosine() is KNN-only in NebulaGraph, so COSINE must always use exact search.
+        use_ann = has_index and not self._force_exact_similarity_search
+
+        # Build WHERE clause from property filter
+        where_clause = ""
+        if property_filter:
+            where_clause = self._render_filter_expr("n", property_filter)
+
+        # Build query based on search mode
+        if use_ann:
+            # ANN search requires a finite limit (default to 1000 like Neo4j)
+            effective_limit = limit if limit is not None else 1000
+
+            # Use fudge factor when filtering to get more candidates
+            if property_filter:
+                search_limit = int(effective_limit * self._fudge_factor)
+            else:
+                search_limit = effective_limit
+
+            distance_func, order_dir = self._DISTANCE_FUNC_AND_ORDER
+            metric_name = self._INDEX_METRIC
+
+            # Build vector literal
+            vec_literal = self._vector_to_gql_literal(query_embedding)
+
+            # Build OPTIONS clause
+            if self._ann_index_type == "IVF":
+                options = (
+                    f"{{METRIC: {metric_name}, TYPE: IVF, NPROBE: {self._ivf_nprobe}}}"
+                )
+            else:  # HNSW
+                options = f"{{METRIC: {metric_name}, TYPE: HNSW, EFSEARCH: {self._hnsw_ef_search}}}"
+
+            # Build query
+            query_parts = [f"MATCH (n:{sanitized_collection})"]
+            if where_clause:
+                query_parts.append(f"WHERE {where_clause}")
+            query_parts.append(
+                f"ORDER BY {distance_func}(n.{sanitized_embedding}, {vec_literal}) {order_dir}"
+            )
+            query_parts.append("APPROXIMATE")
+            query_parts.append(f"LIMIT {search_limit}")
+            query_parts.append(f"OPTIONS {options}")
+            query_parts.append("RETURN n")
+
+            query = "\n".join(query_parts)
+
+            result = await self._client.execute(query)
+
+            # Convert results
+            nodes = []
+            for row in result:
+                node_data = row["n"]
+                # Unwrap ValueWrapper if needed
+                if hasattr(node_data, "cast_primitive"):
+                    node_data = node_data.cast_primitive()
+                    if "properties" in node_data:
+                        node_data = node_data["properties"]
+                nodes.append(self._nebula_result_to_node(collection, node_data))
+
+            # Check fallback threshold
+            if (
+                property_filter
+                and len(nodes) < (limit or 100) * self._fallback_threshold
+            ):
+                # Fall back to exact search
+                logger.info(
+                    "ANN search returned insufficient results (%s), falling back to exact search",
+                    len(nodes),
+                )
+                return await self._exact_similarity_search(
+                    collection=collection,
+                    embedding_name=embedding_name,
+                    query_embedding=query_embedding,
+                    limit=limit,
+                    property_filter=property_filter,
+                )
+
+            # Trim to requested limit
+            if limit and len(nodes) > limit:
+                nodes = nodes[:limit]
+
+            return nodes
+
+        # Exact search (no index or forced)
         return await self._exact_similarity_search(
             collection=collection,
             embedding_name=embedding_name,
@@ -1219,6 +1358,18 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
             return "NULL"
         raise ValueError(f"Unsupported value type: {type(value)}")
 
+    @staticmethod
+    def _unit(vec: list[float]) -> list[float]:
+        """Scale to unit length, so an inner product is a cosine similarity.
+
+        A zero vector has no direction to preserve and is left as it is; it
+        scores 0 against everything either way.
+        """
+        magnitude = math.sqrt(sum(component * component for component in vec))
+        if magnitude == 0.0:
+            return list(vec)
+        return [component / magnitude for component in vec]
+
     def _vector_to_gql_literal(self, vec: list[float]) -> str:
         """
         Convert Python list to GQL VECTOR literal.
@@ -1230,7 +1381,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
             GQL VECTOR literal
 
         """
-        vec_str = ", ".join(str(v) for v in vec)
+        vec_str = ", ".join(str(v) for v in self._unit(vec))
         return f"VECTOR<{len(vec)}, FLOAT>([{vec_str}])"
 
     def _render_filter_expr(
@@ -1598,6 +1749,95 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
 
             # Cache the schema
             self._graph_type_schemas[edge_key] = incoming_schema
+
+    async def _create_vector_index_if_not_exists(
+        self,
+        entity_type: EntityType,
+        node_or_edge_type: str,
+        embedding_name: str,
+        dimensions: int,
+    ) -> None:
+        """
+        Create vector index if it doesn't exist.
+
+        Args:
+            entity_type: NODE or EDGE
+            node_or_edge_type: Type name
+            embedding_name: Embedding property name
+            dimensions: Vector dimensions
+
+        """
+        nebula_metric = self._INDEX_METRIC
+
+        # Use mangled and sanitized embedding name to ensure valid identifier
+        mangled_embedding = mangle_embedding_name(embedding_name)
+        index_name = f"idx_{self._sanitize_name(node_or_edge_type)}_{self._sanitize_name(mangled_embedding)}"
+
+        # Check cache
+        if index_name in self._index_state_cache:
+            return
+
+        # Acquire lock for this index
+        if index_name not in self._index_locks:
+            self._index_locks[index_name] = asyncio.Lock()
+
+        async with self._index_locks[index_name]:
+            # Double-check after acquiring lock
+            if index_name in self._index_state_cache:
+                return
+
+            # Mark as creating
+            self._index_state_cache[index_name] = self.CacheIndexState.CREATING
+
+            try:
+                sanitized_type = self._sanitize_name(node_or_edge_type)
+                sanitized_embedding = self._sanitize_name(mangled_embedding)
+                metric = nebula_metric
+
+                # Build index options based on type
+                if self._ann_index_type == "IVF":
+                    options = f"""{{
+                        DIM: {dimensions},
+                        METRIC: {metric},
+                        TYPE: IVF,
+                        NLIST: {self._ivf_nlist},
+                        TRAINSIZE: 10000
+                    }}"""
+                else:  # HNSW
+                    options = f"""{{
+                        DIM: {dimensions},
+                        METRIC: {metric},
+                        TYPE: HNSW,
+                        MAXDEGREE: {self._hnsw_max_degree},
+                        EFCONSTRUCTION: {self._hnsw_ef_construction},
+                        CAPACITY: 1000000
+                    }}"""
+
+                # Create index (use sanitized embedding name for valid GQL identifier)
+                if entity_type == EntityType.NODE:
+                    create_stmt = f"""
+                    CREATE VECTOR INDEX IF NOT EXISTS {index_name}
+                    ON NODE {sanitized_type}::{sanitized_embedding}
+                    OPTIONS {options}
+                    """
+                else:  # EDGE
+                    create_stmt = f"""
+                    CREATE VECTOR INDEX IF NOT EXISTS {index_name}
+                    ON EDGE {sanitized_type}::{sanitized_embedding}
+                    OPTIONS {options}
+                    """
+
+                await self._client.execute(create_stmt)
+
+                # Mark as online
+                self._index_state_cache[index_name] = self.CacheIndexState.ONLINE
+                logger.info("Created vector index: %s", index_name)
+
+            except Exception:
+                # Remove from cache on error
+                self._index_state_cache.pop(index_name, None)
+                logger.exception("Failed to create vector index %s", index_name)
+                raise
 
     async def _create_range_index_if_not_exists(
         self,

--- a/packages/server/src/memmachine_server/common/vector_graph_store/nebula_graph_vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/nebula_graph_vector_graph_store.py
@@ -11,18 +11,17 @@ interface using NebulaGraph Enterprise as the backend. It supports:
 """
 
 import asyncio
-import hashlib
 import logging
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from nebulagraph_python.py_data_types import NVector
 
-from memmachine_server.common.data_types import OrderedValue, SimilarityMetric
+from memmachine_server.common.data_types import OrderedValue
 from memmachine_server.common.filter.filter_parser import (
     And,
     Comparison,
@@ -115,9 +114,15 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
     with GQL (ISO Graph Query Language) instead of Cypher. Key differences:
     - Schema + Graph model
     - Native VECTOR<N, FLOAT> data type
-    - Vector indexes with IVF/HNSW algorithms
     - SESSION SET SCHEMA and SESSION SET GRAPH for context
+
+    Similarity search is always exact (KNN): NebulaGraph's `cosine()` does not
+    support APPROXIMATE, and its vector indexes only offer L2 and IP metrics,
+    neither of which serves cosine similarity.
     """
+
+    # GQL distance function and ORDER BY direction for cosine similarity.
+    _DISTANCE_FUNC_AND_ORDER: ClassVar[tuple[str, str]] = ("cosine", "DESC")
 
     class CacheIndexState(Enum):
         """Index state tracking for local cache."""
@@ -205,14 +210,14 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
 
         # Collect all properties and embeddings from all nodes to build schema
         all_properties: dict[str, PropertyValue] = {}
-        all_embeddings: dict[str, tuple[list[float], SimilarityMetric]] = {}
+        all_embeddings: dict[str, list[float]] = {}
 
         for node in nodes_list:
             all_properties.update(node.properties)
             # Track embeddings with their dimensions and metrics
-            for emb_name, (emb_vec, metric) in node.embeddings.items():
+            for emb_name, emb_vec in node.embeddings.items():
                 if emb_name not in all_embeddings:
-                    all_embeddings[emb_name] = (emb_vec, metric)
+                    all_embeddings[emb_name] = emb_vec
 
         # Ensure graph type exists with required schema
         await self._ensure_graph_type_for_nodes(
@@ -240,18 +245,11 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 formatted_value = self._format_value(prop_value)
                 prop_assignments.append(f"{sanitized}: {formatted_value}")
 
-            # Add embeddings with companion metric property
-            for emb_name, (emb_vec, metric) in node.embeddings.items():
+            for emb_name, emb_vec in node.embeddings.items():
                 mangled = mangle_embedding_name(emb_name)
                 sanitized = self._sanitize_name(mangled)
                 vec_literal = self._vector_to_gql_literal(emb_vec)
                 prop_assignments.append(f"{sanitized}: {vec_literal}")
-                # Store metric as companion STRING property (mirrors Neo4j pattern)
-                metric_prop = self._similarity_metric_property_name(emb_name)
-                mangled_metric = mangle_property_name(metric_prop)
-                sanitized_metric = self._sanitize_name(mangled_metric)
-                metric_value = self._format_value(metric.value)
-                prop_assignments.append(f"{sanitized_metric}: {metric_value}")
 
             insert_stmt = f"""
             INSERT (n@{sanitized_collection} {{
@@ -264,26 +262,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         current_count = self._collection_node_counts.get(collection, 0)
         new_count = current_count + len(nodes_list)
         self._collection_node_counts[collection] = new_count
-
-        # Check if we should create indexes
-        if (
-            self._vector_index_threshold
-            and new_count >= self._vector_index_threshold
-            and current_count < self._vector_index_threshold
-        ):
-            # Create vector indexes
-            for emb_name, (emb_vec, metric) in all_embeddings.items():
-                task = asyncio.create_task(
-                    self._create_vector_index_if_not_exists(
-                        EntityType.NODE,
-                        collection,
-                        emb_name,
-                        len(emb_vec),
-                        metric,
-                    )
-                )
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
 
         # Create range indexes based on configured hierarchies
         # Note: We don't create a range index on 'uid' because it's declared as PRIMARY KEY
@@ -330,7 +308,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
 
         # Collect all properties and embeddings from all edges
         all_properties: dict[str, PropertyValue] = {}
-        all_embeddings: dict[str, tuple[list[float], SimilarityMetric]] = {}
+        all_embeddings: dict[str, list[float]] = {}
 
         for edge in edges_list:
             all_properties.update(edge.properties)
@@ -363,18 +341,11 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 formatted_value = self._format_value(prop_value)
                 prop_assignments.append(f"{sanitized}: {formatted_value}")
 
-            # Build embedding assignments with companion metric property
-            for emb_name, (emb_vec, metric) in edge.embeddings.items():
+            for emb_name, emb_vec in edge.embeddings.items():
                 mangled = mangle_embedding_name(emb_name)
                 sanitized = self._sanitize_name(mangled)
                 vec_literal = self._vector_to_gql_literal(emb_vec)
                 prop_assignments.append(f"{sanitized}: {vec_literal}")
-                # Store metric as companion STRING property (mirrors Neo4j pattern)
-                metric_prop = self._similarity_metric_property_name(emb_name)
-                mangled_metric = mangle_property_name(metric_prop)
-                sanitized_metric = self._sanitize_name(mangled_metric)
-                metric_value = self._format_value(metric.value)
-                prop_assignments.append(f"{sanitized_metric}: {metric_value}")
 
             # Build INSERT statement with embedded values
             if prop_assignments:
@@ -397,26 +368,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         new_count = current_count + len(edges_list)
         self._relation_edge_counts[relation] = new_count
 
-        # Check if we should create indexes
-        if (
-            self._vector_index_threshold
-            and new_count >= self._vector_index_threshold
-            and current_count < self._vector_index_threshold
-        ):
-            # Create vector indexes for edge embeddings
-            for emb_name, (emb_vec, metric) in all_embeddings.items():
-                task = asyncio.create_task(
-                    self._create_vector_index_if_not_exists(
-                        EntityType.EDGE,
-                        relation,
-                        emb_name,
-                        len(emb_vec),
-                        metric,
-                    )
-                )
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
-
         # Create range indexes based on configured hierarchies when threshold is reached
         if (
             self._range_index_threshold
@@ -438,7 +389,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         collection: str,
         embedding_name: str,
         query_embedding: list[float],
-        similarity_metric: SimilarityMetric = SimilarityMetric.COSINE,
         limit: int | None = 100,
         property_filter: FilterExpr | None = None,
     ) -> list[Node]:
@@ -455,7 +405,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
             collection: Collection name to search
             embedding_name: Name of the embedding vector property
             query_embedding: Query vector
-            similarity_metric: COSINE or EUCLIDEAN
             limit: Maximum results to return
             property_filter: Optional property filter expression
 
@@ -465,121 +414,13 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         """
         await self._discover_existing_indexes()
 
-        sanitized_collection = self._sanitize_name(collection)
-        mangled_embedding = mangle_embedding_name(embedding_name)
-        sanitized_embedding = self._sanitize_name(mangled_embedding)
-
-        # Check if vector index exists
-        # Use mangled and sanitized embedding name to ensure valid identifier
-        index_name = f"idx_{sanitized_collection}_{sanitized_embedding}"
-        has_index = (
-            index_name in self._index_state_cache
-            and self._index_state_cache[index_name] == self.CacheIndexState.ONLINE
-        )
-
-        # Decide on search mode.
-        # ANN requires both a vector index AND a function that supports APPROXIMATE.
-        # cosine() is KNN-only in NebulaGraph, so COSINE must always use exact search.
-        metric_supports_ann = (
-            self._similarity_metric_to_nebula(similarity_metric) is not None
-        )
-        use_ann = (
-            has_index
-            and not self._force_exact_similarity_search
-            and metric_supports_ann
-        )
-
-        # Build WHERE clause from property filter
-        where_clause = ""
-        if property_filter:
-            where_clause = self._render_filter_expr("n", property_filter)
-
-        # Build query based on search mode
-        if use_ann:
-            # ANN search requires a finite limit (default to 1000 like Neo4j)
-            effective_limit = limit if limit is not None else 1000
-
-            # Use fudge factor when filtering to get more candidates
-            if property_filter:
-                search_limit = int(effective_limit * self._fudge_factor)
-            else:
-                search_limit = effective_limit
-
-            # Choose similarity function, order, and index metric
-            distance_func, order_dir = self._get_distance_func_and_order(
-                similarity_metric
-            )
-            metric_name = self._similarity_metric_to_nebula(similarity_metric)
-
-            # Build vector literal
-            vec_literal = self._vector_to_gql_literal(query_embedding)
-
-            # Build OPTIONS clause
-            if self._ann_index_type == "IVF":
-                options = (
-                    f"{{METRIC: {metric_name}, TYPE: IVF, NPROBE: {self._ivf_nprobe}}}"
-                )
-            else:  # HNSW
-                options = f"{{METRIC: {metric_name}, TYPE: HNSW, EFSEARCH: {self._hnsw_ef_search}}}"
-
-            # Build query
-            query_parts = [f"MATCH (n:{sanitized_collection})"]
-            if where_clause:
-                query_parts.append(f"WHERE {where_clause}")
-            query_parts.append(
-                f"ORDER BY {distance_func}(n.{sanitized_embedding}, {vec_literal}) {order_dir}"
-            )
-            query_parts.append("APPROXIMATE")
-            query_parts.append(f"LIMIT {search_limit}")
-            query_parts.append(f"OPTIONS {options}")
-            query_parts.append("RETURN n")
-
-            query = "\n".join(query_parts)
-
-            result = await self._client.execute(query)
-
-            # Convert results
-            nodes = []
-            for row in result:
-                node_data = row["n"]
-                # Unwrap ValueWrapper if needed
-                if hasattr(node_data, "cast_primitive"):
-                    node_data = node_data.cast_primitive()
-                    if "properties" in node_data:
-                        node_data = node_data["properties"]
-                nodes.append(self._nebula_result_to_node(collection, node_data))
-
-            # Check fallback threshold
-            if (
-                property_filter
-                and len(nodes) < (limit or 100) * self._fallback_threshold
-            ):
-                # Fall back to exact search
-                logger.info(
-                    "ANN search returned insufficient results (%s), falling back to exact search",
-                    len(nodes),
-                )
-                return await self._exact_similarity_search(
-                    collection=collection,
-                    embedding_name=embedding_name,
-                    query_embedding=query_embedding,
-                    similarity_metric=similarity_metric,
-                    limit=limit,
-                    property_filter=property_filter,
-                )
-
-            # Trim to requested limit
-            if limit and len(nodes) > limit:
-                nodes = nodes[:limit]
-
-            return nodes
-
-        # Exact search (no index or forced)
+        # NebulaGraph's cosine() is KNN-only -- APPROXIMATE is not supported for
+        # it, and no vector index metric serves it -- so with cosine the only
+        # similarity, search is always exact.
         return await self._exact_similarity_search(
             collection=collection,
             embedding_name=embedding_name,
             query_embedding=query_embedding,
-            similarity_metric=similarity_metric,
             limit=limit,
             property_filter=property_filter,
         )
@@ -590,7 +431,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         collection: str,
         embedding_name: str,
         query_embedding: list[float],
-        similarity_metric: SimilarityMetric,
         limit: int | None,
         property_filter: FilterExpr | None,
     ) -> list[Node]:
@@ -604,7 +444,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
             collection: Collection name
             embedding_name: Embedding property name
             query_embedding: Query vector
-            similarity_metric: COSINE or EUCLIDEAN
             limit: Maximum results
             property_filter: Optional filter
 
@@ -625,7 +464,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         vec_literal = self._vector_to_gql_literal(query_embedding)
 
         # Choose similarity function and order direction
-        distance_func, order_dir = self._get_distance_func_and_order(similarity_metric)
+        distance_func, order_dir = self._DISTANCE_FUNC_AND_ORDER
 
         # Build query (no APPROXIMATE keyword = exact search)
         query_parts = [f"MATCH (n:{sanitized_collection})"]
@@ -1097,21 +936,10 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
             for k, v in node_data.items()
         }
 
-        # Build set of metric companion mangled keys to exclude from regular properties
-        embedding_keys = {k for k in desanitized_data if is_mangled_embedding_name(k)}
-        metric_companion_keys = {
-            mangle_property_name(
-                self._similarity_metric_property_name(demangle_embedding_name(emb_key))
-            )
-            for emb_key in embedding_keys
-        }
-
         for key, value in desanitized_data.items():
             if key == "uid":
                 continue
             if is_mangled_property_name(key):
-                if key in metric_companion_keys:
-                    continue  # Skip metric companions - read alongside embeddings below
                 # Skip NULL values - they represent absent properties from schema evolution
                 # PropertyValue type does not include None, so we filter them out
                 if value is None:
@@ -1120,23 +948,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 properties[prop_name] = value
             elif is_mangled_embedding_name(key):
                 emb_name = demangle_embedding_name(key)
-
-                # Read metric from companion STRING property
-                metric_prop = self._similarity_metric_property_name(emb_name)
-                mangled_metric = mangle_property_name(metric_prop)
-                metric_str = desanitized_data.get(mangled_metric)
-                if metric_str is not None:
-                    try:
-                        sim_metric = SimilarityMetric(metric_str)
-                    except ValueError:
-                        logger.warning(
-                            "Unknown similarity metric '%s' for embedding '%s', defaulting to COSINE",
-                            metric_str,
-                            emb_name,
-                        )
-                        sim_metric = SimilarityMetric.COSINE
-                else:
-                    sim_metric = SimilarityMetric.COSINE  # fallback for legacy data
 
                 # Extract vector value
                 vec = None
@@ -1150,7 +961,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                     logger.warning("Unexpected embedding value type: %s", type(value))
 
                 if vec is not None:
-                    embeddings[emb_name] = (vec, sim_metric)
+                    embeddings[emb_name] = vec
 
         return Node(
             uid=uid,
@@ -1422,86 +1233,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         vec_str = ", ".join(str(v) for v in vec)
         return f"VECTOR<{len(vec)}, FLOAT>([{vec_str}])"
 
-    @staticmethod
-    def _similarity_metric_property_name(embedding_name: str) -> str:
-        """
-        Return the companion property name for storing an embedding's similarity metric.
-
-        Args:
-            embedding_name: Demangled embedding name
-
-        Returns:
-            Property name for the metric companion (e.g., "similarity_metric_for_vec")
-
-        """
-        # Use hash for long embedding names to avoid exceeding NebulaGraph's
-        # 127 character identifier limit after mangling and sanitization
-        if len(embedding_name) > 30:
-            name_hash = hashlib.sha256(embedding_name.encode()).hexdigest()[:16]
-            return f"sim_metric_{name_hash}"
-        return f"similarity_metric_for_{embedding_name}"
-
-    @staticmethod
-    def _similarity_metric_to_nebula(metric: SimilarityMetric) -> str | None:
-        """
-        Convert SimilarityMetric to NebulaGraph vector index METRIC option.
-
-        NebulaGraph vector indexes support only L2 (Euclidean distance) and
-        IP (Inner Product). MANHATTAN has no equivalent index type and returns
-        None, signalling that no vector index can be created for that metric.
-
-        Args:
-            metric: Similarity metric
-
-        Returns:
-            NebulaGraph METRIC string ("L2" or "IP"), or None if not indexable.
-
-        """
-        if metric == SimilarityMetric.EUCLIDEAN:
-            return "L2"
-        if metric == SimilarityMetric.DOT:
-            # Dot product == inner product; IP indexes support ANN for this metric.
-            return "IP"
-        # COSINE: cosine() is KNN-only in NebulaGraph — APPROXIMATE is not supported,
-        # so no vector index can be created for cosine similarity.
-        # MANHATTAN: no NebulaGraph vector index type exists.
-        # Both return None to signal that no vector index should be created.
-        return None
-
-    @staticmethod
-    def _get_distance_func_and_order(metric: SimilarityMetric) -> tuple[str, str]:
-        """
-        Return the GQL distance function name and ORDER BY direction for a metric.
-
-        NebulaGraph supports three distance functions:
-        - euclidean(): KNN and ANN (with L2 index)
-        - inner_product(): KNN and ANN (with IP index)
-        - cosine(): KNN only — APPROXIMATE is not supported for this function
-
-        MANHATTAN has no native NebulaGraph distance function and raises ValueError.
-
-        Args:
-            metric: Similarity metric
-
-        Returns:
-            (distance_function_name, order_direction) e.g. ("euclidean", "ASC")
-
-        Raises:
-            ValueError: If the metric has no native NebulaGraph distance function.
-
-        """
-        if metric == SimilarityMetric.EUCLIDEAN:
-            return "euclidean", "ASC"
-        if metric == SimilarityMetric.DOT:
-            return "inner_product", "DESC"
-        if metric == SimilarityMetric.COSINE:
-            # cosine() is KNN-only; callers must not use APPROXIMATE with this function.
-            return "cosine", "DESC"
-        raise ValueError(
-            f"Similarity metric '{metric.value}' is not supported by NebulaGraph. "
-            "Supported metrics: COSINE, DOT, EUCLIDEAN."
-        )
-
     def _render_filter_expr(
         self,
         node_alias: str,
@@ -1656,7 +1387,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         self,
         collection: str,
         properties: dict[str, PropertyValue],
-        embeddings: dict[str, tuple[list[float], SimilarityMetric]],
+        embeddings: dict[str, list[float]],
     ) -> None:
         """
         Ensure node type exists in graph type for this collection.
@@ -1686,15 +1417,10 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 sanitized = self._sanitize_name(mangled)
                 incoming_schema[sanitized] = self._infer_gql_type(prop_value)
 
-            for emb_name, (vec, _metric) in embeddings.items():
+            for emb_name, vec in embeddings.items():
                 mangled = mangle_embedding_name(emb_name)
                 sanitized = self._sanitize_name(mangled)
                 incoming_schema[sanitized] = f"VECTOR<{len(vec)}, FLOAT>"
-                # Add companion STRING property to persist the similarity metric
-                metric_prop = self._similarity_metric_property_name(emb_name)
-                mangled_metric = mangle_property_name(metric_prop)
-                sanitized_metric = self._sanitize_name(mangled_metric)
-                incoming_schema[sanitized_metric] = "STRING"
 
             # Check if node type already exists in cache
             if collection in self._graph_type_schemas:
@@ -1767,7 +1493,7 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         source_collection: str,
         target_collection: str,
         properties: dict[str, PropertyValue],
-        embeddings: dict[str, tuple[list[float], SimilarityMetric]],
+        embeddings: dict[str, list[float]],
     ) -> None:
         """
         Ensure edge type exists in graph type for this relation.
@@ -1802,15 +1528,10 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
                 sanitized = self._sanitize_name(mangled)
                 incoming_schema[sanitized] = self._infer_gql_type(prop_value)
 
-            for emb_name, (vec, _metric) in embeddings.items():
+            for emb_name, vec in embeddings.items():
                 mangled = mangle_embedding_name(emb_name)
                 sanitized = self._sanitize_name(mangled)
                 incoming_schema[sanitized] = f"VECTOR<{len(vec)}, FLOAT>"
-                # Add companion STRING property to persist the similarity metric
-                metric_prop = self._similarity_metric_property_name(emb_name)
-                mangled_metric = mangle_property_name(metric_prop)
-                sanitized_metric = self._sanitize_name(mangled_metric)
-                incoming_schema[sanitized_metric] = "STRING"
 
             # Check if edge type already exists in cache
             if edge_key in self._graph_type_schemas:
@@ -1877,110 +1598,6 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
 
             # Cache the schema
             self._graph_type_schemas[edge_key] = incoming_schema
-
-    async def _create_vector_index_if_not_exists(
-        self,
-        entity_type: EntityType,
-        node_or_edge_type: str,
-        embedding_name: str,
-        dimensions: int,
-        similarity_metric: SimilarityMetric,
-    ) -> None:
-        """
-        Create vector index if it doesn't exist.
-
-        Args:
-            entity_type: NODE or EDGE
-            node_or_edge_type: Type name
-            embedding_name: Embedding property name
-            dimensions: Vector dimensions
-            similarity_metric: COSINE, DOT, or EUCLIDEAN (MANHATTAN is not supported)
-
-        """
-        # NebulaGraph only supports L2 and IP index metrics.
-        # COSINE (KNN-only) and MANHATTAN have no ANN-capable index; skip creation so search falls back to KNN.
-        nebula_metric = self._similarity_metric_to_nebula(similarity_metric)
-        if nebula_metric is None:
-            logger.warning(
-                "Skipping vector index creation for '%s' on '%s': "
-                "metric '%s' is not supported by NebulaGraph ANN indexes "
-                "(ANN-supported metrics: EUCLIDEAN/L2, DOT/IP). "
-                "Search will use exact KNN instead.",
-                embedding_name,
-                node_or_edge_type,
-                similarity_metric.value,
-            )
-            return
-
-        # Use mangled and sanitized embedding name to ensure valid identifier
-        mangled_embedding = mangle_embedding_name(embedding_name)
-        index_name = f"idx_{self._sanitize_name(node_or_edge_type)}_{self._sanitize_name(mangled_embedding)}"
-
-        # Check cache
-        if index_name in self._index_state_cache:
-            return
-
-        # Acquire lock for this index
-        if index_name not in self._index_locks:
-            self._index_locks[index_name] = asyncio.Lock()
-
-        async with self._index_locks[index_name]:
-            # Double-check after acquiring lock
-            if index_name in self._index_state_cache:
-                return
-
-            # Mark as creating
-            self._index_state_cache[index_name] = self.CacheIndexState.CREATING
-
-            try:
-                sanitized_type = self._sanitize_name(node_or_edge_type)
-                sanitized_embedding = self._sanitize_name(mangled_embedding)
-                metric = nebula_metric
-
-                # Build index options based on type
-                if self._ann_index_type == "IVF":
-                    options = f"""{{
-                        DIM: {dimensions},
-                        METRIC: {metric},
-                        TYPE: IVF,
-                        NLIST: {self._ivf_nlist},
-                        TRAINSIZE: 10000
-                    }}"""
-                else:  # HNSW
-                    options = f"""{{
-                        DIM: {dimensions},
-                        METRIC: {metric},
-                        TYPE: HNSW,
-                        MAXDEGREE: {self._hnsw_max_degree},
-                        EFCONSTRUCTION: {self._hnsw_ef_construction},
-                        CAPACITY: 1000000
-                    }}"""
-
-                # Create index (use sanitized embedding name for valid GQL identifier)
-                if entity_type == EntityType.NODE:
-                    create_stmt = f"""
-                    CREATE VECTOR INDEX IF NOT EXISTS {index_name}
-                    ON NODE {sanitized_type}::{sanitized_embedding}
-                    OPTIONS {options}
-                    """
-                else:  # EDGE
-                    create_stmt = f"""
-                    CREATE VECTOR INDEX IF NOT EXISTS {index_name}
-                    ON EDGE {sanitized_type}::{sanitized_embedding}
-                    OPTIONS {options}
-                    """
-
-                await self._client.execute(create_stmt)
-
-                # Mark as online
-                self._index_state_cache[index_name] = self.CacheIndexState.ONLINE
-                logger.info("Created vector index: %s", index_name)
-
-            except Exception:
-                # Remove from cache on error
-                self._index_state_cache.pop(index_name, None)
-                logger.exception("Failed to create vector index %s", index_name)
-                raise
 
     async def _create_range_index_if_not_exists(
         self,

--- a/packages/server/src/memmachine_server/common/vector_graph_store/neo4j_vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/neo4j_vector_graph_store.py
@@ -20,7 +20,6 @@ from pydantic import BaseModel, Field, InstanceOf
 from memmachine_server.common.data_types import (
     FilterValue,
     OrderedValue,
-    SimilarityMetric,
 )
 from memmachine_server.common.filter.filter_parser import (
     And as FilterAnd,
@@ -234,7 +233,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
             sanitized_collection = Neo4jVectorGraphStore._sanitize_name(collection)
             sanitized_embedding_names = set()
             embedding_dimensions_by_name: dict[str, int] = {}
-            embedding_similarity_by_name: dict[str, SimilarityMetric] = {}
 
             query_nodes = []
             for node in nodes:
@@ -245,33 +243,15 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                     },
                 )
 
-                for embedding_name, (
-                    embedding,
-                    similarity_metric,
-                ) in node.embeddings.items():
+                for embedding_name, embedding in node.embeddings.items():
                     sanitized_embedding_name = Neo4jVectorGraphStore._sanitize_name(
                         mangle_embedding_name(embedding_name),
                     )
-                    sanitized_similarity_metric_name = (
-                        Neo4jVectorGraphStore._sanitize_name(
-                            Neo4jVectorGraphStore._similarity_metric_property_name(
-                                embedding_name,
-                            ),
-                        )
-                    )
-
                     sanitized_embedding_names.add(sanitized_embedding_name)
                     embedding_dimensions_by_name[sanitized_embedding_name] = len(
                         embedding,
                     )
-                    embedding_similarity_by_name[sanitized_embedding_name] = (
-                        similarity_metric
-                    )
-
                     query_node_properties[sanitized_embedding_name] = embedding
-                    query_node_properties[sanitized_similarity_metric_name] = (
-                        similarity_metric.value
-                    )
 
                 query_node: dict[str, PropertyValue | dict[str, PropertyValue]] = {
                     "uid": str(node.uid),
@@ -325,9 +305,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                                     dimensions=embedding_dimensions_by_name[
                                         sanitized_embedding_name
                                     ],
-                                    similarity_metric=embedding_similarity_by_name[
-                                        sanitized_embedding_name
-                                    ],
                                 ),
                             )
                         )
@@ -349,7 +326,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
             sanitized_relation = Neo4jVectorGraphStore._sanitize_name(relation)
             sanitized_embedding_names = set()
             embedding_dimensions_by_name: dict[str, int] = {}
-            embedding_similarity_by_name: dict[str, SimilarityMetric] = {}
 
             query_edges = []
             for edge in edges:
@@ -360,33 +336,15 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                     },
                 )
 
-                for embedding_name, (
-                    embedding,
-                    similarity_metric,
-                ) in edge.embeddings.items():
+                for embedding_name, embedding in edge.embeddings.items():
                     sanitized_embedding_name = Neo4jVectorGraphStore._sanitize_name(
                         mangle_embedding_name(embedding_name),
                     )
-                    sanitized_similarity_metric_name = (
-                        Neo4jVectorGraphStore._sanitize_name(
-                            Neo4jVectorGraphStore._similarity_metric_property_name(
-                                embedding_name,
-                            ),
-                        )
-                    )
-
                     sanitized_embedding_names.add(sanitized_embedding_name)
                     embedding_dimensions_by_name[sanitized_embedding_name] = len(
                         embedding,
                     )
-                    embedding_similarity_by_name[sanitized_embedding_name] = (
-                        similarity_metric
-                    )
-
                     query_edge_properties[sanitized_embedding_name] = embedding
-                    query_edge_properties[sanitized_similarity_metric_name] = (
-                        similarity_metric.value
-                    )
 
                 query_edge = {
                     "uid": str(edge.uid),
@@ -453,9 +411,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                                     dimensions=embedding_dimensions_by_name[
                                         sanitized_embedding_name
                                     ],
-                                    similarity_metric=embedding_similarity_by_name[
-                                        sanitized_embedding_name
-                                    ],
                                 ),
                             )
                         )
@@ -466,7 +421,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
         collection: str,
         embedding_name: str,
         query_embedding: list[float],
-        similarity_metric: SimilarityMetric = SimilarityMetric.COSINE,
         limit: int | None = 100,
         property_filter: FilterExpr | None = None,
     ) -> list[Node]:
@@ -511,10 +465,10 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                     "CALL db.index.vector.queryNodes(\n"
                     "    $vector_index_name, $query_limit, $query_embedding\n"
                     ")\n"
-                    "YIELD node AS n, score AS similarity\n"
+                    "YIELD node AS n, score AS cosine_similarity\n"
                     f"WHERE {query_filter_string}\n"
                     "RETURN n\n"
-                    "ORDER BY similarity DESC\n"
+                    "ORDER BY cosine_similarity DESC\n"
                     "LIMIT $limit"
                 )
 
@@ -539,13 +493,7 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                     do_exact_similarity_search = True
 
             if do_exact_similarity_search:
-                match similarity_metric:
-                    case SimilarityMetric.COSINE:
-                        vector_similarity_function = "vector.similarity.cosine"
-                    case SimilarityMetric.EUCLIDEAN:
-                        vector_similarity_function = "vector.similarity.euclidean"
-                    case _:
-                        vector_similarity_function = "vector.similarity.cosine"
+                vector_similarity_function = "vector.similarity.cosine"
 
                 query = (
                     f"MATCH (n:{sanitized_collection})\n"
@@ -554,9 +502,9 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                     "WITH n,"
                     f"    {vector_similarity_function}("
                     f"        n.{sanitized_embedding_name}, $query_embedding"
-                    "    ) AS similarity\n"
+                    "    ) AS cosine_similarity\n"
                     "RETURN n\n"
-                    "ORDER BY similarity DESC\n"
+                    "ORDER BY cosine_similarity DESC\n"
                     f"{'LIMIT $limit' if limit is not None else ''}"
                 )
 
@@ -1067,7 +1015,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
         sanitized_collection_or_relation: str,
         sanitized_embedding_name: str,
         dimensions: int,
-        similarity_metric: SimilarityMetric = SimilarityMetric.COSINE,
     ) -> None:
         """Create a vector index if missing and wait for it to be online."""
         if not (1 <= dimensions <= 4096):
@@ -1100,14 +1047,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                 Neo4jVectorGraphStore.CacheIndexState.CREATING
             )
 
-            match similarity_metric:
-                case SimilarityMetric.COSINE:
-                    similarity_function = "cosine"
-                case SimilarityMetric.EUCLIDEAN:
-                    similarity_function = "euclidean"
-                case _:
-                    similarity_function = "cosine"
-
             match entity_type:
                 case EntityType.NODE:
                     query_index_for_expression = (
@@ -1134,7 +1073,7 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                     "}"
                 ),
                 dimensions=dimensions,
-                similarity_function=similarity_function,
+                similarity_function="cosine",
             )
 
             await self._await_create_index_if_not_exists(
@@ -1219,20 +1158,6 @@ class Neo4jVectorGraphStore(VectorGraphStore):
         )
 
     @staticmethod
-    def _similarity_metric_property_name(embedding_name: str) -> str:
-        """
-        Get the similarity metric property name for an embedding.
-
-        Args:
-            embedding_name (str): The name of the embedding.
-
-        Returns:
-            str: The similarity metric property name.
-
-        """
-        return f"similarity_metric_for_{embedding_name}"
-
-    @staticmethod
     def _nodes_from_neo4j_nodes(
         neo4j_nodes: Iterable[Neo4jNode],
     ) -> list[Node]:
@@ -1267,21 +1192,7 @@ class Neo4jVectorGraphStore(VectorGraphStore):
                         list[float],
                         value_from_neo4j(neo4j_property_value),
                     )
-                    similarity_metric = SimilarityMetric(
-                        value_from_neo4j(
-                            neo4j_node[
-                                Neo4jVectorGraphStore._sanitize_name(
-                                    Neo4jVectorGraphStore._similarity_metric_property_name(
-                                        embedding_name,
-                                    ),
-                                )
-                            ],
-                        ),
-                    )
-                    node_embeddings[embedding_name] = (
-                        embedding_value,
-                        similarity_metric,
-                    )
+                    node_embeddings[embedding_name] = embedding_value
 
             nodes.append(
                 Node(

--- a/packages/server/src/memmachine_server/common/vector_graph_store/vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/vector_graph_store.py
@@ -8,7 +8,7 @@ and deleting nodes and edges.
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 
-from memmachine_server.common.data_types import OrderedValue, SimilarityMetric
+from memmachine_server.common.data_types import OrderedValue
 from memmachine_server.common.filter.filter_parser import (
     FilterExpr,
 )
@@ -70,7 +70,6 @@ class VectorGraphStore(ABC):
         collection: str,
         embedding_name: str,
         query_embedding: list[float],
-        similarity_metric: SimilarityMetric = SimilarityMetric.COSINE,
         limit: int | None = 100,
         property_filter: FilterExpr | None = None,
     ) -> list[Node]:
@@ -84,9 +83,6 @@ class VectorGraphStore(ABC):
                 The name of the embedding vector property.
             query_embedding (list[float]):
                 The embedding vector to compare against.
-            similarity_metric (SimilarityMetric):
-                The similarity metric to use
-                (default: SimilarityMetric.COSINE).
             limit (int | None):
                 Maximum number of similar nodes to return.
                 If None, return as many similar nodes as possible

--- a/packages/server/src/memmachine_server/common/vector_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_store/data_types.py
@@ -9,7 +9,6 @@ from memmachine_server.common.data_types import (
     PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE,
     PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME,
     PropertyValue,
-    SimilarityMetric,
 )
 
 from .utils import validate_identifier
@@ -22,14 +21,11 @@ class VectorStoreCollectionConfig(BaseModel):
     Attributes:
         vector_dimensions (int):
             Dimensionality of vectors stored in the collection.
-        similarity_metric (SimilarityMetric):
-            Metric used to compare vectors.
         indexed_properties_schema (dict[str, type[PropertyValue]]):
             Schema suggesting which properties should be indexed for filtering.
     """
 
     vector_dimensions: int
-    similarity_metric: SimilarityMetric = SimilarityMetric.COSINE
     indexed_properties_schema: dict[str, type[PropertyValue]] = Field(
         default_factory=dict
     )
@@ -117,7 +113,8 @@ class Record(BaseModel):
         vector (list[float] | None):
             Vector for similarity search.
             `None` is not allowed on input.
-            `None` on output means the vector was not requested (`return_vector=False`)
+            Always `None` on output: a collection stores vectors to search
+            them, and does not read them back out
             (default: None).
         properties (dict[str, PropertyValue] | None):
             Property key-value pairs.
@@ -153,20 +150,14 @@ class QueryMatch(BaseModel):
     A single vector store query match.
 
     Attributes:
-        score (float):
-            The meaning depends on the collection's `SimilarityMetric`:
-            - *cosine*: cosine similarity in [-1, 1].
-            - *dot*: raw dot product [0, inf).
-            - *euclidean*: Euclidean distance [0, inf).
-            - *manhattan*: Manhattan distance [0, inf).
-
-            Use `SimilarityMetric.higher_is_better` to determine which
-            direction indicates a better match.
+        cosine_similarity (float):
+            Cosine similarity between the query vector and the matched
+            record's vector, in [-1, 1]. Higher is a better match.
         record (Record):
             The matched record.
     """
 
-    score: float
+    cosine_similarity: float
     record: Record
 
 

--- a/packages/server/src/memmachine_server/common/vector_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_store/data_types.py
@@ -105,21 +105,21 @@ class VectorStoreCollectionConfigMismatchError(Exception):
 
 class Record(BaseModel):
     """
-    A record in the vector store.
+    A record to write to a vector store collection.
+
+    Records are only ever written. A collection stores vectors to search
+    them and properties to filter on them, and answers a query with
+    `QueryMatch`; neither a vector nor a property is read back out.
 
     Attributes:
         uuid (UUID):
             Unique identifier for the record.
         vector (list[float] | None):
-            Vector for similarity search.
-            `None` is not allowed on input.
-            Always `None` on output: a collection stores vectors to search
-            them, and does not read them back out
+            Vector for similarity search. Required; `None` is rejected
             (default: None).
         properties (dict[str, PropertyValue] | None):
             Property key-value pairs.
-            Use `{}` to represent missing properties; `None` on input is treated as `{}`.
-            `None` on output means the properties were not requested (`return_properties=False`)
+            Use `{}` to represent missing properties; `None` is treated as `{}`
             (default: None).
     """
 
@@ -153,12 +153,12 @@ class QueryMatch(BaseModel):
         cosine_similarity (float):
             Cosine similarity between the query vector and the matched
             record's vector, in [-1, 1]. Higher is a better match.
-        record (Record):
-            The matched record.
+        record_uuid (UUID):
+            UUID of the matched record.
     """
 
     cosine_similarity: float
-    record: Record
+    record_uuid: UUID
 
 
 class QueryResult(BaseModel):

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field, InstanceOf
 from pymilvus import DataType, MilvusClient
 from pymilvus.exceptions import MilvusException
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     And as FilterAnd,
 )
@@ -41,7 +41,7 @@ from memmachine_server.common.properties_json import (
     decode_properties,
     encode_properties,
 )
-from memmachine_server.common.utils import compute_similarity, ensure_tz_aware
+from memmachine_server.common.utils import compute_cosine_similarity, ensure_tz_aware
 
 from .data_types import (
     QueryMatch,
@@ -136,18 +136,6 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         return f"{field} {operator} {_literal(comparison.value)}"
 
     @staticmethod
-    def _passes_threshold(
-        score: float,
-        threshold: float | None,
-        similarity_metric: SimilarityMetric,
-    ) -> bool:
-        if threshold is None:
-            return True
-        if similarity_metric.higher_is_better:
-            return score >= threshold
-        return score <= threshold
-
-    @staticmethod
     def _primary_id(partition_key: str, record_uuid: UUID) -> str:
         """Build a native primary key unique within a shared native collection."""
         return f"{partition_key}:{record_uuid}"
@@ -200,16 +188,9 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
     def _parse_record(
         entity: Mapping[str, Any],
         *,
-        return_vector: bool,
         return_properties: bool,
     ) -> Record:
         """Parse a Milvus entity into a vector store record."""
-        vector: list[float] | None = None
-        if return_vector:
-            raw_vector = entity.get(_VECTOR_FIELD)
-            if raw_vector is not None:
-                vector = list(cast(Sequence[float], raw_vector))
-
         properties: dict[str, PropertyValue] | None = None
         if return_properties:
             properties = decode_properties(
@@ -218,33 +199,27 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
 
         return Record(
             uuid=UUID(str(entity[_RECORD_UUID_FIELD])),
-            vector=vector,
             properties=properties,
         )
 
-    def _output_fields(
-        self, *, return_vector: bool, return_properties: bool
-    ) -> list[str]:
-        fields = [_RECORD_UUID_FIELD]
-        if return_vector:
-            fields.append(_VECTOR_FIELD)
+    def _output_fields(self, *, return_properties: bool) -> list[str]:
+        # The vector always comes back: search scores are recomputed from it.
+        fields = [_RECORD_UUID_FIELD, _VECTOR_FIELD]
         if return_properties:
             fields.append(_PROPERTIES_FIELD)
         return fields
 
     @staticmethod
-    def _score_from_entity_vector(
+    def _cosine_similarity_from_entity_vector(
         query_vector: Sequence[float],
         entity: Mapping[str, Any],
-        similarity_metric: SimilarityMetric,
     ) -> float:
         raw_vector = entity.get(_VECTOR_FIELD)
         if raw_vector is None:
             raise ValueError("Milvus search result did not include the vector field")
-        return compute_similarity(
+        return compute_cosine_similarity(
             list(query_vector),
             [list(cast(Sequence[float], raw_vector))],
-            similarity_metric,
         )[0]
 
     def _partition_filter(self) -> str:
@@ -278,9 +253,8 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         *,
         query_vectors: Iterable[Sequence[float]],
         limit: int,
-        score_threshold: float | None = None,
+        min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         """Query for records matching the criteria by query vectors."""
@@ -308,7 +282,6 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
                 # returns it as similarity. Fetch vectors and compute scores
                 # locally so MemMachine score semantics stay consistent.
                 output_fields=self._output_fields(
-                    return_vector=True,
                     return_properties=return_properties,
                 ),
                 anns_field=_VECTOR_FIELD,
@@ -321,78 +294,85 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
                 matches: list[QueryMatch] = []
                 for raw_match in raw_matches:
                     entity = cast(Mapping[str, Any], raw_match["entity"])
-                    score = self._score_from_entity_vector(
+                    cosine_similarity = self._cosine_similarity_from_entity_vector(
                         query_vector,
                         entity,
-                        self._config.similarity_metric,
                     )
-                    if not self._passes_threshold(
-                        score, score_threshold, self._config.similarity_metric
+                    if (
+                        min_cosine_similarity is not None
+                        and cosine_similarity < min_cosine_similarity
                     ):
                         continue
 
                     matches.append(
                         QueryMatch(
-                            score=score,
+                            cosine_similarity=cosine_similarity,
                             record=self._parse_record(
                                 entity,
-                                return_vector=return_vector,
                                 return_properties=return_properties,
                             ),
                         )
                     )
 
-                matches.sort(
-                    key=lambda match: match.score,
-                    reverse=self._config.similarity_metric.higher_is_better,
-                )
+                matches.sort(key=lambda match: match.cosine_similarity, reverse=True)
                 results.append(QueryResult(matches=matches))
 
             return results
 
     @override
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        """Get records from the collection by their UUIDs."""
-        async with self._tracker("get"):
-            uuid_list = list(record_uuids)
-            if not uuid_list:
-                return []
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        """Replace the properties of records already in the collection."""
+        async with self._tracker("set_properties"):
+            if not record_properties:
+                return
 
+            uuid_list = list(record_properties)
             primary_ids = [
                 self._primary_id(self._partition_key, uuid) for uuid in uuid_list
             ]
+
+            # Milvus has no partial update: an upsert writes the whole row, so
+            # the vector has to be read back to be written again unchanged. A
+            # row Milvus does not hold is skipped rather than inserted without
+            # a vector.
             raw_records = await asyncio.to_thread(
                 self._client.get,
                 collection_name=self._collection_name,
                 ids=primary_ids,
-                output_fields=self._output_fields(
-                    return_vector=return_vector,
-                    return_properties=return_properties,
-                ),
+                output_fields=[_RECORD_UUID_FIELD, _VECTOR_FIELD],
             )
-
-            records_by_uuid = {
-                record.uuid: record
-                for record in (
-                    self._parse_record(
-                        cast(Mapping[str, Any], raw_record),
-                        return_vector=return_vector,
-                        return_properties=return_properties,
-                    )
-                    for raw_record in raw_records
+            vectors_by_uuid = {
+                UUID(str(raw[_RECORD_UUID_FIELD])): list(
+                    cast(Sequence[float], raw[_VECTOR_FIELD])
                 )
+                for raw in (cast(Mapping[str, Any], r) for r in raw_records)
             }
-            return [
-                records_by_uuid[record_uuid]
+
+            entities = [
+                self._build_entity(
+                    Record(
+                        uuid=record_uuid,
+                        vector=vectors_by_uuid[record_uuid],
+                        properties=dict(record_properties[record_uuid]),
+                    )
+                )
                 for record_uuid in uuid_list
-                if record_uuid in records_by_uuid
+                if record_uuid in vectors_by_uuid
             ]
+            if not entities:
+                return
+
+            def _upsert() -> None:
+                self._client.upsert(
+                    collection_name=self._collection_name,
+                    data=entities,
+                )
+
+            await asyncio.to_thread(_upsert)
 
     @override
     async def delete(
@@ -442,15 +422,10 @@ class MilvusVectorStoreParams(BaseModel):
 class MilvusVectorStore(VectorStore):
     """Asynchronous Milvus-based implementation of VectorStore."""
 
-    _SIMILARITY_METRIC_TO_MILVUS_METRIC: ClassVar[dict[SimilarityMetric, str]] = {
-        SimilarityMetric.COSINE: "COSINE",
-        SimilarityMetric.DOT: "IP",
-        SimilarityMetric.EUCLIDEAN: "L2",
-    }
+    _MILVUS_METRIC_TYPE: ClassVar[str] = "COSINE"
 
     _REGISTRY_SUFFIX: ClassVar[str] = "__registry"
     _REGISTRY_VECTOR_DIMENSIONS: ClassVar[str] = "vector_dimensions"
-    _REGISTRY_SIMILARITY_METRIC: ClassVar[str] = "similarity_metric"
     _REGISTRY_INDEXED_PROPERTIES_SCHEMA: ClassVar[str] = "indexed_properties_schema"
     _REGISTRY_CONFIG: ClassVar[str] = "config"
 
@@ -485,21 +460,6 @@ class MilvusVectorStore(VectorStore):
         """Build a deterministic native collection name from namespace and config."""
         digest = hashlib.sha256(config.model_dump_json().encode()).hexdigest()
         return f"memmachine_{namespace}__{digest}"
-
-    @staticmethod
-    def _validate_metric(similarity_metric: SimilarityMetric) -> None:
-        if (
-            similarity_metric
-            not in MilvusVectorStore._SIMILARITY_METRIC_TO_MILVUS_METRIC
-        ):
-            supported = ", ".join(
-                metric.value
-                for metric in MilvusVectorStore._SIMILARITY_METRIC_TO_MILVUS_METRIC
-            )
-            raise ValueError(
-                f"Milvus only supports {supported} similarity metrics, "
-                f"got {similarity_metric.value!r}"
-            )
 
     def __init__(self, params: MilvusVectorStoreParams) -> None:
         """Initialize the vector store with the provided parameters."""
@@ -557,7 +517,7 @@ class MilvusVectorStore(VectorStore):
             index_params.add_index(
                 field_name=_VECTOR_FIELD,
                 index_type="AUTOINDEX",
-                metric_type="COSINE",
+                metric_type=MilvusVectorStore._MILVUS_METRIC_TYPE,
             )
 
             self._client.create_collection(
@@ -625,7 +585,6 @@ class MilvusVectorStore(VectorStore):
         """Parse a VectorStoreCollectionConfig from a registry entry."""
         return VectorStoreCollectionConfig(
             vector_dimensions=entry[MilvusVectorStore._REGISTRY_VECTOR_DIMENSIONS],
-            similarity_metric=entry[MilvusVectorStore._REGISTRY_SIMILARITY_METRIC],
             indexed_properties_schema=entry[
                 MilvusVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA
             ],
@@ -649,7 +608,6 @@ class MilvusVectorStore(VectorStore):
         self, namespace: str, config: VectorStoreCollectionConfig
     ) -> None:
         """Idempotently create the native Milvus collection."""
-        self._validate_metric(config.similarity_metric)
         native_collection_name = MilvusVectorStore._build_native_collection_name(
             namespace, config
         )
@@ -692,9 +650,7 @@ class MilvusVectorStore(VectorStore):
             index_params.add_index(
                 field_name=_VECTOR_FIELD,
                 index_type="AUTOINDEX",
-                metric_type=self._SIMILARITY_METRIC_TO_MILVUS_METRIC[
-                    config.similarity_metric
-                ],
+                metric_type=MilvusVectorStore._MILVUS_METRIC_TYPE,
             )
 
             self._client.create_collection(
@@ -724,7 +680,6 @@ class MilvusVectorStore(VectorStore):
                     _VECTOR_FIELD: [0.0] * _REGISTRY_VECTOR_DIMENSION,
                     self._REGISTRY_CONFIG: {
                         self._REGISTRY_VECTOR_DIMENSIONS: config.vector_dimensions,
-                        self._REGISTRY_SIMILARITY_METRIC: config.similarity_metric.value,
                         self._REGISTRY_INDEXED_PROPERTIES_SCHEMA: config.model_dump(
                             mode="json"
                         )["indexed_properties_schema"],
@@ -750,7 +705,6 @@ class MilvusVectorStore(VectorStore):
             raise ValueError(
                 f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
             )
-        self._validate_metric(config.similarity_metric)
         async with (
             self._client_name_locks[(namespace, name)],
             self._tracker("create_collection"),
@@ -778,7 +732,6 @@ class MilvusVectorStore(VectorStore):
             raise ValueError(
                 f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
             )
-        self._validate_metric(config.similarity_metric)
         async with (
             self._client_name_locks[(namespace, name)],
             self._tracker("open_or_create_collection"),

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -38,7 +38,6 @@ from memmachine_server.common.filter.filter_parser import (
 )
 from memmachine_server.common.metrics_factory import MetricsFactory, OperationTracker
 from memmachine_server.common.properties_json import (
-    decode_properties,
     encode_properties,
 )
 from memmachine_server.common.utils import compute_cosine_similarity, ensure_tz_aware
@@ -184,30 +183,9 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
             entity[_property_field(key)] = _normalize_property_filter_value(value)
         return entity
 
-    @staticmethod
-    def _parse_record(
-        entity: Mapping[str, Any],
-        *,
-        return_properties: bool,
-    ) -> Record:
-        """Parse a Milvus entity into a vector store record."""
-        properties: dict[str, PropertyValue] | None = None
-        if return_properties:
-            properties = decode_properties(
-                cast(Mapping | None, entity.get(_PROPERTIES_FIELD))
-            )
-
-        return Record(
-            uuid=UUID(str(entity[_RECORD_UUID_FIELD])),
-            properties=properties,
-        )
-
-    def _output_fields(self, *, return_properties: bool) -> list[str]:
+    def _output_fields(self) -> list[str]:
         # The vector always comes back: search scores are recomputed from it.
-        fields = [_RECORD_UUID_FIELD, _VECTOR_FIELD]
-        if return_properties:
-            fields.append(_PROPERTIES_FIELD)
-        return fields
+        return [_RECORD_UUID_FIELD, _VECTOR_FIELD]
 
     @staticmethod
     def _cosine_similarity_from_entity_vector(
@@ -255,7 +233,6 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         limit: int,
         min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_properties: bool = True,
     ) -> list[QueryResult]:
         """Query for records matching the criteria by query vectors."""
         async with self._tracker("query"):
@@ -281,9 +258,7 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
                 # Milvus Lite returns COSINE as distance, while Zilliz Cloud
                 # returns it as similarity. Fetch vectors and compute scores
                 # locally so MemMachine score semantics stay consistent.
-                output_fields=self._output_fields(
-                    return_properties=return_properties,
-                ),
+                output_fields=self._output_fields(),
                 anns_field=_VECTOR_FIELD,
             )
 
@@ -307,10 +282,7 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
                     matches.append(
                         QueryMatch(
                             cosine_similarity=cosine_similarity,
-                            record=self._parse_record(
-                                entity,
-                                return_properties=return_properties,
-                            ),
+                            record_uuid=UUID(str(entity[_RECORD_UUID_FIELD])),
                         )
                     )
 
@@ -318,61 +290,6 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
                 results.append(QueryResult(matches=matches))
 
             return results
-
-    @override
-    async def set_properties(
-        self,
-        *,
-        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
-    ) -> None:
-        """Replace the properties of records already in the collection."""
-        async with self._tracker("set_properties"):
-            if not record_properties:
-                return
-
-            uuid_list = list(record_properties)
-            primary_ids = [
-                self._primary_id(self._partition_key, uuid) for uuid in uuid_list
-            ]
-
-            # Milvus has no partial update: an upsert writes the whole row, so
-            # the vector has to be read back to be written again unchanged. A
-            # row Milvus does not hold is skipped rather than inserted without
-            # a vector.
-            raw_records = await asyncio.to_thread(
-                self._client.get,
-                collection_name=self._collection_name,
-                ids=primary_ids,
-                output_fields=[_RECORD_UUID_FIELD, _VECTOR_FIELD],
-            )
-            vectors_by_uuid = {
-                UUID(str(raw[_RECORD_UUID_FIELD])): list(
-                    cast(Sequence[float], raw[_VECTOR_FIELD])
-                )
-                for raw in (cast(Mapping[str, Any], r) for r in raw_records)
-            }
-
-            entities = [
-                self._build_entity(
-                    Record(
-                        uuid=record_uuid,
-                        vector=vectors_by_uuid[record_uuid],
-                        properties=dict(record_properties[record_uuid]),
-                    )
-                )
-                for record_uuid in uuid_list
-                if record_uuid in vectors_by_uuid
-            ]
-            if not entities:
-                return
-
-            def _upsert() -> None:
-                self._client.upsert(
-                    collection_name=self._collection_name,
-                    data=entities,
-                )
-
-            await asyncio.to_thread(_upsert)
 
     @override
     async def delete(

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -18,7 +18,6 @@ from qdrant_client.http.exceptions import ResponseHandlingException, UnexpectedR
 from memmachine_server.common.data_types import (
     OrderedValue,
     PropertyValue,
-    SimilarityMetric,
 )
 from memmachine_server.common.filter.filter_parser import (
     And as FilterAnd,
@@ -338,9 +337,8 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
         *,
         query_vectors: Iterable[Sequence[float]],
         limit: int,
-        score_threshold: float | None = None,
+        min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         """Query for records matching the criteria by query vectors."""
@@ -367,9 +365,9 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
                     shard_key=self._shard_key,
                     query=query_vector,
                     filter=qdrant_filter,
-                    score_threshold=score_threshold,
+                    score_threshold=min_cosine_similarity,
                     limit=limit,
-                    with_vector=return_vector,
+                    with_vector=False,
                     with_payload=return_properties,
                 )
                 for query_vector in query_vectors
@@ -384,20 +382,15 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
             for batch in batch_results:
                 matches: list[QueryMatch] = []
                 for point in batch.points:
-                    vector: list[float] | None = None
-                    if return_vector and point.vector is not None:
-                        vector = cast(list[float], point.vector)
-
                     properties: dict[str, PropertyValue] | None = None
                     if return_properties and point.payload is not None:
                         properties = self._parse_payload(point.payload)
 
                     matches.append(
                         QueryMatch(
-                            score=point.score,
+                            cosine_similarity=point.score,
                             record=Record(
                                 uuid=UUID(str(point.id)),
-                                vector=vector,
                                 properties=properties,
                             ),
                         ),
@@ -407,61 +400,34 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
             return query_results
 
     @override
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        """Get records from the collection by their UUIDs."""
-        async with self._tracker("get"):
-            uuid_list = list(record_uuids)
-            if not uuid_list:
-                return []
-
-            # Always get payload so we can check partition_key.
-            points = await self._client.retrieve(
-                collection_name=self._collection_name,
-                ids=list(uuid_list),
-                with_vectors=return_vector,
-                with_payload=True,
-                shard_key_selector=self._shard_key,
-            )
-
-            points_by_uuid: dict[UUID, models.Record] = {
-                UUID(str(point.id)): point
-                for point in points
-                if point.payload
-                and cast(dict[str, Any], point.payload).get(_PAYLOAD_PARTITION_KEY)
-                == self._partition_key
-            }
-
-            records: list[Record] = []
-            for point_uuid in uuid_list:
-                point = points_by_uuid.get(point_uuid)
-                if point is None:
-                    continue
-
-                vector: list[float] | None = None
-                if return_vector and point.vector is not None:
-                    vector = cast(list[float], point.vector)
-
-                properties: dict[str, PropertyValue] | None = None
-                if return_properties and point.payload is not None:
-                    properties = self._parse_payload(
-                        cast(dict[str, Any] | None, point.payload),
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        """Replace the properties of records already in the collection."""
+        async with self._tracker("set_properties"):
+            for record_uuid, properties in record_properties.items():
+                # Select by filter rather than by id: the id alone would reach a
+                # point another logical collection owns in the same native one,
+                # and an id list raises on an id the collection does not hold
+                # where a filter simply matches nothing, which is the contract.
+                selector = models.FilterSelector(
+                    filter=models.Filter(
+                        must=[
+                            _partition_filter(self._partition_key),
+                            models.HasIdCondition(has_id=[record_uuid]),
+                        ]
                     )
-
-                records.append(
-                    Record(
-                        uuid=point_uuid,
-                        vector=vector,
-                        properties=properties,
-                    ),
                 )
-
-            return records
+                # Overwrite rather than merge: the payload carries the partition
+                # key alongside the properties, so `_build_payload` puts it back.
+                await self._client.overwrite_payload(
+                    collection_name=self._collection_name,
+                    payload=cast(dict[str, Any], self._build_payload(dict(properties))),
+                    points=selector,
+                    shard_key_selector=self._shard_key,
+                )
 
     @override
     async def delete(
@@ -545,14 +511,7 @@ class QdrantVectorStoreParams(BaseModel):
 class QdrantVectorStore(VectorStore):
     """Asynchronous Qdrant-based implementation of VectorStore."""
 
-    _SIMILARITY_METRIC_TO_QDRANT_DISTANCE: ClassVar[
-        dict[SimilarityMetric, models.Distance]
-    ] = {
-        SimilarityMetric.COSINE: models.Distance.COSINE,
-        SimilarityMetric.DOT: models.Distance.DOT,
-        SimilarityMetric.EUCLIDEAN: models.Distance.EUCLID,
-        SimilarityMetric.MANHATTAN: models.Distance.MANHATTAN,
-    }
+    _QDRANT_DISTANCE: ClassVar[models.Distance] = models.Distance.COSINE
 
     _PROPERTY_TYPE_TO_INDEX_TYPE: ClassVar[
         dict[type[PropertyValue], models.PayloadSchemaType]
@@ -568,7 +527,6 @@ class QdrantVectorStore(VectorStore):
     _REGISTRY_SUFFIX: ClassVar[str] = "__registry"
     _REGISTRY_NAME: ClassVar[str] = "name"
     _REGISTRY_VECTOR_DIMENSIONS: ClassVar[str] = "vector_dimensions"
-    _REGISTRY_SIMILARITY_METRIC: ClassVar[str] = "similarity_metric"
     _REGISTRY_INDEXED_PROPERTIES_SCHEMA: ClassVar[str] = "indexed_properties_schema"
 
     # Fixed UUID namespace for deterministic registry point IDs.
@@ -711,7 +669,6 @@ class QdrantVectorStore(VectorStore):
         """Parse a VectorStoreCollectionConfig from a registry entry."""
         return VectorStoreCollectionConfig(
             vector_dimensions=entry[QdrantVectorStore._REGISTRY_VECTOR_DIMENSIONS],
-            similarity_metric=entry[QdrantVectorStore._REGISTRY_SIMILARITY_METRIC],
             indexed_properties_schema=entry[
                 QdrantVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA
             ],
@@ -739,9 +696,7 @@ class QdrantVectorStore(VectorStore):
         native_collection_name = QdrantVectorStore._build_native_collection_name(
             namespace, config
         )
-        distance = QdrantVectorStore._SIMILARITY_METRIC_TO_QDRANT_DISTANCE[
-            config.similarity_metric
-        ]
+        distance = QdrantVectorStore._QDRANT_DISTANCE
         # The collection and its indexes are created under separate guards. Sharing
         # one meant a collection that already existed - a second worker, or a retry
         # after a crash between the two calls - raised on create_collection, took
@@ -818,7 +773,6 @@ class QdrantVectorStore(VectorStore):
                     payload={
                         QdrantVectorStore._REGISTRY_NAME: name,
                         QdrantVectorStore._REGISTRY_VECTOR_DIMENSIONS: config.vector_dimensions,
-                        QdrantVectorStore._REGISTRY_SIMILARITY_METRIC: config.similarity_metric.value,
                         QdrantVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA: config.model_dump(
                             mode="json"
                         )["indexed_properties_schema"],

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -339,7 +339,6 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
         limit: int,
         min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_properties: bool = True,
     ) -> list[QueryResult]:
         """Query for records matching the criteria by query vectors."""
         async with self._tracker("query"):
@@ -368,7 +367,7 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
                     score_threshold=min_cosine_similarity,
                     limit=limit,
                     with_vector=False,
-                    with_payload=return_properties,
+                    with_payload=False,
                 )
                 for query_vector in query_vectors
             ]
@@ -380,54 +379,16 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
 
             query_results: list[QueryResult] = []
             for batch in batch_results:
-                matches: list[QueryMatch] = []
-                for point in batch.points:
-                    properties: dict[str, PropertyValue] | None = None
-                    if return_properties and point.payload is not None:
-                        properties = self._parse_payload(point.payload)
-
-                    matches.append(
-                        QueryMatch(
-                            cosine_similarity=point.score,
-                            record=Record(
-                                uuid=UUID(str(point.id)),
-                                properties=properties,
-                            ),
-                        ),
+                matches = [
+                    QueryMatch(
+                        cosine_similarity=point.score,
+                        record_uuid=UUID(str(point.id)),
                     )
+                    for point in batch.points
+                ]
                 query_results.append(QueryResult(matches=matches))
 
             return query_results
-
-    @override
-    async def set_properties(
-        self,
-        *,
-        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
-    ) -> None:
-        """Replace the properties of records already in the collection."""
-        async with self._tracker("set_properties"):
-            for record_uuid, properties in record_properties.items():
-                # Select by filter rather than by id: the id alone would reach a
-                # point another logical collection owns in the same native one,
-                # and an id list raises on an id the collection does not hold
-                # where a filter simply matches nothing, which is the contract.
-                selector = models.FilterSelector(
-                    filter=models.Filter(
-                        must=[
-                            _partition_filter(self._partition_key),
-                            models.HasIdCondition(has_id=[record_uuid]),
-                        ]
-                    )
-                )
-                # Overwrite rather than merge: the payload carries the partition
-                # key alongside the properties, so `_build_payload` puts it back.
-                await self._client.overwrite_payload(
-                    collection_name=self._collection_name,
-                    payload=cast(dict[str, Any], self._build_payload(dict(properties))),
-                    points=selector,
-                    shard_key_selector=self._shard_key,
-                )
 
     @override
     async def delete(

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -6,7 +6,6 @@ Partition keys are avoided in favor of per-collection tables,
 since sqlite-vec ANN indexes may not support them.
 """
 
-import struct
 from collections.abc import Iterable, Mapping, Sequence
 from typing import ClassVar, override
 from uuid import UUID
@@ -22,10 +21,12 @@ from sqlalchemy import (
     String,
     Table,
     Uuid,
+    bindparam,
     delete,
     event,
     select,
     text,
+    update,
 )
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine.interfaces import DBAPIConnection
@@ -33,7 +34,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase, MappedColumn, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
 from memmachine_server.common.properties_json import (
@@ -70,11 +71,6 @@ class _CollectionRow(BaseSQLiteVecVectorStore):
 class SQLiteVecVectorStoreCollection(VectorStoreCollection):
     """A logical collection backed by SQLite + sqlite-vec."""
 
-    _DISTANCE_FUNCTIONS: ClassVar[dict[SimilarityMetric, str]] = {
-        SimilarityMetric.COSINE: "vec_distance_cosine",
-        SimilarityMetric.EUCLIDEAN: "vec_distance_L2",
-    }
-
     def __init__(
         self,
         *,
@@ -89,8 +85,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         self._records_table = records_table
         self._vector_table_name = vector_table_name
 
-        self._similarity_metric = config.similarity_metric
-
     @property
     @override
     def config(self) -> VectorStoreCollectionConfig:
@@ -101,33 +95,9 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         return sqlite_vec.serialize_float32(list(vector))
 
     @staticmethod
-    def _deserialize_vector(data: bytes) -> list[float]:
-        count = len(data) // 4
-        return list(struct.unpack(f"={count}f", data))
-
-    @staticmethod
-    def _distance_to_score(
-        distance: float, similarity_metric: SimilarityMetric
-    ) -> float:
-        match similarity_metric:
-            case SimilarityMetric.COSINE:
-                return 1.0 - distance
-            case SimilarityMetric.EUCLIDEAN:
-                return distance
-            case _:
-                raise NotImplementedError(similarity_metric)
-
-    @staticmethod
-    def _threshold_to_max_distance(
-        threshold: float, similarity_metric: SimilarityMetric
-    ) -> float:
-        match similarity_metric:
-            case SimilarityMetric.COSINE:
-                return 1.0 - threshold
-            case SimilarityMetric.EUCLIDEAN:
-                return threshold
-            case _:
-                raise NotImplementedError(similarity_metric)
+    def _distance_to_cosine_similarity(distance: float) -> float:
+        """Convert a sqlite-vec cosine distance to a cosine similarity."""
+        return 1.0 - distance
 
     @override
     async def upsert(self, *, records: Iterable[Record]) -> None:
@@ -198,9 +168,8 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         *,
         query_vectors: Iterable[Sequence[float]],
         limit: int,
-        score_threshold: float | None = None,
+        min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         query_vectors = list(query_vectors)
@@ -237,9 +206,8 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
                 matches = await self._build_matches(
                     session=session,
                     rowid_to_distance=rowid_to_distance,
-                    score_threshold=score_threshold,
+                    min_cosine_similarity=min_cosine_similarity,
                     property_filter=property_filter,
-                    return_vector=return_vector,
                     return_properties=return_properties,
                 )
                 results.append(QueryResult(matches=matches))
@@ -250,9 +218,8 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         self,
         session: AsyncSession,
         rowid_to_distance: Mapping[int, float],
-        score_threshold: float | None,
+        min_cosine_similarity: float | None,
         property_filter: FilterExpr | None,
-        return_vector: bool,
         return_properties: bool,
     ) -> list[QueryMatch]:
         matched_rowids = list(rowid_to_distance.keys())
@@ -277,23 +244,16 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
 
         matched_rows = (await session.execute(fetch_records)).all()
 
-        rowid_to_vector: dict[int, list[float]] = {}
-        if return_vector:
-            rowid_to_vector = await self._fetch_vectors(
-                session, [row.rowid for row in matched_rows]
-            )
-
         matches: list[QueryMatch] = []
         for row in matched_rows:
             distance = rowid_to_distance.get(row.rowid)
             if distance is None:
                 continue
 
-            score = self._distance_to_score(distance, self._similarity_metric)
-            if score_threshold is not None and (
-                score < score_threshold
-                if self._similarity_metric.higher_is_better
-                else score > score_threshold
+            cosine_similarity = self._distance_to_cosine_similarity(distance)
+            if (
+                min_cosine_similarity is not None
+                and cosine_similarity < min_cosine_similarity
             ):
                 continue
 
@@ -301,92 +261,40 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
             if return_properties:
                 properties = decode_properties(row.properties)
 
-            vector: list[float] | None = None
-            if return_vector:
-                vector = rowid_to_vector.get(row.rowid)
-
             matches.append(
                 QueryMatch(
-                    score=score,
-                    record=Record(uuid=row.uuid, vector=vector, properties=properties),
+                    cosine_similarity=cosine_similarity,
+                    record=Record(uuid=row.uuid, properties=properties),
                 )
             )
 
-        matches.sort(
-            key=lambda match: match.score,
-            reverse=self._similarity_metric.higher_is_better,
-        )
+        matches.sort(key=lambda match: match.cosine_similarity, reverse=True)
         return matches
 
-    async def _fetch_vectors(
-        self, session: AsyncSession, rowids: Iterable[int]
-    ) -> dict[int, list[float]]:
-        rowids = list(rowids)
-        if not rowids:
-            return {}
-
-        placeholders = ", ".join(f":r{i}" for i in range(len(rowids)))
-        vector_rows = (
-            await session.execute(
-                text(
-                    f"SELECT rowid, vector FROM [{self._vector_table_name}] "
-                    f"WHERE rowid IN ({placeholders})"
-                ),
-                {f"r{i}": rowid for i, rowid in enumerate(rowids)},
-            )
-        ).all()
-        return {row.rowid: self._deserialize_vector(row.vector) for row in vector_rows}
-
     @override
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        record_uuids = list(record_uuids)
-        if not record_uuids:
-            return []
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        # Properties live in the records table and vectors live in the sqlite-vec
+        # virtual table, so replacing properties never reads a vector back.
+        if not record_properties:
+            return
 
-        selected_columns = [self._records_table.c.uuid, self._records_table.c.rowid]
-        if return_properties:
-            selected_columns.append(self._records_table.c.properties)
-
-        async with self._create_session() as session:
-            fetched_rows = (
-                await session.execute(
-                    select(*selected_columns).where(
-                        self._records_table.c.uuid.in_(record_uuids),
-                    )
-                )
-            ).all()
-
-            rowid_to_vector: dict[int, list[float]] = {}
-            if return_vector:
-                rowid_to_vector = await self._fetch_vectors(
-                    session, [row.rowid for row in fetched_rows]
-                )
-
-        record_map: dict[UUID, Record] = {}
-        for row in fetched_rows:
-            record_uuid = row.uuid
-
-            properties: dict[str, PropertyValue] | None = None
-            if return_properties:
-                properties = decode_properties(row.properties)
-
-            vector: list[float] | None = rowid_to_vector.get(row.rowid)
-
-            record_map[record_uuid] = Record(
-                uuid=record_uuid, vector=vector, properties=properties
+        async with self._create_session() as session, session.begin():
+            await session.execute(
+                update(self._records_table).where(
+                    self._records_table.c.uuid == bindparam("target_uuid")
+                ),
+                [
+                    {
+                        "target_uuid": record_uuid,
+                        "properties": encode_properties(dict(properties)),
+                    }
+                    for record_uuid, properties in record_properties.items()
+                ],
             )
-
-        return [
-            record_map[record_uuid]
-            for record_uuid in record_uuids
-            if record_uuid in record_map
-        ]
 
     @override
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:
@@ -460,10 +368,7 @@ class SQLiteVecVectorStore(VectorStore):
     Each logical collection gets its own records table and vec0 virtual table.
     """
 
-    _SIMILARITY_METRIC_TO_SQLITE_VEC_DISTANCE: ClassVar[dict[SimilarityMetric, str]] = {
-        SimilarityMetric.COSINE: "cosine",
-        SimilarityMetric.EUCLIDEAN: "L2",
-    }
+    _SQLITE_VEC_DISTANCE_METRIC: ClassVar[str] = "cosine"
 
     def __init__(self, params: SQLiteVecVectorStoreParams) -> None:
         """Initialize the vector store with the provided parameters."""
@@ -504,8 +409,6 @@ class SQLiteVecVectorStore(VectorStore):
     ) -> None:
         if not validate_identifier(namespace) or not validate_identifier(name):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
-        self._validate_metric(config.similarity_metric)
-
         async with self._create_session() as session, session.begin():
             existing_config = await self._get_stored_config(session, namespace, name)
             if existing_config is not None:
@@ -530,8 +433,6 @@ class SQLiteVecVectorStore(VectorStore):
     ) -> VectorStoreCollection:
         if not validate_identifier(namespace) or not validate_identifier(name):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
-        self._validate_metric(config.similarity_metric)
-
         async with self._create_session() as session, session.begin():
             existing_config = await self._get_stored_config(session, namespace, name)
             if existing_config is not None:
@@ -634,21 +535,6 @@ class SQLiteVecVectorStore(VectorStore):
     def _vector_table_name(namespace: str, name: str) -> str:
         return f"{SQLiteVecVectorStore._collection_prefix(namespace, name)}_vc"
 
-    @staticmethod
-    def _validate_metric(similarity_metric: SimilarityMetric) -> None:
-        if (
-            similarity_metric
-            not in SQLiteVecVectorStore._SIMILARITY_METRIC_TO_SQLITE_VEC_DISTANCE
-        ):
-            supported = ", ".join(
-                similarity_metric.value
-                for similarity_metric in SQLiteVecVectorStore._SIMILARITY_METRIC_TO_SQLITE_VEC_DISTANCE
-            )
-            raise ValueError(
-                f"sqlite-vec only supports {supported} similarity metrics, "
-                f"got {similarity_metric.value!r}"
-            )
-
     async def _get_stored_config(
         self, session: AsyncSession, namespace: str, name: str
     ) -> VectorStoreCollectionConfig | None:
@@ -683,9 +569,6 @@ class SQLiteVecVectorStore(VectorStore):
     ) -> tuple[Table, str]:
         records_table = self._records_table(namespace, name)
         vector_table_name = self._vector_table_name(namespace, name)
-        distance_metric_value = self._SIMILARITY_METRIC_TO_SQLITE_VEC_DISTANCE[
-            config.similarity_metric
-        ]
 
         connection = await session.connection()
         await connection.run_sync(
@@ -696,7 +579,8 @@ class SQLiteVecVectorStore(VectorStore):
         await session.execute(
             text(
                 f"CREATE VIRTUAL TABLE IF NOT EXISTS [{vector_table_name}] USING vec0("
-                f"vector float[{config.vector_dimensions}] distance_metric={distance_metric_value}"
+                f"vector float[{config.vector_dimensions}] "
+                f"distance_metric={SQLiteVecVectorStore._SQLITE_VEC_DISTANCE_METRIC}"
                 f")"
             )
         )

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -21,12 +21,10 @@ from sqlalchemy import (
     String,
     Table,
     Uuid,
-    bindparam,
     delete,
     event,
     select,
     text,
-    update,
 )
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine.interfaces import DBAPIConnection
@@ -34,11 +32,9 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase, MappedColumn, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 
-from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
 from memmachine_server.common.properties_json import (
-    decode_properties,
     encode_properties,
 )
 
@@ -170,7 +166,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         limit: int,
         min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_properties: bool = True,
     ) -> list[QueryResult]:
         query_vectors = list(query_vectors)
         if not query_vectors:
@@ -208,7 +203,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
                     rowid_to_distance=rowid_to_distance,
                     min_cosine_similarity=min_cosine_similarity,
                     property_filter=property_filter,
-                    return_properties=return_properties,
                 )
                 results.append(QueryResult(matches=matches))
 
@@ -220,15 +214,12 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         rowid_to_distance: Mapping[int, float],
         min_cosine_similarity: float | None,
         property_filter: FilterExpr | None,
-        return_properties: bool,
     ) -> list[QueryMatch]:
         matched_rowids = list(rowid_to_distance.keys())
 
-        selected_columns = [self._records_table.c.uuid, self._records_table.c.rowid]
-        if return_properties:
-            selected_columns.append(self._records_table.c.properties)
-
-        fetch_records = select(*selected_columns).where(
+        fetch_records = select(
+            self._records_table.c.uuid, self._records_table.c.rowid
+        ).where(
             self._records_table.c.rowid.in_(matched_rowids),
         )
         if property_filter is not None:
@@ -257,44 +248,15 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
             ):
                 continue
 
-            properties: dict[str, PropertyValue] | None = None
-            if return_properties:
-                properties = decode_properties(row.properties)
-
             matches.append(
                 QueryMatch(
                     cosine_similarity=cosine_similarity,
-                    record=Record(uuid=row.uuid, properties=properties),
+                    record_uuid=row.uuid,
                 )
             )
 
         matches.sort(key=lambda match: match.cosine_similarity, reverse=True)
         return matches
-
-    @override
-    async def set_properties(
-        self,
-        *,
-        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
-    ) -> None:
-        # Properties live in the records table and vectors live in the sqlite-vec
-        # virtual table, so replacing properties never reads a vector back.
-        if not record_properties:
-            return
-
-        async with self._create_session() as session, session.begin():
-            await session.execute(
-                update(self._records_table).where(
-                    self._records_table.c.uuid == bindparam("target_uuid")
-                ),
-                [
-                    {
-                        "target_uuid": record_uuid,
-                        "properties": encode_properties(dict(properties)),
-                    }
-                    for record_uuid, properties in record_properties.items()
-                ],
-            )
 
     @override
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -17,10 +17,10 @@ The index is published atomically but not durably (see
 `vector_search_engine.index_persistence`), so a power failure can revert the
 last publication while the records table -- and the trim that ran behind that
 publication -- stay committed. The result is records whose vectors are missing
-from the index: `get` still returns them, `query` cannot find them, and
-re-upserting them is the repair. Callers that need every record searchable
-after a power failure must be able to re-ingest; nothing here detects the gap
-for them.
+from the index. They are simply unfindable: `query` cannot reach them, and
+nothing else reads a stored vector, so re-upserting them is the repair.
+Callers that need every record searchable after a power failure must be able
+to re-ingest; nothing here detects the gap for them.
 """
 
 import logging
@@ -43,6 +43,7 @@ from sqlalchemy import (
     String,
     Table,
     Uuid,
+    bindparam,
     create_engine,
     delete,
     event,
@@ -58,7 +59,7 @@ from sqlalchemy.orm import DeclarativeBase, MappedColumn, Session, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 from sqlalchemy.sql.elements import ColumnElement
 
-from memmachine_server.common.data_types import PropertyValue, SimilarityMetric
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
 from memmachine_server.common.properties_json import (
@@ -400,9 +401,8 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         *,
         query_vectors: Iterable[Sequence[float]],
         limit: int,
-        score_threshold: float | None = None,
+        min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         query_vectors = list(query_vectors)
@@ -427,9 +427,10 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 results.append(QueryResult(matches=[]))
                 continue
             matches = await self._build_matches(
-                row_id_to_score={m.key: m.score for m in search_result.matches},
-                score_threshold=score_threshold,
-                return_vector=return_vector,
+                row_id_to_similarity={
+                    m.key: m.cosine_similarity for m in search_result.matches
+                },
+                min_cosine_similarity=min_cosine_similarity,
                 return_properties=return_properties,
             )
             results.append(QueryResult(matches=matches))
@@ -456,12 +457,11 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
     async def _build_matches(
         self,
-        row_id_to_score: Mapping[int, float],
-        score_threshold: float | None,
-        return_vector: bool,
+        row_id_to_similarity: Mapping[int, float],
+        min_cosine_similarity: float | None,
         return_properties: bool,
     ) -> list[QueryMatch]:
-        matched_row_ids = list(row_id_to_score.keys())
+        matched_row_ids = list(row_id_to_similarity.keys())
 
         selected_columns = [self._records_table.c.uuid, self._records_table.c.row_id]
         if return_properties:
@@ -474,19 +474,15 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         async with self._create_session() as session:
             matched_rows = (await session.execute(fetch_records)).all()
 
-        vector_map: dict[int, list[float]] = {}
-        if return_vector:
-            vector_map = await self._search_engine.get_vectors(matched_row_ids)
-
-        higher_is_better = self._config.similarity_metric.higher_is_better
         matches: list[QueryMatch] = []
         for row in matched_rows:
-            score = row_id_to_score.get(row.row_id)
-            if score is None:
+            cosine_similarity = row_id_to_similarity.get(row.row_id)
+            if cosine_similarity is None:
                 continue
 
-            if score_threshold is not None and (
-                score < score_threshold if higher_is_better else score > score_threshold
+            if (
+                min_cosine_similarity is not None
+                and cosine_similarity < min_cosine_similarity
             ):
                 continue
 
@@ -494,71 +490,41 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
             if return_properties:
                 properties = decode_properties(row.properties)
 
-            vector: list[float] | None = vector_map.get(row.row_id)
-
             matches.append(
                 QueryMatch(
-                    score=score,
-                    record=Record(uuid=row.uuid, vector=vector, properties=properties),
+                    cosine_similarity=cosine_similarity,
+                    record=Record(uuid=row.uuid, properties=properties),
                 )
             )
 
-        matches.sort(
-            key=lambda match: match.score,
-            reverse=self._config.similarity_metric.higher_is_better,
-        )
+        matches.sort(key=lambda match: match.cosine_similarity, reverse=True)
         return matches
 
     @override
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
-        record_uuids = list(record_uuids)
-        if not record_uuids:
-            return []
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
+        # Properties live in the records table and vectors live in the search
+        # engine, so replacing properties never touches the engine: no pending
+        # operation, no index save, nothing for a crash to lose.
+        if not record_properties:
+            return
 
-        selected_columns = [self._records_table.c.uuid, self._records_table.c.row_id]
-        if return_properties:
-            selected_columns.append(self._records_table.c.properties)
-
-        async with self._create_session() as session:
-            fetched_rows = (
-                await session.execute(
-                    select(*selected_columns).where(
-                        self._records_table.c.uuid.in_(record_uuids),
-                    )
-                )
-            ).all()
-
-        row_id_to_vector: dict[int, list[float]] = {}
-        if return_vector:
-            row_id_to_vector = await self._search_engine.get_vectors(
-                [row.row_id for row in fetched_rows]
+        async with self._create_session() as session, session.begin():
+            await session.execute(
+                update(self._records_table).where(
+                    self._records_table.c.uuid == bindparam("target_uuid")
+                ),
+                [
+                    {
+                        "target_uuid": record_uuid,
+                        "properties": encode_properties(dict(properties)),
+                    }
+                    for record_uuid, properties in record_properties.items()
+                ],
             )
-
-        record_map: dict[UUID, Record] = {}
-        for row in fetched_rows:
-            record_uuid = row.uuid
-
-            properties: dict[str, PropertyValue] | None = None
-            if return_properties:
-                properties = decode_properties(row.properties)
-
-            vector: list[float] | None = row_id_to_vector.get(row.row_id)
-
-            record_map[record_uuid] = Record(
-                uuid=record_uuid, vector=vector, properties=properties
-            )
-
-        return [
-            record_map[record_uuid]
-            for record_uuid in record_uuids
-            if record_uuid in record_map
-        ]
 
     @override
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:
@@ -623,8 +589,8 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         await self._maybe_save_index()
 
 
-VectorSearchEngineFactory = Callable[[int, SimilarityMetric], VectorSearchEngine]
-"""Callable that creates a VectorSearchEngine given (num_dimensions, similarity_metric)."""
+VectorSearchEngineFactory = Callable[[int], VectorSearchEngine]
+"""Callable that creates a VectorSearchEngine given the number of dimensions."""
 
 
 class SQLiteVectorStoreParams(BaseModel):
@@ -633,7 +599,7 @@ class SQLiteVectorStoreParams(BaseModel):
     Attributes:
         sqlalchemy_engine (AsyncEngine):
             Async SQLAlchemy engine (sqlite+aiosqlite).
-        engine_factory (Callable[[int, SimilarityMetric], VectorSearchEngine]):
+        engine_factory (Callable[[int], VectorSearchEngine]):
             Factory for creating :class:`VectorSearchEngine` instances.
             Receives `(ndim, metric)` and returns a search engine.
         index_directory (str | None):
@@ -1042,9 +1008,7 @@ class SQLiteVectorStore(VectorStore):
         if cache_key in self._search_engines:
             return self._search_engines[cache_key]
 
-        search_engine = self._vector_search_engine_factory(
-            config.vector_dimensions, config.similarity_metric
-        )
+        search_engine = self._vector_search_engine_factory(config.vector_dimensions)
 
         index_path = self._index_path(namespace, name)
         if index_path is not None:

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -43,7 +43,6 @@ from sqlalchemy import (
     String,
     Table,
     Uuid,
-    bindparam,
     create_engine,
     delete,
     event,
@@ -59,11 +58,9 @@ from sqlalchemy.orm import DeclarativeBase, MappedColumn, Session, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 from sqlalchemy.sql.elements import ColumnElement
 
-from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
 from memmachine_server.common.properties_json import (
-    decode_properties,
     encode_properties,
 )
 
@@ -403,7 +400,6 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         limit: int,
         min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_properties: bool = True,
     ) -> list[QueryResult]:
         query_vectors = list(query_vectors)
         if not query_vectors:
@@ -427,11 +423,10 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 results.append(QueryResult(matches=[]))
                 continue
             matches = await self._build_matches(
-                row_id_to_similarity={
+                row_id_to_cosine_similarity={
                     m.key: m.cosine_similarity for m in search_result.matches
                 },
                 min_cosine_similarity=min_cosine_similarity,
-                return_properties=return_properties,
             )
             results.append(QueryResult(matches=matches))
 
@@ -457,17 +452,14 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
     async def _build_matches(
         self,
-        row_id_to_similarity: Mapping[int, float],
+        row_id_to_cosine_similarity: Mapping[int, float],
         min_cosine_similarity: float | None,
-        return_properties: bool,
     ) -> list[QueryMatch]:
-        matched_row_ids = list(row_id_to_similarity.keys())
+        matched_row_ids = list(row_id_to_cosine_similarity.keys())
 
-        selected_columns = [self._records_table.c.uuid, self._records_table.c.row_id]
-        if return_properties:
-            selected_columns.append(self._records_table.c.properties)
-
-        fetch_records = select(*selected_columns).where(
+        fetch_records = select(
+            self._records_table.c.uuid, self._records_table.c.row_id
+        ).where(
             self._records_table.c.row_id.in_(matched_row_ids),
         )
 
@@ -476,7 +468,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
         matches: list[QueryMatch] = []
         for row in matched_rows:
-            cosine_similarity = row_id_to_similarity.get(row.row_id)
+            cosine_similarity = row_id_to_cosine_similarity.get(row.row_id)
             if cosine_similarity is None:
                 continue
 
@@ -486,45 +478,15 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
             ):
                 continue
 
-            properties: dict[str, PropertyValue] | None = None
-            if return_properties:
-                properties = decode_properties(row.properties)
-
             matches.append(
                 QueryMatch(
                     cosine_similarity=cosine_similarity,
-                    record=Record(uuid=row.uuid, properties=properties),
+                    record_uuid=row.uuid,
                 )
             )
 
         matches.sort(key=lambda match: match.cosine_similarity, reverse=True)
         return matches
-
-    @override
-    async def set_properties(
-        self,
-        *,
-        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
-    ) -> None:
-        # Properties live in the records table and vectors live in the search
-        # engine, so replacing properties never touches the engine: no pending
-        # operation, no index save, nothing for a crash to lose.
-        if not record_properties:
-            return
-
-        async with self._create_session() as session, session.begin():
-            await session.execute(
-                update(self._records_table).where(
-                    self._records_table.c.uuid == bindparam("target_uuid")
-                ),
-                [
-                    {
-                        "target_uuid": record_uuid,
-                        "properties": encode_properties(dict(properties)),
-                    }
-                    for record_uuid, properties in record_properties.items()
-                ],
-            )
 
     @override
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -2,14 +2,12 @@
 
 import asyncio
 import contextlib
-import math
 from collections.abc import Callable, Container, Iterable, Mapping, Sequence
 from typing import ClassVar, override
 
 import hnswlib  # ty: ignore[unresolved-import]  # C extension, no py.typed
 import numpy as np
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
 from .index_persistence import atomic_index_write, clear_stale_index_temp
@@ -19,11 +17,7 @@ from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 class HnswlibVectorSearchEngine(VectorSearchEngine):
     """Vector search engine backed by hnswlib HNSW."""
 
-    _SPACE_MAP: ClassVar[dict[SimilarityMetric, str]] = {
-        SimilarityMetric.COSINE: "cosine",
-        SimilarityMetric.EUCLIDEAN: "l2",
-        SimilarityMetric.DOT: "ip",
-    }
+    _SPACE: ClassVar[str] = "cosine"
 
     _DEFAULT_M: ClassVar[int] = 16
     _DEFAULT_EF_CONSTRUCTION: ClassVar[int] = 128
@@ -36,7 +30,6 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         self,
         *,
         num_dimensions: int,
-        similarity_metric: SimilarityMetric,
         m: int = _DEFAULT_M,
         ef_construction: int = _DEFAULT_EF_CONSTRUCTION,
         ef_search: int = _DEFAULT_EF_SEARCH,
@@ -54,23 +47,13 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         see https://github.com/nmslib/hnswlib/blob/v0.8.0/hnswlib/hnswalg.h#L981-L987.
         Set to False if you'd rather pay memory growth than the per-replacement updatePoint cost.
         """
-        hnswlib_space = self._SPACE_MAP.get(similarity_metric)
-        if hnswlib_space is None:
-            supported = ", ".join(
-                similarity_metric.value for similarity_metric in self._SPACE_MAP
-            )
-            raise ValueError(
-                f"hnswlib does not support {similarity_metric.value!r}. Supported: {supported}"
-            )
-
         self._num_dimensions = num_dimensions
-        self._similarity_metric = similarity_metric
 
-        self._space = hnswlib_space
+        self._space = self._SPACE
         self._ef_search = ef_search
         self._allow_replace_deleted = allow_replace_deleted
 
-        self._index = hnswlib.Index(space=hnswlib_space, dim=num_dimensions)
+        self._index = hnswlib.Index(space=self._SPACE, dim=num_dimensions)
         self._index.init_index(
             max_elements=initial_capacity,
             ef_construction=ef_construction,
@@ -89,15 +72,10 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
 
         self._lock = AsyncRWLock()
 
-    def _distance_to_score(self, distance: float) -> float:
-        """Convert an hnswlib distance to a pure metric score."""
-        match self._similarity_metric:
-            case SimilarityMetric.COSINE | SimilarityMetric.DOT:
-                return 1.0 - distance
-            case SimilarityMetric.EUCLIDEAN:
-                return math.sqrt(max(0.0, distance))
-            case _:
-                raise NotImplementedError(self._similarity_metric)
+    @staticmethod
+    def _distance_to_cosine_similarity(distance: float) -> float:
+        """Convert an hnswlib cosine distance to a cosine similarity."""
+        return 1.0 - distance
 
     def _ensure_capacity(self, needed: int) -> None:
         """Grow the index if there isn't room for `needed` more elements."""
@@ -252,7 +230,10 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         results: list[SearchResult] = []
         for labels, distances in zip(all_labels, all_distances, strict=True):
             matches = [
-                SearchMatch(key=int(label), score=self._distance_to_score(float(dist)))
+                SearchMatch(
+                    key=int(label),
+                    cosine_similarity=self._distance_to_cosine_similarity(float(dist)),
+                )
                 for label, dist in zip(labels, distances, strict=True)
                 if int(label) >= 0
             ]
@@ -282,29 +263,6 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
                 high = mid - 1
 
         return best
-
-    @override
-    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        async with self._lock.read_lock():
-            return await asyncio.to_thread(self._sync_get_vectors, keys)
-
-    def _sync_get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        keys = list(keys)
-        if not keys:
-            return {}
-
-        try:
-            vectors = self._index.get_items(keys)
-            return {
-                key: list(vector) for key, vector in zip(keys, vectors, strict=True)
-            }
-        except RuntimeError:
-            # Fallback: a deleted key was requested. Fetch one by one.
-            result: dict[int, list[float]] = {}
-            for key in keys:
-                with contextlib.suppress(RuntimeError):
-                    result[key] = list(self._index.get_items([key])[0])
-            return result
 
     @override
     async def remove(self, keys: Iterable[int]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -49,11 +49,12 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         """
         self._num_dimensions = num_dimensions
 
-        self._space = self._SPACE
         self._ef_search = ef_search
         self._allow_replace_deleted = allow_replace_deleted
 
-        self._index = hnswlib.Index(space=self._SPACE, dim=num_dimensions)
+        self._index = hnswlib.Index(
+            space=HnswlibVectorSearchEngine._SPACE, dim=num_dimensions
+        )
         self._index.init_index(
             max_elements=initial_capacity,
             ef_construction=ef_construction,
@@ -293,7 +294,9 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
 
     def _sync_load(self, path: str) -> None:
         clear_stale_index_temp(path)
-        self._index = hnswlib.Index(space=self._space, dim=self._num_dimensions)
+        self._index = hnswlib.Index(
+            space=HnswlibVectorSearchEngine._SPACE, dim=self._num_dimensions
+        )
         self._index.load_index(path, allow_replace_deleted=self._allow_replace_deleted)
         self._index.set_ef(self._ef_search)
         # Reconcile _known_labels with hnswlib's label_lookup_.

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
@@ -1,14 +1,12 @@
 """USearch HNSW implementation of VectorSearchEngine."""
 
 import asyncio
-import math
 from collections.abc import Container, Iterable, Mapping, Sequence
 from typing import ClassVar, override
 
 import numpy as np
 from usearch.index import Index, MetricKind
 
-from memmachine_server.common.data_types import SimilarityMetric
 from memmachine_server.common.rw_locks import AsyncRWLock
 
 from .index_persistence import atomic_index_write, clear_stale_index_temp
@@ -18,11 +16,7 @@ from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 class USearchVectorSearchEngine(VectorSearchEngine):
     """Vector search engine backed by USearch HNSW."""
 
-    _METRIC_MAP: ClassVar[dict[SimilarityMetric, MetricKind]] = {
-        SimilarityMetric.COSINE: MetricKind.Cos,
-        SimilarityMetric.EUCLIDEAN: MetricKind.L2sq,
-        SimilarityMetric.DOT: MetricKind.IP,
-    }
+    _METRIC_KIND: ClassVar[MetricKind] = MetricKind.Cos
 
     _DEFAULT_M: ClassVar[int] = 16
     _DEFAULT_EF_CONSTRUCTION: ClassVar[int] = 128
@@ -34,42 +28,26 @@ class USearchVectorSearchEngine(VectorSearchEngine):
         self,
         *,
         num_dimensions: int,
-        similarity_metric: SimilarityMetric,
         m: int = _DEFAULT_M,
         ef_construction: int = _DEFAULT_EF_CONSTRUCTION,
         ef_search: int = _DEFAULT_EF_SEARCH,
     ) -> None:
         """Initialize."""
-        usearch_metric = self._METRIC_MAP.get(similarity_metric)
-        if usearch_metric is None:
-            supported = ", ".join(
-                similarity_metric.value for similarity_metric in self._METRIC_MAP
-            )
-            raise ValueError(
-                f"USearch does not support {similarity_metric.value!r}. Supported: {supported}"
-            )
-
         self._index = Index(
             ndim=num_dimensions,
-            metric=usearch_metric,
+            metric=self._METRIC_KIND,
             dtype="f32",
             connectivity=m,
             expansion_add=ef_construction,
             expansion_search=ef_search,
         )
-        self._similarity_metric = similarity_metric
 
         self._lock = AsyncRWLock()
 
-    def _distance_to_score(self, distance: float) -> float:
-        """Convert a USearch distance to a pure metric score."""
-        match self._similarity_metric:
-            case SimilarityMetric.COSINE | SimilarityMetric.DOT:
-                return 1.0 - distance
-            case SimilarityMetric.EUCLIDEAN:
-                return math.sqrt(max(0.0, distance))
-            case _:
-                raise NotImplementedError(self._similarity_metric)
+    @staticmethod
+    def _distance_to_cosine_similarity(distance: float) -> float:
+        """Convert a USearch cosine distance to a cosine similarity."""
+        return 1.0 - distance
 
     @override
     async def add(self, vectors: Mapping[int, Sequence[float]]) -> None:
@@ -140,7 +118,9 @@ class USearchVectorSearchEngine(VectorSearchEngine):
                     matches.append(
                         SearchMatch(
                             key=int_key,
-                            score=self._distance_to_score(float(dist)),
+                            cosine_similarity=self._distance_to_cosine_similarity(
+                                float(dist)
+                            ),
                         )
                     )
                     if len(matches) >= limit:
@@ -155,24 +135,6 @@ class USearchVectorSearchEngine(VectorSearchEngine):
             overfetch_factor *= USearchVectorSearchEngine._OVERFETCH_BASE
 
         return [r if r is not None else SearchResult(matches=[]) for r in final_results]
-
-    @override
-    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        keys = list(keys)
-        if not keys:
-            return {}
-
-        keys_array = np.array(keys, dtype=np.int64)
-        async with self._lock.read_lock():
-            vectors = await asyncio.to_thread(self._index.get, keys_array)
-
-        result: dict[int, list[float]] = {}
-        for i, key in enumerate(keys):
-            vector = vectors[i] if vectors is not None else None
-            if vector is not None:
-                result[key] = list(vector)
-
-        return result
 
     @override
     async def remove(self, keys: Iterable[int]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
@@ -11,16 +11,13 @@ class SearchMatch:
     A single search match.
 
     Attributes:
-        score (float):
-            The meaning depends on the collection's `SimilarityMetric`:
-            - *cosine*: cosine similarity in [-1, 1].
-            - *dot*: raw dot product [0, inf).
-            - *euclidean*: Euclidean distance [0, inf).
-            - *manhattan*: Manhattan distance [0, inf).
+        cosine_similarity (float):
+            Cosine similarity between the query vector and the matched
+            vector, in [-1, 1]. Higher is a better match.
         key (int): Engine key for the matched vector.
     """
 
-    score: float
+    cosine_similarity: float
     key: int
 
 
@@ -90,21 +87,6 @@ class VectorSearchEngine(ABC):
             list[SearchResult]:
                 Results for each query vector,
                 ordered as in the input iterable.
-        """
-
-    @abstractmethod
-    async def get_vectors(self, keys: Iterable[int]) -> dict[int, list[float]]:
-        """
-        Retrieve vectors by key.
-
-        Args:
-            keys (Iterable[int]):
-                Keys of vectors to retrieve.
-
-        Returns:
-            dict[int, list[float]]:
-                Mapping of key to vector for keys that exist.
-                Missing keys are omitted.
         """
 
     @abstractmethod

--- a/packages/server/src/memmachine_server/common/vector_store/vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_store.py
@@ -5,9 +5,10 @@ Defines the interface for adding, querying, and deleting records.
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from uuid import UUID
 
+from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     FilterExpr,
 )
@@ -66,9 +67,8 @@ class VectorStoreCollection(ABC):
         *,
         query_vectors: Iterable[Sequence[float]],
         limit: int,
-        score_threshold: float | None = None,
+        min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_vector: bool = False,
         return_properties: bool = True,
     ) -> list[QueryResult]:
         """
@@ -79,16 +79,14 @@ class VectorStoreCollection(ABC):
                 The vectors to compare against.
             limit (int):
                 Maximum number of matching records to return per query vector.
-            score_threshold (float | None):
-                Score threshold to consider a match
+            min_cosine_similarity (float | None):
+                If provided, only return matches whose cosine similarity
+                is greater than or equal to this value
                 (default: None).
             property_filter (FilterExpr | None):
                 Filter expression tree.
                 If None or empty, no property filtering is applied
                 (default: None).
-            return_vector (bool):
-                Whether to include the vector in the returned records
-                (default: False).
             return_properties (bool):
                 Whether to include the properties in the returned records
                 (default: True).
@@ -101,30 +99,25 @@ class VectorStoreCollection(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def get(
+    async def set_properties(
         self,
         *,
-        record_uuids: Iterable[UUID],
-        return_vector: bool = False,
-        return_properties: bool = True,
-    ) -> list[Record]:
+        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
+    ) -> None:
         """
-        Get records from the collection by their UUIDs.
+        Replace the properties of records already in the collection.
+
+        Each record keeps the vector it was stored with, so a caller that is
+        only correcting a record's properties does not have to hold the vector
+        to write it back. UUIDs the collection does not hold are ignored, the
+        way `delete` ignores them: whether a backend can tell a missing record
+        from one it just wrote varies, so the contract does not promise to.
 
         Args:
-            record_uuids (Iterable[UUID]):
-                Iterable of UUIDs of the records to retrieve.
-            return_vector (bool):
-                Whether to include the vector in the returned records
-                (default: False).
-            return_properties (bool):
-                Whether to include the properties in the returned records
-                (default: True).
-
-        Returns:
-            list[Record]:
-                Iterable of records with the specified UUIDs,
-                ordered as in the input iterable.
+            record_properties (Mapping[UUID, Mapping[str, PropertyValue]]):
+                Mapping of record UUID to the properties that replace whatever
+                that record currently holds. Properties not in the indexed
+                properties schema are allowed.
         """
         raise NotImplementedError
 
@@ -153,7 +146,7 @@ class VectorStore(ABC):
     The consumer is responsible for sharding names across processes.
 
     Different namespaces are fully independent (separate native collections).
-    Multiple logical collections with the same (namespace, vector dimensions, similarity metric, indexed properties schema)
+    Multiple logical collections with the same (namespace, vector dimensions, indexed properties schema)
     may share a native collection to reduce overhead.
 
     Naming constraints:
@@ -184,8 +177,7 @@ class VectorStore(ABC):
         Create a logical collection in the vector store and return a handle to it.
 
         A (namespace, name) pair uniquely identifies a collection.
-        The configuration (dimensions, similarity metric, schema)
-        is fixed at creation time.
+        The configuration (dimensions, schema) is fixed at creation time.
 
         Args:
             namespace (str):

--- a/packages/server/src/memmachine_server/common/vector_store/vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_store.py
@@ -5,10 +5,9 @@ Defines the interface for adding, querying, and deleting records.
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
 from uuid import UUID
 
-from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.filter.filter_parser import (
     FilterExpr,
 )
@@ -27,8 +26,8 @@ class VectorStoreCollection(ABC):
     Identified by a (namespace, name) pair.
     All data operations are scoped to this logical collection.
 
-    Implementations must support storing, filtering on, and returning
-    record properties not declared in the configured indexed properties schema.
+    Implementations must support storing and filtering on record properties
+    not declared in the configured indexed properties schema.
 
     The schema exists to support indexing on fixed-type record properties.
     Record properties not declared in the schema may have mixed-type values.
@@ -69,10 +68,15 @@ class VectorStoreCollection(ABC):
         limit: int,
         min_cosine_similarity: float | None = None,
         property_filter: FilterExpr | None = None,
-        return_properties: bool = True,
     ) -> list[QueryResult]:
         """
         Query for records matching the criteria by query vectors.
+
+        Answers with UUIDs and scores. Stored properties are filterable but
+        never returned: this store is not the authority for a record's
+        content, and its copy is only as fresh as the last write to it -- a
+        caller that needs a record's fields reads them from whatever owns
+        them.
 
         Args:
             query_vectors (Iterable[Sequence[float]]):
@@ -87,37 +91,11 @@ class VectorStoreCollection(ABC):
                 Filter expression tree.
                 If None or empty, no property filtering is applied
                 (default: None).
-            return_properties (bool):
-                Whether to include the properties in the returned records
-                (default: True).
 
         Returns:
             list[QueryResult]:
                 Results for each query vector,
                 ordered as in the input iterable.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    async def set_properties(
-        self,
-        *,
-        record_properties: Mapping[UUID, Mapping[str, PropertyValue]],
-    ) -> None:
-        """
-        Replace the properties of records already in the collection.
-
-        Each record keeps the vector it was stored with, so a caller that is
-        only correcting a record's properties does not have to hold the vector
-        to write it back. UUIDs the collection does not hold are ignored, the
-        way `delete` ignores them: whether a backend can tell a missing record
-        from one it just wrote varies, so the contract does not promise to.
-
-        Args:
-            record_properties (Mapping[UUID, Mapping[str, PropertyValue]]):
-                Mapping of record UUID to the properties that replace whatever
-                that record currently holds. Properties not in the indexed
-                properties schema are allowed.
         """
         raise NotImplementedError
 

--- a/packages/server/src/memmachine_server/episodic_memory/declarative_memory/declarative_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/declarative_memory/declarative_memory.py
@@ -167,7 +167,7 @@ class DeclarativeMemory:
                     DeclarativeMemory._embedding_name(
                         self._embedder.model_id,
                         self._embedder.dimensions,
-                    ): (embedding, self._embedder.similarity_metric),
+                    ): embedding,
                 },
             )
             for derivative, embedding in zip(
@@ -361,7 +361,6 @@ class DeclarativeMemory:
                 )
             ),
             query_embedding=query_embedding,
-            similarity_metric=self._embedder.similarity_metric,
             limit=min(5 * max_num_episodes, 200),
             property_filter=mangled_property_filter,
         )

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
@@ -108,11 +108,10 @@ class EventMemory:
     """Event memory system."""
 
     # System-defined metadata field names. Reserved.
-    _SEGMENT_UUID_FIELD_NAME = "_segment_uuid"
     _TIMESTAMP_FIELD_NAME = "_timestamp"
 
     _BASE_EVENT_MEMORY_FIELD_NAMES: ClassVar[frozenset[str]] = frozenset(
-        {_SEGMENT_UUID_FIELD_NAME, _TIMESTAMP_FIELD_NAME}
+        {_TIMESTAMP_FIELD_NAME}
     )
 
     @classmethod
@@ -124,7 +123,6 @@ class EventMemory:
         when creating the collection so that EventMemory's reserved fields are efficiently filterable.
         """
         return {
-            cls._SEGMENT_UUID_FIELD_NAME: cast(type[PropertyValue], str),
             cls._TIMESTAMP_FIELD_NAME: cast(type[PropertyValue], datetime.datetime),
         }
 
@@ -325,7 +323,6 @@ class EventMemory:
         properties: dict[str, PropertyValue] = {}
 
         # System-defined metadata (underscore-prefixed).
-        properties[cls._SEGMENT_UUID_FIELD_NAME] = str(derivative.segment_uuid)
         properties[cls._TIMESTAMP_FIELD_NAME] = derivative.timestamp
 
         # User-defined properties.
@@ -424,27 +421,27 @@ class EventMemory:
             query_vectors=[query_embedding],
             limit=vector_search_limit,
             property_filter=collection_filter,
-            return_properties=True,
         )
         t_vector_query = time.monotonic()
 
-        # Extract seed segment UUIDs and their best embedding scores.
+        segment_by_derivative = (
+            await self._segment_store_partition.get_segment_uuids_by_derivative_uuids(
+                match.record_uuid for match in query_result.matches
+            )
+        )
+
         # Deduplicate by first occurrence (multiple derivatives can map to the same segment).
         # First occurrence has the best score since matches are ordered best-to-worst.
-        seed_embedding_scores: dict[UUID, float] = {}
+        seed_cosine_similarities: dict[UUID, float] = {}
         for match in query_result.matches:
-            segment_uuid = UUID(
-                str(
-                    cast(
-                        dict[str, PropertyValue],
-                        match.record.properties,
-                    )[EventMemory._SEGMENT_UUID_FIELD_NAME]
-                )
-            )
-            if segment_uuid not in seed_embedding_scores:
-                seed_embedding_scores[segment_uuid] = match.cosine_similarity
+            segment_uuid = segment_by_derivative.get(match.record_uuid)
+            if segment_uuid is None:
+                # The derivative's segment is gone; its vector outlived it.
+                continue
+            if segment_uuid not in seed_cosine_similarities:
+                seed_cosine_similarities[segment_uuid] = match.cosine_similarity
 
-        seed_segment_uuids = list(seed_embedding_scores)
+        seed_segment_uuids = list(seed_cosine_similarities)
 
         max_backward_segments = expand_context // 3
         max_forward_segments = expand_context - max_backward_segments
@@ -473,7 +470,7 @@ class EventMemory:
         # Use embedding scores if reranker is not available.
         if self._reranker is None:
             scores = [
-                seed_embedding_scores[seed_uuid]
+                seed_cosine_similarities[seed_uuid]
                 for seed_uuid in kept_seed_segment_uuids
             ]
         else:

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
@@ -424,7 +424,6 @@ class EventMemory:
             query_vectors=[query_embedding],
             limit=vector_search_limit,
             property_filter=collection_filter,
-            return_vector=False,
             return_properties=True,
         )
         t_vector_query = time.monotonic()
@@ -443,7 +442,7 @@ class EventMemory:
                 )
             )
             if segment_uuid not in seed_embedding_scores:
-                seed_embedding_scores[segment_uuid] = match.score
+                seed_embedding_scores[segment_uuid] = match.cosine_similarity
 
         seed_segment_uuids = list(seed_embedding_scores)
 
@@ -486,13 +485,6 @@ class EventMemory:
             )
         t_scoring = time.monotonic()
 
-        # Reranker scores are always higher-is-better.
-        # Embedding scores depend on the similarity metric.
-        higher_is_better = (
-            self._reranker is not None
-            or self._vector_store_collection.config.similarity_metric.higher_is_better
-        )
-
         # Return scored contexts ordered by score.
         scored_segment_contexts = [
             ScoredSegmentContext(
@@ -506,7 +498,7 @@ class EventMemory:
                     strict=True,
                 ),
                 key=lambda triple: triple[0],
-                reverse=higher_is_better,
+                reverse=True,
             )
         ]
 

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
@@ -113,6 +113,28 @@ class SegmentStorePartition(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    async def get_segment_uuids_by_derivative_uuids(
+        self,
+        derivative_uuids: Iterable[UUID],
+    ) -> dict[UUID, UUID]:
+        """
+        Get the segment each of the given derivatives belongs to.
+
+        A derivative belongs to exactly one segment, so this is the inverse of
+        `get_derivative_uuids_by_segment_uuids` and answers one UUID rather
+        than a list. UUIDs the partition does not hold are omitted.
+
+        Args:
+            derivative_uuids (Iterable[UUID]):
+                The UUIDs of the derivatives whose owning segments to look up.
+
+        Returns:
+            dict[UUID, UUID]:
+                A mapping from each derivative UUID to its segment's UUID.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     async def delete_segments(
         self,
         segment_uuids: Iterable[UUID],

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
@@ -765,6 +765,34 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
             result[segment_uuid].append(derivative_uuid)
         return dict(result)
 
+    @override
+    async def get_segment_uuids_by_derivative_uuids(
+        self,
+        derivative_uuids: Iterable[UUID],
+    ) -> dict[UUID, UUID]:
+        derivative_uuids = set(derivative_uuids)
+        if not derivative_uuids:
+            return {}
+
+        async with (
+            self._tracker("get_segment_uuids_by_derivative_uuids"),
+            self._create_session() as session,
+        ):
+            # Served by the primary key, which leads on the same two columns
+            # this filters: the mapping is the derivative row itself.
+            query = select(
+                DerivativeLinkRow.uuid, DerivativeLinkRow.segment_uuid
+            ).where(
+                DerivativeLinkRow.incarnation == self._incarnation,
+                DerivativeLinkRow.uuid.in_(derivative_uuids),
+                self._registry_row_query().exists(),
+            )
+            rows = (await session.execute(query)).all()
+            if not rows:
+                await self._ensure_partition_live(session)
+
+        return {row.uuid: row.segment_uuid for row in rows}
+
     # Deletion
 
     @override

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -192,13 +192,6 @@ class LongTermMemory:
         self._segment_store: SegmentStore | None = None
         self._partition_key: str | None = None
         self._episode_storage: EpisodeStorage | None = None
-        # Event backend only: whether scores from `EventMemory.query` are
-        # higher-is-better. Matches the same derivation inside EventMemory.query
-        # (reranker scores are higher-is-better; raw vector scores depend on the
-        # collection's similarity metric — cosine is higher-is-better, euclidean
-        # is lower-is-better). Used to apply `score_threshold` in the correct
-        # direction so it doesn't invert under euclidean with no reranker.
-        self._score_higher_is_better: bool = True
         # Event backend only: configured user-property names from
         # properties_schema. Empty means "no validation"; non-empty means the
         # set is closed and filter expressions referencing `m.<unknown>` raise
@@ -234,10 +227,6 @@ class LongTermMemory:
                 self._segment_store = params.segment_store
                 self._partition_key = params.partition_key
                 self._episode_storage = params.episode_storage
-                self._score_higher_is_better = (
-                    params.reranker is not None
-                    or params.vector_store_collection.config.similarity_metric.higher_is_better
-                )
                 self._user_property_keys = params.user_property_keys
 
     async def add_episodes(self, episodes: Iterable[Episode]) -> None:
@@ -264,12 +253,11 @@ class LongTermMemory:
     ) -> list[tuple[float, Episode]]:
         """Score-thresholded query.
 
-        `score_threshold=None` (default) keeps every result. With a numeric
-        value, the comparison direction matches the scoring metric:
-        higher-is-better metrics (cosine, dot, any reranker) drop scores BELOW
-        the threshold; lower-is-better metrics (raw euclidean / manhattan with
-        no reranker) drop scores ABOVE it. Avoids the prior `-inf` sentinel,
-        which silently inverted to "drop everything" under euclidean.
+        `score_threshold=None` (default) keeps every result. A numeric value
+        drops scores below it: every score here is a cosine similarity or a
+        reranker score, and both are higher-is-better, so the comparison needs
+        no direction. Avoids the prior `-inf` sentinel, which silently
+        inverted to "drop everything" under a lower-is-better metric.
         """
         if self._backend == "declarative":
             return await self._search_scored_declarative(
@@ -360,10 +348,8 @@ class LongTermMemory:
         # Map seed segment -> _episode_uid (system field already lives on
         # event/segment.properties under the underscore-prefixed key). Keep
         # first-seen score per episode_uid; preserve query result ordering.
-        # The threshold comparison direction depends on the scoring metric:
-        # higher-is-better (cosine + any reranker) → drop scores BELOW threshold;
-        # lower-is-better (raw euclidean without a reranker) → drop scores
-        # ABOVE threshold.
+        # Cosine similarities and reranker scores are both higher-is-better,
+        # so the threshold always drops scores below it.
         ordered_uids: list[str] = []
         scores_by_uid: dict[str, float] = {}
         for scored_context in result.scored_segment_contexts:
@@ -461,17 +447,13 @@ class LongTermMemory:
     def _score_passes_threshold(
         self, score: float, score_threshold: float | None
     ) -> bool:
-        """Apply `score_threshold` in the correct direction for the metric.
+        """Drop scores below `score_threshold`; None never drops.
 
-        higher-is-better → drop scores BELOW threshold;
-        lower-is-better  → drop scores ABOVE threshold;
-        None             → never drop.
+        Reranker scores and cosine similarities are both higher-is-better.
         """
         if score_threshold is None:
             return True
-        if self._score_higher_is_better:
-            return score >= score_threshold
-        return score <= score_threshold
+        return score >= score_threshold
 
     def _require_event_backend_live(self) -> EventMemory:
         """Return the EventMemory or raise if the instance was dropped."""

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
@@ -115,7 +115,6 @@ async def _event_params(
         user_schema = _resolve_user_properties_schema(config.properties_schema)
         collection_config = VectorStoreCollectionConfig(
             vector_dimensions=embedder.dimensions,
-            similarity_metric=embedder.similarity_metric,
             indexed_properties_schema={
                 **EventMemory.expected_vector_store_collection_schema(),
                 **EVENT_BACKEND_SYSTEM_FIELDS,

--- a/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Mapping, MutableMapping, Sequence
-from datetime import UTC, datetime
+from datetime import UTC
 from typing import Any, cast
-from uuid import UUID, uuid5
+from uuid import UUID, uuid4
 
 import numpy as np
 from pydantic import AwareDatetime, InstanceOf, TypeAdapter, ValidationError
@@ -20,6 +20,7 @@ from sqlalchemy import (
     Integer,
     String,
     Table,
+    Uuid,
     delete,
     insert,
     select,
@@ -51,13 +52,7 @@ from memmachine_server.semantic_memory.storage.storage_base import (
 )
 from memmachine_server.semantic_memory.storage.text_sanitizer import sanitize_pg_text
 
-_FEATURE_VECTOR_NAMESPACE = UUID("f4f9f7b0-99dd-4a4a-9f24-682077ae1ebd")
 _DEFAULT_VECTOR_QUERY_LIMIT = 10_000
-
-
-def feature_vector_uuid(feature_id: FeatureIdT) -> UUID:
-    """Return the stable vector record UUID for a semantic feature id."""
-    return uuid5(_FEATURE_VECTOR_NAMESPACE, str(feature_id))
 
 
 class BaseVectorSemanticStorage(DeclarativeBase):
@@ -87,6 +82,10 @@ class VectorSemanticFeature(BaseVectorSemanticStorage):
     __tablename__ = "vector_semantic_feature"
 
     id = mapped_column(Integer, primary_key=True)
+    # The feature's record in the vector store. This is the mapping that lets a
+    # search hit be resolved back to a feature; the vector store holds no copy
+    # of anything this table owns.
+    vector_uuid = mapped_column(Uuid, nullable=False, unique=True, default=uuid4)
     set_id = mapped_column(String, nullable=False, index=True)
     semantic_category_id = mapped_column(String, nullable=False)
     tag_id = mapped_column(String, nullable=False)
@@ -172,7 +171,13 @@ class VectorSemanticSetIngestedHistory(BaseVectorSemanticStorage):
 
 
 class VectorStoreSemanticStorage(SemanticStorage):
-    """SemanticStorage using SQLAlchemy metadata and VectorStore embeddings."""
+    """SemanticStorage using SQLAlchemy metadata and VectorStore embeddings.
+
+    The feature row is the authority for everything but the embedding: it
+    carries `vector_uuid`, its own pointer into the collection. Vector records
+    therefore hold a vector and no properties -- every field they used to carry
+    was a copy of a column on that row, and nothing filtered on it.
+    """
 
     backend_name = "vector_store"
 
@@ -201,12 +206,13 @@ class VectorStoreSemanticStorage(SemanticStorage):
 
     async def delete_all(self) -> None:
         feature_ids = await self._feature_ids_for_filter(None)
+        vector_uuids = await self._vector_uuids_for_features(feature_ids)
         async with self._create_session() as session:
             await session.execute(delete(vector_citation_association_table))
             await session.execute(delete(VectorSemanticSetIngestedHistory))
             await session.execute(delete(VectorSemanticFeature))
             await session.commit()
-        await self._delete_vector_records(feature_ids)
+        await self._vector_collection.delete(record_uuids=vector_uuids)
 
     async def reset_set_ids(self, set_ids: Sequence[SetIdT]) -> None:
         del set_ids
@@ -222,9 +228,11 @@ class VectorStoreSemanticStorage(SemanticStorage):
         embedding: InstanceOf[np.ndarray],
         metadata: Mapping[str, Any] | None = None,
     ) -> FeatureIdT:
+        vector_uuid = uuid4()
         stmt = (
             insert(VectorSemanticFeature)
             .values(
+                vector_uuid=vector_uuid,
                 set_id=set_id,
                 semantic_category_id=category_name,
                 tag_id=sanitize_pg_text(tag, context="feature.tag"),
@@ -240,15 +248,8 @@ class VectorStoreSemanticStorage(SemanticStorage):
             await session.commit()
             feature_id = FeatureIdT(str(result.scalar_one()))
 
-        await self._upsert_vector_record(
-            feature_id=feature_id,
-            set_id=set_id,
-            category_name=category_name,
-            feature=feature,
-            value=value,
-            tag=tag,
-            embedding=embedding,
-            metadata=metadata,
+        await self._vector_collection.upsert(
+            records=[Record(uuid=vector_uuid, vector=embedding.tolist())]
         )
         return feature_id
 
@@ -294,49 +295,12 @@ class VectorStoreSemanticStorage(SemanticStorage):
         if row is None:
             raise ResourceNotFoundError(f"Feature ID not found: {feature_id}")
 
-        if embedding is not None or values:
-            await self._refresh_vector_record(
-                feature_id=feature_id, row=row, embedding=embedding
+        # Only an embedding reaches the vector store; everything else this
+        # method can change lives on the row above.
+        if embedding is not None:
+            await self._vector_collection.upsert(
+                records=[Record(uuid=row.vector_uuid, vector=embedding.tolist())]
             )
-
-    async def _refresh_vector_record(
-        self,
-        *,
-        feature_id: FeatureIdT,
-        row: VectorSemanticFeature,
-        embedding: InstanceOf[np.ndarray] | None,
-    ) -> None:
-        """Bring a feature's vector record back in line with its relational row."""
-        if embedding is None:
-            # The embedding is a function of `value` alone, so a caller that did
-            # not pass one changed nothing the embedding depends on; only the
-            # properties mirroring the relational row need to catch up, and the
-            # stored vector stays where it is rather than being read back out.
-            await self._vector_collection.set_properties(
-                record_properties={
-                    feature_vector_uuid(feature_id): self._vector_properties(
-                        feature_id=feature_id,
-                        set_id=row.set_id,
-                        category_name=row.semantic_category_id,
-                        feature=row.feature,
-                        value=row.value,
-                        tag=row.tag_id,
-                        metadata=row.json_metadata,
-                    )
-                }
-            )
-            return
-
-        await self._upsert_vector_record(
-            feature_id=feature_id,
-            set_id=row.set_id,
-            category_name=row.semantic_category_id,
-            feature=row.feature,
-            value=row.value,
-            tag=row.tag_id,
-            embedding=embedding,
-            metadata=row.json_metadata,
-        )
 
     async def get_feature(
         self,
@@ -402,6 +366,9 @@ class VectorStoreSemanticStorage(SemanticStorage):
         except ValidationError as e:
             raise ResourceNotFoundError(f"Invalid feature IDs: {feature_ids}") from e
 
+        vector_uuids = await self._vector_uuids_for_features(
+            [FeatureIdT(str(fid)) for fid in feature_id_ints]
+        )
         async with self._create_session() as session:
             await session.execute(
                 delete(VectorSemanticFeature).where(
@@ -410,9 +377,7 @@ class VectorStoreSemanticStorage(SemanticStorage):
             )
             await session.commit()
 
-        await self._delete_vector_records(
-            [FeatureIdT(str(fid)) for fid in feature_id_ints]
-        )
+        await self._vector_collection.delete(record_uuids=vector_uuids)
 
     async def delete_feature_set(
         self,
@@ -420,12 +385,13 @@ class VectorStoreSemanticStorage(SemanticStorage):
         filter_expr: FilterExpr | None = None,
     ) -> None:
         feature_ids = await self._feature_ids_for_filter(filter_expr)
+        vector_uuids = await self._vector_uuids_for_features(feature_ids)
         stmt = delete(VectorSemanticFeature)
         stmt = self._apply_feature_filter(stmt, filter_expr=filter_expr)
         async with self._create_session() as session:
             await session.execute(stmt)
             await session.commit()
-        await self._delete_vector_records(feature_ids)
+        await self._vector_collection.delete(record_uuids=vector_uuids)
 
     async def add_citations(
         self,
@@ -616,43 +582,24 @@ class VectorStoreSemanticStorage(SemanticStorage):
             async for set_id in result.scalars():
                 yield SetIdT(set_id)
 
-    async def _upsert_vector_record(
-        self,
-        *,
-        feature_id: FeatureIdT,
-        set_id: SetIdT,
-        category_name: str,
-        feature: str,
-        value: str,
-        tag: str,
-        embedding: InstanceOf[np.ndarray],
-        metadata: Mapping[str, Any] | None,
-    ) -> None:
-        properties = self._vector_properties(
-            feature_id=feature_id,
-            set_id=set_id,
-            category_name=category_name,
-            feature=feature,
-            value=value,
-            tag=tag,
-            metadata=metadata,
-        )
-        await self._vector_collection.upsert(
-            records=[
-                Record(
-                    uuid=feature_vector_uuid(feature_id),
-                    vector=[float(item) for item in embedding.tolist()],
-                    properties=properties,
-                )
-            ]
-        )
+    async def _vector_uuids_for_features(
+        self, feature_ids: Sequence[FeatureIdT]
+    ) -> list[UUID]:
+        """Read the vector records these features own.
 
-    async def _delete_vector_records(self, feature_ids: Sequence[FeatureIdT]) -> None:
+        Must run before the rows are deleted: the row is what says which vector
+        record belongs to the feature, so once it is gone the mapping is too.
+        """
         if not feature_ids:
-            return
-        await self._vector_collection.delete(
-            record_uuids=[feature_vector_uuid(feature_id) for feature_id in feature_ids]
-        )
+            return []
+        feature_id_ints = [self._coerce_feature_id(f) for f in feature_ids]
+        async with self._create_session() as session:
+            result = await session.execute(
+                select(VectorSemanticFeature.vector_uuid).where(
+                    VectorSemanticFeature.id.in_(feature_id_ints)
+                )
+            )
+        return list(result.scalars().all())
 
     async def _vector_search_features(
         self,
@@ -672,12 +619,24 @@ class VectorStoreSemanticStorage(SemanticStorage):
             query_vectors=[vector_search_opts.query_embedding.tolist()],
             limit=limit,
             min_cosine_similarity=vector_search_opts.min_distance,
-            return_properties=True,
         )
+        matched_uuids = [match.record_uuid for match in query_result.matches]
+        # Resolve hits through the column that owns the mapping, keeping the
+        # order the search returned them in. A hit whose feature is gone is
+        # dropped: its vector outlived the row.
+        async with self._create_session() as session:
+            rows = (
+                await session.execute(
+                    select(
+                        VectorSemanticFeature.vector_uuid, VectorSemanticFeature.id
+                    ).where(VectorSemanticFeature.vector_uuid.in_(matched_uuids))
+                )
+            ).all()
+        feature_id_by_uuid = {row.vector_uuid: row.id for row in rows}
         ordered_ids = [
-            FeatureIdT(str((match.record.properties or {})["feature_id"]))
-            for match in query_result.matches
-            if match.record.properties and "feature_id" in match.record.properties
+            FeatureIdT(str(feature_id_by_uuid[matched_uuid]))
+            for matched_uuid in matched_uuids
+            if matched_uuid in feature_id_by_uuid
         ]
         features = await self._features_by_ids(
             ordered_ids,
@@ -837,39 +796,6 @@ class VectorStoreSemanticStorage(SemanticStorage):
         for feature_id, history_id in result:
             citations.setdefault(feature_id, []).append(EpisodeIdT(history_id))
         return citations
-
-    @staticmethod
-    def _vector_properties(
-        *,
-        feature_id: FeatureIdT,
-        set_id: SetIdT,
-        category_name: str,
-        feature: str,
-        value: str,
-        tag: str,
-        metadata: Mapping[str, Any] | None,
-    ) -> dict[str, str | int | float | bool | datetime]:
-        properties: dict[str, str | int | float | bool | datetime] = {
-            "feature_id": feature_id,
-            "set_id": set_id,
-            "set": set_id,
-            "semantic_category_id": category_name,
-            "category_name": category_name,
-            "category": category_name,
-            "tag_id": tag,
-            "tag": tag,
-            "feature": feature,
-            "feature_name": feature,
-            "value": value,
-        }
-        properties.update(
-            {
-                key: item
-                for key, item in (metadata or {}).items()
-                if isinstance(item, bool | int | float | str | datetime)
-            }
-        )
-        return properties
 
     @staticmethod
     def _coerce_feature_id(feature_id: FeatureIdT) -> int:

--- a/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
@@ -294,22 +294,49 @@ class VectorStoreSemanticStorage(SemanticStorage):
         if row is None:
             raise ResourceNotFoundError(f"Feature ID not found: {feature_id}")
 
-        if values or embedding is not None:
-            existing_record = await self._get_existing_vector_record(feature_id)
-            await self._upsert_vector_record(
-                feature_id=feature_id,
-                set_id=row.set_id,
-                category_name=row.semantic_category_id,
-                feature=row.feature,
-                value=row.value,
-                tag=row.tag_id,
-                embedding=(
-                    embedding
-                    if embedding is not None
-                    else np.array(existing_record.vector, dtype=float)
-                ),
-                metadata=row.json_metadata,
+        if embedding is not None or values:
+            await self._refresh_vector_record(
+                feature_id=feature_id, row=row, embedding=embedding
             )
+
+    async def _refresh_vector_record(
+        self,
+        *,
+        feature_id: FeatureIdT,
+        row: VectorSemanticFeature,
+        embedding: InstanceOf[np.ndarray] | None,
+    ) -> None:
+        """Bring a feature's vector record back in line with its relational row."""
+        if embedding is None:
+            # The embedding is a function of `value` alone, so a caller that did
+            # not pass one changed nothing the embedding depends on; only the
+            # properties mirroring the relational row need to catch up, and the
+            # stored vector stays where it is rather than being read back out.
+            await self._vector_collection.set_properties(
+                record_properties={
+                    feature_vector_uuid(feature_id): self._vector_properties(
+                        feature_id=feature_id,
+                        set_id=row.set_id,
+                        category_name=row.semantic_category_id,
+                        feature=row.feature,
+                        value=row.value,
+                        tag=row.tag_id,
+                        metadata=row.json_metadata,
+                    )
+                }
+            )
+            return
+
+        await self._upsert_vector_record(
+            feature_id=feature_id,
+            set_id=row.set_id,
+            category_name=row.semantic_category_id,
+            feature=row.feature,
+            value=row.value,
+            tag=row.tag_id,
+            embedding=embedding,
+            metadata=row.json_metadata,
+        )
 
     async def get_feature(
         self,
@@ -620,31 +647,6 @@ class VectorStoreSemanticStorage(SemanticStorage):
             ]
         )
 
-    async def _get_existing_vector_record(self, feature_id: FeatureIdT) -> Record:
-        """Read back a feature's stored embedding.
-
-        A vector store publishes its index atomically but not durably (see
-        `common.vector_store.sqlite_vector_store`), so a power failure can
-        leave a record the store still knows about but whose vector the index
-        no longer holds. The two cases are reported apart because the caller
-        can act on them differently: a missing embedding is repaired by
-        passing a fresh one to `update_feature`, while a missing record is
-        not.
-        """
-        records = await self._vector_collection.get(
-            record_uuids=[feature_vector_uuid(feature_id)],
-            return_vector=True,
-            return_properties=False,
-        )
-        if not records:
-            raise ResourceNotFoundError(f"Vector record not found: {feature_id}")
-        if records[0].vector is None:
-            raise ResourceNotFoundError(
-                f"Vector record {feature_id} has no stored embedding; "
-                "pass an embedding to update this feature"
-            )
-        return records[0]
-
     async def _delete_vector_records(self, feature_ids: Sequence[FeatureIdT]) -> None:
         if not feature_ids:
             return
@@ -669,8 +671,7 @@ class VectorStoreSemanticStorage(SemanticStorage):
         [query_result] = await self._vector_collection.query(
             query_vectors=[vector_search_opts.query_embedding.tolist()],
             limit=limit,
-            score_threshold=vector_search_opts.min_distance,
-            return_vector=False,
+            min_cosine_similarity=vector_search_opts.min_distance,
             return_properties=True,
         )
         ordered_ids = [

--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -49,7 +49,6 @@ semantic_memory:
   # feature_store: profile_storage
   # vector_collection: semantic_vector_store
   # vector_dimensions: 1536
-  # vector_similarity_metric: cosine
 
 session_manager:
   database: profile_storage
@@ -161,7 +160,6 @@ resources:
         aws_access_key_id: <AWS_ACCESS_KEY_ID>
         aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>
         model_id: "amazon.titan-embed-text-v2:0"
-        similarity_metric: "cosine"
     ollama_embedder:
       provider: openai
       config:

--- a/sample_configs/episodic_memory_config.gpu.sample
+++ b/sample_configs/episodic_memory_config.gpu.sample
@@ -48,7 +48,6 @@ semantic_memory:
   # feature_store: profile_storage
   # vector_collection: semantic_vector_store
   # vector_dimensions: 1536
-  # vector_similarity_metric: cosine
 
 session_manager:
   database: profile_storage
@@ -160,7 +159,6 @@ resources:
         aws_access_key_id: <AWS_ACCESS_KEY_ID>
         aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>
         model_id: "amazon.titan-embed-text-v2:0"
-        similarity_metric: "cosine"
     ollama_embedder:
       provider: openai
       config:

--- a/sample_configs/episodic_memory_config.nebula.sample
+++ b/sample_configs/episodic_memory_config.nebula.sample
@@ -158,7 +158,6 @@ resources:
         aws_access_key_id: <AWS_ACCESS_KEY_ID>
         aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>
         model_id: "amazon.titan-embed-text-v2:0"
-        similarity_metric: "cosine"
     ollama_embedder:
       provider: openai
       config:


### PR DESCRIPTION
Replaces #1591 and #1593, resliced. The engine that was in front is now behind, so it never has to ship a method it cannot implement.

### Purpose of the change

Three things the vector store was doing that it is not the authority for.

**It carried four similarity metrics and shipped one.** Every embedder here produces vectors meant to be compared by cosine — OpenAI hard-coded it, Bedrock defaulted to it, SentenceTransformer only reported what the model declared — while every layer that touched a score paid for the other three in direction flags, threshold directions, and per-backend tables mapping the enum onto native metric names.

**It handed vectors back.** `VectorStoreCollection.get` had one production caller: the semantic storage read a feature's stored embedding back so it could write the same embedding again with fresh properties, because `upsert` demands a whole record. `return_vector=True` was passed there and nowhere else, and `VectorSearchEngine.get_vectors` existed to serve it.

**It handed properties back.** Both consumers were reading that copy to get from a search hit to a domain id, and what the copy cost them differed: semantic memory's was of mutable columns, only as fresh as the last write to it, while event memory's was an immutable uuid pairing that stayed correct but duplicated a mapping the segment store already served from an index.

### Description

`SimilarityMetric` is gone. Scores are cosine similarities in `[-1, 1]`, and the names say so: `QueryMatch.score` → `cosine_similarity`, `query(score_threshold=)` → `query(min_cosine_similarity=)`, which no longer needs a direction to be meaningful. The Bedrock embedder's `similarity_metric` config key goes with it, and the install and configuration docs drop it.

`get` is **removed**, with nothing offered in its place, and `VectorSearchEngine.get_vectors` goes with it. Semantic memory's read-modify-write is gone (see below), so nothing reads a stored vector back at all.

No scoring-by-id entry point takes its place. One would be needed if a caller assembled a candidate set outside the store and asked for those ids to be scored — what a selective-filter plan running *above* the store would do. Property filtering stays inside the store instead, so the candidate set stays there too, and a store-side regime reaches engine keys directly without a public method addressed by record UUID.

`QueryMatch` answers a `record_uuid` and a score. Properties stay **stored and filterable** — a filter is evaluated against the copy rather than trusted as the record — and are never returned. That ends `return_properties`, `Record` on the read path, and `set_properties`.

Each consumer now owns its own mapping:

- **Event memory** used a `_segment_uuid` property. The segment store already holds that mapping on the derivative's own row, non-null, under a primary key leading on exactly the columns the lookup filters — so the copy bought nothing an indexed read does not. `get_segment_uuids_by_derivative_uuids` mirrors the forward lookup that was already there.
- **Semantic memory** had nothing to reach for: its record uuid was `uuid5(namespace, feature_id)`, one-way, so the feature id rode along in the properties. It now owns a unique `vector_uuid` column and resolves hits through it. Every property that collection carried was a copy of a column on the feature row, never filtered on, so the payload goes entirely. The delete paths read the column *before* deleting the rows, since the row is what says which vector record a feature owns.

### Two consequences beyond the vector store

The vector graph stores carried a metric per stored embedding, as a companion property beside every vector. That is gone; `Node.embeddings` holds plain vectors.

NebulaGraph's `cosine()` cannot take `APPROXIMATE` and its vector indexes offer only L2 and IP. Cosine similarity between unit vectors *is* their inner product, so embeddings are normalized on the way in and compared with `inner_product()` against an IP index: cosine ranking that, unlike `cosine()`, can be approximate. Normalization happens in `_vector_to_gql_literal`, the one place any vector becomes a GQL literal, so the stored side and the query side cannot disagree. **Its tests skip everywhere, CI included** — they need a real NebulaGraph server rather than a testcontainer — so this is the least-exercised part of the change and wants a reviewer who can run against a licensed 5.x server.

### Breaking

Data on `speedkick` does not survive this: existing semantic features have no `vector_uuid`, and existing collections carry properties nothing reads.

### Verification

- `pytest packages/server/server_tests`: 1898 passed, 3 skipped, 1 failed.
- `pytest -m integration packages/server/server_tests/memmachine_server/common`, against real containers: 282 passed, 106 skipped.
- `ty check --project packages/server`: clean.
- `ruff check` / `ruff format --check`: clean.

The one failure is `test_get_version`. It rejects the `.post` segment `git describe` puts into the derived version — here `0.3.9.post2.dev10+g21105d6e6.d20260909` — which the test's regex does not allow. Nothing in this PR touches versioning or tags, and it fails the same way on untouched `speedkick`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKmF9xNph9QH3ozNw3ZnJL





