### PR TITLE
Own the search engine's concurrency in the store, not in each engine (speedkick)

### DIFF
--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -967,15 +967,11 @@ class TestConcurrentAsync:
         await asyncio.gather(query_loop(), upsert_more())
 
 
-# ── row_id reuse (issue #1468) ──
+# ── Engine access ──
 
 
-class _GatedSearchEngine(VectorSearchEngine):
-    """Delegates to a real engine; the next search() parks after scoring.
-
-    query() scores keys and then resolves them to rows without a lock, so a
-    write can retire a scored row in the gap. The gate parks in that gap.
-    """
+class _GatedAfterRemoveEngine(VectorSearchEngine):
+    """Delegates to a real engine; the next remove() parks after removing."""
 
     def __init__(self, inner: VectorSearchEngine) -> None:
         self.inner = inner
@@ -987,22 +983,91 @@ class _GatedSearchEngine(VectorSearchEngine):
 
     async def remove(self, keys):
         await self.inner.remove(keys)
-
-    async def search(self, vectors, *, limit, allowed_keys=None):
-        results = await self.inner.search(
-            vectors, limit=limit, allowed_keys=allowed_keys
-        )
         if self.gate is not None:
             gate, self.gate = self.gate, None
             self.gate_reached.set()
             await gate.wait()
-        return results
+
+    async def search(self, vectors, *, limit, allowed_keys=None):
+        return await self.inner.search(vectors, limit=limit, allowed_keys=allowed_keys)
 
     async def save(self, path):
         await self.inner.save(path)
 
     async def load(self, path):
         await self.inner.load(path)
+
+
+class TestEngineAccess:
+    """The store serializes engine access: searches share, mutations exclude."""
+
+    @pytest.mark.asyncio
+    async def test_a_reader_never_sees_a_rewrite_half_done(self, tmp_path):
+        """A rewrite removes the old vector and adds the new one as one step.
+
+        Engines are not safe for concurrent use, so the store holds the lock
+        across both calls. A query issued while the rewrite is parked between
+        them waits and sees the new vector, never neither.
+        """
+        db_path = tmp_path / "test.db"
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+        wrapped: list[_GatedAfterRemoveEngine] = []
+
+        def factory(ndim):
+            gated = _GatedAfterRemoveEngine(
+                USearchVectorSearchEngine(num_dimensions=ndim)
+            )
+            wrapped.append(gated)
+            return gated
+
+        store = SQLiteVectorStore(
+            SQLiteVectorStoreParams(
+                sqlalchemy_engine=engine, vector_search_engine_factory=factory
+            )
+        )
+        await store.startup()
+        try:
+            collection = await store.open_or_create_collection(
+                namespace=NAMESPACE,
+                name=NAME,
+                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
+            )
+            (gated_engine,) = wrapped
+            record_uuid = uuid4()
+            await collection.upsert(
+                records=[
+                    _make_record(uuid=record_uuid, vector=_normalize([1.0, 0.0, 0.0]))
+                ]
+            )
+
+            gate = asyncio.Event()
+            gated_engine.gate = gate
+            rewrite_task = asyncio.create_task(
+                collection.upsert(
+                    records=[
+                        _make_record(
+                            uuid=record_uuid, vector=_normalize([0.0, 1.0, 0.0])
+                        )
+                    ]
+                )
+            )
+            await gated_engine.gate_reached.wait()
+
+            # Issued while the old vector is gone and the new one not yet added.
+            query_task = asyncio.create_task(
+                collection.query(query_vectors=[_normalize([0.0, 1.0, 0.0])], limit=1)
+            )
+
+            gate.set()
+            await rewrite_task
+            [result] = await query_task
+            assert [m.record_uuid for m in result.matches] == [record_uuid]
+        finally:
+            await store.shutdown()
+            await engine.dispose()
+
+
+# ── row_id reuse (issue #1468) ──
 
 
 class TestRowIdReuse:
@@ -1040,7 +1105,9 @@ class TestRowIdReuse:
         assert row_id_b != row_id_a
 
     @pytest.mark.asyncio
-    async def test_a_query_cannot_return_a_record_it_never_scored(self, tmp_path):
+    async def test_a_query_cannot_return_a_record_it_never_scored(
+        self, collection, monkeypatch
+    ):
         """A key the engine scored must never resolve to a later record.
 
         Writes run freely between scoring and row lookup, so a reused row_id
@@ -1048,55 +1115,37 @@ class TestRowIdReuse:
         record orthogonal to the query as a perfect hit. With ids never reused
         the stale key matches no row and is dropped.
         """
-        db_path = tmp_path / "test.db"
-        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
-        gated_engines: list[_GatedSearchEngine] = []
+        scored = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
+        await collection.upsert(records=[scored])
 
-        def factory(ndim):
-            gated = _GatedSearchEngine(USearchVectorSearchEngine(num_dimensions=ndim))
-            gated_engines.append(gated)
-            return gated
+        # The query parks holding the scored key, after the engine search and
+        # before the row lookup: the highest row_id, and so the one a reused
+        # id would hand out next.
+        gate = asyncio.Event()
+        gate_reached = asyncio.Event()
+        build_matches = collection._build_matches
 
-        store = SQLiteVectorStore(
-            SQLiteVectorStoreParams(
-                sqlalchemy_engine=engine,
-                vector_search_engine_factory=factory,
-            )
+        async def parked_build_matches(*args, **kwargs):
+            gate_reached.set()
+            await gate.wait()
+            return await build_matches(*args, **kwargs)
+
+        monkeypatch.setattr(collection, "_build_matches", parked_build_matches)
+        query_task = asyncio.create_task(
+            collection.query(query_vectors=[_normalize([1.0, 0.0, 0.0])], limit=1)
         )
-        await store.startup()
-        try:
-            collection = await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name=NAME,
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-            )
-            (gated_engine,) = gated_engines
+        await gate_reached.wait()
 
-            scored = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
-            await collection.upsert(records=[scored])
+        await collection.delete(record_uuids=[scored.uuid])
+        successor = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
+        await collection.upsert(records=[successor])
 
-            # The query parks holding the scored key: the highest row_id, and
-            # so the one a reused id would hand out next.
-            gate = asyncio.Event()
-            gated_engine.gate = gate
-            query_task = asyncio.create_task(
-                collection.query(query_vectors=[_normalize([1.0, 0.0, 0.0])], limit=1)
-            )
-            await gated_engine.gate_reached.wait()
+        gate.set()
+        results = await query_task
 
-            await collection.delete(record_uuids=[scored.uuid])
-            successor = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
-            await collection.upsert(records=[successor])
-
-            gate.set()
-            results = await query_task
-
-            assert [match.record_uuid for match in results[0].matches] == [], (
-                "a record the engine never scored was returned"
-            )
-        finally:
-            await store.shutdown()
-            await engine.dispose()
+        assert [match.record_uuid for match in results[0].matches] == [], (
+            "a record the engine never scored was returned"
+        )
 
 
 # ── Crash recovery & pending operations ──

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -63,6 +63,7 @@ from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
 from memmachine_server.common.properties_json import (
     encode_properties,
 )
+from memmachine_server.common.rw_locks import AsyncRWLock
 
 from .data_types import (
     QueryMatch,
@@ -153,6 +154,7 @@ async def _save_collection_index(
     namespace: str,
     name: str,
     search_engine: VectorSearchEngine,
+    engine_lock: AsyncRWLock,
     path: str,
 ) -> None:
     """Publish a collection's index to disk and trim the operations it holds.
@@ -165,7 +167,8 @@ async def _save_collection_index(
     committed. See the module docstring for what that leaves behind.
     """
     # Write index to path.
-    await search_engine.save(path)
+    async with engine_lock.write_lock():
+        await search_engine.save(path)
 
     # Delete applied pending operations and flip index_saved to True.
     async with create_session() as session, session.begin():
@@ -244,6 +247,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         sync_sqlalchemy_engine: Engine,
         records_table: Table,
         search_engine: VectorSearchEngine,
+        engine_lock: AsyncRWLock,
         namespace: str,
         name: str,
         config: VectorStoreCollectionConfig,
@@ -255,6 +259,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         self._sync_sqlalchemy_engine = sync_sqlalchemy_engine
         self._records_table = records_table
         self._search_engine = search_engine
+        self._engine_lock = engine_lock
 
         self._namespace = namespace
         self._name = name
@@ -291,6 +296,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 namespace=self._namespace,
                 name=self._name,
                 search_engine=self._search_engine,
+                engine_lock=self._engine_lock,
                 path=self._index_path,
             )
 
@@ -367,8 +373,11 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         }
 
         if engine_vectors:
-            await self._search_engine.remove(engine_vectors.keys())
-            await self._search_engine.add(engine_vectors)
+            # One hold for both, so no search sees the record's old vector gone
+            # and its new one not yet there.
+            async with self._engine_lock.write_lock():
+                await self._search_engine.remove(engine_vectors.keys())
+                await self._search_engine.add(engine_vectors)
 
             async with self._create_session() as session, session.begin():
                 await session.execute(
@@ -407,9 +416,10 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
         key_filter = self._build_key_filter(property_filter)
 
-        search_results = await self._search_engine.search(
-            query_vectors, limit=limit, allowed_keys=key_filter
-        )
+        async with self._engine_lock.read_lock():
+            search_results = await self._search_engine.search(
+                query_vectors, limit=limit, allowed_keys=key_filter
+            )
 
         results: list[QueryResult] = []
         for search_result in search_results:
@@ -530,7 +540,8 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 )
             )
 
-        await self._search_engine.remove(record_row_ids)
+        async with self._engine_lock.write_lock():
+            await self._search_engine.remove(record_row_ids)
         async with self._create_session() as session, session.begin():
             await session.execute(
                 update(_PendingOperationRow)
@@ -629,6 +640,7 @@ class SQLiteVectorStore(VectorStore):
             self._sqlalchemy_engine, expire_on_commit=False
         )
         self._search_engines: dict[tuple[str, str], VectorSearchEngine] = {}
+        self._engine_locks: dict[tuple[str, str], AsyncRWLock] = {}
         self._sa_metadata = MetaData()
 
         self._sync_sqlalchemy_engine = create_engine(
@@ -716,9 +728,10 @@ class SQLiteVectorStore(VectorStore):
         if not all_row_ids:
             return
 
-        await search_engine.remove(all_row_ids)
-        if upserted_vectors:
-            await search_engine.add(upserted_vectors)
+        async with self._engine_lock_for(namespace, name).write_lock():
+            await search_engine.remove(all_row_ids)
+            if upserted_vectors:
+                await search_engine.add(upserted_vectors)
 
         async with self._create_session() as session, session.begin():
             await session.execute(
@@ -743,6 +756,7 @@ class SQLiteVectorStore(VectorStore):
                     namespace=namespace,
                     name=name,
                     search_engine=search_engine,
+                    engine_lock=self._engine_lock_for(namespace, name),
                     path=str(path),
                 )
         self._search_engines.clear()
@@ -804,6 +818,7 @@ class SQLiteVectorStore(VectorStore):
                     sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
                     records_table=records_table,
                     search_engine=search_engine,
+                    engine_lock=self._engine_lock_for(namespace, name),
                     namespace=namespace,
                     name=name,
                     config=existing_config,
@@ -828,6 +843,7 @@ class SQLiteVectorStore(VectorStore):
             sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
             records_table=records_table,
             search_engine=search_engine,
+            engine_lock=self._engine_lock_for(namespace, name),
             namespace=namespace,
             name=name,
             config=config,
@@ -862,6 +878,7 @@ class SQLiteVectorStore(VectorStore):
             sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
             records_table=records_table,
             search_engine=search_engine,
+            engine_lock=self._engine_lock_for(namespace, name),
             namespace=namespace,
             name=name,
             config=existing,
@@ -929,6 +946,16 @@ class SQLiteVectorStore(VectorStore):
             sqlite_autoincrement=True,
         )
 
+    def _engine_lock_for(self, namespace: str, name: str) -> AsyncRWLock:
+        """Get or create the lock guarding a collection's search engine.
+
+        Engines are not safe for concurrent use: searches take the read side,
+        everything else the write side. Shared by every handle on the
+        collection and kept for the store's lifetime: a lock replaced while
+        held would guard nobody.
+        """
+        return self._engine_locks.setdefault((namespace, name), AsyncRWLock())
+
     def _index_path(self, namespace: str, name: str) -> Path | None:
         """Return the on-disk index path for a collection, or None if in-memory."""
         if self._index_directory is None:
@@ -988,7 +1015,8 @@ class SQLiteVectorStore(VectorStore):
                 # The engine just propagates whatever its backend raises.
                 # Wrap any failure as IndexLoadError so callers see one type.
                 try:
-                    await search_engine.load(str(index_path))
+                    async with self._engine_lock_for(namespace, name).write_lock():
+                        await search_engine.load(str(index_path))
                 except Exception as e:
                     raise IndexLoadError(namespace, name, index_path) from e
 

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/hnswlib_engine.py
@@ -8,8 +8,6 @@ from typing import ClassVar, override
 import hnswlib  # ty: ignore[unresolved-import]  # C extension, no py.typed
 import numpy as np
 
-from memmachine_server.common.rw_locks import AsyncRWLock
-
 from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
@@ -71,8 +69,6 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         # which does not affect correctness (but may be suboptimal).
         self._known_labels: set[int] = set()
 
-        self._lock = AsyncRWLock()
-
     @staticmethod
     def _distance_to_cosine_similarity(distance: float) -> float:
         """Convert an hnswlib cosine distance to a cosine similarity."""
@@ -96,8 +92,7 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
     async def add(self, vectors: Mapping[int, Sequence[float]]) -> None:
         if not vectors:
             return
-        async with self._lock.write_lock():
-            await asyncio.to_thread(self._sync_add, vectors)
+        await asyncio.to_thread(self._sync_add, vectors)
 
     def _sync_add(self, vectors: Mapping[int, Sequence[float]]) -> None:
         if not self._allow_replace_deleted:
@@ -149,10 +144,7 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
         if self._index.element_count == 0 or not vectors:
             return [SearchResult(matches=[]) for _ in vectors]
 
-        async with self._lock.read_lock():
-            return await asyncio.to_thread(
-                self._sync_search, vectors, limit, allowed_keys
-            )
+        return await asyncio.to_thread(self._sync_search, vectors, limit, allowed_keys)
 
     def _sync_search(
         self,
@@ -267,8 +259,7 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
 
     @override
     async def remove(self, keys: Iterable[int]) -> None:
-        async with self._lock.write_lock():
-            await asyncio.to_thread(self._sync_remove, keys)
+        await asyncio.to_thread(self._sync_remove, keys)
 
     def _sync_remove(self, keys: Iterable[int]) -> None:
         for key in keys:
@@ -277,8 +268,7 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
 
     @override
     async def save(self, path: str) -> None:
-        async with self._lock.write_lock():
-            await asyncio.to_thread(self._sync_save, path)
+        await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
         with atomic_index_write(path) as temp_path:
@@ -289,8 +279,7 @@ class HnswlibVectorSearchEngine(VectorSearchEngine):
 
     @override
     async def load(self, path: str) -> None:
-        async with self._lock.write_lock():
-            await asyncio.to_thread(self._sync_load, path)
+        await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> None:
         clear_stale_index_temp(path)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/usearch_engine.py
@@ -7,8 +7,6 @@ from typing import ClassVar, override
 import numpy as np
 from usearch.index import Index, MetricKind
 
-from memmachine_server.common.rw_locks import AsyncRWLock
-
 from .index_persistence import atomic_index_write, clear_stale_index_temp
 from .vector_search_engine import SearchMatch, SearchResult, VectorSearchEngine
 
@@ -42,8 +40,6 @@ class USearchVectorSearchEngine(VectorSearchEngine):
             expansion_search=ef_search,
         )
 
-        self._lock = AsyncRWLock()
-
     @staticmethod
     def _distance_to_cosine_similarity(distance: float) -> float:
         """Convert a USearch cosine distance to a cosine similarity."""
@@ -53,8 +49,7 @@ class USearchVectorSearchEngine(VectorSearchEngine):
     async def add(self, vectors: Mapping[int, Sequence[float]]) -> None:
         if not vectors:
             return
-        async with self._lock.write_lock():
-            await asyncio.to_thread(self._sync_add, vectors)
+        await asyncio.to_thread(self._sync_add, vectors)
 
     def _sync_add(self, vectors: Mapping[int, Sequence[float]]) -> None:
         keys_array = np.array(list(vectors.keys()), dtype=np.int64)
@@ -73,10 +68,7 @@ class USearchVectorSearchEngine(VectorSearchEngine):
         if self._index.size == 0 or not vectors:
             return [SearchResult(matches=[]) for _ in vectors]
 
-        async with self._lock.read_lock():
-            return await asyncio.to_thread(
-                self._sync_search, vectors, limit, allowed_keys
-            )
+        return await asyncio.to_thread(self._sync_search, vectors, limit, allowed_keys)
 
     def _sync_search(
         self,
@@ -138,8 +130,7 @@ class USearchVectorSearchEngine(VectorSearchEngine):
 
     @override
     async def remove(self, keys: Iterable[int]) -> None:
-        async with self._lock.write_lock():
-            await asyncio.to_thread(self._sync_remove, keys)
+        await asyncio.to_thread(self._sync_remove, keys)
 
     def _sync_remove(self, keys: Iterable[int]) -> None:
         index = self._index
@@ -148,8 +139,7 @@ class USearchVectorSearchEngine(VectorSearchEngine):
 
     @override
     async def save(self, path: str) -> None:
-        async with self._lock.write_lock():
-            await asyncio.to_thread(self._sync_save, path)
+        await asyncio.to_thread(self._sync_save, path)
 
     def _sync_save(self, path: str) -> None:
         with atomic_index_write(path) as temp_path:
@@ -157,8 +147,7 @@ class USearchVectorSearchEngine(VectorSearchEngine):
 
     @override
     async def load(self, path: str) -> None:
-        async with self._lock.write_lock():
-            await asyncio.to_thread(self._sync_load, path)
+        await asyncio.to_thread(self._sync_load, path)
 
     def _sync_load(self, path: str) -> None:
         clear_stale_index_temp(path)

--- a/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_search_engine/vector_search_engine.py
@@ -41,7 +41,9 @@ class VectorSearchEngine(ABC):
 
     Results are returned ordered from best to worst.
 
-    Safe for concurrent use from async tasks (single event loop).
+    Not safe for concurrent use; the owner serializes calls. Searches may run
+    concurrently with each other, and every other call runs alone.
+    `SQLiteVectorStore` holds a read-write lock per engine for this.
     Not safe across threads or processes.
     """
 


### PR DESCRIPTION
### Purpose of the change

Each vector search engine wrapped its five methods in its own read-write lock, and the abstract class promised "safe for concurrent use". The store is the only caller, and it already knows which calls must exclude which: a search shares the engine with other searches, and everything else runs alone. This moves that lock into the store.

Two things follow. Every exclusion now lives in the one file that reads the engine, so questions like "who excludes whom during a save" are answered by the store alone. And a rule the engines could not express holds: a rewrite's `remove` and `add` are one step to a reader. Before, each call took and released the engine's lock on its own, so a search could run between them and see neither version of the record.

Engines drop their lock and keep only the index calls; the abstract class states that the owner serializes. The store keeps one read-write lock per collection beside the engine (`_engine_lock_for`, kept for the store's lifetime like #1607's writer mutex) and takes it at every engine call: searches on the read side; mutations, loads, and the index save on the write side. A rewrite's `remove` and `add` sit under one hold. The save's trim runs after the lock is released, so readers wait for the file write and never for SQL.

No production behavior changes apart from the one-step rewrite. The turbovec engine in flight (#1499) carries the same lock and needs the same subtraction.

### Tests

`test_a_reader_never_sees_a_rewrite_half_done` parks a rewrite between its `remove` and its `add` and issues a query; the query must wait and see the new vector. It fails against the engines' own locks and passes here.

The row-id regression test from #1589 parked inside a wrapper engine's `search`, which sat outside the real engine's lock. Under the store's lock that parks the read side, and the delete and upsert the test then awaits cannot proceed. It now parks at the store's `_build_matches`, which is where it meant to be: between the engine search and the row lookup.

### Cost

Mixed workload on one collection seeded with 20k 64-dimensional records, file-backed with a checkpoint every 2000 applied rows, 8 seconds per run, medians of three runs (five for writes-only):

| readers | writers | metric | engines' own locks | store's lock |
|---|---|---|---|---|
| 4 | 0 | reads/s | 2379 | 2392 |
| 4 | 0 | read p50 / p99 / max ms | 1.60 / 3.13 / 75.1 | 1.61 / 2.35 / 50.6 |
| 0 | 2 | writes/s | 5600 | 5429 |
| 4 | 2 | reads/s | 820 | 889 |
| 4 | 2 | writes/s | 3711 | 3796 |
| 4 | 2 | read p50 / p99 / max ms | 3.94 / 23.3 / 101 | 3.80 / 20.9 / 125 |

Everything moves within a few percent in both directions; the read maximum is the noisy statistic in both columns.

### Verification

- `pytest packages/server/server_tests/memmachine_server/common/vector_store`: 274 passed.
- `ty check --project packages/server`: all checks passed.
- `ruff check` / `ruff format --check`: clean.

This goes under the open stack #1607 → #1608 → #1609 → #1610, which is re-based on it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESpWYTmCR7X3bJEpoA8SAn

