### PR TITLE
Refuse a pending row replay cannot honor, instead of dropping it (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -5,6 +5,7 @@ import math
 from datetime import UTC, datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
+import numpy as np
 import pytest
 import pytest_asyncio
 from pydantic import ValidationError
@@ -26,6 +27,7 @@ from memmachine_server.common.vector_store.data_types import (
 )
 from memmachine_server.common.vector_store.sqlite_vector_store import (
     IndexLoadError,
+    PendingOperationCorruptError,
     SQLiteVectorStore,
     SQLiteVectorStoreCollection,
     SQLiteVectorStoreParams,
@@ -1227,6 +1229,186 @@ async def _set_all_pending_operations_unapplied(engine) -> None:
         await session.execute(update(_PendingOperationRow).values(applied=False))
 
 
+class TestPendingLogStates:
+    """The log's state machine, exercised across a restart."""
+
+    @pytest.mark.asyncio
+    async def test_replay_refuses_an_undecodable_vector(self, tmp_path):
+        """A blob that is not a float32 vector is damage, not a shorter vector."""
+        db_path = tmp_path / "test.db"
+        store1, engine1 = await _fresh_store(db_path, tmp_path)
+        coll = await store1.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
+
+        session_factory = async_sessionmaker(engine1, expire_on_commit=False)
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                update(_PendingOperationRow).values(vector=b"\x01\x02\x03")
+            )
+        await engine1.dispose()
+
+        with pytest.raises(PendingOperationCorruptError, match="cannot be decoded"):
+            await _fresh_store(db_path, tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_replay_refuses_a_vector_of_the_wrong_width(self, tmp_path):
+        """A blob of whole float32s that is not the collection's width is damage too."""
+        db_path = tmp_path / "test.db"
+        store1, engine1 = await _fresh_store(db_path, tmp_path)
+        coll = await store1.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
+
+        session_factory = async_sessionmaker(engine1, expire_on_commit=False)
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                update(_PendingOperationRow).values(
+                    vector=np.zeros(VECTOR_DIM - 1, dtype=np.float32).tobytes()
+                )
+            )
+        await engine1.dispose()
+
+        with pytest.raises(PendingOperationCorruptError, match="dimension"):
+            await _fresh_store(db_path, tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_a_rewritten_uuid_replays_its_last_write(self, tmp_path):
+        """Replay restores a uuid's last write.
+
+        A second write to a uuid overwrites its log row rather than queueing
+        behind it, which is only observable across a restart.
+        """
+        db_path = tmp_path / "test.db"
+        store1, engine1 = await _fresh_store(db_path, tmp_path)
+        coll = await store1.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        first = _normalize([1.0, 0.0, 0.0])
+        second = _normalize([0.0, 1.0, 0.0])
+        record_uuid = uuid4()
+        await coll.upsert(records=[_make_record(uuid=record_uuid, vector=first)])
+        await coll.upsert(records=[_make_record(uuid=record_uuid, vector=second)])
+
+        # Crash: dispose without shutting down, so nothing is saved or trimmed.
+        await engine1.dispose()
+
+        store2, engine2 = await _fresh_store(db_path, tmp_path)
+        coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        assert coll2 is not None
+
+        results = await coll2.query(query_vectors=[second], limit=1)
+        assert results[0].matches[0].record_uuid == record_uuid
+        assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
+
+        # And the superseded vector is not still indexed under a second key.
+        stale = await coll2.query(query_vectors=[first], limit=5)
+        assert [m.record_uuid for m in stale[0].matches] == [record_uuid]
+
+        await store2.shutdown()
+        await engine2.dispose()
+
+    @pytest.mark.asyncio
+    async def test_an_upsert_then_delete_of_one_uuid_stays_deleted(self, tmp_path):
+        """A delete staged over an untrimmed upsert wins the replay."""
+        db_path = tmp_path / "test.db"
+        store1, engine1 = await _fresh_store(db_path, tmp_path)
+        coll = await store1.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        vector = _normalize([1.0, 0.0, 0.0])
+        record = _make_record(vector=vector)
+        await coll.upsert(records=[record])
+        await coll.delete(record_uuids=[record.uuid])
+        await engine1.dispose()
+
+        store2, engine2 = await _fresh_store(db_path, tmp_path)
+        coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        assert coll2 is not None
+        results = await coll2.query(query_vectors=[vector], limit=5)
+        assert results[0].matches == []
+
+        await store2.shutdown()
+        await engine2.dispose()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_index_save_leaves_the_write_replayable(self, tmp_path):
+        """A save that fails must not take the write with it.
+
+        The log is trimmed only after the save returns.
+        """
+        db_path = tmp_path / "test.db"
+        store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=1)
+        coll = await store1.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        vector = _normalize([1.0, 0.0, 0.0])
+        record = _make_record(vector=vector)
+
+        search_engine = store1._search_engines[NAMESPACE, NAME]
+
+        async def failing_save(path: str) -> None:
+            raise OSError("no space left on device")
+
+        original_save = search_engine.save
+        search_engine.save = failing_save
+        with pytest.raises(OSError, match="no space"):
+            await coll.upsert(records=[record])
+        search_engine.save = original_save
+
+        assert await _pending_operation_count(engine1) == 1
+        await engine1.dispose()
+
+        store2, engine2 = await _fresh_store(db_path, tmp_path)
+        coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        assert coll2 is not None
+        results = await coll2.query(query_vectors=[vector], limit=1)
+        assert results[0].matches[0].record_uuid == record.uuid
+
+        await store2.shutdown()
+        await engine2.dispose()
+
+    @pytest.mark.asyncio
+    async def test_save_threshold_counts_log_rows_not_writes(self, tmp_path):
+        """The trigger counts log rows, and one uuid only ever has one.
+
+        Rewriting a single record never advances it, however often it is
+        written.
+        """
+        db_path = tmp_path / "test.db"
+        store, engine = await _fresh_store(db_path, tmp_path, save_threshold=3)
+        coll = await store.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        record_uuid = uuid4()
+        for i in range(6):
+            await coll.upsert(
+                records=[
+                    _make_record(
+                        uuid=record_uuid, vector=_normalize([1.0, float(i) + 1.0, 0.0])
+                    )
+                ]
+            )
+
+        # Six writes, one row, so the threshold of three was never reached.
+        assert await _pending_operation_count(engine) == 1
+
+        # Three distinct records do reach it.
+        await coll.upsert(
+            records=[
+                _make_record(vector=_normalize([1.0, 0.0, 0.0])),
+                _make_record(vector=_normalize([0.0, 1.0, 0.0])),
+                _make_record(vector=_normalize([0.0, 0.0, 1.0])),
+            ]
+        )
+        assert await _pending_operation_count(engine) == 0
+
+        await store.shutdown()
+        await engine.dispose()
+
+
 class TestBatchEdges:
     """Batches that name one record more than once."""
 
@@ -1400,6 +1582,50 @@ class TestConcurrentWrites:
 
 class TestCrashRecovery:
     """Tests for pending operations replay on startup."""
+
+    @pytest.mark.asyncio
+    async def test_replay_refuses_an_upsert_with_no_vector(self, tmp_path):
+        """A damaged log row fails the restart instead of vanishing.
+
+        Until the next index save the log holds the only copy of the vector,
+        so a skipped row is a record no search can find.
+        """
+        db_path = tmp_path / "test.db"
+        store1, engine1 = await _fresh_store(db_path, tmp_path)
+        coll = await store1.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
+
+        session_factory = async_sessionmaker(engine1, expire_on_commit=False)
+        async with session_factory() as session, session.begin():
+            await session.execute(update(_PendingOperationRow).values(vector=None))
+        await engine1.dispose()
+
+        with pytest.raises(PendingOperationCorruptError, match="no vector"):
+            await _fresh_store(db_path, tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_replay_refuses_an_unknown_operation_type(self, tmp_path):
+        """An operation_type replay does not understand fails the restart."""
+        db_path = tmp_path / "test.db"
+        store1, engine1 = await _fresh_store(db_path, tmp_path)
+        coll = await store1.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+        await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
+
+        session_factory = async_sessionmaker(engine1, expire_on_commit=False)
+        async with session_factory() as session, session.begin():
+            await session.execute(
+                update(_PendingOperationRow).values(operation_type="rewrite")
+            )
+        await engine1.dispose()
+
+        with pytest.raises(
+            PendingOperationCorruptError, match="unknown operation_type"
+        ):
+            await _fresh_store(db_path, tmp_path)
 
     @pytest.mark.asyncio
     async def test_replay_upserts_after_crash(self, tmp_path):

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -82,7 +82,14 @@ logger = logging.getLogger(__name__)
 
 
 class IndexLoadError(RuntimeError):
-    """Raised when a collection's on-disk index file cannot be loaded."""
+    """A collection's saved index could not be loaded.
+
+    The cause is not classified: engines propagate whatever their backend
+    raises, and backends report a truncated index and a permission denial the
+    same way. `__cause__` says which. Rebuilding from content is right for a
+    corrupt index and useless for an unreadable one, so read the cause before
+    choosing a remedy.
+    """
 
     def __init__(self, namespace: str, name: str, path: Path) -> None:
         """Initialize with the collection namespace, name, and index file path."""
@@ -92,6 +99,31 @@ class IndexLoadError(RuntimeError):
         super().__init__(
             f"Index for collection ({namespace!r}, {name!r}) "
             f"at {path} could not be loaded"
+        )
+
+
+class PendingOperationCorruptError(RuntimeError):
+    """A pending operation row cannot be replayed as written.
+
+    An upsert with no vector, a vector that is not whole float32s or not the
+    collection's width, or an operation type this store never writes. This code produces none of those,
+    so something else wrote the database.
+
+    Do not clear the log to get past it: until the next index save it holds
+    the only durable copy of those vectors. Repair the row, or accept the loss
+    deliberately.
+    """
+
+    def __init__(
+        self, namespace: str, name: str, record_row_id: int, reason: str
+    ) -> None:
+        """Initialize with the collection, the row, and what is wrong with it."""
+        self.namespace = namespace
+        self.name = name
+        self.record_row_id = record_row_id
+        super().__init__(
+            f"Pending operation for row {record_row_id} of collection "
+            f"({namespace!r}, {name!r}) cannot be replayed: {reason}"
         )
 
 
@@ -729,16 +761,50 @@ class SQLiteVectorStore(VectorStore):
             namespace, name, config
         )
 
+        # A row that cannot be replayed is damage to a durable record: until
+        # the next index save the log holds the only copy of the vector, so
+        # skipping the row would leave a record no search can find. Refuse,
+        # and leave the log for whoever repairs it.
         upserted_vectors: dict[int, list[float]] = {}
         deleted_row_ids: list[int] = []
         for operation in operations:
-            if operation.operation_type == "upsert" and operation.vector is not None:
-                vector = np.frombuffer(operation.vector, dtype=np.float32)
+            if operation.operation_type == "upsert":
+                if operation.vector is None:
+                    raise PendingOperationCorruptError(
+                        namespace,
+                        name,
+                        operation.record_row_id,
+                        "upsert with no vector",
+                    )
+                try:
+                    vector = np.frombuffer(operation.vector, dtype=np.float32)
+                except ValueError as error:
+                    raise PendingOperationCorruptError(
+                        namespace,
+                        name,
+                        operation.record_row_id,
+                        f"vector cannot be decoded: {error}",
+                    ) from error
+                if vector.size != config.vector_dimensions:
+                    raise PendingOperationCorruptError(
+                        namespace,
+                        name,
+                        operation.record_row_id,
+                        f"holds a {vector.size}-dimension vector in a "
+                        f"{config.vector_dimensions}-dimension collection",
+                    )
                 upserted_vectors[operation.record_row_id] = [
                     float(value) for value in vector.flat
                 ]
             elif operation.operation_type == "delete":
                 deleted_row_ids.append(operation.record_row_id)
+            else:
+                raise PendingOperationCorruptError(
+                    namespace,
+                    name,
+                    operation.record_row_id,
+                    f"unknown operation_type {operation.operation_type!r}",
+                )
 
         all_row_ids = list(upserted_vectors.keys()) + deleted_row_ids
         if not all_row_ids:
@@ -1045,8 +1111,9 @@ class SQLiteVectorStore(VectorStore):
                 ).scalar_one_or_none()
 
             if saved:
-                # The engine just propagates whatever its backend raises.
-                # Wrap any failure as IndexLoadError so callers see one type.
+                # Backends raise unclassified errors, so nothing narrower than
+                # Exception can be caught. `IndexLoadError` says what a caller
+                # can do with the cause.
                 try:
                     async with self._engine_lock_for(namespace, name).write_lock():
                         await search_engine.load(str(index_path))


### PR DESCRIPTION
### Purpose of the change

Replay matched `operation_type == "upsert" and vector is not None` and let everything else fall through. An upsert row with no vector, a vector that is not a whole number of float32s (numpy's `ValueError` about buffer sizes escaped as is), or a row with an unknown `operation_type` was skipped, and because the skipped row reached neither the engine `remove` set nor the mark-applied update, it survived the restart to be skipped again on the next one. A decodable vector of the wrong width was the mild case: it reached the engine, which refused it with its own dimension error at startup.

Between a write returning and the next index save, the log holds the only copy of the vector. So the outcome was a record that exists in SQLite, cannot be found by any search, and reports nothing, permanently.

That is damage to a durable record, not a state to heal. Replay now raises `PendingOperationCorruptError` naming the collection, the row and the fault, leaving the log intact for whoever repairs it. Both error types' docstrings now say what a caller should do, since the two remedies are opposites: read the cause of an `IndexLoadError` before choosing between rebuilding the index and fixing the disk; never clear the log to get past a `PendingOperationCorruptError`.

### Tests

Four corrupt a log row each way and assert the restart refuses. The rest of `TestPendingLogStates` pins what replay guarantees for intact rows: a rewritten uuid replays its last write, an upsert then delete stays deleted, a failed save leaves the write replayable, and the save threshold counts log rows rather than writes.

### Verification

- `test_sqlite_vector_store.py`: 90 passed. Against #1607's store, with the error class stubbed so the file imports, the refusal tests fail and the rest pass; the wrong-width test fails on the engine's own `ValueError` without the guard.
- `ruff check` / `ruff format --check`: clean.

Stacked on #1607, so the diff here includes #1612 and #1607 until they merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESpWYTmCR7X3bJEpoA8SAn


