### PR TITLE
Honor semantic_memory.enabled on every request path, not only at startup (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_resource_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_resource_manager.py
@@ -35,6 +35,7 @@ from memmachine_server.common.errors import (
     InvalidLanguageModelError,
     InvalidRerankerError,
     ResourceManagerClosedError,
+    ResourceNotReadyError,
 )
 from memmachine_server.common.resource_manager import CommonResourceManager
 from memmachine_server.common.resource_manager import (
@@ -318,3 +319,33 @@ async def test_get_segment_store_after_close_raises(invalid_resource_manager):
     await invalid_resource_manager.close()
     with pytest.raises(ResourceManagerClosedError):
         await invalid_resource_manager.get_segment_store(SQLDB_ID)
+
+
+@pytest.fixture
+def semantic_disabled_resource_manager(invalid_configure) -> CommonResourceManager:
+    invalid_configure.semantic_memory.enabled = False
+    return ResourceManagerImpl(invalid_configure)
+
+
+@pytest.mark.asyncio
+async def test_get_semantic_manager_refuses_when_semantic_memory_disabled(
+    semantic_disabled_resource_manager,
+):
+    with pytest.raises(ResourceNotReadyError, match="disabled"):
+        await semantic_disabled_resource_manager.get_semantic_manager()
+
+
+@pytest.mark.asyncio
+async def test_get_semantic_service_refuses_when_semantic_memory_disabled(
+    semantic_disabled_resource_manager,
+):
+    with pytest.raises(ResourceNotReadyError, match="disabled"):
+        await semantic_disabled_resource_manager.get_semantic_service()
+
+
+@pytest.mark.asyncio
+async def test_get_semantic_session_manager_refuses_when_semantic_memory_disabled(
+    semantic_disabled_resource_manager,
+):
+    with pytest.raises(ResourceNotReadyError, match="disabled"):
+        await semantic_disabled_resource_manager.get_semantic_session_manager()

--- a/packages/server/server_tests/memmachine_server/main/conftest.py
+++ b/packages/server/server_tests/memmachine_server/main/conftest.py
@@ -258,6 +258,7 @@ def memmachine_config(
             reranker=reranker_id,
         ),
         semantic_memory=SemanticMemoryConf(
+            enabled=True,
             database=postgres_db,
             config_database=postgres_db,
             llm_model=language_model_id,

--- a/packages/server/server_tests/memmachine_server/main/test_memmachine_delete_session.py
+++ b/packages/server/server_tests/memmachine_server/main/test_memmachine_delete_session.py
@@ -146,10 +146,12 @@ async def test_delete_episode_store_processes_in_batches(
 
     conf = MagicMock()
     conf.episodic_memory.enabled = False
-    conf.semantic_memory.enabled = False
+    conf.semantic_memory.enabled = True
 
     resources = MagicMock()
     resources.close = AsyncMock()
+    resources.get_semantic_service = AsyncMock()
+    resources.get_semantic_session_manager = AsyncMock()
     session_manager = MagicMock()
     session_manager.get_session_info = AsyncMock(
         return_value=MagicMock(status="active")

--- a/packages/server/server_tests/memmachine_server/main/test_memmachine_mock.py
+++ b/packages/server/server_tests/memmachine_server/main/test_memmachine_mock.py
@@ -26,14 +26,14 @@ from memmachine_server.common.episode_store import (
     EpisodeEntry,
     EpisodeResponse,
 )
-from memmachine_server.common.errors import SessionNotFoundError
+from memmachine_server.common.errors import ResourceNotReadyError, SessionNotFoundError
 from memmachine_server.common.filter.filter_parser import And as FilterAnd
 from memmachine_server.common.filter.filter_parser import Comparison as FilterComparison
 from memmachine_server.common.session_manager.session_data_manager import (
     SessionDataManager,
 )
 from memmachine_server.episodic_memory import EpisodicMemory
-from memmachine_server.main.memmachine import MemMachine, MemoryType
+from memmachine_server.main.memmachine import ALL_MEMORY_TYPES, MemMachine, MemoryType
 from memmachine_server.retrieval_agent.common.agent_api import AgentToolBase
 from memmachine_server.semantic_memory.semantic_model import SemanticFeature
 
@@ -933,3 +933,225 @@ async def test_start_deletes_marked_sessions(minimal_conf, patched_resource_mana
     )
 
     session_manager.delete_session.assert_awaited_once_with(session_key=session_key)
+
+
+def test_enabled_memory_types_follows_configuration(
+    minimal_conf, patched_resource_manager
+):
+    minimal_conf.semantic_memory.enabled = True
+    memmachine = MemMachine(minimal_conf, patched_resource_manager)
+    assert memmachine.enabled_memory_types == frozenset(ALL_MEMORY_TYPES)
+
+    minimal_conf.semantic_memory.enabled = False
+    assert memmachine.enabled_memory_types == frozenset({MemoryType.Episodic})
+
+    minimal_conf.episodic_memory.enabled = False
+    assert memmachine.enabled_memory_types == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_query_search_skips_semantic_memory_when_disabled(
+    minimal_conf, patched_resource_manager, monkeypatch
+):
+    minimal_conf.semantic_memory.enabled = False
+    async_episodic = AsyncMock(
+        return_value=EpisodicMemory.QueryResponse(
+            long_term_memory=EpisodicMemory.QueryResponse.LongTermMemoryResponse(
+                episodes=[]
+            ),
+            short_term_memory=EpisodicMemory.QueryResponse.ShortTermMemoryResponse(
+                episodes=[],
+                episode_summary=[],
+            ),
+        )
+    )
+    monkeypatch.setattr(MemMachine, "_search_episodic_memory", async_episodic)
+
+    memmachine = MemMachine(minimal_conf, patched_resource_manager)
+    result = await memmachine.query_search(
+        DummySessionData("s1"),
+        target_memories=ALL_MEMORY_TYPES,
+        query="hello world",
+    )
+
+    async_episodic.assert_awaited_once()
+    patched_resource_manager.get_semantic_session_manager.assert_not_awaited()
+    assert result.episodic_memory is async_episodic.return_value
+    assert result.semantic_memory is None
+
+
+@pytest.mark.asyncio
+async def test_query_search_skips_episodic_memory_when_disabled(
+    minimal_conf, patched_resource_manager, monkeypatch
+):
+    minimal_conf.episodic_memory.enabled = False
+    minimal_conf.semantic_memory.enabled = True
+    async_episodic = AsyncMock()
+    monkeypatch.setattr(MemMachine, "_search_episodic_memory", async_episodic)
+
+    semantic_features = [
+        SemanticFeature(
+            category="profile",
+            tag="name",
+            feature_name="value",
+            value="semantic-response",
+        )
+    ]
+
+    async def mock_search(*args, **kwargs):
+        for feature in semantic_features:
+            yield feature
+
+    semantic_manager = MagicMock()
+    semantic_manager.search = mock_search
+    patched_resource_manager.get_semantic_session_manager = AsyncMock(
+        return_value=semantic_manager
+    )
+
+    memmachine = MemMachine(minimal_conf, patched_resource_manager)
+    result = await memmachine.query_search(
+        DummySessionData("s1"),
+        target_memories=ALL_MEMORY_TYPES,
+        query="hello world",
+    )
+
+    async_episodic.assert_not_awaited()
+    assert result.episodic_memory is None
+    assert result.semantic_memory == semantic_features
+
+
+@pytest.mark.asyncio
+async def test_add_episodes_skips_semantic_memory_when_disabled(
+    minimal_conf, patched_resource_manager
+):
+    minimal_conf.semantic_memory.enabled = False
+    episode = _make_episode("e1", "s1")
+    episode_storage = AsyncMock()
+    episode_storage.add_episodes = AsyncMock(return_value=[episode])
+    patched_resource_manager.get_episode_storage = AsyncMock(
+        return_value=episode_storage
+    )
+
+    episodic_session = MagicMock()
+    episodic_session.add_memory_episodes = AsyncMock()
+    episodic_memory_manager = MagicMock()
+    episodic_memory_manager.open_or_create_episodic_memory = MagicMock(
+        return_value=_async_cm(episodic_session)
+    )
+    patched_resource_manager.get_episodic_memory_manager = AsyncMock(
+        return_value=episodic_memory_manager
+    )
+
+    memmachine = MemMachine(minimal_conf, patched_resource_manager)
+    episode_ids = await memmachine.add_episodes(
+        DummySessionData("s1"),
+        [EpisodeEntry(content="hello", producer_id="user", producer_role="user")],
+        target_memories=ALL_MEMORY_TYPES,
+    )
+
+    assert episode_ids == ["e1"]
+    episodic_session.add_memory_episodes.assert_awaited_once_with([episode])
+    patched_resource_manager.get_semantic_session_manager.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_list_search_skips_semantic_memory_when_disabled(
+    minimal_conf, patched_resource_manager
+):
+    minimal_conf.semantic_memory.enabled = False
+    episode_storage = AsyncMock()
+    episode_storage.get_episode_messages = AsyncMock(return_value=[])
+    patched_resource_manager.get_episode_storage = AsyncMock(
+        return_value=episode_storage
+    )
+
+    memmachine = MemMachine(minimal_conf, patched_resource_manager)
+    result = await memmachine.list_search(
+        DummySessionData("s1"),
+        target_memories=ALL_MEMORY_TYPES,
+    )
+
+    episode_storage.get_episode_messages.assert_awaited_once()
+    patched_resource_manager.get_semantic_session_manager.assert_not_awaited()
+    assert result.episodic_memory == []
+    assert result.semantic_memory is None
+
+
+@pytest.mark.asyncio
+async def test_delete_episodes_skips_semantic_history_when_disabled(
+    minimal_conf, patched_resource_manager
+):
+    minimal_conf.semantic_memory.enabled = False
+    episode_storage = AsyncMock()
+    patched_resource_manager.get_episode_storage = AsyncMock(
+        return_value=episode_storage
+    )
+    patched_resource_manager.get_semantic_service = AsyncMock(
+        side_effect=ResourceNotReadyError(
+            "No database configured for semantic storage.", "semantic_memory"
+        )
+    )
+
+    memmachine = MemMachine(minimal_conf, patched_resource_manager)
+    await memmachine.delete_episodes(["e1", "e2"])
+
+    episode_storage.delete_episodes.assert_awaited_once_with(["e1", "e2"])
+    patched_resource_manager.get_semantic_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_session_completes_with_semantic_memory_disabled(
+    minimal_conf, patched_resource_manager
+):
+    minimal_conf.semantic_memory.enabled = False
+    session_manager = AsyncMock()
+    session_manager.get_session_info = AsyncMock(
+        return_value=MagicMock(status=SessionDataManager.SessionStatus.Active)
+    )
+    patched_resource_manager.get_session_data_manager = AsyncMock(
+        return_value=session_manager
+    )
+    episode_storage = AsyncMock()
+    episode_storage.get_episode_ids = AsyncMock(side_effect=[["e1", "e2"], []])
+    patched_resource_manager.get_episode_storage = AsyncMock(
+        return_value=episode_storage
+    )
+    patched_resource_manager.get_semantic_service = AsyncMock(
+        side_effect=ResourceNotReadyError(
+            "No database configured for semantic storage.", "semantic_memory"
+        )
+    )
+
+    memmachine = MemMachine(minimal_conf, patched_resource_manager)
+    await memmachine.start()
+    try:
+        await memmachine.delete_session(DummySessionData("s1"))
+        await memmachine._deletion_queue.join()
+    finally:
+        await memmachine.stop()
+
+    episode_storage.delete_episodes.assert_awaited_once_with(["e1", "e2"])
+    session_manager.delete_session.assert_awaited_once_with(session_key="s1")
+    patched_resource_manager.get_semantic_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_all_skips_semantic_stores_when_disabled(
+    minimal_conf, patched_resource_manager
+):
+    minimal_conf.semantic_memory.enabled = False
+    episode_storage = AsyncMock()
+    patched_resource_manager.get_episode_storage = AsyncMock(
+        return_value=episode_storage
+    )
+    patched_resource_manager.get_semantic_manager = AsyncMock(
+        side_effect=ResourceNotReadyError(
+            "Semantic memory is disabled.", "semantic_memory"
+        )
+    )
+
+    memmachine = MemMachine(minimal_conf, patched_resource_manager)
+    await memmachine.delete_all()
+
+    episode_storage.delete_all.assert_awaited_once()
+    patched_resource_manager.get_semantic_manager.assert_not_awaited()

--- a/packages/server/server_tests/memmachine_server/server/api_v2/test_service.py
+++ b/packages/server/server_tests/memmachine_server/server/api_v2/test_service.py
@@ -11,11 +11,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from memmachine_common.api import MemoryType
 from memmachine_common.api.spec import (
+    DeleteMemoriesSpec,
     ListMemoriesSpec,
     SearchMemoriesSpec,
 )
 
 from memmachine_server.server.api_v2.service import (
+    _delete_memories,
     _list_target_memories,
     _search_target_memories,
 )
@@ -218,3 +220,41 @@ async def test_list_target_memories_other_fields_still_passed():
     assert call_kwargs["page_size"] == 25
     assert call_kwargs["page_num"] == 2
     assert call_kwargs["set_metadata"] == {"user_id": "u2"}
+
+
+# ---------------------------------------------------------------------------
+# _delete_memories
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_memories_skips_semantic_delete_without_semantic_uids():
+    """No semantic uids named means the semantic stack is never asked for."""
+    spec = DeleteMemoriesSpec.model_validate(
+        {"org_id": "org", "project_id": "proj", "episodic_memory_uids": ["e1"]}
+    )
+    memmachine = AsyncMock()
+
+    await _delete_memories(spec=spec, memmachine=memmachine)
+
+    memmachine.delete_episodes.assert_awaited_once()
+    assert memmachine.delete_episodes.call_args[1]["episode_ids"] == ["e1"]
+    memmachine.delete_features.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_memories_deletes_features_when_semantic_uids_given():
+    spec = DeleteMemoriesSpec.model_validate(
+        {
+            "org_id": "org",
+            "project_id": "proj",
+            "episodic_memory_uids": ["e1"],
+            "semantic_memory_uids": ["f1"],
+        }
+    )
+    memmachine = AsyncMock()
+
+    await _delete_memories(spec=spec, memmachine=memmachine)
+
+    memmachine.delete_episodes.assert_awaited_once()
+    memmachine.delete_features.assert_awaited_once_with(feature_ids=["f1"])

--- a/packages/server/src/memmachine_server/common/resource_manager/resource_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/resource_manager.py
@@ -17,7 +17,10 @@ from memmachine_server.common.episode_store import (
 from memmachine_server.common.episode_store.episode_sqlalchemy_store import (
     SqlAlchemyEpisodeStore,
 )
-from memmachine_server.common.errors import ResourceManagerClosedError
+from memmachine_server.common.errors import (
+    ResourceManagerClosedError,
+    ResourceNotReadyError,
+)
 from memmachine_server.common.language_model import LanguageModel
 from memmachine_server.common.metrics_factory import MetricsFactory
 from memmachine_server.common.reranker import Reranker
@@ -299,6 +302,10 @@ class ResourceManagerImpl:
 
     async def get_semantic_manager(self) -> SemanticResourceManager:
         """Return the semantic resource manager, constructing if needed."""
+        if not self._conf.semantic_memory.enabled:
+            raise ResourceNotReadyError(
+                "Semantic memory is disabled.", "semantic_memory"
+            )
         if self._semantic_manager is None:
             async with self._semantic_manager_lock:
                 if self._semantic_manager is None:

--- a/packages/server/src/memmachine_server/main/memmachine.py
+++ b/packages/server/src/memmachine_server/main/memmachine.py
@@ -381,7 +381,8 @@ class MemMachine:
             )
             if not episode_ids:
                 break
-            await self._cleanup_semantic_history(episode_ids)
+            if self._conf.semantic_memory.enabled:
+                await self._cleanup_semantic_history(episode_ids)
             await episode_store.delete_episodes(episode_ids)
 
     async def _delete_session_episodic_memory(self, session_key: str) -> None:
@@ -615,23 +616,6 @@ class MemMachine:
             session_key, status=SessionDataManager.SessionStatus.Active
         )
 
-    async def _cleanup_semantic_history(
-        self,
-        episode_ids: list[EpisodeIdT],
-    ) -> None:
-        """Remove semantic history and citations for the given episode IDs."""
-        try:
-            semantic_service = await self._resources.get_semantic_service()
-        except ResourceNotReadyError:
-            logger.exception(
-                "Semantic service not ready during history cleanup; "
-                "skipping cleanup for episode IDs %s",
-                episode_ids,
-            )
-            return
-
-        await semantic_service.delete_history(episode_ids)
-
     async def delete_session(self, session_data: SessionData) -> None:
         """
         Delete all data associated with a session.
@@ -732,6 +716,16 @@ class MemMachine:
             return left
         return FilterAnd(left=left, right=right)
 
+    @property
+    def enabled_memory_types(self) -> frozenset[MemoryType]:
+        """Memory types this instance serves, per the configuration flags."""
+        enabled: set[MemoryType] = set()
+        if self._conf.episodic_memory.enabled:
+            enabled.add(MemoryType.Episodic)
+        if self._conf.semantic_memory.enabled:
+            enabled.add(MemoryType.Semantic)
+        return frozenset(enabled)
+
     async def add_episodes(
         self,
         session_data: InstanceOf[SessionData],
@@ -745,12 +739,16 @@ class MemMachine:
         Args:
             session_data: Session context used to route writes.
             episode_entries: Episode messages/entries to add.
-            target_memories: Memory types to update (episodic, semantic).
+            target_memories: Memory types to update (episodic, semantic). Types
+                disabled in the configuration are skipped.
 
         Returns:
             IDs of the created episodes.
 
         """
+        target_memories = [
+            memory for memory in target_memories if memory in self.enabled_memory_types
+        ]
         episode_storage = await self._resources.get_episode_storage()
         episodes = await episode_storage.add_episodes(
             session_data.session_key,
@@ -1018,7 +1016,8 @@ class MemMachine:
 
         Args:
             session_data: Session context used to route the search.
-            target_memories: Which memory types to query.
+            target_memories: Which memory types to query. Types disabled in the
+                configuration are skipped and come back as `None`.
             set_metadata: Optional metadata tags used to select semantic sets.
             query: Query string.
             limit: Optional maximum number of results per memory.
@@ -1031,6 +1030,9 @@ class MemMachine:
             Aggregated search results across memory types.
 
         """
+        target_memories = [
+            memory for memory in target_memories if memory in self.enabled_memory_types
+        ]
         episodic_task: Task | None = None
         semantic_task: Task | None = None
 
@@ -1092,7 +1094,8 @@ class MemMachine:
 
         Args:
             session_data: Session context used to route the query.
-            target_memories: Which memory types to query.
+            target_memories: Which memory types to query. Types disabled in the
+                configuration are skipped and come back as `None`.
             set_metadata: Optional metadata tags used to select semantic sets.
             search_filter: Optional filter string applied to the query.
             page_size: Optional page size.
@@ -1102,6 +1105,9 @@ class MemMachine:
             Aggregated list results across memory types.
 
         """
+        target_memories = [
+            memory for memory in target_memories if memory in self.enabled_memory_types
+        ]
         search_filter_expr = parse_filter(search_filter) if search_filter else None
 
         episodic_task: Task | None = None
@@ -1200,7 +1206,11 @@ class MemMachine:
 
         """
         episode_storage = await self._resources.get_episode_storage()
-        semantic_service = await self._resources.get_semantic_service()
+        semantic_service = (
+            await self._resources.get_semantic_service()
+            if self._conf.semantic_memory.enabled
+            else None
+        )
 
         tasks: list[Coroutine[Any, Any, Any]] = []
 
@@ -1215,7 +1225,8 @@ class MemMachine:
                 tasks.append(t)
 
         tasks.append(episode_storage.delete_episodes(episode_ids))
-        tasks.append(semantic_service.delete_history(episode_ids))
+        if semantic_service is not None:
+            tasks.append(semantic_service.delete_history(episode_ids))
         await asyncio.gather(*tasks)
 
     async def _cleanup_semantic_history(self, episode_ids: list[str]) -> None:
@@ -1712,15 +1723,17 @@ class MemMachine:
 
         # TODO: Add episodic memory deletion
 
-        semantic_resource_manager = await self._resources.get_semantic_manager()
-        semantic_storage = await semantic_resource_manager.get_semantic_storage()
-        semantic_config_storage = (
-            await semantic_resource_manager.get_semantic_config_storage()
-        )
-
         episodic_store = await self._resources.get_episode_storage()
 
         async with asyncio.TaskGroup() as tg:
-            tg.create_task(semantic_storage.delete_all())
-            tg.create_task(semantic_config_storage.delete_all())
+            if self._conf.semantic_memory.enabled:
+                semantic_resource_manager = await self._resources.get_semantic_manager()
+                semantic_storage = (
+                    await semantic_resource_manager.get_semantic_storage()
+                )
+                semantic_config_storage = (
+                    await semantic_resource_manager.get_semantic_config_storage()
+                )
+                tg.create_task(semantic_storage.delete_all())
+                tg.create_task(semantic_config_storage.delete_all())
             tg.create_task(episodic_store.delete_all())

--- a/packages/server/src/memmachine_server/server/api_v2/service.py
+++ b/packages/server/src/memmachine_server/server/api_v2/service.py
@@ -84,17 +84,20 @@ async def _delete_memories(
     spec: DeleteMemoriesSpec,
     memmachine: MemMachine,
 ) -> None:
-    delete_episodes = memmachine.delete_episodes(
-        session_data=_SessionData(
-            org_id=spec.org_id,
-            project_id=spec.project_id,
-        ),
-        episode_ids=spec.episodic_memory_uids,
-    )
-    delete_semantics = memmachine.delete_features(
-        feature_ids=spec.semantic_memory_uids,
-    )
-    await asyncio.gather(delete_episodes, delete_semantics)
+    deletions = [
+        memmachine.delete_episodes(
+            session_data=_SessionData(
+                org_id=spec.org_id,
+                project_id=spec.project_id,
+            ),
+            episode_ids=spec.episodic_memory_uids,
+        )
+    ]
+    if spec.semantic_memory_uids:
+        deletions.append(
+            memmachine.delete_features(feature_ids=spec.semantic_memory_uids)
+        )
+    await asyncio.gather(*deletions)
 
 
 async def _search_target_memories(


### PR DESCRIPTION
Fixes #1600 and #1575. Both are the same missing gate: `semantic_memory.enabled` was consulted once, in `start()`, and nowhere on the request-serving side.

### Purpose of the change

With `semantic_memory.enabled: false`, every request path that could name the semantic type still resolved the semantic stack lazily and used it. `add_episodes`, `query_search` and `list_search` branched on `target_memories` alone, and the `SemanticResourceManager` getters built storage, config store, embedder and language model on first use without reading the flag, running Alembic migrations on the request path for pgvector. The flag changed who paid to bring the stack up, not whether it came up:

- Complete semantic config but `enabled: false`: the request succeeded and did real work. Measured on 2026-08-27 at `231ce171`: a search naming both types cost 2.00 embedder calls per request at steady state, 4 on the first request after a start.
- Incomplete config with `enabled: false`, which is what #1580 now produces by default: `get_semantic_storage` raised `ResourceNotReadyError("No database configured for semantic storage.")` from inside the request.

The REST router has defaulted `types` to episodic since #1555, so an untyped REST call was shielded. An explicit `types`, the Python client (which sends both types on every add and search), and both MCP tools (which hardcode `ALL_MEMORY_TYPES`) were not.

Deletion had the same gap with a twist. `memmachine.py` defined `_cleanup_semantic_history` twice; both arrived in #1151. The later definition, which requests the semantic service unconditionally, shadowed the earlier one that caught `ResourceNotReadyError`. So with semantic memory disabled, every project deletion raised in the worker, dropped the job, and left the session in `delete` status until a restart re-queued it and failed the same way (#1575). `delete_episodes` requested the service unconditionally too.

### Description

**`ResourceManagerImpl.get_semantic_manager`** (`common/resource_manager/resource_manager.py`): raises `ResourceNotReadyError("Semantic memory is disabled.", "semantic_memory")` when the flag is off, so nothing semantic is constructed. `get_semantic_service` and `get_semantic_session_manager` go through it. The semantic-only `MemMachine` operations (features, set types, and so on) now fail with that message instead of building a stack the operator turned off; their routes already map unexpected exceptions to 500, and I have left the status mapping alone.

**Where the flag is read.** Two places, both on the server side: `MemMachine` routes requests (the filter below, and the delete guards), and the composition root refuses to build a component the deployment does not have, the same contract it has for an embedder name that is not configured. `SemanticResourceManager` and everything below it never see the flag. The first revision of this PR had the semantic manager's own getters read it; that was the wrong layer, and the episodic side already shows the right one, with "Episodic memory is disabled" raised in `MemMachine`.

**`MemMachine`** (`main/memmachine.py`):

- New `enabled_memory_types` property, read from `episodic_memory.enabled` and `semantic_memory.enabled` at call time.
- `add_episodes`, `query_search` and `list_search` filter `target_memories` through it. A request naming a disabled type gets `None` for that field, exactly as when it did not name the type. The docstring of `query_search` already promised "Search across enabled memory types"; now it does.
- The shadowed `_cleanup_semantic_history` is removed. The surviving one is called only when semantic memory is enabled, matching the guard `_delete_queued_session` already applied to the semantic delete itself. `delete_episodes` resolves the semantic service under the same guard, in the same position as before so an enabled-but-broken semantic store still fails before anything is deleted.

**Two more mixed paths.** With the composition root refusing, anything that reached the semantic stack unconditionally on a non-semantic request would have started failing on a disabled deployment. Two did. The MCP `delete_memory` tool goes through `_delete_memories` in `server/api_v2/service.py`, which called `delete_features` even when no semantic uids were named, so an episodic-only delete over MCP would have failed. It now calls `delete_features` only when semantic uids were named. `MemMachine.delete_all` asked for the semantic manager before touching the episode store; it now touches the semantic stores only when semantic memory is enabled. Both are routing decisions in the server layer, and both have tests.

**Skip, not reject.** #1600 left the choice open. The client settles it: `memmachine_client` sends `[Episodic, Semantic]` on every add and search, so rejecting a request that names a disabled type would fail every client call against the default configuration. Episodic gets the same treatment, so a semantic-only deployment no longer stores the episode and then raises "Episodic memory is disabled" on the same request. The MCP tools are unchanged; `ALL_MEMORY_TYPES` now means every type the server has.

**Tests.** The `main/conftest.py` integration configuration built a complete `SemanticMemoryConf` without saying `enabled=True` and relied on the lazy build; it now says it. The batched-deletion test flips semantic memory on so its per-batch cleanup assertion keeps meaning something.

Not in scope: the second half of #1575, that a failed deletion leaves a session no API call can revisit. That is #1577.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Behavior change worth stating: a request that names a disabled memory type used to either do hidden work or fail; it now returns `None` for that type. The semantic-only endpoints now fail with "Semantic memory is disabled." where they previously failed with a storage error or silently built the stack.

### How Has This Been Tested?

- [x] Unit Test

Thirteen new tests. The seven `MemMachine` ones from the first revision were run against the unfixed code first; all failed there, and the deletion one failed with the exact log line from #1575 (`Failed to delete session s1 ... No database configured for semantic storage.`).

`test_memmachine_mock.py`: `enabled_memory_types` follows the flags; `query_search` skips semantic when disabled (episodic still searched, semantic session manager never requested, `semantic_memory is None`); `query_search` skips episodic when disabled; `add_episodes` skips semantic; `list_search` skips semantic; `delete_episodes` skips semantic history; and `delete_session` completes with semantic disabled (episodes deleted, session row deleted, semantic service never requested, with the getter mocked to raise the #1575 error).

`test_resource_manager.py`: `get_semantic_manager`, `get_semantic_service` and `get_semantic_session_manager` on a `ResourceManagerImpl` whose config has semantic memory disabled raise `ResourceNotReadyError` matching "disabled". No other code path produces that message, so these fail without the gate.

`test_service.py`: `_delete_memories` never calls `delete_features` when no semantic uids are named, and calls it with the uids when they are. `test_memmachine_mock.py`: `delete_all` with semantic memory disabled deletes the episode store and never requests the semantic manager (mocked to raise the disabled error).

**Test Results:**

```
targeted suites (main, server/api_v2, common/resource_manager, semantic history cleanup):
349 passed, 9 skipped, 69 deselected

integration-marked batched-deletion test, run explicitly:
1 passed, 3 deselected

full server suite (one module skipped at collection for an optional extra absent locally, hnswlib):
1 failed, 1926 passed, 16 skipped, 1509 deselected, 1 error
  the failure is test_version.py::test_get_version, which rejects the setuptools-scm
  version string an untagged checkout produces (a .devN+g<sha> string);
  nothing in this diff touches versioning

ruff check: All checks passed!
ruff format: 1 file reformatted (this branch's own edit)
ty check packages: 23 diagnostics, all unresolved-import for optional extras absent from this venv, none in touched files
```

### Checklist

- [x] I have signed the commit(s) within this pull request
- [x] My code follows the style guidelines of this project (See STYLE_GUIDE.md)
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nSC7JKXByD1WADJukvupg
