### PR TITLE
Verify the version in the package workflow, not in a unit test (speedkick)

### DIFF
--- a/.github/workflows/test-server-package.yml
+++ b/.github/workflows/test-server-package.yml
@@ -63,6 +63,21 @@ jobs:
           fi
           pip install --find-links dist/ "${local_whls[@]}"
 
+      - name: Check the installed server reports the wheel's version
+        shell: bash
+        run: |
+          set -eo pipefail
+          shopt -s nullglob
+          server_whls=(dist/memmachine_server-*.whl)
+          if [ ${#server_whls[@]} -ne 1 ]; then
+            echo "Expected one server wheel in dist/, found ${#server_whls[@]}" >&2
+            exit 1
+          fi
+          wheel_version=$(basename "${server_whls[0]}" | cut -d- -f2)
+          reported=$(memmachine-server --version)
+          echo "$reported"
+          grep -qxF "server: ${wheel_version}" <<<"$reported"
+
       - name: Test server package imports
         shell: bash
         run: |

--- a/packages/server/server_tests/memmachine_server/common/api/test_version.py
+++ b/packages/server/server_tests/memmachine_server/common/api/test_version.py
@@ -1,39 +1,6 @@
 """test version information."""
 
-import re
-
 from memmachine_common.api.spec import Version
-
-from memmachine_server.common.api.version import get_version
-
-
-def test_get_version():
-    # Matches:
-    # 0.1
-    # 0.2.2
-    # 0.1.dev93
-    # 0.2.2.dev93
-    # 0.1.dev93+g2b5fd8250.d20260203
-    # 0.2.2.dev93+g2b5fd8250
-    pattern = re.compile(
-        r"""
-        ^\d+\.\d+(?:\.\d+)?             # major.minor or major.minor.patch
-        (?:                             # optional dev release
-            \.dev\d+                    # .devN
-            (?:\+[a-z0-9]+(?:\.[a-z0-9]+)*)?  # +local(.local)*
-        )?
-        $
-        """,
-        re.VERBOSE,
-    )
-
-    version = get_version()
-    assert pattern.match(version.server_version), (
-        f"Invalid server version: {version.server_version}"
-    )
-    assert pattern.match(version.client_version), (
-        f"Invalid client version: {version.client_version}"
-    )
 
 
 def test_version_string():


### PR DESCRIPTION
Every pull request against `speedkick` fails the "Run Python unit tests" job on ubuntu and macos with

```
FAILED packages/server/server_tests/memmachine_server/common/api/test_version.py::test_get_version
AssertionError: Invalid server version: 0.3.9.post2.dev14+g2c69bb83e
```

## Cause

The annotated tag `v0.3.9-post1` ("Post-release build from speedkick, after v0.3.9", 2026-08-31) sits on speedkick's ancestry and is the nearest tag for every commit since. setuptools-scm therefore renders each speedkick build as `0.3.9.post2.devN+g<sha>`. The test's hand-written pattern only allowed `release[.devN[+local]]`, so it rejected a version setuptools-scm produces by design. `main` is unaffected because the tag is not reachable from it.

## Why the test is deleted rather than patched

`get_version()` is a wrapper around `importlib.metadata.version` for two distribution names. Nothing in it produces a version shape; the shape comes from setuptools-scm, the repository's tags and the working tree. So the test could only ever fail for environmental reasons, and that is its whole history:

| Date | PR | What broke the regex |
|---|---|---|
| 2026-01-29 | #993 | dotted local segment `+g<sha>.d<date>` |
| 2026-02-04 | #1038 | two-component tag `0.1` |
| 2026-09-10 | this | post-release tag `v0.3.9-post1` |

The function under test has not changed since #951 wrote it. The test also rejected a documented output: #951 specifies `client_version` as "not available" when memmachine-client is not installed, which is the case for a wheel install of the server (the server package does not depend on the client). It passed only because the uv workspace installs every member.

`test_version_string` stays; it tests the model's own string form.

## Where the check goes instead

The Test Server Package workflow already builds the wheels and installs them. A new step runs the installed `memmachine-server --version` and requires the reported server version to equal the version in the wheel's filename. That ties the binary to the artifact it shipped in without asserting anything about the version's format, so tag conventions can change without touching it.

## Verification

- The trimmed test file passes and is clean under `ruff check` and `ruff format --check`.
- The new workflow step, extracted verbatim from the YAML and run against wheels built from this tree and installed into a fresh virtualenv, passes.

## Out of scope: the windows unit-test jobs mask this failure

The windows jobs report success only because the step runs under pwsh, which does not stop on the first command's non-zero exit and returns the status of the last command (the client suite). The windows server run on #1602 actually fails three tests: this one plus two windows-only failures, `test_nebula_graph_vector_literals.py::test_only_one_site_turns_a_vector_into_a_literal` (cp1252 decode of a file read without an encoding) and `test_index_persistence.py::TestFlushGuards::test_a_writer_that_replaces_the_file_fails_the_save` (error-message regex mismatch). Forcing bash on the step would turn windows red until those two are fixed, so the masking is left as is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zu1CSWVso2NA4bWPYmw8Z
