### PR TITLE
Take SQLite's write lock at BEGIN, not at the first write (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -1,6 +1,7 @@
 """Tests for SQLiteVectorStore."""
 
 import asyncio
+import contextlib
 import math
 from datetime import UTC, datetime, timedelta, timezone
 from uuid import UUID, uuid4
@@ -10,6 +11,7 @@ import pytest
 import pytest_asyncio
 from pydantic import ValidationError
 from sqlalchemy import func, select, update
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from memmachine_server.common.filter.filter_parser import (
@@ -33,6 +35,7 @@ from memmachine_server.common.vector_store.sqlite_vector_store import (
     SQLiteVectorStoreParams,
     _CollectionRow,
     _PendingOperationRow,
+    _write_transaction,
 )
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
@@ -1578,6 +1581,83 @@ class TestConcurrentWrites:
 
         await store2.shutdown()
         await engine2.dispose()
+
+    @pytest.mark.asyncio
+    async def test_racing_creates_admit_exactly_one(self, store):
+        """Two creates of one name: one wins, the rest are refused."""
+        attempts = [
+            store.create_collection(namespace=NAMESPACE, name="raced", config=CONFIG)
+            for _ in range(4)
+        ]
+        outcomes = await asyncio.gather(*attempts, return_exceptions=True)
+
+        created = [o for o in outcomes if not isinstance(o, BaseException)]
+        refused = [
+            o
+            for o in outcomes
+            if isinstance(o, VectorStoreCollectionAlreadyExistsError)
+        ]
+        assert len(created) == 1
+        assert len(refused) == len(outcomes) - 1
+
+
+class TestWriteTransactions:
+    """A write transaction takes SQLite's write lock at BEGIN."""
+
+    @pytest.mark.asyncio
+    async def test_a_write_transaction_can_still_write_after_it_has_read(
+        self, tmp_path
+    ):
+        """A write transaction's read and write are one atomic unit.
+
+        Under a deferred BEGIN a transaction that reads first leaves a gap
+        another writer can take the lock in, and the reader then loses: its
+        write cannot upgrade, and SQLite reports that at once rather than
+        waiting out `busy_timeout`, since waiting could only deadlock.
+
+        The assertion is that the reading transaction completes. Without
+        `BEGIN IMMEDIATE` it raises, in either journal mode.
+        """
+        db_path = tmp_path / "test.db"
+        store, engine = await _fresh_store(db_path, tmp_path)
+        await store.open_or_create_collection(
+            namespace=NAMESPACE, name=NAME, config=CONFIG
+        )
+
+        # A second connection with a short busy timeout, so a blocked write
+        # reports instead of waiting out the default five seconds.
+        other = create_async_engine(
+            f"sqlite+aiosqlite:///{db_path}", connect_args={"timeout": 0.2}
+        )
+        other_session = async_sessionmaker(other, expire_on_commit=False)
+
+        create_session = async_sessionmaker(engine, expire_on_commit=False)
+        async with _write_transaction(create_session) as session:
+            # Read first, exactly as `delete` does, and write nothing yet.
+            await session.execute(select(func.count()).select_from(_CollectionRow))
+
+            # A second writer takes what it can in the gap and holds it across
+            # the write below. `BEGIN IMMEDIATE` shuts it out; a deferred BEGIN
+            # lets it in.
+            blocked = other_session()
+            try:
+                with contextlib.suppress(OperationalError):
+                    await blocked.execute(
+                        update(_PendingOperationRow).values(applied=True)
+                    )
+
+                await session.execute(
+                    update(_CollectionRow)
+                    .where(_CollectionRow.namespace == NAMESPACE)
+                    .values(index_saved=False)
+                )
+            finally:
+                await blocked.rollback()
+                await blocked.close()
+
+        await other.dispose()
+        await store.shutdown()
+        await engine.dispose()
 
 
 class TestCrashRecovery:

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -24,9 +24,10 @@ to re-ingest; nothing here detects the gap for them.
 """
 
 import asyncio
+import contextlib
 import logging
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import override
 from uuid import UUID
@@ -52,7 +53,7 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase, MappedColumn, Session, mapped_column
@@ -181,6 +182,52 @@ class _PendingOperationRow(BaseSQLiteVectorStore):
     applied: MappedColumn[bool] = mapped_column(Boolean, nullable=False, default=False)
 
 
+_BEGIN_IMMEDIATE_OPTION = "memmachine_sqlite_begin_immediate"
+"""Execution option asking the begin hook for `BEGIN IMMEDIATE`."""
+
+
+def _register_sqlite_begin(engine: AsyncEngine) -> None:
+    """Emit `BEGIN` explicitly, and `BEGIN IMMEDIATE` where asked for.
+
+    With the DBAPI connection in autocommit, pysqlite emits no `BEGIN` of its
+    own, so the mode is chosen here, per transaction. Reads keep the deferred
+    `BEGIN`.
+    """
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _disable_implicit_begin(
+        dbapi_connection: DBAPIConnection, _record: ConnectionPoolEntry
+    ) -> None:
+        dbapi_connection.isolation_level = None
+
+    @event.listens_for(engine.sync_engine, "begin")
+    def _begin(connection: Connection) -> None:
+        if connection.get_execution_options().get(_BEGIN_IMMEDIATE_OPTION):
+            connection.exec_driver_sql("BEGIN IMMEDIATE")
+        else:
+            connection.exec_driver_sql("BEGIN")
+
+
+@contextlib.asynccontextmanager
+async def _write_transaction(
+    create_session: async_sessionmaker[AsyncSession],
+) -> AsyncIterator[AsyncSession]:
+    """A transaction holding SQLite's write lock from `BEGIN`.
+
+    A deferred `BEGIN` would take the lock at the first write, letting another
+    writer commit between an earlier read and it. Taking it at `BEGIN` makes
+    read-then-write atomic.
+    """
+    async with create_session() as session:
+        # Set before the transaction begins, where the begin hook reads it.
+        await session.connection(execution_options={_BEGIN_IMMEDIATE_OPTION: True})
+        yield session
+        # A body that raises is rolled back when the session closes. A rollback
+        # issued here could fail and mask the body's error; one issued by the
+        # pool is logged and invalidates the connection instead.
+        await session.commit()
+
+
 async def _save_collection_index(
     *,
     create_session: async_sessionmaker[AsyncSession],
@@ -204,7 +251,7 @@ async def _save_collection_index(
         await search_engine.save(path)
 
     # Delete applied pending operations and flip index_saved to True.
-    async with create_session() as session, session.begin():
+    async with _write_transaction(create_session) as session:
         await session.execute(
             delete(_PendingOperationRow).where(
                 _PendingOperationRow.namespace == namespace,
@@ -352,7 +399,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
             return
 
         async with self._write_lock:
-            async with self._create_session() as session, session.begin():
+            async with _write_transaction(self._create_session) as session:
                 upsert_records = (
                     sqlite_insert(self._records_table)
                     .on_conflict_do_update(
@@ -425,7 +472,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 await self._search_engine.remove(engine_vectors.keys())
                 await self._search_engine.add(engine_vectors)
 
-            async with self._create_session() as session, session.begin():
+            async with _write_transaction(self._create_session) as session:
                 await session.execute(
                     update(_PendingOperationRow)
                     .where(
@@ -547,7 +594,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         record_uuids = list(uuid_list)
 
         async with self._write_lock:
-            async with self._create_session() as session, session.begin():
+            async with _write_transaction(self._create_session) as session:
                 rows = (
                     await session.execute(
                         select(self._records_table.c.row_id).where(
@@ -589,7 +636,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
             async with self._engine_lock.write_lock():
                 await self._search_engine.remove(record_row_ids)
-            async with self._create_session() as session, session.begin():
+            async with _write_transaction(self._create_session) as session:
                 await session.execute(
                     update(_PendingOperationRow)
                     .where(
@@ -694,6 +741,8 @@ class SQLiteVectorStore(VectorStore):
         self._sync_sqlalchemy_engine = create_engine(
             str(self._sqlalchemy_engine.url).replace("aiosqlite", "pysqlite")
         )
+
+        _register_sqlite_begin(self._sqlalchemy_engine)
 
         @event.listens_for(self._sqlalchemy_engine.sync_engine, "connect")
         @event.listens_for(self._sync_sqlalchemy_engine, "connect")
@@ -815,7 +864,7 @@ class SQLiteVectorStore(VectorStore):
             if upserted_vectors:
                 await search_engine.add(upserted_vectors)
 
-        async with self._create_session() as session, session.begin():
+        async with _write_transaction(self._create_session) as session:
             await session.execute(
                 update(_PendingOperationRow)
                 .where(
@@ -860,7 +909,7 @@ class SQLiteVectorStore(VectorStore):
         if not validate_identifier(namespace) or not validate_identifier(name):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
 
-        async with self._create_session() as session, session.begin():
+        async with _write_transaction(self._create_session) as session:
             existing_config = await self._get_stored_config(session, namespace, name)
             if existing_config is not None:
                 raise VectorStoreCollectionAlreadyExistsError(namespace, name)
@@ -889,7 +938,7 @@ class SQLiteVectorStore(VectorStore):
 
         index_path = self._index_path(namespace, name)
 
-        async with self._create_session() as session, session.begin():
+        async with _write_transaction(self._create_session) as session:
             existing_config = await self._get_stored_config(session, namespace, name)
             if existing_config is not None:
                 if existing_config != config:
@@ -991,7 +1040,7 @@ class SQLiteVectorStore(VectorStore):
             return
 
         records_table = self._records_table(namespace, name)
-        async with self._create_session() as session, session.begin():
+        async with _write_transaction(self._create_session) as session:
             connection = await session.connection()
             await connection.run_sync(
                 self._sa_metadata.drop_all, tables=[records_table]


### PR DESCRIPTION
### Purpose of the change

`delete` resolves row ids and then writes, in one transaction. Under SQLite's default deferred `BEGIN` the write lock is taken at the *first write*, so another writer can take it between that read and the write, and the transaction that read first is the one that loses: its own write cannot upgrade, and SQLite reports that immediately rather than waiting out `busy_timeout`, because waiting could only deadlock.

Measured in both journal modes, so this is not a WAL-only concern:

| `journal_mode` | `BEGIN` | other writer | our write |
|---|---|---|---|
| `delete` | deferred | shut out | **fails** |
| `delete` | `IMMEDIATE` | shut out | ok |
| `wal` | deferred | commits | **fails** |
| `wal` | `IMMEDIATE` | shut out | ok |

The store now emits `BEGIN` explicitly and lets a transaction ask for `BEGIN IMMEDIATE`, which every write path does. The mode is per transaction, not per engine: a hook that asked for `IMMEDIATE` unconditionally would make every read take the write lock, and two readers would then serialize against each other. This makes read-then-write atomic by construction rather than by every write transaction happening to write first.

### Tests

Two fail without it. `test_a_write_transaction_can_still_write_after_it_has_read` holds a competing lock across a read-then-write transaction and asserts that transaction completes. Two earlier versions passed either way: asserting that the *other* writer is excluded passes because a deferred `BEGIN` shuts it out too, later and by a different lock; letting the other writer's context manager exit before our write passes because rollback releases the lock first. `test_racing_creates_admit_exactly_one` races four creates of one name: under a deferred `BEGIN` the losers read no stored config, go on to `CREATE TABLE`, and fail there with SQLite's "table already exists" instead of `VectorStoreCollectionAlreadyExistsError`.

### Verification

- `test_sqlite_vector_store.py`: 90 passed. Against the replay-refusal PR's store, with `_write_transaction` stubbed as a plain `session.begin()` so the file imports, the 2 tests above fail and the other 88 pass.

Stacked on #1608, so the diff here includes #1612, #1607 and #1608 until they merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESpWYTmCR7X3bJEpoA8SAn

