### PR TITLE
Give every write a fresh row id, so a key names one version (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import math
+import threading
 from datetime import UTC, datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
@@ -21,6 +22,7 @@ from memmachine_server.common.filter.filter_parser import (
     Not,
     Or,
 )
+from memmachine_server.common.properties_json import decode_properties
 from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionAlreadyExistsError,
@@ -1097,6 +1099,36 @@ class TestEngineAccess:
 # ── row_id reuse (issue #1468) ──
 
 
+async def _row_id_of(collection, record_uuid) -> int:
+    async with collection._create_session() as session:
+        return (
+            await session.execute(
+                select(collection._records_table.c.row_id).where(
+                    collection._records_table.c.uuid == record_uuid
+                )
+            )
+        ).scalar_one()
+
+
+async def _all_row_ids(collection) -> set[int]:
+    async with collection._create_session() as session:
+        rows = (await session.execute(select(collection._records_table.c.row_id))).all()
+    return {row.row_id for row in rows}
+
+
+async def _committed_name_is(collection, record_uuid, name: str) -> bool:
+    """Whether SQLite currently holds `name` as the record's `name` property."""
+    async with collection._create_session() as session:
+        properties = (
+            await session.execute(
+                select(collection._records_table.c.properties).where(
+                    collection._records_table.c.uuid == record_uuid
+                )
+            )
+        ).scalar_one_or_none()
+    return properties is not None and decode_properties(properties)["name"] == name
+
+
 class TestRowIdReuse:
     """Regression tests for row_id reuse (issue #1468).
 
@@ -1106,28 +1138,18 @@ class TestRowIdReuse:
     id policy itself.
     """
 
-    async def _row_id_of(self, collection, record_uuid):
-        async with collection._create_session() as session:
-            return (
-                await session.execute(
-                    select(collection._records_table.c.row_id).where(
-                        collection._records_table.c.uuid == record_uuid
-                    )
-                )
-            ).scalar_one()
-
     @pytest.mark.asyncio
     async def test_row_ids_are_never_reused(self, collection):
         """A new record must not be assigned a previously deleted row_id."""
         record_a = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
         await collection.upsert(records=[record_a])
-        row_id_a = await self._row_id_of(collection, record_a.uuid)
+        row_id_a = await _row_id_of(collection, record_a.uuid)
 
         await collection.delete(record_uuids=[record_a.uuid])
 
         record_b = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
         await collection.upsert(records=[record_b])
-        row_id_b = await self._row_id_of(collection, record_b.uuid)
+        row_id_b = await _row_id_of(collection, record_b.uuid)
 
         assert row_id_b != row_id_a
 
@@ -1173,6 +1195,136 @@ class TestRowIdReuse:
         assert [match.record_uuid for match in results[0].matches] == [], (
             "a record the engine never scored was returned"
         )
+
+
+class _GatedKeyFilter:
+    """Wraps a query's key filter; the first check parks until `gate` is set.
+
+    The check runs on the engine's worker thread, inside the search, so
+    parking it holds the query between scoring and filtering while the event
+    loop runs a rewrite.
+    """
+
+    def __init__(self, inner, loop: asyncio.AbstractEventLoop) -> None:
+        self.inner = inner
+        self.gate = threading.Event()
+        self.gate_reached = asyncio.Event()
+        self._loop = loop
+        self._parked = False
+
+    def __contains__(self, key: object) -> bool:
+        if not self._parked:
+            self._parked = True
+            self._loop.call_soon_threadsafe(self.gate_reached.set)
+            self.gate.wait()
+        return key in self.inner
+
+
+class TestVersionedKeys:
+    """A key names one version of a record.
+
+    Every write takes a fresh row id, so the score the engine computed under a
+    key, the filter verdict for that key, and the uuid it resolves to belong
+    to one version. A rewrite retires the old key.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_rewrite_moves_the_record_to_a_new_row_id(self, collection):
+        record_uuid = uuid4()
+        await collection.upsert(
+            records=[_make_record(uuid=record_uuid, vector=_normalize([1.0, 0.0, 0.0]))]
+        )
+        first_row_id = await _row_id_of(collection, record_uuid)
+
+        await collection.upsert(
+            records=[_make_record(uuid=record_uuid, vector=_normalize([0.0, 1.0, 0.0]))]
+        )
+
+        assert await _row_id_of(collection, record_uuid) != first_row_id
+        assert first_row_id not in await _all_row_ids(collection)
+
+    @pytest.mark.asyncio
+    async def test_a_query_cannot_pair_a_score_with_a_later_version(
+        self, collection, monkeypatch
+    ):
+        """Version 1 fails the filter and scores high; version 2 passes, low.
+
+        The query scores version 1 and parks before the filter check, and
+        version 2 commits in that gap. The check must not admit version 1's
+        score on version 2's properties: the record is absent, or it comes
+        back with version 2's score.
+        """
+        record_uuid = uuid4()
+        query_vector = _normalize([1.0, 0.0, 0.0])
+        await collection.upsert(
+            records=[
+                _make_record(
+                    uuid=record_uuid, vector=query_vector, properties={"name": "alice"}
+                )
+            ]
+        )
+
+        loop = asyncio.get_running_loop()
+        gated: list[_GatedKeyFilter] = []
+        key_filter_built = asyncio.Event()
+        build_key_filter = collection._build_key_filter
+
+        def build_gated_key_filter(property_filter):
+            key_filter = build_key_filter(property_filter)
+            if gated:
+                # Only the first query is held; the one at the end runs free.
+                return key_filter
+            gated.append(_GatedKeyFilter(key_filter, loop))
+            key_filter_built.set()
+            return gated[0]
+
+        monkeypatch.setattr(collection, "_build_key_filter", build_gated_key_filter)
+        query_task = asyncio.create_task(
+            collection.query(
+                query_vectors=[query_vector],
+                limit=1,
+                property_filter=Comparison(field="name", op="=", value="bob"),
+            )
+        )
+        try:
+            await key_filter_built.wait()
+            await gated[0].gate_reached.wait()
+
+            # Version 2 commits while the check is parked. Its engine apply
+            # waits for the search to finish, which is fine: the check reads
+            # SQLite.
+            rewrite_task = asyncio.create_task(
+                collection.upsert(
+                    records=[
+                        _make_record(
+                            uuid=record_uuid,
+                            vector=_normalize([0.0, 1.0, 0.0]),
+                            properties={"name": "bob"},
+                        )
+                    ]
+                )
+            )
+            await _wait_for(lambda: _committed_name_is(collection, record_uuid, "bob"))
+        finally:
+            for key_filter in gated:
+                key_filter.gate.set()
+
+        results = await query_task
+        await rewrite_task
+        for match in results[0].matches:
+            assert match.record_uuid == record_uuid
+            assert match.cosine_similarity < 0.5, (
+                "version 1's score was returned for version 2"
+            )
+
+        # Once the rewrite has fully applied, version 2 is what a query finds.
+        [settled] = await collection.query(
+            query_vectors=[query_vector],
+            limit=1,
+            property_filter=Comparison(field="name", op="=", value="bob"),
+        )
+        assert [m.record_uuid for m in settled.matches] == [record_uuid]
+        assert settled.matches[0].cosine_similarity < 0.5
 
 
 # ── Crash recovery & pending operations ──
@@ -1374,11 +1526,11 @@ class TestPendingLogStates:
         await engine2.dispose()
 
     @pytest.mark.asyncio
-    async def test_save_threshold_counts_log_rows_not_writes(self, tmp_path):
-        """The trigger counts log rows, and one uuid only ever has one.
+    async def test_save_threshold_counts_log_rows(self, tmp_path):
+        """The trigger counts log rows, and a rewrite adds two.
 
-        Rewriting a single record never advances it, however often it is
-        written.
+        A rewrite retires the old key and adds a new one, so rewriting one
+        record advances the threshold like writing two.
         """
         db_path = tmp_path / "test.db"
         store, engine = await _fresh_store(db_path, tmp_path, save_threshold=3)
@@ -1395,10 +1547,11 @@ class TestPendingLogStates:
                 ]
             )
 
-        # Six writes, one row, so the threshold of three was never reached.
-        assert await _pending_operation_count(engine) == 1
+        # Writes 3 and 5 cross the threshold of three and trim the log,
+        # leaving the two rows of write 6.
+        assert await _pending_operation_count(engine) == 2
 
-        # Three distinct records do reach it.
+        # Three distinct records reach it again.
         await coll.upsert(
             records=[
                 _make_record(vector=_normalize([1.0, 0.0, 0.0])),

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -394,27 +394,36 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
     @override
     async def upsert(self, *, records: Iterable[Record]) -> None:
-        records = list(records)
+        # A batch may name a uuid more than once; the last write wins, as it
+        # would were the batch applied one record at a time.
+        records = list({record.uuid: record for record in records}.values())
         if not records:
             return
 
         async with self._write_lock:
             async with _write_transaction(self._create_session) as session:
-                upsert_records = (
-                    sqlite_insert(self._records_table)
-                    .on_conflict_do_update(
-                        index_elements=[self._records_table.c.uuid],
-                        set_={
-                            "properties": sqlite_insert(
-                                self._records_table
-                            ).excluded.properties,
-                        },
-                    )
-                    .returning(self._records_table.c.uuid, self._records_table.c.row_id)
+                # Every write takes a fresh row id, so a key names one version
+                # of a record. A query that scored the previous version finds
+                # no row under its key and drops it, rather than pairing that
+                # score with this version's properties.
+                replaced_row_ids = list(
+                    (
+                        await session.execute(
+                            delete(self._records_table)
+                            .where(
+                                self._records_table.c.uuid.in_(
+                                    [record.uuid for record in records]
+                                )
+                            )
+                            .returning(self._records_table.c.row_id)
+                        )
+                    ).scalars()
                 )
                 rows = (
                     await session.execute(
-                        upsert_records,
+                        sqlite_insert(self._records_table).returning(
+                            self._records_table.c.uuid, self._records_table.c.row_id
+                        ),
                         [
                             {
                                 "uuid": record.uuid,
@@ -430,6 +439,16 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                     {
                         "namespace": self._namespace,
                         "name": self._name,
+                        "record_row_id": row_id,
+                        "operation_type": "delete",
+                        "vector": None,
+                        "applied": False,
+                    }
+                    for row_id in replaced_row_ids
+                ] + [
+                    {
+                        "namespace": self._namespace,
+                        "name": self._name,
                         "record_row_id": uuid_to_row_id[record.uuid],
                         "operation_type": "upsert",
                         "vector": np.array(record.vector, dtype=np.float32).tobytes(),
@@ -437,56 +456,57 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                     }
                     for record in records
                 ]
-                if pending_operation_values:
-                    upsert_pending_operation = sqlite_insert(_PendingOperationRow)
-                    await session.execute(
-                        upsert_pending_operation.on_conflict_do_update(
-                            index_elements=["namespace", "name", "record_row_id"],
-                            set_={
-                                "operation_type": upsert_pending_operation.excluded.operation_type,
-                                "vector": upsert_pending_operation.excluded.vector,
-                                "applied": upsert_pending_operation.excluded.applied,
-                            },
-                        ),
-                        pending_operation_values,
-                    )
+                upsert_pending_operation = sqlite_insert(_PendingOperationRow)
+                await session.execute(
+                    upsert_pending_operation.on_conflict_do_update(
+                        index_elements=["namespace", "name", "record_row_id"],
+                        set_={
+                            "operation_type": upsert_pending_operation.excluded.operation_type,
+                            "vector": upsert_pending_operation.excluded.vector,
+                            "applied": upsert_pending_operation.excluded.applied,
+                        },
+                    ),
+                    pending_operation_values,
+                )
 
-            await self._apply_engine_upserts(records, uuid_to_row_id)
+            await self._apply_engine_upserts(records, uuid_to_row_id, replaced_row_ids)
 
     async def _apply_engine_upserts(
         self,
         records: Iterable[Record],
         uuid_to_row_id: Mapping[UUID, int],
+        replaced_row_ids: Sequence[int],
     ) -> None:
         """Update search engine index after SQLite commit."""
-        engine_vectors: dict[int, list[float]] = {
+        vectors_by_row_id: dict[int, list[float]] = {
             uuid_to_row_id[record.uuid]: record.vector
             for record in records
             if record.vector is not None
         }
 
-        if engine_vectors:
-            # One hold for both, so no search sees the record's old vector gone
-            # and its new one not yet there.
-            async with self._engine_lock.write_lock():
-                await self._search_engine.remove(engine_vectors.keys())
-                await self._search_engine.add(engine_vectors)
+        async with self._engine_lock.write_lock():
+            if replaced_row_ids:
+                await self._search_engine.remove(replaced_row_ids)
+            if vectors_by_row_id:
+                await self._search_engine.add(vectors_by_row_id)
 
-            async with _write_transaction(self._create_session) as session:
-                await session.execute(
-                    update(_PendingOperationRow)
-                    .where(
-                        _PendingOperationRow.namespace == self._namespace,
-                        _PendingOperationRow.name == self._name,
-                        _PendingOperationRow.record_row_id.in_(
-                            list(engine_vectors.keys())
-                        ),
-                        _PendingOperationRow.applied.is_(False),
-                    )
-                    .values(applied=True)
+        applied_row_ids = [*replaced_row_ids, *vectors_by_row_id.keys()]
+        if not applied_row_ids:
+            return
+
+        async with _write_transaction(self._create_session) as session:
+            await session.execute(
+                update(_PendingOperationRow)
+                .where(
+                    _PendingOperationRow.namespace == self._namespace,
+                    _PendingOperationRow.name == self._name,
+                    _PendingOperationRow.record_row_id.in_(applied_row_ids),
+                    _PendingOperationRow.applied.is_(False),
                 )
+                .values(applied=True)
+            )
 
-            await self._maybe_save_index()
+        await self._maybe_save_index()
 
     @override
     async def query(


### PR DESCRIPTION
### Purpose of the change

An upsert of an existing uuid kept its row id, so one engine key spanned every version of a record. A query reads the engine, then each candidate's properties, then its uuid, at three instants with nothing held between them. A rewrite of the very record being returned could land between those reads, pairing one version's score with another version's filter verdict. Concretely, with a record that fails the filter at version 1 and passes at version 2: the engine scores version 1, the rewrite commits, the filter check reads version 2's properties and passes, and version 1's score comes back for a record that only qualifies as version 2. The write lock (#1607) does not help, because reads deliberately take none.

Every write now takes a fresh row id: the previous row is deleted and a new one inserted in the same transaction, a delete for the old key is staged beside the upsert for the new, and the engine removes the old key and adds the new. Rows are immutable, so a key names one version, and the score computed under it, the filter verdict for it, and the uuid it resolves to belong to that version. A key whose version has been rewritten resolves to no row and is dropped. `AUTOINCREMENT` (#1589) remains what keeps a retired key from being reissued, and the write lock what keeps two rewrites of one record in order.

A batch that names a uuid twice is collapsed to its last record before the insert, which the on-conflict update used to do implicitly. The save threshold counts log rows and a rewrite now adds two, so a rewrite-heavy workload checkpoints about twice as often.

### Cost

Medians of three runs on one machine, records per second, 64-dimensional vectors, file-backed store with an index directory:

| batch | save threshold | insert before → after | rewrite before → after |
|---|---|---|---|
| 500 | 1000 | 20477 → 19290 | 16450 → 12902 |
| 500 | none | 21228 → 22486 | 19013 → 15899 |
| 1 | none | 341 → 345 | 316 → 274 |

Inserts move within run-to-run noise, in both directions. Rewrites cost 13 to 22 percent more; the upper end is the configuration where the doubled log rows double the number of index saves. MemMachine's callers write vector records once and rarely rewrite them, so the insert path is the one that matters, and the read path is untouched.

### Tests

`test_a_query_cannot_pair_a_score_with_a_later_version` drives the case above deterministically: a wrapper around the query's key filter parks the engine's worker thread between scoring and the filter check, a rewrite commits in the gap, and the check must not admit the old score. `test_a_rewrite_moves_the_record_to_a_new_row_id` pins the mechanism. The mirror case, an old verdict admitting a new score, cannot be reproduced with the USearch engine because its read lock spans the whole search including overfetch rounds, so the mechanism test is what covers it.

### Verification

- `test_sqlite_vector_store.py`: 93 passed. Against #1609's store, the two new tests and the re-derived save-threshold test fail and the rest pass.
- On this tree, the top of the stack: `pytest packages/server/server_tests` 1923 passed, 3 skipped; `ty check --project packages/server` all checks passed; `ruff check` / `ruff format --check` clean.

Stacked on #1609, so the diff here includes #1612, #1607, #1608 and #1609 until they merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESpWYTmCR7X3bJEpoA8SAn


