### PR TITLE
Require a vector on the record type nothing reads back (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -68,13 +68,13 @@ async def _present_uuids(collection, record_uuids) -> list[UUID]:
 def _make_record(
     *,
     uuid: UUID | None = None,
-    vector: list[float] | None = None,
+    vector: list[float],
     properties: dict | None = None,
 ) -> Record:
     return Record(
         uuid=uuid or uuid4(),
         vector=vector,
-        properties=properties,
+        properties=properties or {},
     )
 
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -112,13 +112,13 @@ async def _present_uuids(collection, record_uuids) -> list[UUID]:
 def _make_record(
     *,
     uuid: UUID | None = None,
-    vector: list[float] | None = None,
+    vector: list[float],
     properties: dict | None = None,
 ) -> Record:
     return Record(
         uuid=uuid or uuid4(),
         vector=vector,
-        properties=properties,
+        properties=properties or {},
     )
 
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 
 import pytest
 import pytest_asyncio
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from memmachine_server.common.filter.filter_parser import (
@@ -66,13 +67,13 @@ async def _present_uuids(collection, record_uuids) -> list[UUID]:
 def _make_record(
     *,
     uuid=None,
-    vector: list[float] | None = None,
+    vector: list[float],
     properties: dict | None = None,
 ) -> Record:
     return Record(
         uuid=uuid or uuid4(),
         vector=vector,
-        properties=properties,
+        properties=properties or {},
     )
 
 
@@ -830,16 +831,18 @@ class TestNoProperties:
 
 
 class TestInputValidation:
-    @pytest.mark.asyncio
-    async def test_upsert_rejects_none_vector(self, collection):
-        record = _make_record(vector=None)
-        with pytest.raises(ValueError, match="vector=None"):
-            await collection.upsert(records=[record])
+    def test_record_requires_a_vector(self):
+        """The model rejects it, so no store has to re-check."""
+        with pytest.raises(ValidationError):
+            Record(uuid=uuid4())  # ty: ignore[missing-argument]
+
+    def test_record_defaults_properties_to_empty(self):
+        record = Record(uuid=uuid4(), vector=_normalize([1.0, 0.0, 0.0]))
+        assert record.properties == {}
 
     @pytest.mark.asyncio
-    async def test_upsert_none_properties_treated_as_empty(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        record = _make_record(vector=v1, properties=None)
+    async def test_upsert_accepts_a_record_without_properties(self, collection):
+        record = Record(uuid=uuid4(), vector=_normalize([1.0, 0.0, 0.0]))
         await collection.upsert(records=[record])
         assert await _present_uuids(collection, [record.uuid]) == [record.uuid]
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -6,6 +6,7 @@ from uuid import UUID, uuid4
 
 import pytest
 import pytest_asyncio
+from pydantic import ValidationError
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -67,13 +68,13 @@ async def _present_uuids(collection, record_uuids) -> list[UUID]:
 def _make_record(
     *,
     uuid=None,
-    vector: list[float] | None = None,
+    vector: list[float],
     properties: dict | None = None,
 ) -> Record:
     return Record(
         uuid=uuid or uuid4(),
         vector=vector,
-        properties=properties,
+        properties=properties or {},
     )
 
 
@@ -839,16 +840,18 @@ class TestNoProperties:
 
 
 class TestInputValidation:
-    @pytest.mark.asyncio
-    async def test_upsert_rejects_none_vector(self, collection):
-        record = _make_record(vector=None)
-        with pytest.raises(ValueError, match="vector=None"):
-            await collection.upsert(records=[record])
+    def test_record_requires_a_vector(self):
+        """The model rejects it, so no store has to re-check."""
+        with pytest.raises(ValidationError):
+            Record(uuid=uuid4())  # ty: ignore[missing-argument]
+
+    def test_record_defaults_properties_to_empty(self):
+        record = Record(uuid=uuid4(), vector=_normalize([1.0, 0.0, 0.0]))
+        assert record.properties == {}
 
     @pytest.mark.asyncio
-    async def test_upsert_none_properties_treated_as_empty(self, collection):
-        v1 = _normalize([1.0, 0.0, 0.0])
-        record = _make_record(vector=v1, properties=None)
+    async def test_upsert_accepts_a_record_without_properties(self, collection):
+        record = Record(uuid=uuid4(), vector=_normalize([1.0, 0.0, 0.0]))
         await collection.upsert(records=[record])
         assert await _present_uuids(collection, [record.uuid]) == [record.uuid]
 

--- a/packages/server/src/memmachine_server/common/vector_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_store/data_types.py
@@ -114,24 +114,23 @@ class Record(BaseModel):
     Attributes:
         uuid (UUID):
             Unique identifier for the record.
-        vector (list[float] | None):
-            Vector for similarity search. Required; `None` is rejected
-            (default: None).
-        properties (dict[str, PropertyValue] | None):
+        vector (list[float]):
+            Vector for similarity search.
+        properties (dict[str, PropertyValue]):
             Property key-value pairs.
-            Use `{}` to represent missing properties; `None` is treated as `{}`
-            (default: None).
+            Stored for property filtering; never returned
+            (default: `{}`).
     """
 
     uuid: UUID
-    vector: list[float] | None = None
-    properties: dict[str, PropertyValue] | None = None
+    vector: list[float]
+    properties: dict[str, PropertyValue] = Field(default_factory=dict)
 
-    @field_validator("properties")
+    @field_validator("properties", mode="after")
     @classmethod
     def _validate_property_keys(
-        cls, v: dict[str, PropertyValue] | None
-    ) -> dict[str, PropertyValue] | None:
+        cls, v: dict[str, PropertyValue]
+    ) -> dict[str, PropertyValue]:
         if v:
             for key in v:
                 if not validate_identifier(key):

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -163,11 +163,6 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
 
     def _build_entity(self, record: Record) -> dict[str, Any]:
         """Build a Milvus entity from a vector store record."""
-        if record.vector is None:
-            raise ValueError(
-                f"Record {record.uuid} has vector=None, which is not allowed on input."
-            )
-
         properties = record.properties if record.properties is not None else {}
         entity: dict[str, Any] = {
             _ID_FIELD: self._primary_id(self._partition_key, record.uuid),

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -300,11 +300,7 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
         async with self._tracker("upsert"):
             points: list[models.PointStruct] = []
             for record in records:
-                if record.vector is None:
-                    raise ValueError(
-                        f"Record {record.uuid} has vector=None, which is not allowed on input."
-                    )
-                properties = record.properties if record.properties is not None else {}
+                properties = record.properties
                 points.append(
                     models.PointStruct(
                         id=record.uuid,

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -101,12 +101,6 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         if not records:
             return
 
-        for record in records:
-            if record.vector is None:
-                raise ValueError(
-                    f"Record {record.uuid} has vector=None, which is not allowed on input."
-                )
-
         async with self._create_session() as session, session.begin():
             upsert_records = (
                 sqlite_insert(self._records_table)

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -300,12 +300,6 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         if not records:
             return
 
-        for record in records:
-            if record.vector is None:
-                raise ValueError(
-                    f"Record {record.uuid} has vector=None, which is not allowed on input."
-                )
-
         async with self._create_session() as session, session.begin():
             upsert_records = (
                 sqlite_insert(self._records_table)


### PR DESCRIPTION
### Purpose of the change

`Record` is input-only since #1598: a collection stores vectors to search them and properties to filter on them, and answers a query with `QueryMatch`. Nothing reads a record back.

Its type never caught up. `vector: list[float] | None = None` says a caller may omit the vector, which no caller may do — so every store re-stated the rule at its own `upsert`, four copies of the same message:

```python
if record.vector is None:
    raise ValueError(f"Record {record.uuid} has vector=None, which is not allowed on input.")
```

`properties` was optional the same way, leaving Qdrant with `record.properties if record.properties is not None else {}`.

### Description

- `vector: list[float]` — required.
- `properties: dict[str, PropertyValue] = Field(default_factory=dict)` — never `None`.
- The four runtime checks go, in sqlite, sqlite-vec, Qdrant and Milvus, along with Qdrant's `None` coalescing.
- Rejection moves to the model, so a caller meets it at construction rather than at a write.

### Tests

The two `test_upsert_rejects_none_vector` tests asserted that a *store* raises. They now assert the model does — `pytest.raises(ValidationError)` on a `Record` built without a vector — plus a new test that `properties` defaults to `{}`. The four `_make_record` helpers require a vector.

### Verification

- `pytest packages/server/server_tests`: 1913 passed, 3 skipped, 1 failed.
- `ty check --project packages/server`: clean — and clean on the base, so this introduces none.
- `ruff check` / `ruff format --check`: clean.

The one failure is `test_get_version`, pre-existing on `speedkick`: it rejects the `.post` segment `git describe` puts into the derived version. Nothing here touches versioning or tags.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKmF9xNph9QH3ozNw3ZnJL

