### PR TITLE
DEFERRED (until lifecycle/DDL changes): Route filtered queries by selectivity, and score allowlists exactly (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -1435,3 +1435,167 @@ class TestIndexFileDurability:
 
         await store2.shutdown()
         await engine2.dispose()
+
+
+# ── Filter routing ──
+
+
+class TestFilterRouting:
+    """
+    Property filters route by selectivity.
+
+    A LIMIT probe resolves the filter to an allowlist when it matches few
+    records (pre-filter, scored directly); otherwise the search runs
+    unrestricted and results are post-filtered with bounded widening.
+    """
+
+    async def _seed(self, collection):
+        vectors = [_normalize([1.0, float(index) * 0.01, 0.0]) for index in range(8)]
+        records = [
+            _make_record(
+                vector=vector,
+                properties={"name": "even" if index % 2 == 0 else "odd", "age": index},
+            )
+            for index, vector in enumerate(vectors)
+        ]
+        await collection.upsert(records=records)
+        return records, vectors
+
+    async def _broad_store(self, tmp_path, **params_overrides):
+        db_path = tmp_path / "broad.db"
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+        params = SQLiteVectorStoreParams(
+            sqlalchemy_engine=engine,
+            vector_search_engine_factory=lambda ndim: USearchVectorSearchEngine(
+                num_dimensions=ndim
+            ),
+            selective_filter_limit=0,
+            **params_overrides,
+        )
+        vector_store = SQLiteVectorStore(params)
+        await vector_store.startup()
+        return vector_store, engine
+
+    @pytest_asyncio.fixture
+    async def broad_collection(self, tmp_path):
+        vector_store, engine = await self._broad_store(tmp_path)
+        coll = await vector_store.open_or_create_collection(
+            namespace=NAMESPACE,
+            name=NAME,
+            config=VectorStoreCollectionConfig(
+                vector_dimensions=VECTOR_DIM,
+                indexed_properties_schema={"name": str, "age": int},
+            ),
+        )
+        yield coll
+        await vector_store.shutdown()
+        await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_broad_path_filters_and_ranks(self, broad_collection):
+        records, vectors = await self._seed(broad_collection)
+
+        results = await broad_collection.query(
+            query_vectors=[vectors[0]],
+            limit=3,
+            property_filter=Comparison(field="name", op="=", value="odd"),
+        )
+        matches = results[0].matches
+        assert len(matches) == 3
+        odd_uuids = {r.uuid for i, r in enumerate(records) if i % 2 == 1}
+        assert {m.record_uuid for m in matches} <= odd_uuids
+        assert all(
+            matches[i].cosine_similarity >= matches[i + 1].cosine_similarity
+            for i in range(len(matches) - 1)
+        )
+
+    @pytest.mark.asyncio
+    async def test_broad_path_exhausts_on_sparse_filter(self, broad_collection):
+        records, vectors = await self._seed(broad_collection)
+
+        results = await broad_collection.query(
+            query_vectors=[vectors[0]],
+            limit=10,
+            property_filter=Comparison(field="age", op="=", value=7),
+        )
+        assert [m.record_uuid for m in results[0].matches] == [records[7].uuid]
+
+    @pytest.mark.asyncio
+    async def test_broad_path_widens_until_filled(self, broad_collection):
+        vectors = [_normalize([1.0, float(index) * 0.05, 0.0]) for index in range(40)]
+        records = [
+            _make_record(vector=vector, properties={"age": index})
+            for index, vector in enumerate(vectors)
+        ]
+        await broad_collection.upsert(records=records)
+
+        # Matches only ranks 30..39 for a query at rank 0: the first fetch
+        # (limit * 4 = 20) holds no survivors, forcing a widening round.
+        results = await broad_collection.query(
+            query_vectors=[vectors[0]],
+            limit=5,
+            property_filter=Comparison(field="age", op=">=", value=30),
+        )
+        matches = results[0].matches
+        assert len(matches) == 5
+        assert {m.record_uuid for m in matches} == {r.uuid for r in records[30:35]}
+
+    @pytest.mark.asyncio
+    async def test_broad_path_caps_widening(self, tmp_path):
+        vector_store, engine = await self._broad_store(tmp_path, max_overfetch_factor=2)
+        try:
+            coll = await vector_store.open_or_create_collection(
+                namespace=NAMESPACE,
+                name=NAME,
+                config=VectorStoreCollectionConfig(
+                    vector_dimensions=VECTOR_DIM,
+                    indexed_properties_schema={"age": int},
+                ),
+            )
+            vectors = [
+                _normalize([1.0, float(index) * 0.05, 0.0]) for index in range(40)
+            ]
+            records = [
+                _make_record(vector=vector, properties={"age": index})
+                for index, vector in enumerate(vectors)
+            ]
+            await coll.upsert(records=records)
+
+            # Survivors rank below the capped fetch (limit * 2 = 10), so the
+            # query returns fewer than `limit` rather than widening further.
+            results = await coll.query(
+                query_vectors=[vectors[0]],
+                limit=5,
+                property_filter=Comparison(field="age", op=">=", value=30),
+            )
+            assert results[0].matches == []
+        finally:
+            await vector_store.shutdown()
+            await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_selective_and_broad_agree(self, collection, broad_collection):
+        records, vectors = await self._seed(collection)
+        await broad_collection.upsert(records=records)
+
+        property_filter = Comparison(field="name", op="=", value="even")
+        [selective_result] = await collection.query(
+            query_vectors=[vectors[1]],
+            limit=3,
+            property_filter=property_filter,
+        )
+        [broad_result] = await broad_collection.query(
+            query_vectors=[vectors[1]],
+            limit=3,
+            property_filter=property_filter,
+        )
+
+        assert [m.record_uuid for m in selective_result.matches] == [
+            m.record_uuid for m in broad_result.matches
+        ]
+        for selective_match, broad_match in zip(
+            selective_result.matches, broad_result.matches, strict=True
+        ):
+            assert selective_match.cosine_similarity == pytest.approx(
+                broad_match.cosine_similarity, abs=1e-4
+            )

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_hnswlib_engine.py
@@ -147,6 +147,107 @@ class TestRemove:
 # -- Search: Cosine --
 
 
+# -- Search: non-unit input --
+
+
+class TestNonUnitVectors:
+    """Vectors are scaled to unit length on the way in, so scores are cosines.
+
+    Every other test here passes unit vectors, under which the scaling is a
+    no-op. These pass magnitudes and pin that the score is the cosine of the
+    originals rather than their raw inner product.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stored_magnitude_does_not_reach_the_score(self):
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add({1: [3.0, 4.0, 0.0]})
+
+        result = await _search_one(engine, [1.0, 0.0, 0.0], limit=1)
+        # Raw inner product would be 3.0; the cosine is 0.6.
+        assert result.matches[0].cosine_similarity == pytest.approx(0.6, abs=1e-3)
+
+    @pytest.mark.asyncio
+    async def test_query_magnitude_does_not_reach_the_score(self):
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add({1: _normalize([1.0, 0.0, 0.0])})
+
+        result = await _search_one(engine, [50.0, 0.0, 0.0], limit=1)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=1e-3)
+
+    @pytest.mark.asyncio
+    async def test_allowlist_scores_are_cosines(self):
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add({1: [3.0, 4.0, 0.0], 2: [0.0, 0.0, 9.0]})
+
+        result = await _search_one(engine, [2.0, 0.0, 0.0], limit=2, allowlist=[1, 2])
+        scores = {m.key: m.cosine_similarity for m in result.matches}
+        assert scores[1] == pytest.approx(0.6, abs=1e-3)
+        assert scores[2] == pytest.approx(0.0, abs=1e-3)
+
+    @pytest.mark.asyncio
+    async def test_scores_stay_within_the_cosine_range(self):
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add({key: _normalize([1.0, 0.0, 0.0]) for key in range(20)})
+
+        result = await _search_one(
+            engine, _normalize([1.0, 0.0, 0.0]), limit=20, allowlist=list(range(20))
+        )
+        assert all(-1.0 <= m.cosine_similarity <= 1.0 for m in result.matches)
+
+
+# -- Search: allowlist --
+
+
+class TestSearchAllowlist:
+    @pytest.mark.asyncio
+    async def test_allowlist_restricts_results(self):
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add(
+            {
+                1: _normalize([1, 0, 0]),
+                2: _normalize([0, 1, 0]),
+                3: _normalize([0, 0, 1]),
+            }
+        )
+        result = await _search_one(
+            engine, _normalize([1, 0, 0]), limit=3, allowlist=[2, 3]
+        )
+        assert {m.key for m in result.matches} == {2, 3}
+
+    @pytest.mark.asyncio
+    async def test_allowlist_excludes_best_match(self):
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add(
+            {
+                1: _normalize([1, 0, 0]),
+                2: _normalize([0, 1, 0]),
+                3: _normalize([0, 0, 1]),
+            }
+        )
+        result = await _search_one(
+            engine, _normalize([1, 0, 0]), limit=1, allowlist=[2, 3]
+        )
+        assert len(result.matches) == 1
+        assert result.matches[0].key in {2, 3}
+
+    @pytest.mark.asyncio
+    async def test_empty_allowlist_returns_nothing(self):
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add({1: _normalize([1, 0, 0])})
+        result = await _search_one(engine, _normalize([1, 0, 0]), limit=1, allowlist=[])
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_missing_allowlist_keys_ignored(self):
+        engine = HnswlibVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add({1: _normalize([1, 0, 0])})
+        result = await _search_one(
+            engine, _normalize([1, 0, 0]), limit=2, allowlist=[1, 99]
+        )
+        assert [m.key for m in result.matches] == [1]
+
+
 class TestSearchCosine:
     @pytest.mark.asyncio
     async def test_basic_knn(self):

--- a/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/vector_search_engine/test_usearch_engine.py
@@ -109,6 +109,107 @@ class TestRemove:
 # -- Search: Cosine --
 
 
+# -- Search: non-unit input --
+
+
+class TestNonUnitVectors:
+    """Vectors are scaled to unit length on the way in, so scores are cosines.
+
+    Every other test here passes unit vectors, under which the scaling is a
+    no-op. These pass magnitudes and pin that the score is the cosine of the
+    originals rather than their raw inner product.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stored_magnitude_does_not_reach_the_score(self):
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add({1: [3.0, 4.0, 0.0]})
+
+        result = await _search_one(engine, [1.0, 0.0, 0.0], limit=1)
+        # Raw inner product would be 3.0; the cosine is 0.6.
+        assert result.matches[0].cosine_similarity == pytest.approx(0.6, abs=1e-3)
+
+    @pytest.mark.asyncio
+    async def test_query_magnitude_does_not_reach_the_score(self):
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add({1: _normalize([1.0, 0.0, 0.0])})
+
+        result = await _search_one(engine, [50.0, 0.0, 0.0], limit=1)
+        assert result.matches[0].cosine_similarity == pytest.approx(1.0, abs=1e-3)
+
+    @pytest.mark.asyncio
+    async def test_allowlist_scores_are_cosines(self):
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add({1: [3.0, 4.0, 0.0], 2: [0.0, 0.0, 9.0]})
+
+        result = await _search_one(engine, [2.0, 0.0, 0.0], limit=2, allowlist=[1, 2])
+        scores = {m.key: m.cosine_similarity for m in result.matches}
+        assert scores[1] == pytest.approx(0.6, abs=1e-3)
+        assert scores[2] == pytest.approx(0.0, abs=1e-3)
+
+    @pytest.mark.asyncio
+    async def test_scores_stay_within_the_cosine_range(self):
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add({key: _normalize([1.0, 0.0, 0.0]) for key in range(20)})
+
+        result = await _search_one(
+            engine, _normalize([1.0, 0.0, 0.0]), limit=20, allowlist=list(range(20))
+        )
+        assert all(-1.0 <= m.cosine_similarity <= 1.0 for m in result.matches)
+
+
+# -- Search: allowlist --
+
+
+class TestSearchAllowlist:
+    @pytest.mark.asyncio
+    async def test_allowlist_restricts_results(self):
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add(
+            {
+                1: _normalize([1, 0, 0]),
+                2: _normalize([0, 1, 0]),
+                3: _normalize([0, 0, 1]),
+            }
+        )
+        result = await _search_one(
+            engine, _normalize([1, 0, 0]), limit=3, allowlist=[2, 3]
+        )
+        assert {m.key for m in result.matches} == {2, 3}
+
+    @pytest.mark.asyncio
+    async def test_allowlist_excludes_best_match(self):
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add(
+            {
+                1: _normalize([1, 0, 0]),
+                2: _normalize([0, 1, 0]),
+                3: _normalize([0, 0, 1]),
+            }
+        )
+        result = await _search_one(
+            engine, _normalize([1, 0, 0]), limit=1, allowlist=[2, 3]
+        )
+        assert len(result.matches) == 1
+        assert result.matches[0].key in {2, 3}
+
+    @pytest.mark.asyncio
+    async def test_empty_allowlist_returns_nothing(self):
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add({1: _normalize([1, 0, 0])})
+        result = await _search_one(engine, _normalize([1, 0, 0]), limit=1, allowlist=[])
+        assert result.matches == []
+
+    @pytest.mark.asyncio
+    async def test_missing_allowlist_keys_ignored(self):
+        engine = USearchVectorSearchEngine(num_dimensions=NDIM)
+        await engine.add({1: _normalize([1, 0, 0])})
+        result = await _search_one(
+            engine, _normalize([1, 0, 0]), limit=2, allowlist=[1, 99]
+        )
+        assert [m.key for m in result.matches] == [1]
+
+
 class TestSearchCosine:
     @pytest.mark.asyncio
     async def test_basic_knn(self):

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -241,7 +241,9 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
             if distance is None:
                 continue
 
-            cosine_similarity = self._distance_to_cosine_similarity(distance)
+            cosine_similarity = (
+                SQLiteVecVectorStoreCollection._distance_to_cosine_similarity(distance)
+            )
             if (
                 min_cosine_similarity is not None
                 and cosine_similarity < min_cosine_similarity

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -23,6 +23,7 @@ Callers that need every record searchable after a power failure must be able
 to re-ingest; nothing here detects the gap for them.
 """
 
+import heapq
 import logging
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -43,7 +44,6 @@ from sqlalchemy import (
     String,
     Table,
     Uuid,
-    create_engine,
     delete,
     event,
     func,
@@ -51,10 +51,9 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
-from sqlalchemy.engine import Engine
 from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
-from sqlalchemy.orm import DeclarativeBase, MappedColumn, Session, mapped_column
+from sqlalchemy.orm import DeclarativeBase, MappedColumn, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -187,61 +186,16 @@ async def _save_collection_index(
         )
 
 
+_OVERFETCH_BASE = 4
+
+
 class SQLiteVectorStoreCollection(VectorStoreCollection):
     """A logical collection backed by SQLite + a pluggable vector search engine."""
-
-    class _KeyFilter:
-        """Per-candidate SQL filter using a sync SQLAlchemy session."""
-
-        def __init__(
-            self,
-            sync_sqlalchemy_engine: Engine,
-            records_table: Table,
-            filter_expression: ColumnElement[bool],
-        ) -> None:
-            """Initialize with a sync SQLAlchemy engine, records table, and filter expression."""
-            self._sync_sqlalchemy_engine = sync_sqlalchemy_engine
-            self._records_table = records_table
-            self._filter_expression = filter_expression
-
-            self._cache: dict[int, bool] = {}
-            self._session: Session | None = None
-
-        def _get_session(self) -> Session:
-            if self._session is None:
-                self._session = Session(self._sync_sqlalchemy_engine)
-            return self._session
-
-        def __contains__(self, key: object) -> bool:
-            """Return whether the key passes the SQL filter."""
-            if not isinstance(key, int):
-                return False
-            if key in self._cache:
-                return self._cache[key]
-
-            row = (
-                self._get_session()
-                .execute(
-                    select(self._records_table.c.row_id).where(
-                        self._records_table.c.row_id == key,
-                        self._filter_expression,
-                    )
-                )
-                .scalar()
-            )
-            result = row is not None
-            self._cache[key] = result
-            return result
-
-        def __del__(self) -> None:
-            if self._session is not None:
-                self._session.close()
 
     def __init__(
         self,
         *,
         create_session: async_sessionmaker[AsyncSession],
-        sync_sqlalchemy_engine: Engine,
         records_table: Table,
         search_engine: VectorSearchEngine,
         namespace: str,
@@ -249,10 +203,11 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         config: VectorStoreCollectionConfig,
         index_path: str | None,
         save_threshold: int,
+        selective_filter_limit: int,
+        max_overfetch_factor: int,
     ) -> None:
         """Initialize a collection handle."""
         self._create_session = create_session
-        self._sync_sqlalchemy_engine = sync_sqlalchemy_engine
         self._records_table = records_table
         self._search_engine = search_engine
 
@@ -263,6 +218,8 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
         self._index_path = index_path
         self._save_threshold = save_threshold
+        self._selective_filter_limit = selective_filter_limit
+        self._max_overfetch_factor = max_overfetch_factor
 
     @property
     @override
@@ -408,13 +365,34 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         if limit <= 0:
             return [QueryResult(matches=[]) for _ in query_vectors]
 
-        if property_filter is not None and not validate_filter(property_filter):
-            raise ValueError("Filter contains invalid field names")
+        allowlist: list[int] | None = None
+        if property_filter is not None:
+            if not validate_filter(property_filter):
+                raise ValueError("Filter contains invalid field names")
 
-        key_filter = self._build_key_filter(property_filter)
+            filter_expression = compile_sql_filter(
+                property_filter,
+                lambda field: (
+                    self._records_table.c.properties[field],
+                    "properties_json",
+                ),
+            )
+            # One row past the threshold is what separates "at most this
+            # many" from "more than this many".
+            matching_row_ids = await self._matching_row_ids(
+                filter_expression, limit=self._selective_filter_limit + 1
+            )
+            if len(matching_row_ids) > self._selective_filter_limit:
+                return [
+                    await self._query_broad(
+                        query_vector, filter_expression, limit, min_cosine_similarity
+                    )
+                    for query_vector in query_vectors
+                ]
+            allowlist = matching_row_ids
 
         search_results = await self._search_engine.search(
-            query_vectors, limit=limit, allowed_keys=key_filter
+            query_vectors, limit=limit, allowlist=allowlist
         )
 
         results: list[QueryResult] = []
@@ -432,23 +410,80 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
         return results
 
-    def _build_key_filter(
-        self, property_filter: FilterExpr | None
-    ) -> _KeyFilter | None:
-        if property_filter is None:
-            return None
+    async def _matching_row_ids(
+        self, filter_expression: ColumnElement[bool], *, limit: int
+    ) -> list[int]:
+        """The row_ids matching the filter, at most `limit` of them.
 
-        return SQLiteVectorStoreCollection._KeyFilter(
-            sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
-            records_table=self._records_table,
-            filter_expression=compile_sql_filter(
-                property_filter,
-                lambda field: (
-                    self._records_table.c.properties[field],
-                    "properties_json",
-                ),
-            ),
-        )
+        Enumerating up to a bound costs no more than counting would.
+        """
+        async with self._create_session() as session:
+            rows = (
+                await session.execute(
+                    select(self._records_table.c.row_id)
+                    .where(filter_expression)
+                    .limit(limit)
+                )
+            ).all()
+        return [row.row_id for row in rows]
+
+    async def _query_broad(
+        self,
+        query_vector: Sequence[float],
+        filter_expression: ColumnElement[bool],
+        limit: int,
+        min_cosine_similarity: float | None,
+    ) -> QueryResult:
+        """
+        Post-filter: search unrestricted, keep survivors, widen as needed.
+
+        Widens the fetch until `limit` results survive the filter, the index
+        is exhausted, or the fetch reaches `limit * max_overfetch_factor` --
+        at the cap the query returns what survived, which may be fewer than
+        `limit` results.
+        """
+        max_fetch = limit * self._max_overfetch_factor
+        fetch_limit = min(limit * _OVERFETCH_BASE, max_fetch)
+        while True:
+            [search_result] = await self._search_engine.search(
+                [query_vector], limit=fetch_limit
+            )
+            row_id_to_cosine_similarity = {
+                match.key: match.cosine_similarity for match in search_result.matches
+            }
+
+            surviving_row_ids: set[int] = set()
+            if row_id_to_cosine_similarity:
+                async with self._create_session() as session:
+                    surviving_row_ids = set(
+                        (
+                            await session.execute(
+                                select(self._records_table.c.row_id).where(
+                                    self._records_table.c.row_id.in_(
+                                        row_id_to_cosine_similarity
+                                    ),
+                                    filter_expression,
+                                )
+                            )
+                        ).scalars()
+                    )
+
+            exhausted = len(search_result.matches) < fetch_limit
+            if len(surviving_row_ids) >= limit or exhausted or fetch_limit >= max_fetch:
+                surviving = {
+                    row_id: similarity
+                    for row_id, similarity in row_id_to_cosine_similarity.items()
+                    if row_id in surviving_row_ids
+                }
+                top = heapq.nlargest(limit, surviving.items(), key=lambda item: item[1])
+                return QueryResult(
+                    matches=await self._build_matches(
+                        row_id_to_cosine_similarity=dict(top),
+                        min_cosine_similarity=min_cosine_similarity,
+                    )
+                )
+
+            fetch_limit = min(fetch_limit * _OVERFETCH_BASE, max_fetch)
 
     async def _build_matches(
         self,
@@ -561,9 +596,9 @@ class SQLiteVectorStoreParams(BaseModel):
     Attributes:
         sqlalchemy_engine (AsyncEngine):
             Async SQLAlchemy engine (sqlite+aiosqlite).
-        engine_factory (Callable[[int], VectorSearchEngine]):
+        vector_search_engine_factory (Callable[[int], VectorSearchEngine]):
             Factory for creating :class:`VectorSearchEngine` instances.
-            Receives `(ndim, metric)` and returns a search engine.
+            Receives `(ndim)` and returns a search engine.
         index_directory (str | None):
             Directory for persisting index files.
             If None, indexes are in-memory only
@@ -572,6 +607,14 @@ class SQLiteVectorStoreParams(BaseModel):
             Number of engine operations before auto-saving the index to disk.
             Only applies when index_directory is set
             (default: 1000).
+        selective_filter_limit (int):
+            Filters matching at most this many records are pre-filtered into
+            an allowlist. Broader ones post-filter an unrestricted search
+            (default: 10000).
+        max_overfetch_factor (int):
+            Cap on post-filter widening, as a multiple of `limit`.
+            A broad query may return fewer than `limit` results
+            (default: 64).
     """
 
     sqlalchemy_engine: InstanceOf[AsyncEngine] = Field(
@@ -581,7 +624,7 @@ class SQLiteVectorStoreParams(BaseModel):
         ...,
         description=(
             "Factory for creating VectorSearchEngine instances. "
-            "Receives `(ndim, metric)` and returns a search engine"
+            "Receives `(ndim)` and returns a search engine"
         ),
     )
     index_directory: str | None = Field(
@@ -595,6 +638,22 @@ class SQLiteVectorStoreParams(BaseModel):
         description=(
             "Number of engine operations before auto-saving the index to disk. "
             "Only applies when index_directory is set"
+        ),
+    )
+    selective_filter_limit: int = Field(
+        10_000,
+        ge=0,
+        description=(
+            "Filters matching at most this many records are pre-filtered into "
+            "an allowlist. Broader ones post-filter an unrestricted search"
+        ),
+    )
+    max_overfetch_factor: int = Field(
+        64,
+        ge=1,
+        description=(
+            "Cap on post-filter widening, as a multiple of `limit`. "
+            "A broad query may return fewer than `limit` results"
         ),
     )
 
@@ -630,6 +689,8 @@ class SQLiteVectorStore(VectorStore):
             Path(params.index_directory) if params.index_directory else None
         )
         self._save_threshold = params.save_threshold
+        self._selective_filter_limit = params.selective_filter_limit
+        self._max_overfetch_factor = params.max_overfetch_factor
 
         self._create_session = async_sessionmaker(
             self._sqlalchemy_engine, expire_on_commit=False
@@ -637,12 +698,7 @@ class SQLiteVectorStore(VectorStore):
         self._search_engines: dict[tuple[str, str], VectorSearchEngine] = {}
         self._sa_metadata = MetaData()
 
-        self._sync_sqlalchemy_engine = create_engine(
-            str(self._sqlalchemy_engine.url).replace("aiosqlite", "pysqlite")
-        )
-
         @event.listens_for(self._sqlalchemy_engine.sync_engine, "connect")
-        @event.listens_for(self._sync_sqlalchemy_engine, "connect")
         def _enable_sqlite_foreign_keys(
             dbapi_connection: DBAPIConnection,
             _connection_record: ConnectionPoolEntry,
@@ -805,7 +861,6 @@ class SQLiteVectorStore(VectorStore):
                 )
                 return SQLiteVectorStoreCollection(
                     create_session=self._create_session,
-                    sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
                     records_table=records_table,
                     search_engine=search_engine,
                     namespace=namespace,
@@ -813,6 +868,8 @@ class SQLiteVectorStore(VectorStore):
                     config=existing_config,
                     index_path=str(index_path) if index_path is not None else None,
                     save_threshold=self._save_threshold,
+                    selective_filter_limit=self._selective_filter_limit,
+                    max_overfetch_factor=self._max_overfetch_factor,
                 )
 
             self._clear_search_engine_state(namespace, name)
@@ -829,7 +886,6 @@ class SQLiteVectorStore(VectorStore):
 
         return SQLiteVectorStoreCollection(
             create_session=self._create_session,
-            sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
             records_table=records_table,
             search_engine=search_engine,
             namespace=namespace,
@@ -837,6 +893,8 @@ class SQLiteVectorStore(VectorStore):
             config=config,
             index_path=str(index_path) if index_path is not None else None,
             save_threshold=self._save_threshold,
+            selective_filter_limit=self._selective_filter_limit,
+            max_overfetch_factor=self._max_overfetch_factor,
         )
 
     @override
@@ -863,7 +921,6 @@ class SQLiteVectorStore(VectorStore):
         index_path = self._index_path(namespace, name)
         return SQLiteVectorStoreCollection(
             create_session=self._create_session,
-            sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
             records_table=records_table,
             search_engine=search_engine,
             namespace=namespace,
@@ -871,6 +928,8 @@ class SQLiteVectorStore(VectorStore):
             config=existing,
             index_path=str(index_path) if index_path is not None else None,
             save_threshold=self._save_threshold,
+            selective_filter_limit=self._selective_filter_limit,
+            max_overfetch_factor=self._max_overfetch_factor,
         )
 
     @override

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -2,15 +2,17 @@
 
 import asyncio
 import contextlib
-from collections.abc import Callable, Container, Iterable, Mapping, Sequence
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from typing import ClassVar, override
 
 import hnswlib  # ty: ignore[unresolved-import]  # C extension, no py.typed
 import numpy as np
+import numpy.typing as npt
 
 from memmachine_server.common.rw_locks import AsyncRWLock
 
 from .index_persistence import atomic_index_write, clear_stale_index_temp
+from .utils import top_k_matches, unit_normalize
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -143,46 +145,65 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         vectors: Iterable[Sequence[float]],
         *,
         limit: int,
-        allowed_keys: Container[int] | None = None,
+        allowlist: Collection[int] | None = None,
     ) -> list[SearchResult]:
         vectors = list(vectors)
-        if self._index.element_count == 0 or not vectors:
+        if (
+            self._index.element_count == 0
+            or not vectors
+            or (allowlist is not None and not allowlist)
+        ):
             return [SearchResult(matches=[]) for _ in vectors]
 
         async with self._lock.read_lock():
-            return await asyncio.to_thread(
-                self._sync_search, vectors, limit, allowed_keys
-            )
+            return await asyncio.to_thread(self._sync_search, vectors, limit, allowlist)
 
     def _sync_search(
         self,
-        vectors: Iterable[Sequence[float]],
+        vectors: Sequence[Sequence[float]],
         limit: int,
-        allowed_keys: Container[int] | None,
+        allowlist: Collection[int] | None,
     ) -> list[SearchResult]:
-        vectors = list(vectors)
-        if not vectors:
-            return []
+        # hnswlib normalizes what it stores under the cosine space, so a
+        # gathered vector is already unit; only the query is left to scale.
+        query = unit_normalize(np.array(vectors, dtype=np.float32))
 
-        query = np.array(vectors, dtype=np.float32)
+        if allowlist is not None:
+            return self._sync_search_allowlist(query, limit, allowlist)
 
         effective_limit = min(limit, self._index.element_count)
         if effective_limit <= 0:
             return [SearchResult(matches=[]) for _ in vectors]
 
-        filter_fn = (
-            (lambda idx: idx in allowed_keys) if allowed_keys is not None else None
-        )
-        return self._binary_search_query(query, effective_limit, filter_fn)
+        return self._binary_search_query(query, effective_limit)
+
+    def _sync_search_allowlist(
+        self,
+        unit_queries: npt.NDArray[np.float32],
+        limit: int,
+        allowlist: Collection[int],
+    ) -> list[SearchResult]:
+        """Exact: gather the allowed vectors and score them directly.
+
+        Both sides are unit vectors by now, so the inner product
+        `top_k_matches` ranks by is the cosine similarity.
+        """
+        present_keys, matrix = self._sync_gather_vectors(allowlist)
+        if not present_keys:
+            return [SearchResult(matches=[]) for _ in unit_queries]
+
+        return [
+            SearchResult(matches=top_k_matches(query, present_keys, matrix, limit))
+            for query in unit_queries
+        ]
 
     def _binary_search_query(
         self,
         query: np.ndarray,
         k: int,
-        filter_fn: Callable[[int], bool] | None,
     ) -> list[SearchResult]:
         # Fast path: hnswlib filled k for the entire batch in one call.
-        result = self._try_knn_query(query, k, filter_fn)
+        result = self._try_knn_query(query, k)
         if result is not None:
             return self._build_search_results_from_knn(result)
 
@@ -193,13 +214,11 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         results: list[SearchResult] = []
         for query_vector in query:
             single = query_vector[np.newaxis, :]
-            single_result = self._try_knn_query(single, k, filter_fn)
+            single_result = self._try_knn_query(single, k)
 
             if single_result is None:
                 # k is already known to fail for this query, so search strictly below it.
-                single_result = self._largest_fillable_knn_query(
-                    single, k - 1, filter_fn
-                )
+                single_result = self._largest_fillable_knn_query(single, k - 1)
                 if single_result is None:
                     results.append(SearchResult(matches=[]))
                     continue
@@ -212,14 +231,10 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         self,
         query: np.ndarray,
         k: int,
-        filter_fn: Callable[[int], bool] | None,
     ) -> tuple[np.ndarray, np.ndarray] | None:
         """Run knn_query, returning None if hnswlib raises."""
         try:
-            kwargs: dict = {"k": k, "num_threads": 1}
-            if filter_fn is not None:
-                kwargs["filter"] = filter_fn
-            return self._index.knn_query(query, **kwargs)
+            return self._index.knn_query(query, k=k, num_threads=1)
         except RuntimeError:
             return None
 
@@ -233,7 +248,9 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
             matches = [
                 SearchMatch(
                     key=int(label),
-                    cosine_similarity=self._distance_to_cosine_similarity(float(dist)),
+                    cosine_similarity=HnswlibVectorSearchEngine._distance_to_cosine_similarity(
+                        float(dist)
+                    ),
                 )
                 for label, dist in zip(labels, distances, strict=True)
                 if int(label) >= 0
@@ -245,7 +262,6 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         self,
         query: np.ndarray,
         limit: int,
-        filter_fn: Callable[[int], bool] | None,
     ) -> tuple[np.ndarray, np.ndarray] | None:
         """
         Binary search for the largest k in [1, limit] that hnswlib can fill, for a single query.
@@ -256,7 +272,7 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         best: tuple[np.ndarray, np.ndarray] | None = None
         while low <= high:
             mid = (low + high) // 2
-            result = self._try_knn_query(query, mid, filter_fn)
+            result = self._try_knn_query(query, mid)
             if result is not None:
                 best = result
                 low = mid + 1
@@ -264,6 +280,36 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
                 high = mid - 1
 
         return best
+
+    def _sync_gather_vectors(
+        self, keys: Iterable[int]
+    ) -> tuple[list[int], npt.NDArray[np.float32]]:
+        """Gather stored vectors by key as a float32 matrix; missing keys drop."""
+        keys = list(set(keys))
+        empty = np.empty((0, self._num_dimensions), dtype=np.float32)
+        if not keys:
+            return [], empty
+
+        try:
+            return keys, np.asarray(
+                self._index.get_items(keys, return_type="numpy"), dtype=np.float32
+            )
+        except RuntimeError:
+            # Fallback: a missing key was requested. Fetch one by one.
+            present_keys: list[int] = []
+            rows: list[np.ndarray] = []
+            for key in keys:
+                with contextlib.suppress(RuntimeError):
+                    rows.append(
+                        np.asarray(
+                            self._index.get_items([key], return_type="numpy"),
+                            dtype=np.float32,
+                        )[0]
+                    )
+                    present_keys.append(key)
+            if not present_keys:
+                return [], empty
+            return present_keys, np.vstack(rows)
 
     @override
     async def remove(self, keys: Iterable[int]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
@@ -1,15 +1,17 @@
 """USearch HNSW implementation of VectorSearchEngine."""
 
 import asyncio
-from collections.abc import Container, Iterable, Mapping, Sequence
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from typing import ClassVar, override
 
 import numpy as np
+import numpy.typing as npt
 from usearch.index import Index, MetricKind
 
 from memmachine_server.common.rw_locks import AsyncRWLock
 
 from .index_persistence import atomic_index_write, clear_stale_index_temp
+from .utils import top_k_matches, unit_normalize
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
 
@@ -21,8 +23,6 @@ class USearchVectorSearchEngine(VectorSearchEngine):
     _DEFAULT_M: ClassVar[int] = 16
     _DEFAULT_EF_CONSTRUCTION: ClassVar[int] = 128
     _DEFAULT_EF_SEARCH: ClassVar[int] = 128
-
-    _OVERFETCH_BASE: ClassVar[int] = 4
 
     def __init__(
         self,
@@ -58,7 +58,9 @@ class USearchVectorSearchEngine(VectorSearchEngine):
 
     def _sync_add(self, vectors: Mapping[int, Sequence[float]]) -> None:
         keys_array = np.array(list(vectors.keys()), dtype=np.int64)
-        vectors_array = np.array(list(vectors.values()), dtype=np.float32)
+        vectors_array = unit_normalize(
+            np.array(list(vectors.values()), dtype=np.float32)
+        )
         self._index.add(keys_array, vectors_array)
 
     @override
@@ -67,74 +69,95 @@ class USearchVectorSearchEngine(VectorSearchEngine):
         vectors: Iterable[Sequence[float]],
         *,
         limit: int,
-        allowed_keys: Container[int] | None = None,
+        allowlist: Collection[int] | None = None,
     ) -> list[SearchResult]:
         vectors = list(vectors)
-        if self._index.size == 0 or not vectors:
+        if (
+            self._index.size == 0
+            or not vectors
+            or (allowlist is not None and not allowlist)
+        ):
             return [SearchResult(matches=[]) for _ in vectors]
 
         async with self._lock.read_lock():
-            return await asyncio.to_thread(
-                self._sync_search, vectors, limit, allowed_keys
-            )
+            return await asyncio.to_thread(self._sync_search, vectors, limit, allowlist)
 
     def _sync_search(
         self,
         vectors: Sequence[Sequence[float]],
         limit: int,
-        allowed_keys: Container[int] | None,
+        allowlist: Collection[int] | None,
     ) -> list[SearchResult]:
-        query = np.array(vectors, dtype=np.float32)
-        num_queries = query.shape[0]
+        query = unit_normalize(np.array(vectors, dtype=np.float32))
 
-        overfetch_factor = (
-            1 if allowed_keys is None else USearchVectorSearchEngine._OVERFETCH_BASE
-        )
+        if allowlist is not None:
+            return self._sync_search_allowlist(query, limit, allowlist)
 
-        final_results: list[SearchResult | None] = [None] * num_queries
-        pending_indices = list(range(num_queries))
+        fetch_limit = min(limit, self._index.size)
 
-        while pending_indices:
-            pending_query = query[pending_indices]
-            fetch_limit = min(limit * overfetch_factor, self._index.size)
+        results = self._index.search(query, fetch_limit)
+        all_keys = np.atleast_2d(results.keys)
+        all_distances = np.atleast_2d(results.distances)
 
-            results = self._index.search(pending_query, fetch_limit)
-            all_keys = np.atleast_2d(results.keys)
-            all_distances = np.atleast_2d(results.distances)
+        search_results: list[SearchResult] = []
+        for keys, distances in zip(all_keys, all_distances, strict=True):
+            matches = [
+                SearchMatch(
+                    key=int(key),
+                    cosine_similarity=USearchVectorSearchEngine._distance_to_cosine_similarity(
+                        float(dist)
+                    ),
+                )
+                for key, dist in zip(keys, distances, strict=True)
+                if int(key) >= 0
+            ]
+            search_results.append(SearchResult(matches=matches))
+        return search_results
 
-            still_pending: list[int] = []
-            for batch_idx, original_idx in enumerate(pending_indices):
-                matches: list[SearchMatch] = []
-                for key, dist in zip(
-                    all_keys[batch_idx], all_distances[batch_idx], strict=True
-                ):
-                    int_key = int(key)
-                    if int_key < 0:
-                        continue
+    def _sync_search_allowlist(
+        self,
+        unit_queries: npt.NDArray[np.float32],
+        limit: int,
+        allowlist: Collection[int],
+    ) -> list[SearchResult]:
+        """Exact: gather the allowed vectors and score them directly.
 
-                    if allowed_keys is not None and int_key not in allowed_keys:
-                        continue
+        Both sides are unit vectors by now, so the inner product
+        `top_k_matches` ranks by is the cosine similarity.
+        """
+        present_keys, matrix = self._sync_gather_vectors(allowlist)
+        if not present_keys:
+            return [SearchResult(matches=[]) for _ in unit_queries]
 
-                    matches.append(
-                        SearchMatch(
-                            key=int_key,
-                            cosine_similarity=self._distance_to_cosine_similarity(
-                                float(dist)
-                            ),
-                        )
-                    )
-                    if len(matches) >= limit:
-                        break
+        return [
+            SearchResult(matches=top_k_matches(query, present_keys, matrix, limit))
+            for query in unit_queries
+        ]
 
-                if len(matches) >= limit or fetch_limit >= self._index.size:
-                    final_results[original_idx] = SearchResult(matches=matches)
-                else:
-                    still_pending.append(original_idx)
+    def _sync_gather_vectors(
+        self, keys: Iterable[int]
+    ) -> tuple[list[int], npt.NDArray[np.float32]]:
+        """Gather stored vectors by key as a float32 matrix; missing keys drop."""
+        keys = list(set(keys))
+        empty = np.empty((0, self._index.ndim), dtype=np.float32)
+        if not keys:
+            return [], empty
 
-            pending_indices = still_pending
-            overfetch_factor *= USearchVectorSearchEngine._OVERFETCH_BASE
+        gathered = self._index.get(np.array(keys, dtype=np.int64))
+        if gathered is None:
+            return [], empty
+        if isinstance(gathered, np.ndarray):
+            return keys, np.asarray(gathered, dtype=np.float32).reshape(len(keys), -1)
 
-        return [r if r is not None else SearchResult(matches=[]) for r in final_results]
+        present_keys: list[int] = []
+        rows: list[np.ndarray] = []
+        for key, row in zip(keys, gathered, strict=True):
+            if row is not None:
+                present_keys.append(key)
+                rows.append(np.asarray(row, dtype=np.float32))
+        if not present_keys:
+            return [], empty
+        return present_keys, np.vstack(rows)
 
     @override
     async def remove(self, keys: Iterable[int]) -> None:

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/utils.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/utils.py
@@ -1,0 +1,50 @@
+"""Shared utilities for vector search engine implementations."""
+
+from collections.abc import Sequence
+
+import numpy as np
+import numpy.typing as npt
+
+from .vector_search_engine import SearchMatch
+
+
+def unit_normalize(vectors: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
+    """Scale each row to unit length, leaving zero rows as they are."""
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    norms[norms == 0.0] = 1.0
+    return vectors / norms
+
+
+def inner_products(
+    query_vector: Sequence[float], matrix: npt.NDArray[np.float32]
+) -> npt.NDArray[np.float32]:
+    """Inner product of `query_vector` with each row of `matrix`."""
+    return matrix @ np.asarray(query_vector, dtype=np.float32)
+
+
+def top_k_matches(
+    query_vector: Sequence[float],
+    keys: Sequence[int],
+    matrix: npt.NDArray[np.float32],
+    limit: int,
+) -> list[SearchMatch]:
+    """The best `limit` rows of `matrix` as matches keyed by `keys`.
+
+    `query_vector` and every row of `matrix` must be a unit vector, so that
+    the inner product this ranks by is their cosine similarity. Scores are
+    clamped onto the cosine range, which quantized storage can otherwise
+    carry a fraction outside.
+    """
+    similarities = inner_products(query_vector, matrix)
+    k = min(limit, similarities.shape[0])
+    if k <= 0:
+        return []
+    top = np.argpartition(-similarities, k - 1)[:k]
+    top = top[np.argsort(-similarities[top])]
+    return [
+        SearchMatch(
+            key=keys[index],
+            cosine_similarity=min(1.0, max(-1.0, float(similarities[index]))),
+        )
+        for index in top
+    ]

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
@@ -1,7 +1,7 @@
 """Abstract base class for a vector search engine."""
 
 from abc import ABC, abstractmethod
-from collections.abc import Container, Iterable, Mapping, Sequence
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 
 
@@ -65,7 +65,7 @@ class VectorSearchEngine(ABC):
         vectors: Iterable[Sequence[float]],
         *,
         limit: int,
-        allowed_keys: Container[int] | None = None,
+        allowlist: Collection[int] | None = None,
     ) -> list[SearchResult]:
         """
         Search for vectors similar to the query vectors.
@@ -77,10 +77,9 @@ class VectorSearchEngine(ABC):
                 Query vectors.
             limit (int):
                 Maximum number of results per query.
-            allowed_keys (Container[int] | None):
-                If provided, only return results whose keys
-                are in this container. The container's ``__contains__``
-                is called synchronously per candidate during search
+            allowlist (Collection[int] | None):
+                If provided, restrict results to these keys.
+                Keys that do not exist are ignored
                 (default: None).
 
         Returns:


### PR DESCRIPTION
### Purpose of the change

A property filter reached the search engine as a `Container[int]` — a predicate backed by SQL, issuing **one point query per candidate the search touched**, memoized within a call. An HNSW traversal touches hundreds to thousands of candidates, so a filtered query paid that many round trips.

It also closed off a capability. A container that only answers `in` cannot be handed to an engine that has a native allowlist, so no engine could restrict its scan to the allowed set — every one of them had to search unrestricted and discard.

### Description

**The filter resolves before the search.** A LIMIT probe fetches one row past `selective_filter_limit` — the extra row is what separates "at most this many" from "more than this many":

- **Selective** (at or under the threshold): the probe already holds every matching `row_id`, so it goes to the engine as an allowlist. One SQL query for the whole query batch.
- **Broad** (over it): the search runs unrestricted and survivors are post-filtered with bounded widening — 4× per round up to `limit * max_overfetch_factor`, then returning what survived rather than widening without end.

**`allowed_keys: Container[int]` becomes `allowlist: Collection[int]`**, and hnswlib and usearch answer an allowlist by gathering those vectors and scoring them directly.

That change is about **correctness, not only cost**. Overfetch-and-post-filter is approximate: allowed vectors the unrestricted search never reaches are simply missed. Gather-and-score reaches every one. hnswlib also stops threading a filter callback through its `knn_query` fallbacks, and turbovec can now be handed the allowlist its native search already accepts (#1599).

**One engine instead of two.** `_KeyFilter` was the only consumer of the store's synchronous SQLAlchemy engine — a second `pysqlite` engine built from the async URL, with its own `connect` hook registering the foreign-keys pragma. Both go with it.

### Scoring is an inner product now

Scoring a gathered vector by cosine meant dividing by its norm, and that division was most of the work — the row-norm pass is unvectorized where the matmul is BLAS:

```
np.linalg.norm(m, axis=1)   1.78 ms     # 10_000 x 768
m @ q  (BLAS gemv)          0.28 ms
```

**85% of the time, guarding the 15%.** It was also recomputed per query vector, over a matrix gathered once.

Vectors are scaled to unit length on the way in instead — usearch on `add`, where its scale-invariant metric is indifferent to the change; hnswlib already does it under `space="cosine"` — and queries at the top of the search, before the allowlist branch. Scoring is then a plain inner product, which for unit vectors *is* the cosine similarity, and the helpers say so: `cosine_similarities` → `inner_products`, `unit_vectors` is the one place scaling happens, and `top_k_matches` states the precondition it ranks under.

```
Q=1:  1.89 ms -> 0.31 ms   (6.1x)
Q=8: 15.50 ms -> 2.59 ms   (6.0x)
```

Scores are clamped onto `[-1, 1]`: usearch's f16 storage returns gathered vectors at 0.999–1.0009, which the old division hid and a raw dot does not. That is O(k), not O(N·D).

### New knobs

| | default | meaning |
|---|---|---|
| `selective_filter_limit` | 10 000 | at or under this many matching records, pre-filter and score directly |
| `max_overfetch_factor` | 64 | cap on post-filter widening; a broad query may return fewer than `limit` |

### Tests

Neither engine had a single allowlist test, and neither knob was exercised. This adds 21, and no test passed a vector that was not already unit. Eight new ones pin that magnitudes never reach the score, on both the engine's own path and the allowlist path. The other 13: `test_allowlist_restricts_results`, `test_allowlist_excludes_best_match`, `test_empty_allowlist_returns_nothing` and `test_missing_allowlist_keys_ignored` for hnswlib and usearch, plus five store-level regime tests covering ranking, sparse filters, widening, the widening cap, and that the two regimes agree.

I checked they discriminate rather than trusting a green run. Ablating the engine allowlist path fails exactly five — `restricts_results` and `excludes_best_match` on both engines, plus `selective_and_broad_agree`. The eight survivors are correctly independent of it: the empty-allowlist tests are caught by the guard in `search()` before `_sync_search`, the missing-key tests hold one-key indexes, and the broad-path tests set `selective_filter_limit=0` to force the store-side post-filter. Ablating the widening loop fails `test_broad_path_widens_until_filled` alone.

### Verification

- `pytest packages/server/server_tests`: 1919 passed, 3 skipped, 1 failed.
- `ty check --project packages/server`: clean.
- `ruff check` / `ruff format --check`: clean.

The one failure is `test_get_version`, pre-existing on `speedkick`: it rejects the `.post` segment `git describe` puts into the derived version. Nothing here touches versioning or tags.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKmF9xNph9QH3ozNw3ZnJL


