### PR TITLE
Serialize a collection's writes so the engine sees them in order (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -82,6 +82,28 @@ def _make_record(
     )
 
 
+_RACE_WINDOW_SECONDS = 2.0
+
+
+async def _wait_for(condition) -> None:
+    """Poll `condition` until it holds, or give up quietly at the deadline.
+
+    Both outcomes are expected: the interleavings below are what unfixed code
+    does while another write is parked, and serialized writes cannot start at
+    all. The assertions tell the cases apart.
+    """
+    # Polling, because the condition is what another task committed to the
+    # database, which no in-process event tracks. The deadline sits between
+    # polls: cancelling a query mid-flight returns its connection to the pool
+    # with a read transaction still open, which blocks the next commit.
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _RACE_WINDOW_SECONDS
+    while loop.time() < deadline:
+        if await condition():
+            return
+        await asyncio.sleep(0.01)
+
+
 @pytest_asyncio.fixture
 async def store(tmp_path):
     db_path = tmp_path / "test.db"
@@ -1205,6 +1227,177 @@ async def _set_all_pending_operations_unapplied(engine) -> None:
         await session.execute(update(_PendingOperationRow).values(applied=False))
 
 
+class TestBatchEdges:
+    """Batches that name one record more than once."""
+
+    @pytest.mark.asyncio
+    async def test_upsert_batch_with_a_repeated_uuid_keeps_the_last(self, collection):
+        record_uuid = uuid4()
+        v1 = _normalize([1.0, 0.0, 0.0])
+        v2 = _normalize([0.0, 1.0, 0.0])
+        await collection.upsert(
+            records=[
+                _make_record(uuid=record_uuid, vector=v1, properties={"name": "first"}),
+                _make_record(uuid=record_uuid, vector=v2, properties={"name": "last"}),
+            ]
+        )
+
+        # Properties are filterable but never returned, so a filter is what
+        # observes them.
+        [named_last] = await collection.query(
+            query_vectors=[v2],
+            limit=5,
+            property_filter=Comparison(field="name", op="=", value="last"),
+        )
+        assert [m.record_uuid for m in named_last.matches] == [record_uuid]
+
+        results = await collection.query(query_vectors=[v2], limit=5)
+        assert [m.record_uuid for m in results[0].matches] == [record_uuid]
+
+    @pytest.mark.asyncio
+    async def test_delete_tolerates_a_repeated_uuid(self, collection):
+        record = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
+        await collection.upsert(records=[record])
+
+        await collection.delete(record_uuids=[record.uuid, record.uuid])
+
+        assert await _present_uuids(collection, [record.uuid]) == []
+
+    @pytest.mark.asyncio
+    async def test_tied_scores_return_distinct_records(self, collection):
+        """Identical vectors must not collapse into one match or duplicate one."""
+        vector = _normalize([1.0, 0.0, 0.0])
+        records = [_make_record(vector=vector) for _ in range(3)]
+        await collection.upsert(records=records)
+
+        results = await collection.query(query_vectors=[vector], limit=3)
+        matched = [m.record_uuid for m in results[0].matches]
+        assert len(matched) == 3
+        assert set(matched) == {record.uuid for record in records}
+
+
+class TestOneLockPerCollection:
+    """The lock belongs to the store, not to a handle.
+
+    A handle is constructed per `open_collection` call, so a per-handle lock
+    would serialize nothing across handles.
+    """
+
+    @pytest.mark.asyncio
+    async def test_two_handles_on_one_collection_are_serialized(self, tmp_path):
+        """The same-uuid interleaving as one handle, across two handles.
+
+        upsert(U) on one handle parks at its engine apply; delete(U) on the
+        other commits and applies in that window; the upsert resumes and
+        re-adds a vector for a record SQLite says is gone.
+        """
+        db_path = tmp_path / "test.db"
+        store, engine, wrapped = await _wrapped_engine_store(
+            db_path, tmp_path, _GatedRemoveEngine
+        )
+        try:
+            writer = await store.open_or_create_collection(
+                namespace=NAMESPACE, name=NAME, config=CONFIG
+            )
+            deleter = await store.open_collection(namespace=NAMESPACE, name=NAME)
+            assert deleter is not None
+            assert deleter is not writer
+            (gated_engine,) = wrapped
+
+            decoy = _make_record(vector=_normalize([1.0, 1.0, 0.0]))
+            racer = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+            await writer.upsert(records=[decoy, racer])
+
+            gate = asyncio.Event()
+            gated_engine.gate = gate
+            upsert_task = asyncio.create_task(
+                writer.upsert(
+                    records=[
+                        _make_record(
+                            uuid=racer.uuid, vector=_normalize([1.0, 0.0, 0.0])
+                        )
+                    ]
+                )
+            )
+            await gated_engine.gate_reached.wait()
+
+            # A task, not an await: with per-handle locks this runs to
+            # completion inside the window; with the store's lock it waits.
+            delete_task = asyncio.create_task(deleter.delete(record_uuids=[racer.uuid]))
+            await _wait_for(lambda: _a_delete_has_been_applied(engine))
+
+            gate.set()
+            await asyncio.gather(upsert_task, delete_task)
+
+            # The racer's vector scores 1.0 here, so if it is still in the
+            # engine it takes the only slot and resolves to nothing.
+            results = await writer.query(
+                query_vectors=[_normalize([1.0, 0.0, 0.0])], limit=1
+            )
+            assert [match.record_uuid for match in results[0].matches] == [
+                decoy.uuid
+            ], "a vector belonging to no record is still in the engine"
+        finally:
+            await store.shutdown()
+            await engine.dispose()
+
+
+class TestConcurrentWrites:
+    """Writers that do not contend for the same record still must not lose."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_upsert_and_delete_of_disjoint_sets(self, collection):
+        """Deleting one set while upserting another loses neither."""
+        kept = [
+            _make_record(vector=_normalize([1.0, float(i) + 1.0, 0.0]))
+            for i in range(5)
+        ]
+        doomed = [
+            _make_record(vector=_normalize([0.0, 1.0, float(i) + 1.0]))
+            for i in range(5)
+        ]
+        await collection.upsert(records=doomed)
+
+        await asyncio.gather(
+            collection.upsert(records=kept),
+            collection.delete(record_uuids=[record.uuid for record in doomed]),
+        )
+
+        candidates = [record.uuid for record in kept + doomed]
+        surviving = set(await _present_uuids(collection, candidates))
+        assert surviving == {record.uuid for record in kept}
+
+    @pytest.mark.asyncio
+    async def test_writes_racing_a_checkpoint_are_not_lost(self, tmp_path):
+        """A save runs under the same lock as a write, so none can slip past it.
+
+        With a threshold of one every write checkpoints, driving the save and
+        write paths against each other continuously.
+        """
+        db_path = tmp_path / "test.db"
+        store, engine = await _fresh_store(db_path, tmp_path, save_threshold=1)
+        coll = await store.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        records = [
+            _make_record(vector=_normalize([1.0, float(i) + 1.0, float(i)]))
+            for i in range(20)
+        ]
+        await asyncio.gather(*(coll.upsert(records=[record]) for record in records))
+
+        await store.shutdown()
+        await engine.dispose()
+
+        store2, engine2 = await _fresh_store(db_path, tmp_path)
+        coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        assert coll2 is not None
+        found = set(await _present_uuids(coll2, [record.uuid for record in records]))
+        assert found == {record.uuid for record in records}
+
+        await store2.shutdown()
+        await engine2.dispose()
+
+
 class TestCrashRecovery:
     """Tests for pending operations replay on startup."""
 
@@ -1407,6 +1600,322 @@ class TestCrashRecovery:
             await store.delete_collection(namespace=NAMESPACE, name=NAME)
 
         await engine.dispose()
+
+
+# ── Concurrent write ordering (issue #1468) ──
+
+
+class _GatedRemoveEngine(VectorSearchEngine):
+    """Delegates to a real engine; the next remove() waits on `gate` first.
+
+    delete() already suspends at its engine remove(), after the SQL commit;
+    the gate widens that window so the interleaving is deterministic.
+    """
+
+    def __init__(self, inner: VectorSearchEngine) -> None:
+        self.inner = inner
+        self.gate: asyncio.Event | None = None
+        self.gate_reached = asyncio.Event()
+
+    async def add(self, vectors):
+        await self.inner.add(vectors)
+
+    async def remove(self, keys):
+        if self.gate is not None:
+            gate, self.gate = self.gate, None
+            self.gate_reached.set()
+            await gate.wait()
+        await self.inner.remove(keys)
+
+    async def search(self, vectors, *, limit, allowed_keys=None):
+        return await self.inner.search(vectors, limit=limit, allowed_keys=allowed_keys)
+
+    async def save(self, path):
+        await self.inner.save(path)
+
+    async def load(self, path):
+        await self.inner.load(path)
+
+
+class _GatedSaveEngine(VectorSearchEngine):
+    """Delegates to a real engine; the first save parks after writing the index.
+
+    A save writes the index and then trims the log. Parking between the two
+    widens the window in which another write can apply to the engine: too late
+    for the file, early enough for the trim to delete its log row.
+
+    Later saves park before writing, so a test can reach its crash without a
+    save publishing what it is trying to observe.
+    """
+
+    def __init__(self, inner: VectorSearchEngine) -> None:
+        self.inner = inner
+        self.gate: asyncio.Event | None = None
+        self.gate_reached = asyncio.Event()
+        self.saves_blocked = False
+        self.blocked_save_reached = asyncio.Event()
+
+    async def add(self, vectors):
+        await self.inner.add(vectors)
+
+    async def remove(self, keys):
+        await self.inner.remove(keys)
+
+    async def search(self, vectors, *, limit, allowed_keys=None):
+        return await self.inner.search(vectors, limit=limit, allowed_keys=allowed_keys)
+
+    async def save(self, path):
+        if self.gate is None:
+            if self.saves_blocked:
+                self.blocked_save_reached.set()
+                await asyncio.Event().wait()
+            await self.inner.save(path)
+            return
+
+        gate, self.gate = self.gate, None
+        self.saves_blocked = True
+        await self.inner.save(path)
+        self.gate_reached.set()
+        await gate.wait()
+
+    async def load(self, path):
+        await self.inner.load(path)
+
+
+async def _wrapped_engine_store(db_path, tmp_path, wrap, *, save_threshold=1000):
+    """Create a store whose engines are wrapped by `wrap`, and collect them."""
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    wrapped: list = []
+
+    def factory(ndim):
+        gated = wrap(_engine_factory(ndim))
+        wrapped.append(gated)
+        return gated
+
+    store = SQLiteVectorStore(
+        SQLiteVectorStoreParams(
+            sqlalchemy_engine=engine,
+            vector_search_engine_factory=factory,
+            index_directory=str(tmp_path / "indexes"),
+            save_threshold=save_threshold,
+        )
+    )
+    await store.startup()
+    return store, engine, wrapped
+
+
+async def _record_exists(engine, store, record_uuid) -> bool:
+    """Whether a concurrent upsert's transaction has committed yet."""
+    return record_uuid in await _stored_record_uuids(engine, store)
+
+
+async def _a_delete_has_been_applied(engine) -> bool:
+    """Whether a concurrent delete has reached the search engine.
+
+    Its pending row is marked applied last, so this is true only once the
+    delete has both committed and removed from the engine.
+    """
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        applied_deletes = (
+            await session.execute(
+                select(func.count())
+                .select_from(_PendingOperationRow)
+                .where(
+                    _PendingOperationRow.operation_type == "delete",
+                    _PendingOperationRow.applied.is_(True),
+                )
+            )
+        ).scalar_one()
+    return applied_deletes > 0
+
+
+async def _both_writes_applied(engine) -> bool:
+    """Whether a second write has reached the engine behind a parked save."""
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        applied = (
+            await session.execute(
+                select(func.count())
+                .select_from(_PendingOperationRow)
+                .where(_PendingOperationRow.applied.is_(True))
+            )
+        ).scalar_one()
+    return applied == 2
+
+
+class TestConcurrentWriteOrdering:
+    """The engine must see a collection's writes in the order SQLite committed.
+
+    A write commits to SQLite before applying to the engine, so unserialized
+    writers could reach the engine in the opposite order. Never reusing a
+    row_id does not cover this: both writes address one uuid, which keeps its
+    row_id across upserts.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_upsert_survives_a_delete_of_another_record(self, tmp_path):
+        """A delete must not carry an unrelated concurrent upsert with it.
+
+        delete(A) commits and parks at its engine removal; upsert(B) lands in
+        that window; delete(A) resumes and removes the row_id it was given. B
+        stays searchable: it never had A's row_id, and now cannot run in that
+        window at all.
+        """
+        db_path = tmp_path / "test.db"
+        store, engine, wrapped = await _wrapped_engine_store(
+            db_path, tmp_path, _GatedRemoveEngine
+        )
+        try:
+            coll = await store.open_or_create_collection(
+                namespace=NAMESPACE, name=NAME, config=CONFIG
+            )
+            (gated_engine,) = wrapped
+
+            deleted = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
+            await coll.upsert(records=[deleted])
+
+            gate = asyncio.Event()
+            gated_engine.gate = gate
+            delete_task = asyncio.create_task(coll.delete(record_uuids=[deleted.uuid]))
+            await gated_engine.gate_reached.wait()
+
+            # A task, not an await: unfixed code runs this inside the window,
+            # serialized writes make it wait for the delete.
+            upserted = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+            upsert_task = asyncio.create_task(coll.upsert(records=[upserted]))
+            await _wait_for(lambda: _record_exists(engine, store, upserted.uuid))
+
+            gate.set()
+            await asyncio.gather(delete_task, upsert_task)
+
+            results = await coll.query(
+                query_vectors=[_normalize([0.0, 1.0, 0.0])], limit=5
+            )
+            assert upserted.uuid in {
+                match.record_uuid for match in results[0].matches
+            }, "upserted record lost from the search engine"
+        finally:
+            await store.shutdown()
+            await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_an_upsert_cannot_overtake_a_delete_of_the_same_uuid(self, tmp_path):
+        """A vector re-added after its record is deleted belongs to nothing.
+
+        upsert(U) commits and parks at its engine apply; delete(U) commits and
+        applies in that window; upsert(U) resumes and re-adds its vector. The
+        vector resolves to no row, is dropped from every result it wins, and
+        the next save publishes it for good.
+        """
+        db_path = tmp_path / "test.db"
+        store, engine, wrapped = await _wrapped_engine_store(
+            db_path, tmp_path, _GatedRemoveEngine
+        )
+        try:
+            coll = await store.open_or_create_collection(
+                namespace=NAMESPACE, name=NAME, config=CONFIG
+            )
+            (gated_engine,) = wrapped
+
+            # The record the query should return once the racers are done.
+            decoy = _make_record(vector=_normalize([1.0, 1.0, 0.0]))
+            racer = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+            await coll.upsert(records=[decoy, racer])
+
+            # upsert(racer) commits, then parks at its engine apply.
+            gate = asyncio.Event()
+            gated_engine.gate = gate
+            upsert_task = asyncio.create_task(
+                coll.upsert(
+                    records=[
+                        _make_record(
+                            uuid=racer.uuid, vector=_normalize([1.0, 0.0, 0.0])
+                        )
+                    ]
+                )
+            )
+            await gated_engine.gate_reached.wait()
+
+            # delete(racer) commits and applies while the upsert is parked.
+            delete_task = asyncio.create_task(coll.delete(record_uuids=[racer.uuid]))
+            await _wait_for(lambda: _a_delete_has_been_applied(engine))
+
+            gate.set()
+            await asyncio.gather(upsert_task, delete_task)
+
+            # The racer's vector scores 1.0 here, so if it is still in the
+            # engine it takes the only slot and resolves to nothing.
+            results = await coll.query(
+                query_vectors=[_normalize([1.0, 0.0, 0.0])], limit=1
+            )
+            assert [match.record_uuid for match in results[0].matches] == [decoy.uuid]
+        finally:
+            await store.shutdown()
+            await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_a_save_cannot_trim_a_write_it_did_not_publish(self, tmp_path):
+        """A write applied behind a save must not be trimmed by that save.
+
+        A write that applies to the engine after the index is written but
+        before the trim is in neither the file nor the log: live in memory,
+        gone from disk, lost to a process crash.
+        """
+        db_path = tmp_path / "test.db"
+        store, engine, wrapped = await _wrapped_engine_store(
+            db_path, tmp_path, _GatedSaveEngine, save_threshold=1
+        )
+        coll = await store.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        (gated_engine,) = wrapped
+
+        # This write's own save parks with the index written and the trim
+        # still to come.
+        gate = asyncio.Event()
+        gated_engine.gate = gate
+        published = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
+        publish_task = asyncio.create_task(coll.upsert(records=[published]))
+        await gated_engine.gate_reached.wait()
+
+        # A second write lands in that window: applied to the engine and
+        # marked applied, but absent from the index just written.
+        behind = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+        behind_task = asyncio.create_task(coll.upsert(records=[behind]))
+        await _wait_for(lambda: _both_writes_applied(engine))
+
+        gate.set()
+        await publish_task
+
+        # The second write parks in its own save, which never writes: through
+        # the window on unfixed code, after its turn once serialized. Either
+        # way it is committed, applied, and marked applied.
+        async with asyncio.timeout(_RACE_WINDOW_SECONDS):
+            await gated_engine.blocked_save_reached.wait()
+
+        # Crash.
+        behind_task.cancel()
+        await asyncio.gather(behind_task, return_exceptions=True)
+        await engine.dispose()
+
+        store2, engine2 = await _fresh_store(db_path, tmp_path)
+        try:
+            coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+            assert coll2 is not None
+
+            # The record is still a row.
+            assert behind.uuid in await _stored_record_uuids(engine2, store2)
+
+            results = await coll2.query(
+                query_vectors=[_normalize([0.0, 1.0, 0.0])], limit=5
+            )
+            assert behind.uuid in {match.record_uuid for match in results[0].matches}, (
+                "a committed write was trimmed by a save that never published it"
+            )
+        finally:
+            await store2.shutdown()
+            await engine2.dispose()
 
 
 # ── Index file durability contract ──

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -23,6 +23,7 @@ Callers that need every record searchable after a power failure must be able
 to re-ingest; nothing here detects the gap for them.
 """
 
+import asyncio
 import logging
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -191,7 +192,12 @@ async def _save_collection_index(
 
 
 class SQLiteVectorStoreCollection(VectorStoreCollection):
-    """A logical collection backed by SQLite + a pluggable vector search engine."""
+    """A logical collection backed by SQLite + a pluggable vector search engine.
+
+    Reads run freely. Writes are serialized by `write_lock`, which the store
+    shares among every handle on one collection, so the engine sees a
+    collection's writes in the order SQLite committed them.
+    """
 
     class _KeyFilter:
         """Per-candidate SQL filter using a sync SQLAlchemy session."""
@@ -248,6 +254,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         records_table: Table,
         search_engine: VectorSearchEngine,
         engine_lock: AsyncRWLock,
+        write_lock: asyncio.Lock,
         namespace: str,
         name: str,
         config: VectorStoreCollectionConfig,
@@ -260,6 +267,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         self._records_table = records_table
         self._search_engine = search_engine
         self._engine_lock = engine_lock
+        self._write_lock = write_lock
 
         self._namespace = namespace
         self._name = name
@@ -275,7 +283,12 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         return self._config
 
     async def _maybe_save_index(self) -> None:
-        """Save the index to disk if applied pending operations exceed the threshold."""
+        """Save the index to disk if applied pending operations exceed the threshold.
+
+        Call with the write lock held: saving trims every applied operation
+        from the log, and the log is the only other copy of a vector applied
+        after the index was written.
+        """
         if self._index_path is None:
             return
 
@@ -306,59 +319,60 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         if not records:
             return
 
-        async with self._create_session() as session, session.begin():
-            upsert_records = (
-                sqlite_insert(self._records_table)
-                .on_conflict_do_update(
-                    index_elements=[self._records_table.c.uuid],
-                    set_={
-                        "properties": sqlite_insert(
-                            self._records_table
-                        ).excluded.properties,
-                    },
-                )
-                .returning(self._records_table.c.uuid, self._records_table.c.row_id)
-            )
-            rows = (
-                await session.execute(
-                    upsert_records,
-                    [
-                        {
-                            "uuid": record.uuid,
-                            "properties": encode_properties(record.properties),
-                        }
-                        for record in records
-                    ],
-                )
-            ).all()
-            uuid_to_row_id: dict[UUID, int] = {row.uuid: row.row_id for row in rows}
-
-            pending_operation_values = [
-                {
-                    "namespace": self._namespace,
-                    "name": self._name,
-                    "record_row_id": uuid_to_row_id[record.uuid],
-                    "operation_type": "upsert",
-                    "vector": np.array(record.vector, dtype=np.float32).tobytes(),
-                    "applied": False,
-                }
-                for record in records
-            ]
-            if pending_operation_values:
-                upsert_pending_operation = sqlite_insert(_PendingOperationRow)
-                await session.execute(
-                    upsert_pending_operation.on_conflict_do_update(
-                        index_elements=["namespace", "name", "record_row_id"],
+        async with self._write_lock:
+            async with self._create_session() as session, session.begin():
+                upsert_records = (
+                    sqlite_insert(self._records_table)
+                    .on_conflict_do_update(
+                        index_elements=[self._records_table.c.uuid],
                         set_={
-                            "operation_type": upsert_pending_operation.excluded.operation_type,
-                            "vector": upsert_pending_operation.excluded.vector,
-                            "applied": upsert_pending_operation.excluded.applied,
+                            "properties": sqlite_insert(
+                                self._records_table
+                            ).excluded.properties,
                         },
-                    ),
-                    pending_operation_values,
+                    )
+                    .returning(self._records_table.c.uuid, self._records_table.c.row_id)
                 )
+                rows = (
+                    await session.execute(
+                        upsert_records,
+                        [
+                            {
+                                "uuid": record.uuid,
+                                "properties": encode_properties(record.properties),
+                            }
+                            for record in records
+                        ],
+                    )
+                ).all()
+                uuid_to_row_id: dict[UUID, int] = {row.uuid: row.row_id for row in rows}
 
-        await self._apply_engine_upserts(records, uuid_to_row_id)
+                pending_operation_values = [
+                    {
+                        "namespace": self._namespace,
+                        "name": self._name,
+                        "record_row_id": uuid_to_row_id[record.uuid],
+                        "operation_type": "upsert",
+                        "vector": np.array(record.vector, dtype=np.float32).tobytes(),
+                        "applied": False,
+                    }
+                    for record in records
+                ]
+                if pending_operation_values:
+                    upsert_pending_operation = sqlite_insert(_PendingOperationRow)
+                    await session.execute(
+                        upsert_pending_operation.on_conflict_do_update(
+                            index_elements=["namespace", "name", "record_row_id"],
+                            set_={
+                                "operation_type": upsert_pending_operation.excluded.operation_type,
+                                "vector": upsert_pending_operation.excluded.vector,
+                                "applied": upsert_pending_operation.excluded.applied,
+                            },
+                        ),
+                        pending_operation_values,
+                    )
+
+            await self._apply_engine_upserts(records, uuid_to_row_id)
 
     async def _apply_engine_upserts(
         self,
@@ -500,60 +514,61 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
         record_uuids = list(uuid_list)
 
-        async with self._create_session() as session, session.begin():
-            rows = (
+        async with self._write_lock:
+            async with self._create_session() as session, session.begin():
+                rows = (
+                    await session.execute(
+                        select(self._records_table.c.row_id).where(
+                            self._records_table.c.uuid.in_(record_uuids),
+                        )
+                    )
+                ).all()
+                if not rows:
+                    return
+
+                record_row_ids = [row.row_id for row in rows]
+
+                upsert_pending_operation = sqlite_insert(_PendingOperationRow)
                 await session.execute(
-                    select(self._records_table.c.row_id).where(
+                    upsert_pending_operation.on_conflict_do_update(
+                        index_elements=["namespace", "name", "record_row_id"],
+                        set_={
+                            "operation_type": upsert_pending_operation.excluded.operation_type,
+                            "applied": upsert_pending_operation.excluded.applied,
+                        },
+                    ),
+                    [
+                        {
+                            "namespace": self._namespace,
+                            "name": self._name,
+                            "record_row_id": record_row_id,
+                            "operation_type": "delete",
+                            "applied": False,
+                        }
+                        for record_row_id in record_row_ids
+                    ],
+                )
+
+                await session.execute(
+                    delete(self._records_table).where(
                         self._records_table.c.uuid.in_(record_uuids),
                     )
                 )
-            ).all()
-            if not rows:
-                return
 
-            record_row_ids = [row.row_id for row in rows]
-
-            upsert_pending_operation = sqlite_insert(_PendingOperationRow)
-            await session.execute(
-                upsert_pending_operation.on_conflict_do_update(
-                    index_elements=["namespace", "name", "record_row_id"],
-                    set_={
-                        "operation_type": upsert_pending_operation.excluded.operation_type,
-                        "applied": upsert_pending_operation.excluded.applied,
-                    },
-                ),
-                [
-                    {
-                        "namespace": self._namespace,
-                        "name": self._name,
-                        "record_row_id": record_row_id,
-                        "operation_type": "delete",
-                        "applied": False,
-                    }
-                    for record_row_id in record_row_ids
-                ],
-            )
-
-            await session.execute(
-                delete(self._records_table).where(
-                    self._records_table.c.uuid.in_(record_uuids),
+            async with self._engine_lock.write_lock():
+                await self._search_engine.remove(record_row_ids)
+            async with self._create_session() as session, session.begin():
+                await session.execute(
+                    update(_PendingOperationRow)
+                    .where(
+                        _PendingOperationRow.namespace == self._namespace,
+                        _PendingOperationRow.name == self._name,
+                        _PendingOperationRow.record_row_id.in_(record_row_ids),
+                        _PendingOperationRow.applied.is_(False),
+                    )
+                    .values(applied=True)
                 )
-            )
-
-        async with self._engine_lock.write_lock():
-            await self._search_engine.remove(record_row_ids)
-        async with self._create_session() as session, session.begin():
-            await session.execute(
-                update(_PendingOperationRow)
-                .where(
-                    _PendingOperationRow.namespace == self._namespace,
-                    _PendingOperationRow.name == self._name,
-                    _PendingOperationRow.record_row_id.in_(record_row_ids),
-                    _PendingOperationRow.applied.is_(False),
-                )
-                .values(applied=True)
-            )
-        await self._maybe_save_index()
+            await self._maybe_save_index()
 
 
 VectorSearchEngineFactory = Callable[[int], VectorSearchEngine]
@@ -641,6 +656,7 @@ class SQLiteVectorStore(VectorStore):
         )
         self._search_engines: dict[tuple[str, str], VectorSearchEngine] = {}
         self._engine_locks: dict[tuple[str, str], AsyncRWLock] = {}
+        self._write_locks: dict[tuple[str, str], asyncio.Lock] = {}
         self._sa_metadata = MetaData()
 
         self._sync_sqlalchemy_engine = create_engine(
@@ -751,14 +767,18 @@ class SQLiteVectorStore(VectorStore):
             for (namespace, name), search_engine in self._search_engines.items():
                 path = self._index_path(namespace, name)
                 assert path is not None
-                await _save_collection_index(
-                    create_session=self._create_session,
-                    namespace=namespace,
-                    name=name,
-                    search_engine=search_engine,
-                    engine_lock=self._engine_lock_for(namespace, name),
-                    path=str(path),
-                )
+                # Hold the collection's write lock for the whole save. A write
+                # that applied after the index file was written but before the
+                # trim would be absent from the file and trimmed from the log.
+                async with self._write_lock_for(namespace, name):
+                    await _save_collection_index(
+                        create_session=self._create_session,
+                        namespace=namespace,
+                        name=name,
+                        search_engine=search_engine,
+                        engine_lock=self._engine_lock_for(namespace, name),
+                        path=str(path),
+                    )
         self._search_engines.clear()
         self._started = False
 
@@ -819,6 +839,7 @@ class SQLiteVectorStore(VectorStore):
                     records_table=records_table,
                     search_engine=search_engine,
                     engine_lock=self._engine_lock_for(namespace, name),
+                    write_lock=self._write_lock_for(namespace, name),
                     namespace=namespace,
                     name=name,
                     config=existing_config,
@@ -844,6 +865,7 @@ class SQLiteVectorStore(VectorStore):
             records_table=records_table,
             search_engine=search_engine,
             engine_lock=self._engine_lock_for(namespace, name),
+            write_lock=self._write_lock_for(namespace, name),
             namespace=namespace,
             name=name,
             config=config,
@@ -879,6 +901,7 @@ class SQLiteVectorStore(VectorStore):
             records_table=records_table,
             search_engine=search_engine,
             engine_lock=self._engine_lock_for(namespace, name),
+            write_lock=self._write_lock_for(namespace, name),
             namespace=namespace,
             name=name,
             config=existing,
@@ -955,6 +978,16 @@ class SQLiteVectorStore(VectorStore):
         held would guard nobody.
         """
         return self._engine_locks.setdefault((namespace, name), AsyncRWLock())
+
+    def _write_lock_for(self, namespace: str, name: str) -> asyncio.Lock:
+        """Get or create the lock serializing a collection's writes.
+
+        Held from SQL commit through engine apply, mark-applied, and any save,
+        so the engine sees writes in commit order and a save's trim cannot land
+        between another write's apply and its bookkeeping. Kept for the store's
+        lifetime: replacing a held lock would serialize nobody.
+        """
+        return self._write_locks.setdefault((namespace, name), asyncio.Lock())
 
     def _index_path(self, namespace: str, name: str) -> Path | None:
         """Return the on-disk index path for a collection, or None if in-memory."""


### PR DESCRIPTION
### Purpose of the change

A write commits to SQLite and only then applies to the search engine, so two writers to one uuid could reach the engine in the opposite order to the one they committed in: an upsert overtaking a delete re-adds a vector for a record that is gone (it wins result slots and is dropped from them, and the next save publishes it for good), and two upserts inverting leave the engine serving the older vector. Never reusing a row id (#1589) does not cover this: an upsert of an existing uuid keeps its row id.

A save falling in that window costs a write outright. A save publishes the index and then trims every applied log row, and the log is the only other copy of those vectors, so a write that applied after the index was written is then in neither.

A per-collection `asyncio.Lock` now spans a write from SQL commit through engine apply, mark-applied, and any save it triggers; shutdown's save takes it too. The lock belongs to the store, not to a collection handle: a handle is constructed per `open_collection` call, so several can address one collection, and only a shared lock serializes them. Readers are untouched.

Fixes #1468.

### Tests

Three fail without the lock, each interleaving made deterministic by gating the engine: an upsert overtaking a delete of the same uuid, a save trimming a write it did not publish, and that overtake across two handles on one collection, which a per-handle lock passes. The interleaving tests poll for what another task has committed; the deadline sits between polls rather than in a timeout around them, because cancelling a query mid-flight leaves its read transaction open on the pooled connection and blocks the next commit.

The rest pin behavior the lock must preserve: an upsert surviving a delete of another record, disjoint concurrent upserts and deletes, writes racing a checkpoint, and batches that name one uuid twice.

### Verification

- `test_sqlite_vector_store.py`: 81 passed. Against #1589's store, the 3 tests above fail and the other 78 pass.
- `ruff check` / `ruff format --check`: clean.

Stacked on #1612, which moved the engine's lock into the store, so the diff here includes it until it merges. The stack is #1612 → this → #1608 → #1609 → #1610.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESpWYTmCR7X3bJEpoA8SAn

