### PR TITLE
Add VectorSearchEngine backed by turbovec (speedkick)

### DIFF
--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -79,6 +79,9 @@ litellm = [
     # keeps the resolved OpenAI SDK on the 2.x line.
     "litellm>=1.93.0",
 ]
+turbovec = [
+    "turbovec>=1.0.0",
+]
 
 [project.scripts]
 memmachine-server = "memmachine_server.server.app:main"

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_turbovec_engine.py
@@ -1,0 +1,506 @@
+"""Tests for TurboVecVectorSearchEngine.
+
+turbovec stores TurboQuant-compressed vectors, so scores are approximate: a
+self-match lands near the exact value, and orthogonal pairs land near zero
+rather than exactly zero. Tests therefore assert ranking and membership (robust
+under quantization) and only loosely assert score magnitudes. The one exact
+bound is the cosine range, which the engine clamps.
+"""
+
+import math
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("turbovec")
+
+from memmachine_server.common.vector_store.vector_search_engine.turbovec_engine import (
+    TurboVecVectorSearchEngine,
+)
+
+NDIM = 8
+
+QUANT_ABS = 0.05
+
+
+def _normalize(v: list[float]) -> list[float]:
+    magnitude = math.sqrt(sum(x * x for x in v))
+    return [x / magnitude for x in v]
+
+
+def _one_hot(index: int, value: float = 1.0) -> list[float]:
+    """A length-NDIM vector with `value` at `index`, zeros elsewhere."""
+    vector = [0.0] * NDIM
+    vector[index] = value
+    return vector
+
+
+def _entry_names(directory: Path) -> list[str]:
+    """Names of everything in `directory`. Sync: the tests calling it are not."""
+    return [entry.name for entry in directory.iterdir()]
+
+
+def _spread(seed: int) -> list[float]:
+    """A deterministic unit vector, distinct per `seed`."""
+    return _normalize(
+        [math.cos(seed * (axis + 1) * 0.7 + axis) for axis in range(NDIM)]
+    )
+
+
+async def _search_one(engine, vector, limit=10, **kwargs):
+    """Helper: search a single vector, return the one SearchResult."""
+    results = await engine.search([vector], limit=limit, **kwargs)
+    return results[0]
+
+
+def _make_engine(**kwargs):
+    return TurboVecVectorSearchEngine(num_dimensions=NDIM, **kwargs)
+
+
+# -- Construction --
+
+
+class TestConstruction:
+    def test_valid_bit_widths(self):
+        for bit_width in (2, 3, 4):
+            _make_engine(bit_width=bit_width)
+
+    def test_invalid_bit_width_raises(self):
+        with pytest.raises(ValueError, match="bit_width"):
+            _make_engine(bit_width=5)
+
+    def test_unaligned_dimensions_are_accepted(self):
+        TurboVecVectorSearchEngine(num_dimensions=7)
+
+
+# -- Add --
+
+
+class TestAdd:
+    @pytest.mark.asyncio
+    async def test_add_single(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches[0].key == 1
+
+    @pytest.mark.asyncio
+    async def test_add_batch(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                10: _normalize(_one_hot(0)),
+                20: _normalize(_one_hot(1)),
+                30: _normalize(_one_hot(2)),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        assert {m.key for m in result.matches} == {10, 20, 30}
+
+    @pytest.mark.asyncio
+    async def test_add_empty(self):
+        engine = _make_engine()
+        await engine.add({})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_remove_then_add_replaces_key(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        await engine.remove([1])
+        await engine.add({1: _normalize(_one_hot(1))})
+        result = await _search_one(engine, _normalize(_one_hot(1)), limit=1)
+        assert result.matches[0].key == 1
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_repeated_reupsert_of_same_key(self):
+        engine = _make_engine()
+        for index in range(NDIM):
+            await engine.remove([7])
+            await engine.add({7: _normalize(_one_hot(index))})
+        result = await _search_one(engine, _normalize(_one_hot(NDIM - 1)), limit=1)
+        assert result.matches[0].key == 7
+
+
+# -- Remove --
+
+
+class TestRemove:
+    @pytest.mark.asyncio
+    async def test_remove_existing(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        await engine.remove([1])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=2)
+        keys = {m.key for m in result.matches}
+        assert 1 not in keys
+        assert 2 in keys
+
+    @pytest.mark.asyncio
+    async def test_remove_missing_is_ignored(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        await engine.remove([99, 100])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches[0].key == 1
+
+    @pytest.mark.asyncio
+    async def test_remove_all(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize(_one_hot(2)),
+            }
+        )
+        await engine.remove([1, 2, 3])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_remove_empty_iterable(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        await engine.remove([])
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert result.matches[0].key == 1
+
+
+# -- Search: Cosine --
+
+
+class TestSearchCosine:
+    @pytest.mark.asyncio
+    async def test_basic_knn(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize([1, 1, 0, 0, 0, 0, 0, 0]),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        assert len(result.matches) == 3
+        assert result.matches[0].key == 1
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[1].key == 3
+        assert result.matches[2].key == 2
+
+    @pytest.mark.asyncio
+    async def test_orthogonal_scores_near_zero(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=2)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=QUANT_ABS)
+        assert result.matches[1].cosine_similarity == pytest.approx(0.0, abs=0.1)
+
+    @pytest.mark.asyncio
+    async def test_scores_ordered_best_first(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize([1, 1, 0, 0, 0, 0, 0, 0]),
+            }
+        )
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=3)
+        for i in range(len(result.matches) - 1):
+            assert (
+                result.matches[i].cosine_similarity
+                >= result.matches[i + 1].cosine_similarity
+            )
+
+    @pytest.mark.asyncio
+    async def test_k_larger_than_index(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=10)
+        assert len(result.matches) == 1
+
+    @pytest.mark.asyncio
+    async def test_search_empty_index(self):
+        engine = _make_engine()
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=5)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_limit_zero_returns_empty(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=0)
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_empty_query_list(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        results = await engine.search([], limit=3)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_batched_search(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+        results = await engine.search(
+            [_normalize(_one_hot(0)), _normalize(_one_hot(1))], limit=1
+        )
+        assert len(results) == 2
+        assert results[0].matches[0].key == 1
+        assert results[1].matches[0].key == 2
+
+
+# -- Search: allowed_keys filtering --
+
+
+class TestSearchAllowedKeys:
+    @pytest.mark.asyncio
+    async def test_allowed_keys_restrict_results(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize(_one_hot(2)),
+                4: _normalize(_one_hot(3)),
+            }
+        )
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=4, allowed_keys=[2, 3]
+        )
+        assert {m.key for m in result.matches} == {2, 3}
+
+    @pytest.mark.asyncio
+    async def test_allowed_keys_exclude_best_match(self):
+        engine = _make_engine()
+        await engine.add(
+            {
+                1: _normalize(_one_hot(0)),
+                2: _normalize(_one_hot(1)),
+                3: _normalize(_one_hot(2)),
+            }
+        )
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=1, allowed_keys=[2, 3]
+        )
+        assert len(result.matches) == 1
+        assert result.matches[0].key in {2, 3}
+
+    @pytest.mark.asyncio
+    async def test_empty_allowed_keys_return_nothing(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=1, allowed_keys=[]
+        )
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_absent_allowed_keys_are_ignored(self):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=2, allowed_keys=[1, 12345]
+        )
+        assert [m.key for m in result.matches] == [1]
+
+    @pytest.mark.asyncio
+    async def test_low_ranked_allowed_key_found(self):
+        engine = _make_engine()
+        vectors = {index: _spread(index) for index in range(2 * NDIM)}
+        await engine.add(vectors)
+
+        target = 2 * NDIM - 1
+        result = await _search_one(
+            engine, _normalize(_one_hot(0)), limit=1, allowed_keys=[target]
+        )
+        assert [m.key for m in result.matches] == [target]
+
+
+class TestPersistence:
+    @pytest.mark.asyncio
+    async def test_save_and_load(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0)), 2: _normalize(_one_hot(1))})
+
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        engine2 = _make_engine()
+        await engine2.load(path)
+
+        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=2)
+        assert {m.key for m in result.matches} == {1, 2}
+        assert result.matches[0].key == 1
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_save_leaves_no_temp_file(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+
+        path = tmp_path / "test.idx"
+        await engine.save(str(path))
+
+        assert _entry_names(tmp_path) == ["test.idx"]
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_carries_adds_and_mass_removals(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({key: _spread(key) for key in range(1, 2001)})
+
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        doomed = [key for key in range(1, 2001) if key % 4 != 0]
+        await engine.remove(doomed)
+        await engine.add({key: _spread(key) for key in range(10_001, 10_033)})
+        await engine.save(path)
+
+        engine2 = _make_engine()
+        await engine2.load(path)
+
+        expected = set(range(4, 2001, 4)) | set(range(10_001, 10_033))
+        result = await _search_one(engine2, _spread(1), limit=len(expected) + 10)
+        assert {match.key for match in result.matches} == expected
+
+    @pytest.mark.asyncio
+    async def test_load_replaces_existing_index(self, tmp_path: Path):
+        engine = _make_engine()
+        await engine.add({1: _normalize(_one_hot(0))})
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        engine2 = _make_engine()
+        await engine2.add({2: _normalize(_one_hot(1))})
+        await engine2.load(path)
+
+        result = await _search_one(engine2, _normalize(_one_hot(0)), limit=5)
+        keys = {m.key for m in result.matches}
+        assert keys == {1}
+
+
+# -- SearchResult types --
+
+
+class TestUnalignedDimensions:
+    @pytest.mark.asyncio
+    async def test_search_at_an_unaligned_width(self):
+        engine = TurboVecVectorSearchEngine(num_dimensions=5)
+        await engine.add(
+            {
+                1: [1.0, 0.0, 0.0, 0.0, 0.0],
+                2: [0.0, 1.0, 0.0, 0.0, 0.0],
+            }
+        )
+
+        results = await engine.search([[1.0, 0.0, 0.0, 0.0, 0.0]], limit=2)
+        matches = results[0].matches
+        assert [match.key for match in matches] == [1, 2]
+        assert matches[0].cosine_similarity == pytest.approx(1.0, abs=QUANT_ABS)
+        assert matches[1].cosine_similarity == pytest.approx(0.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_save_and_load_at_an_unaligned_width(self, tmp_path: Path):
+        def make_engine():
+            return TurboVecVectorSearchEngine(num_dimensions=5)
+
+        engine = make_engine()
+        await engine.add({1: [1.0, 0.0, 0.0, 0.0, 0.0]})
+        path = str(tmp_path / "test.idx")
+        await engine.save(path)
+
+        loaded = make_engine()
+        await loaded.load(path)
+
+        results = await loaded.search([[1.0, 0.0, 0.0, 0.0, 0.0]], limit=1)
+        assert [match.key for match in results[0].matches] == [1]
+
+    @pytest.mark.asyncio
+    async def test_wrong_width_vector_is_rejected(self):
+        engine = TurboVecVectorSearchEngine(num_dimensions=5)
+        with pytest.raises(ValueError, match="must have 5 dimensions"):
+            await engine.add({1: [1.0, 0.0, 0.0]})
+
+
+class TestNonUnitVectors:
+    """Vectors are normalized on the way in, so scores are cosines.
+
+    Every other test here feeds unit vectors, under which normalization is a
+    no-op. These use SHORT vectors rather than long ones on purpose: an
+    over-long raw inner product is hidden by the clamp onto [-1, 1], while an
+    under-long one lands inside the range and is visible.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_short_stored_vector_still_self_matches(self):
+        engine = _make_engine()
+        await engine.add({1: _one_hot(0, value=0.02)})
+
+        result = await _search_one(engine, _one_hot(0), limit=1)
+        # Without normalization the raw inner product is 0.02.
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_a_short_query_vector_still_self_matches(self):
+        engine = _make_engine()
+        await engine.add({1: _one_hot(0)})
+
+        result = await _search_one(engine, _one_hot(0, value=0.02), limit=1)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=QUANT_ABS)
+
+    @pytest.mark.asyncio
+    async def test_magnitude_does_not_outrank_direction(self):
+        """A raw inner product would rank the longer vector first."""
+        aligned_but_short = _one_hot(0, value=0.02)
+        misaligned_but_unit = _normalize([1.0, 1.0] + [0.0] * (NDIM - 2))
+        engine = _make_engine()
+        await engine.add({1: aligned_but_short, 2: misaligned_but_unit})
+
+        # Raw: 0.02 for key 1 against ~0.707 for key 2, so key 2 would win.
+        # By cosine: 1.0 against ~0.707, so key 1 wins.
+        result = await _search_one(engine, _one_hot(0), limit=2)
+        assert [match.key for match in result.matches] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_score_is_scale_invariant(self):
+        """The same direction at any length must score the same."""
+        engine = _make_engine()
+        await engine.add({1: _one_hot(1), 2: _one_hot(1, value=0.02)})
+
+        result = await _search_one(engine, _one_hot(1), limit=2)
+        scores = {match.key: match.cosine_similarity for match in result.matches}
+        assert scores[1] == pytest.approx(scores[2], abs=QUANT_ABS)
+
+
+class TestScoreRange:
+    @pytest.mark.asyncio
+    async def test_cosine_scores_stay_within_range(self):
+        engine = _make_engine()
+        vectors = {key: _spread(key) for key in range(1, 51)}
+        await engine.add(vectors)
+
+        for vector in vectors.values():
+            result = await _search_one(engine, vector, limit=5)
+            for match in result.matches:
+                assert -1.0 <= match.cosine_similarity <= 1.0
+
+
+class TestSearchResultTypes:
+    @pytest.mark.asyncio
+    async def test_keys_are_ints(self):
+        engine = _make_engine()
+        await engine.add({42: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert isinstance(result.matches[0].key, int)
+
+    @pytest.mark.asyncio
+    async def test_scores_are_floats(self):
+        engine = _make_engine()
+        await engine.add({42: _normalize(_one_hot(0))})
+        result = await _search_one(engine, _normalize(_one_hot(0)), limit=1)
+        assert isinstance(result.matches[0].cosine_similarity, float)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/turbovec_engine.py
@@ -1,0 +1,159 @@
+"""turbovec (TurboQuant) implementation of VectorSearchEngine."""
+
+import asyncio
+import math
+from collections.abc import Container, Iterable, Mapping, Sequence
+from typing import ClassVar, override
+
+import numpy as np
+from turbovec import IdMapIndex
+
+from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
+
+
+class TurboVecVectorSearchEngine(VectorSearchEngine):
+    """
+    Vector search engine backed by turbovec.
+
+    turbovec indexes a dimensionality that is a multiple of 8, so a vector of
+    any other width is zero-padded up to one. Padding is exact -- a zero
+    coordinate adds nothing to an inner product and nothing to a norm -- so
+    the padded index answers as the unpadded one would, and any embedding
+    width the other engines accept works here too.
+    """
+
+    _VALID_BIT_WIDTHS: ClassVar[frozenset[int]] = frozenset({2, 3, 4})
+    _DEFAULT_BIT_WIDTH: ClassVar[int] = 4
+    _OVERFETCH_BASE: ClassVar[int] = 4
+
+    def __init__(
+        self,
+        *,
+        num_dimensions: int,
+        bit_width: int = _DEFAULT_BIT_WIDTH,
+    ) -> None:
+        """Initialize."""
+        if bit_width not in self._VALID_BIT_WIDTHS:
+            raise ValueError(
+                f"turbovec bit_width must be one of "
+                f"{sorted(self._VALID_BIT_WIDTHS)}, got {bit_width}"
+            )
+
+        self._num_dimensions = num_dimensions
+        self._padded_dimensions = math.ceil(num_dimensions / 8) * 8
+        self._index = IdMapIndex(dim=self._padded_dimensions, bit_width=bit_width)
+
+    @override
+    async def add(self, vectors: Mapping[int, Sequence[float]]) -> None:
+        if not vectors:
+            return
+        await asyncio.to_thread(self._sync_add, vectors)
+
+    def _sync_add(self, vectors: Mapping[int, Sequence[float]]) -> None:
+        keys = np.array(list(vectors.keys()), dtype=np.uint64)
+        array = self._prepare_vectors(list(vectors.values()))
+        self._index.add_with_ids(array, keys)
+
+    @override
+    async def search(
+        self,
+        vectors: Iterable[Sequence[float]],
+        *,
+        limit: int,
+        allowed_keys: Container[int] | None = None,
+    ) -> list[SearchResult]:
+        vectors = list(vectors)
+        if not vectors or limit <= 0:
+            return [SearchResult(matches=[]) for _ in vectors]
+        return await asyncio.to_thread(self._sync_search, vectors, limit, allowed_keys)
+
+    def _sync_search(
+        self,
+        vectors: Sequence[Sequence[float]],
+        limit: int,
+        allowed_keys: Container[int] | None,
+    ) -> list[SearchResult]:
+        query = self._prepare_vectors(vectors)
+        num_queries = query.shape[0]
+        size = len(self._index)
+        if size == 0:
+            return [SearchResult(matches=[]) for _ in vectors]
+
+        # turbovec has a native allowlist search, but it needs the allowed ids
+        # enumerated and `allowed_keys` only answers membership. So, like the
+        # engines beside it, this one fetches unrestricted, drops what the
+        # filter rejects, and widens the fetch until `limit` survive or the
+        # whole index has been scanned.
+        overfetch_factor = 1 if allowed_keys is None else self._OVERFETCH_BASE
+        final_results: list[SearchResult | None] = [None] * num_queries
+        pending_indices = list(range(num_queries))
+        while pending_indices:
+            pending_query = query[pending_indices]
+            fetch_limit = min(limit * overfetch_factor, size)
+            inner_products, ids = self._index.search(pending_query, fetch_limit)
+            still_pending: list[int] = []
+            for batch_index, original_index in enumerate(pending_indices):
+                matches: list[SearchMatch] = []
+                for inner_product, key in zip(
+                    inner_products[batch_index], ids[batch_index], strict=True
+                ):
+                    int_key = int(key)
+                    if allowed_keys is not None and int_key not in allowed_keys:
+                        continue
+                    matches.append(
+                        SearchMatch(
+                            key=int_key,
+                            cosine_similarity=self._to_cosine_similarity(inner_product),
+                        )
+                    )
+                    if len(matches) >= limit:
+                        break
+                if len(matches) >= limit or fetch_limit >= size:
+                    final_results[original_index] = SearchResult(matches=matches)
+                else:
+                    still_pending.append(original_index)
+            pending_indices = still_pending
+            overfetch_factor *= self._OVERFETCH_BASE
+        return [
+            result if result is not None else SearchResult(matches=[])
+            for result in final_results
+        ]
+
+    @staticmethod
+    def _to_cosine_similarity(inner_product: float) -> float:
+        """Clamp a quantized inner product onto the cosine range."""
+        return min(1.0, max(-1.0, float(inner_product)))
+
+    def _prepare_vectors(self, vectors: Sequence[Sequence[float]]) -> np.ndarray:
+        array = np.zeros((len(vectors), self._padded_dimensions), dtype=np.float32)
+        try:
+            array[:, : self._num_dimensions] = vectors
+        except ValueError as error:
+            raise ValueError(
+                f"vectors must have {self._num_dimensions} dimensions"
+            ) from error
+        norms = np.linalg.norm(array, axis=1, keepdims=True)
+        norms[norms == 0.0] = 1.0
+        return array / norms
+
+    @override
+    async def remove(self, keys: Iterable[int]) -> None:
+        await asyncio.to_thread(self._sync_remove, keys)
+
+    def _sync_remove(self, keys: Iterable[int]) -> None:
+        for key in keys:
+            self._index.remove(key)
+
+    @override
+    async def save(self, path: str) -> None:
+        await asyncio.to_thread(self._sync_save, path)
+
+    def _sync_save(self, path: str) -> None:
+        self._index.sync(path)
+
+    @override
+    async def load(self, path: str) -> None:
+        self._index = await asyncio.to_thread(self._sync_load, path)
+
+    def _sync_load(self, path: str) -> IdMapIndex:
+        return IdMapIndex.load(path)

--- a/uv.lock
+++ b/uv.lock
@@ -2377,6 +2377,9 @@ nebula = [
 qdrant = [
     { name = "qdrant-client" },
 ]
+turbovec = [
+    { name = "turbovec" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2412,11 +2415,12 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'gpu'", specifier = ">=5.1.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.43" },
     { name = "sqlite-vec", specifier = ">=0.1.9" },
+    { name = "turbovec", marker = "extra == 'turbovec'", specifier = ">=1.0.0" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.1" },
     { name = "usearch", specifier = ">=2.25.1" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
-provides-extras = ["gpu", "hnswlib", "nebula", "qdrant", "milvus", "litellm"]
+provides-extras = ["gpu", "hnswlib", "nebula", "qdrant", "milvus", "litellm", "turbovec"]
 
 [[package]]
 name = "milvus-lite"
@@ -4860,6 +4864,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "turbovec"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/d2/00c981bd1a6be5b6a875435bf678e627f191e3daf47ea70e1b5ee3109c36/turbovec-1.0.0.tar.gz", hash = "sha256:4ceb3c4ad08e48c6b3483b88aca63d81a06449f90d5fbc1b162dd11df10b8fb2", size = 702952, upload-time = "2026-08-18T20:43:31.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/e0/d759918244236356199b0f4d868ee331d0440a9824f147780aaefa8fe1af/turbovec-1.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:a69e8e2e26ba943f31fba546ab595b60e9b4c25087ed905c3e6ceb0d297ee234", size = 668359, upload-time = "2026-08-18T20:43:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e9/8de1e7d2636a8f5c73d39c64ec6fb4bd20180d8c966962d919356d06e175/turbovec-1.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:09aa495e802701f139820e21700dc947ea21734446112afefb4e480a8f65fa90", size = 700020, upload-time = "2026-08-18T20:43:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/6d/c1acf31a1ef381b588de86ebebb32c3ca7d310cbb84279ac1f65c3a3e854/turbovec-1.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c810f50b967c2163b78d1e27d29e153ab5e8820de23921ad959227acca8bb06a", size = 719275, upload-time = "2026-08-18T20:43:28.402Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/7d/e0c14b09f6dfb7ff156d1f884119daebc5c8bf9f5b8fc72ada26c2674256/turbovec-1.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:cd855e0b318a57dc57c733f9a62ae98de5192f4f6c2c760e305523e8ceb1b090", size = 611788, upload-time = "2026-08-18T20:43:29.854Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Purpose of the change

A `VectorSearchEngine` over turbovec: an in-memory index of 4-bit TurboQuant codes.

It scans every vector, like the engines beside it, so it changes no asymptotics. What it changes is the memory traffic an exhaustive scan is bound by, which 4-bit codes cut about eightfold.

### Why it lands after #1598

Under the engine contract before #1598 this engine had to supply `get_vectors`, and it could only ever raise: turbovec keeps quantized codes and does not retain the originals. Adding a method that exists to refuse, and retiring it a PR later, is churn that says nothing. On the contract #1598 left behind there is no keyed vector access to refuse, so every method this engine declares, it implements.

### Description

- Scores are clamped onto `[-1, 1]`: quantization can carry an inner product slightly outside it, and a similarity reading `1.0000001` is a lie about the range the contract promises.
- Vectors are zero-padded to a multiple of eight — the width the index can hold — and normalized on the way in, so the inner product it computes is cosine.
- turbovec has a native allowlist search, but it needs the allowed ids enumerated, and the engine contract's `allowed_keys` only answers membership. So the engine fetches unrestricted, drops what the filter rejects, and widens the fetch until `limit` survive or the whole index has been scanned, as usearch does. Handing turbovec the ids directly waits for the contract to carry them (#1602, deferred).
- Like the engines beside it since #1612, it holds no lock of its own: the store serializes access.
- `turbovec>=1.0.0` as an optional extra; 1.0.0 is upstream's first stable release and commits to the on-disk format this persists through.

### Verification

- `pytest packages/server/server_tests`: 1963 passed, 3 skipped.
- `ty check --project packages/server`: clean.
- `ruff check` / `ruff format --check` / `uv lock --check`: clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKmF9xNph9QH3ozNw3ZnJL






