### PR TITLE
(Depends on #1606) Make a vector store one collection, its handles partitions, and its lookup get_partition on both stores (speedkick)

### DIFF
--- a/docs/open_source/configuration.mdx
+++ b/docs/open_source/configuration.mdx
@@ -345,6 +345,9 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
               # token: $MILVUS_TOKEN
               # db_name: default
               consistency_level: Session
+              request_timeout: 30
+              # indexed_properties:
+              #   category: str
       ```
     </Tab>
     <Tab title="With Comments">
@@ -376,6 +379,9 @@ To see a complete example of a potential `cfg.yml` file, check out [GPU-based Sa
               # token: $MILVUS_TOKEN # Required for Zilliz Cloud or auth-enabled Milvus
               # db_name: default # Optional Milvus database name
               consistency_level: Session # Strong, Session, Bounded, or Eventually
+              request_timeout: 30 # Seconds a request may take; required
+              # indexed_properties: # Property keys every collection indexes, by type name
+              #   category: str
       ```
     </Tab>
     </Tabs>

--- a/packages/server/server_tests/memmachine_server/common/configuration/test_database_conf.py
+++ b/packages/server/server_tests/memmachine_server/common/configuration/test_database_conf.py
@@ -122,6 +122,13 @@ def db_conf_dict() -> dict:
                     "api_key": "test-key",
                     "is_distributed": True,
                     "registry_replication_factor": 3,
+                    "request_timeout": 12.5,
+                    "indexed_properties": {"category": "str"},
+                    "hnsw_config": {"ef_construct": 256, "payload_m": 32},
+                    "optimizers_config": {"default_segment_number": 4},
+                    "quantization_config": {
+                        "turbo": {"always_ram": True, "bits": "bits2"}
+                    },
                 },
             },
             "my_milvus": {
@@ -131,6 +138,7 @@ def db_conf_dict() -> dict:
                     "token": "test-token",
                     "db_name": "memory",
                     "consistency_level": "Strong",
+                    "request_timeout": 7.0,
                 },
             },
             "my_sqlite_vs": {
@@ -206,6 +214,13 @@ def test_parse_valid_storage_dict(db_conf_dict):
     assert qdrant_conf.api_key == SecretStr("test-key")
     assert qdrant_conf.is_distributed is True
     assert qdrant_conf.registry_replication_factor == 3
+    assert qdrant_conf.request_timeout == 12.5
+    assert qdrant_conf.indexed_properties == {"category": "str"}
+    assert qdrant_conf.hnsw_config == {"ef_construct": 256, "payload_m": 32}
+    assert qdrant_conf.optimizers_config == {"default_segment_number": 4}
+    assert qdrant_conf.quantization_config == {
+        "turbo": {"always_ram": True, "bits": "bits2"}
+    }
 
     # Milvus check
     milvus_conf = storage_conf.milvus_confs["my_milvus"]
@@ -214,6 +229,7 @@ def test_parse_valid_storage_dict(db_conf_dict):
     assert milvus_conf.token == SecretStr("test-token")
     assert milvus_conf.db_name == "memory"
     assert milvus_conf.consistency_level == "Strong"
+    assert milvus_conf.request_timeout == 7.0
 
     # SQLiteVectorStore (hnswlib engine)
     sqlite_vs_conf = storage_conf.sqlite_vector_store_confs["my_sqlite_vs"]
@@ -281,7 +297,7 @@ def test_serialize_deserialize_database_conf(db_conf_dict):
 
 
 def test_milvus_conf_defaults():
-    conf = MilvusConf()
+    conf = MilvusConf(request_timeout=30.0)
     assert conf.uri == "./milvus.db"
     assert conf.token == SecretStr("")
     assert conf.db_name == ""
@@ -293,6 +309,7 @@ def test_milvus_conf_reads_env(monkeypatch):
     monkeypatch.setenv("MILVUS_TOKEN", "env-token")
     monkeypatch.setenv("MILVUS_DB_NAME", "memory")
     conf = MilvusConf(
+        request_timeout=30.0,
         uri="$MILVUS_URI",
         token=SecretStr("${MILVUS_TOKEN}"),
         db_name="$MILVUS_DB_NAME",
@@ -304,9 +321,9 @@ def test_milvus_conf_reads_env(monkeypatch):
 
 def test_milvus_conf_rejects_invalid_values():
     with pytest.raises(ValueError, match="non-empty 'uri'"):
-        MilvusConf(uri="")
+        MilvusConf(request_timeout=30.0, uri="")
     with pytest.raises(ValueError, match="consistency_level"):
-        MilvusConf(consistency_level="Linearizable")
+        MilvusConf(request_timeout=30.0, consistency_level="Linearizable")
 
 
 def test_neo4j_pool_lifecycle_fields():
@@ -358,7 +375,7 @@ def test_neo4j_uri_with_special_host():
 
 
 def test_qdrant_conf_defaults():
-    conf = QdrantConf()
+    conf = QdrantConf(request_timeout=30.0)
     assert conf.host == "localhost"
     assert conf.port == 6333
     assert conf.grpc_port == 6334
@@ -371,18 +388,24 @@ def test_qdrant_conf_defaults():
 
 def test_qdrant_conf_api_key_from_env(monkeypatch):
     monkeypatch.setenv("QDRANT_API_KEY", "env-qdrant-key")
-    conf = QdrantConf(api_key=SecretStr("$QDRANT_API_KEY"))
+    conf = QdrantConf(request_timeout=30.0, api_key=SecretStr("$QDRANT_API_KEY"))
     assert conf.api_key == SecretStr("env-qdrant-key")
 
 
 def test_qdrant_build_config():
     config = SupportedDB.QDRANT.build_config(
-        {"host": "qdrant.local", "port": 9333, "is_distributed": True}
+        {
+            "host": "qdrant.local",
+            "port": 9333,
+            "is_distributed": True,
+            "request_timeout": 5.0,
+        }
     )
     assert isinstance(config, QdrantConf)
     assert config.host == "qdrant.local"
     assert config.port == 9333
     assert config.is_distributed is True
+    assert config.request_timeout == 5.0
 
 
 def test_sqlite_vector_store_conf_defaults():

--- a/packages/server/server_tests/memmachine_server/common/episode_store/test_count_caching_episode_storage.py
+++ b/packages/server/server_tests/memmachine_server/common/episode_store/test_count_caching_episode_storage.py
@@ -7,7 +7,9 @@ from memmachine_server.common.episode_store import (
     EpisodeEntry,
     EpisodeStorage,
 )
-from memmachine_server.common.filter.filter_parser import Comparison
+from memmachine_server.common.filter import (
+    Equals,
+)
 
 
 @pytest.fixture
@@ -29,8 +31,8 @@ async def test_caches_counts_per_key(wrapped_store):
     wrapped_store.get_episode_messages_count = AsyncMock(side_effect=[2, 5])
     storage = CountCachingEpisodeStorage(wrapped_store)
 
-    filter_a = Comparison(field="session_key", op="=", value="a")
-    filter_b = Comparison(field="session_key", op="=", value="b")
+    filter_a = Equals(field="session_key", value="a")
+    filter_b = Equals(field="session_key", value="b")
 
     first_a = await storage.get_episode_messages_count(filter_expr=filter_a)
     second_a = await storage.get_episode_messages_count(filter_expr=filter_a)
@@ -47,7 +49,7 @@ async def test_mutations_invalidate_cache(wrapped_store):
     wrapped_store.get_episode_messages_count = AsyncMock(side_effect=[1, 3])
     storage = CountCachingEpisodeStorage(wrapped_store)
 
-    session_filter = Comparison(field="session_key", op="=", value="abc")
+    session_filter = Equals(field="session_key", value="abc")
 
     first = await storage.get_episode_messages_count(filter_expr=session_filter)
     second = await storage.get_episode_messages_count(filter_expr=session_filter)
@@ -70,7 +72,7 @@ async def test_deletes_clear_cached_counts(wrapped_store):
     wrapped_store.get_episode_messages_count = AsyncMock(side_effect=[4, 6, 8])
     storage = CountCachingEpisodeStorage(wrapped_store)
 
-    session_filter = Comparison(field="session_key", op="=", value="s")
+    session_filter = Equals(field="session_key", value="s")
 
     initial = await storage.get_episode_messages_count(filter_expr=session_filter)
     assert initial == 4
@@ -101,7 +103,7 @@ async def test_non_session_filters_bypass_cache(wrapped_store):
     wrapped_store.get_episode_messages_count = AsyncMock(side_effect=[7, 9])
     storage = CountCachingEpisodeStorage(wrapped_store)
 
-    topic_filter = Comparison(field="topic", op="=", value="alpha")
+    topic_filter = Equals(field="topic", value="alpha")
 
     first = await storage.get_episode_messages_count(filter_expr=topic_filter)
     second = await storage.get_episode_messages_count(filter_expr=topic_filter)
@@ -117,7 +119,7 @@ async def test_get_episode_ids_passes_through(wrapped_store):
     wrapped_store.get_episode_ids.return_value = ["1", "2", "3"]
     storage = CountCachingEpisodeStorage(wrapped_store)
 
-    session_filter = Comparison(field="session_key", op="=", value="s1")
+    session_filter = Equals(field="session_key", value="s1")
     result = await storage.get_episode_ids(
         filter_expr=session_filter,
         page_size=10,

--- a/packages/server/server_tests/memmachine_server/common/episode_store/test_episode_storage.py
+++ b/packages/server/server_tests/memmachine_server/common/episode_store/test_episode_storage.py
@@ -14,7 +14,12 @@ from memmachine_server.common.episode_store import (
     EpisodeType,
 )
 from memmachine_server.common.errors import InvalidArgumentError
-from memmachine_server.common.filter.filter_parser import FilterExpr, parse_filter
+from memmachine_server.common.filter import (
+    FilterExpr,
+)
+from memmachine_server.common.filter.filter_parser import (
+    parse_filter,
+)
 
 DEFAULT_HISTORY_ARGS = {
     "session_key": "session-default",

--- a/packages/server/server_tests/memmachine_server/common/filter/nodes.py
+++ b/packages/server/server_tests/memmachine_server/common/filter/nodes.py
@@ -1,0 +1,24 @@
+"""Helpers for building filter nodes in parametrized tests."""
+
+from memmachine_server.common.data_types import PropertyValue
+from memmachine_server.common.filter import (
+    Equals,
+    FilterExpr,
+    NotEquals,
+    Ordering,
+)
+
+
+def comparison(field: str, op: str, value: PropertyValue) -> FilterExpr:
+    """The node a textual comparison operator denotes."""
+    match op:
+        case "=":
+            return Equals(field=field, value=value)
+        case "!=":
+            return NotEquals(field=field, value=value)
+        case ">" | "<" | ">=" | "<=":
+            if isinstance(value, bool | str):
+                raise TypeError(f"{op} does not order {type(value).__name__}")
+            return Ordering(field=field, op=op, value=value)
+        case _:
+            raise ValueError(f"Unknown comparison operator {op!r}")

--- a/packages/server/server_tests/memmachine_server/common/filter/test_filter_parser.py
+++ b/packages/server/server_tests/memmachine_server/common/filter/test_filter_parser.py
@@ -2,30 +2,34 @@ import datetime
 
 import pytest
 
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
     And,
-    Comparison,
-    FilterParseError,
+    Equals,
     In,
-    IsNull,
+    IsMissing,
     Not,
+    NotEquals,
     Or,
+    Ordering,
     map_filter_fields,
+)
+from memmachine_server.common.filter.filter_parser import (
+    FilterParseError,
     normalize_filter_field,
     parse_filter,
     to_property_filter,
 )
 
 
-def _flatten_and(expr: And) -> list[Comparison]:
-    result: list[Comparison] = []
+def _flatten_and(expr: And) -> list[Equals | NotEquals | Ordering]:
+    result: list[Equals | NotEquals | Ordering] = []
 
     def _walk(node):
         if isinstance(node, And):
-            _walk(node.left)
-            _walk(node.right)
+            for operand in node.operands:
+                _walk(operand)
         else:
-            assert isinstance(node, Comparison)
+            assert isinstance(node, Equals | NotEquals | Ordering)
             result.append(node)
 
     _walk(expr)
@@ -39,62 +43,62 @@ def test_parse_filter_empty_string() -> None:
 
 def test_parse_filter_simple_equality() -> None:
     expr = parse_filter("owner = 'alice'")
-    assert expr == Comparison(field="owner", op="=", value="alice")
+    assert expr == Equals(field="owner", value="alice")
 
 
 def test_parse_filter_in_clause() -> None:
     expr = parse_filter("priority in (HIGH,LOW)")
-    assert expr == In(field="priority", values=["HIGH", "LOW"])
+    assert expr == In(field="priority", values=("HIGH", "LOW"))
 
 
 def test_parse_filter_boolean_and_numeric_values() -> None:
     expr = parse_filter("count = 10 AND pi = 3.14 AND done = true AND flag = FALSE")
     assert isinstance(expr, And)
     children = _flatten_and(expr)
-    assert children[0] == Comparison(field="count", op="=", value=10)
-    assert children[1] == Comparison(field="pi", op="=", value=3.14)
-    assert children[2] == Comparison(field="done", op="=", value=True)
-    assert children[3] == Comparison(field="flag", op="=", value=False)
+    assert children[0] == Equals(field="count", value=10)
+    assert children[1] == Equals(field="pi", value=3.14)
+    assert children[2] == Equals(field="done", value=True)
+    assert children[3] == Equals(field="flag", value=False)
 
 
 def test_parse_filter_greater_and_less_than() -> None:
     expr = parse_filter("count > 10 AND pi < 3.14")
     assert isinstance(expr, And)
     children = _flatten_and(expr)
-    assert children[0] == Comparison(field="count", op=">", value=10)
-    assert children[1] == Comparison(field="pi", op="<", value=3.14)
+    assert children[0] == Ordering(field="count", op=">", value=10)
+    assert children[1] == Ordering(field="pi", op="<", value=3.14)
 
 
 def test_parse_filter_greater_equal_and_less_equal() -> None:
     expr = parse_filter("count >= 10 AND pi <= 3.14")
     assert isinstance(expr, And)
     children = _flatten_and(expr)
-    assert children[0] == Comparison(field="count", op=">=", value=10)
-    assert children[1] == Comparison(field="pi", op="<=", value=3.14)
+    assert children[0] == Ordering(field="count", op=">=", value=10)
+    assert children[1] == Ordering(field="pi", op="<=", value=3.14)
 
 
 def test_parse_filter_and_or_precedence() -> None:
     expr = parse_filter("owner = alice OR priority = HIGH AND status = OPEN")
     assert isinstance(expr, Or)
-    left = expr.left
-    right = expr.right
-    assert left == Comparison(field="owner", op="=", value="alice")
+    left = expr.operands[0]
+    right = expr.operands[1]
+    assert left == Equals(field="owner", value="alice")
     assert isinstance(right, And)
     assert _flatten_and(right) == [
-        Comparison(field="priority", op="=", value="HIGH"),
-        Comparison(field="status", op="=", value="OPEN"),
+        Equals(field="priority", value="HIGH"),
+        Equals(field="status", value="OPEN"),
     ]
 
 
 def test_parse_filter_grouping_changes_precedence() -> None:
     expr = parse_filter("(owner = alice OR priority = HIGH) AND status = OPEN")
     assert isinstance(expr, And)
-    left = expr.left
-    right = expr.right
+    left = expr.operands[0]
+    right = expr.operands[1]
     assert isinstance(left, Or)
-    assert left.left == Comparison(field="owner", op="=", value="alice")
-    assert left.right == Comparison(field="priority", op="=", value="HIGH")
-    assert right == Comparison(field="status", op="=", value="OPEN")
+    assert left.operands[0] == Equals(field="owner", value="alice")
+    assert left.operands[1] == Equals(field="priority", value="HIGH")
+    assert right == Equals(field="status", value="OPEN")
 
 
 def test_parse_filter_complex_parentheses_precedence() -> None:
@@ -102,16 +106,16 @@ def test_parse_filter_complex_parentheses_precedence() -> None:
         "status = OPEN AND (project = memmachine OR project = memguard) OR owner = bob"
     )
     assert isinstance(expr, Or)
-    assert isinstance(expr.left, And)
-    assert isinstance(expr.left.right, Or)
-    assert expr.left.left == Comparison(field="status", op="=", value="OPEN")
-    assert expr.left.right.left == Comparison(
-        field="project", op="=", value="memmachine"
+    assert isinstance(expr.operands[0], And)
+    assert isinstance(expr.operands[0].operands[1], Or)
+    assert expr.operands[0].operands[0] == Equals(field="status", value="OPEN")
+    assert expr.operands[0].operands[1].operands[0] == Equals(
+        field="project", value="memmachine"
     )
-    assert expr.left.right.right == Comparison(
-        field="project", op="=", value="memguard"
+    assert expr.operands[0].operands[1].operands[1] == Equals(
+        field="project", value="memguard"
     )
-    assert expr.right == Comparison(field="owner", op="=", value="bob")
+    assert expr.operands[1] == Equals(field="owner", value="bob")
 
 
 def test_parse_filter_deeply_nested_groups() -> None:
@@ -119,25 +123,29 @@ def test_parse_filter_deeply_nested_groups() -> None:
         "((project = 'memmachine' AND owner = 'alice') OR (priority = 'HIGH' AND (status = 'OPEN' OR status = 'NEW'))) AND flag = TRUE"
     )
     assert isinstance(expr, And)
-    assert expr.right == Comparison(field="flag", op="=", value=True)
+    assert expr.operands[1] == Equals(field="flag", value=True)
 
-    left = expr.left
+    left = expr.operands[0]
     assert isinstance(left, Or)
 
-    assert isinstance(left.left, And)
-    assert left.left.left == Comparison(field="project", op="=", value="memmachine")
-    assert left.left.right == Comparison(field="owner", op="=", value="alice")
+    assert isinstance(left.operands[0], And)
+    assert left.operands[0].operands[0] == Equals(field="project", value="memmachine")
+    assert left.operands[0].operands[1] == Equals(field="owner", value="alice")
 
-    assert isinstance(left.right, And)
-    assert left.right.left == Comparison(field="priority", op="=", value="HIGH")
-    assert isinstance(left.right.right, Or)
-    assert left.right.right.left == Comparison(field="status", op="=", value="OPEN")
-    assert left.right.right.right == Comparison(field="status", op="=", value="NEW")
+    assert isinstance(left.operands[1], And)
+    assert left.operands[1].operands[0] == Equals(field="priority", value="HIGH")
+    assert isinstance(left.operands[1].operands[1], Or)
+    assert left.operands[1].operands[1].operands[0] == Equals(
+        field="status", value="OPEN"
+    )
+    assert left.operands[1].operands[1].operands[1] == Equals(
+        field="status", value="NEW"
+    )
 
 
 def test_parse_filter_is_null_operator() -> None:
     expr = parse_filter("metadata.note IS NULL")
-    assert expr == IsNull(field="metadata.note")
+    assert expr == IsMissing(field="metadata.note")
 
 
 def test_parse_filter_is_not_null_and_or_combination() -> None:
@@ -145,17 +153,17 @@ def test_parse_filter_is_not_null_and_or_combination() -> None:
         "(metadata.note IS NOT NULL AND status = 'OPEN') OR owner IS NULL"
     )
     assert isinstance(expr, Or)
-    assert isinstance(expr.left, And)
-    assert expr.left.left == Not(expr=IsNull(field="metadata.note"))
-    assert expr.left.right == Comparison(field="status", op="=", value="OPEN")
-    assert expr.right == IsNull(field="owner")
+    assert isinstance(expr.operands[0], And)
+    assert expr.operands[0].operands[0] == Not(IsMissing(field="metadata.note"))
+    assert expr.operands[0].operands[1] == Equals(field="status", value="OPEN")
+    assert expr.operands[1] == IsMissing(field="owner")
 
 
 def test_keywords_case_insensitive() -> None:
     expr = parse_filter("Owner In ('Alice', 'Bob') or PRIORITY = high")
     assert isinstance(expr, Or)
-    assert expr.left == In(field="Owner", values=["Alice", "Bob"])
-    assert expr.right == Comparison(field="PRIORITY", op="=", value="high")
+    assert expr.operands[0] == In(field="Owner", values=("Alice", "Bob"))
+    assert expr.operands[1] == Equals(field="PRIORITY", value="high")
 
 
 def test_legacy_mapping_generation() -> None:
@@ -198,7 +206,7 @@ def valid_filters(request) -> str:
 def test_datetime_parsing() -> None:
     expr = parse_filter("created_at < date('2026-01-19T01:56:41.513342Z')")
     assert expr is not None
-    assert expr == Comparison(
+    assert expr == Ordering(
         field="created_at",
         op="<",
         value=datetime.datetime.fromisoformat("2026-01-19T01:56:41.513342Z"),
@@ -209,8 +217,8 @@ def test_datetime_parsing_with_and_expression() -> None:
     expr = parse_filter("name='test' AND created_at >= date('2025-01-01T00:00:00')")
     assert isinstance(expr, And)
     children = _flatten_and(expr)
-    assert children[0] == Comparison(field="name", op="=", value="test")
-    assert children[1] == Comparison(
+    assert children[0] == Equals(field="name", value="test")
+    assert children[1] == Ordering(
         field="created_at",
         op=">=",
         value=datetime.datetime.fromisoformat("2025-01-01T00:00:00"),
@@ -219,16 +227,15 @@ def test_datetime_parsing_with_and_expression() -> None:
 
 def test_datetime_parsing_with_equality() -> None:
     expr = parse_filter("created_at = date('2026-01-19T01:56:41Z')")
-    assert expr == Comparison(
+    assert expr == Equals(
         field="created_at",
-        op="=",
         value=datetime.datetime.fromisoformat("2026-01-19T01:56:41Z"),
     )
 
 
 def test_comparison_normalizes_datetime_values_at_construction() -> None:
     """The language owns datetime semantics: instants, naive means UTC."""
-    offset_aware = Comparison(
+    offset_aware = Ordering(
         field="created_at",
         op=">=",
         value=datetime.datetime.fromisoformat("2024-01-01T13:30:45-08:00"),
@@ -239,7 +246,7 @@ def test_comparison_normalizes_datetime_values_at_construction() -> None:
     )
     assert offset_aware.value.tzinfo == datetime.UTC
 
-    naive = Comparison(
+    naive = Ordering(
         field="created_at",
         op=">=",
         value=datetime.datetime.fromisoformat("2024-01-01T13:30:45"),
@@ -251,7 +258,7 @@ def test_comparison_normalizes_datetime_values_at_construction() -> None:
 def test_parsed_date_literals_carry_utc_instants() -> None:
     """A date() literal's offset is consumed into a UTC instant."""
     expr = parse_filter("created_at >= date('2024-01-01T13:30:45-08:00')")
-    assert isinstance(expr, Comparison)
+    assert isinstance(expr, Ordering)
     assert isinstance(expr.value, datetime.datetime)
     assert expr.value == datetime.datetime(2024, 1, 1, 21, 30, 45, tzinfo=datetime.UTC)
     assert expr.value.tzinfo == datetime.UTC
@@ -267,41 +274,41 @@ def test_valid_fixtures_return(valid_filters) -> None:
     assert expr is not None
 
 
-# --- != / <> (Comparison with op="!=") ---
+# --- != / <> (Ordering with op="!=") ---
 
 
 def test_parse_filter_ne_bang_equal() -> None:
     expr = parse_filter("status != 'CLOSED'")
-    assert expr == Comparison(field="status", op="!=", value="CLOSED")
+    assert expr == NotEquals(field="status", value="CLOSED")
 
 
 def test_parse_filter_ne_diamond() -> None:
     expr = parse_filter("status <> 'CLOSED'")
-    assert expr == Comparison(field="status", op="!=", value="CLOSED")
+    assert expr == NotEquals(field="status", value="CLOSED")
 
 
 def test_parse_filter_ne_numeric() -> None:
     expr = parse_filter("count != 0")
-    assert expr == Comparison(field="count", op="!=", value=0)
+    assert expr == NotEquals(field="count", value=0)
 
 
 def test_parse_filter_ne_boolean() -> None:
     expr = parse_filter("active <> false")
-    assert expr == Comparison(field="active", op="!=", value=False)
+    assert expr == NotEquals(field="active", value=False)
 
 
 def test_parse_filter_ne_in_conjunction() -> None:
     expr = parse_filter("owner = 'alice' AND status != 'CLOSED'")
     assert isinstance(expr, And)
-    assert expr.left == Comparison(field="owner", op="=", value="alice")
-    assert expr.right == Comparison(field="status", op="!=", value="CLOSED")
+    assert expr.operands[0] == Equals(field="owner", value="alice")
+    assert expr.operands[1] == NotEquals(field="status", value="CLOSED")
 
 
 def test_parse_filter_ne_in_disjunction() -> None:
     expr = parse_filter("status <> 'CLOSED' OR priority != 'LOW'")
     assert isinstance(expr, Or)
-    assert expr.left == Comparison(field="status", op="!=", value="CLOSED")
-    assert expr.right == Comparison(field="priority", op="!=", value="LOW")
+    assert expr.operands[0] == NotEquals(field="status", value="CLOSED")
+    assert expr.operands[1] == NotEquals(field="priority", value="LOW")
 
 
 def test_legacy_mapping_rejects_ne() -> None:
@@ -315,98 +322,98 @@ def test_legacy_mapping_rejects_ne() -> None:
 def test_parse_filter_not_simple() -> None:
     expr = parse_filter("NOT status = 'CLOSED'")
     assert isinstance(expr, Not)
-    assert expr.expr == Comparison(field="status", op="=", value="CLOSED")
+    assert expr.operand == Equals(field="status", value="CLOSED")
 
 
 def test_parse_filter_not_with_parenthesized_or() -> None:
     expr = parse_filter("NOT (status = 'CLOSED' OR status = 'ARCHIVED')")
     assert isinstance(expr, Not)
-    inner = expr.expr
+    inner = expr.operand
     assert isinstance(inner, Or)
-    assert inner.left == Comparison(field="status", op="=", value="CLOSED")
-    assert inner.right == Comparison(field="status", op="=", value="ARCHIVED")
+    assert inner.operands[0] == Equals(field="status", value="CLOSED")
+    assert inner.operands[1] == Equals(field="status", value="ARCHIVED")
 
 
 def test_parse_filter_not_binds_tighter_than_and() -> None:
     # NOT x = 1 AND y = 2  =>  (NOT (x = 1)) AND (y = 2)
     expr = parse_filter("NOT x = 1 AND y = 2")
     assert isinstance(expr, And)
-    assert isinstance(expr.left, Not)
-    assert expr.left.expr == Comparison(field="x", op="=", value=1)
-    assert expr.right == Comparison(field="y", op="=", value=2)
+    assert isinstance(expr.operands[0], Not)
+    assert expr.operands[0].operand == Equals(field="x", value=1)
+    assert expr.operands[1] == Equals(field="y", value=2)
 
 
 def test_parse_filter_not_binds_tighter_than_or() -> None:
     # NOT x = 1 OR y = 2  =>  (NOT (x = 1)) OR (y = 2)
     expr = parse_filter("NOT x = 1 OR y = 2")
     assert isinstance(expr, Or)
-    assert isinstance(expr.left, Not)
-    assert expr.left.expr == Comparison(field="x", op="=", value=1)
-    assert expr.right == Comparison(field="y", op="=", value=2)
+    assert isinstance(expr.operands[0], Not)
+    assert expr.operands[0].operand == Equals(field="x", value=1)
+    assert expr.operands[1] == Equals(field="y", value=2)
 
 
 def test_parse_filter_double_not() -> None:
     expr = parse_filter("NOT NOT status = 'OPEN'")
     assert isinstance(expr, Not)
-    assert isinstance(expr.expr, Not)
-    assert expr.expr.expr == Comparison(field="status", op="=", value="OPEN")
+    assert isinstance(expr.operand, Not)
+    assert expr.operand.operand == Equals(field="status", value="OPEN")
 
 
 def test_parse_filter_not_with_in() -> None:
     expr = parse_filter("NOT priority IN ('LOW', 'MEDIUM')")
     assert isinstance(expr, Not)
-    assert expr.expr == In(field="priority", values=["LOW", "MEDIUM"])
+    assert expr.operand == In(field="priority", values=("LOW", "MEDIUM"))
 
 
 def test_parse_filter_not_with_is_null() -> None:
     expr = parse_filter("NOT owner IS NULL")
     assert isinstance(expr, Not)
-    assert expr.expr == IsNull(field="owner")
+    assert expr.operand == IsMissing(field="owner")
 
 
 def test_parse_filter_not_with_ne() -> None:
     # NOT status != 'OPEN'  =>  NOT(status != 'OPEN')
     expr = parse_filter("NOT status != 'OPEN'")
     assert isinstance(expr, Not)
-    assert expr.expr == Comparison(field="status", op="!=", value="OPEN")
+    assert expr.operand == NotEquals(field="status", value="OPEN")
 
 
 def test_parse_filter_not_case_insensitive() -> None:
     expr = parse_filter("not status = 'CLOSED'")
     assert isinstance(expr, Not)
-    assert expr.expr == Comparison(field="status", op="=", value="CLOSED")
+    assert expr.operand == Equals(field="status", value="CLOSED")
 
 
 def test_parse_filter_not_and_or_full_precedence() -> None:
     # NOT a = 1 OR b = 2 AND c = 3  =>  (NOT (a = 1)) OR ((b = 2) AND (c = 3))
     expr = parse_filter("NOT a = 1 OR b = 2 AND c = 3")
     assert isinstance(expr, Or)
-    assert isinstance(expr.left, Not)
-    assert expr.left.expr == Comparison(field="a", op="=", value=1)
-    assert isinstance(expr.right, And)
-    assert expr.right.left == Comparison(field="b", op="=", value=2)
-    assert expr.right.right == Comparison(field="c", op="=", value=3)
+    assert isinstance(expr.operands[0], Not)
+    assert expr.operands[0].operand == Equals(field="a", value=1)
+    assert isinstance(expr.operands[1], And)
+    assert expr.operands[1].operands[0] == Equals(field="b", value=2)
+    assert expr.operands[1].operands[1] == Equals(field="c", value=3)
 
 
 def test_parse_filter_not_inside_and_or_chain() -> None:
     # a = 1 AND NOT b = 2 OR c = 3  =>  ((a = 1) AND (NOT (b = 2))) OR (c = 3)
     expr = parse_filter("a = 1 AND NOT b = 2 OR c = 3")
     assert isinstance(expr, Or)
-    assert isinstance(expr.left, And)
-    assert expr.left.left == Comparison(field="a", op="=", value=1)
-    assert isinstance(expr.left.right, Not)
-    assert expr.left.right.expr == Comparison(field="b", op="=", value=2)
-    assert expr.right == Comparison(field="c", op="=", value=3)
+    assert isinstance(expr.operands[0], And)
+    assert expr.operands[0].operands[0] == Equals(field="a", value=1)
+    assert isinstance(expr.operands[0].operands[1], Not)
+    assert expr.operands[0].operands[1].operand == Equals(field="b", value=2)
+    assert expr.operands[1] == Equals(field="c", value=3)
 
 
 def test_parse_filter_multiple_nots_in_expression() -> None:
     # NOT a = 1 AND NOT b = 2  =>  (NOT (a = 1)) AND (NOT (b = 2))
     expr = parse_filter("NOT a = 1 AND NOT b = 2")
     assert isinstance(expr, And)
-    assert isinstance(expr.left, Not)
-    assert expr.left.expr == Comparison(field="a", op="=", value=1)
-    assert isinstance(expr.right, Not)
-    assert expr.right.expr == Comparison(field="b", op="=", value=2)
+    assert isinstance(expr.operands[0], Not)
+    assert expr.operands[0].operand == Equals(field="a", value=1)
+    assert isinstance(expr.operands[1], Not)
+    assert expr.operands[1].operand == Equals(field="b", value=2)
 
 
 def test_legacy_mapping_rejects_not() -> None:
@@ -419,36 +426,36 @@ def test_legacy_mapping_rejects_not() -> None:
 
 def test_parse_filter_not_in_simple() -> None:
     expr = parse_filter("priority NOT IN ('LOW', 'MEDIUM')")
-    assert expr == Not(expr=In(field="priority", values=["LOW", "MEDIUM"]))
+    assert expr == Not(In(field="priority", values=("LOW", "MEDIUM")))
 
 
 def test_parse_filter_not_in_single_value() -> None:
     expr = parse_filter("status NOT IN ('CLOSED')")
-    assert expr == Not(expr=In(field="status", values=["CLOSED"]))
+    assert expr == Not(In(field="status", values=("CLOSED",)))
 
 
 def test_parse_filter_not_in_numeric_values() -> None:
     expr = parse_filter("code NOT IN (1, 2, 3)")
-    assert expr == Not(expr=In(field="code", values=[1, 2, 3]))
+    assert expr == Not(In(field="code", values=(1, 2, 3)))
 
 
 def test_parse_filter_not_in_with_and() -> None:
     expr = parse_filter("owner = 'alice' AND status NOT IN ('CLOSED', 'ARCHIVED')")
     assert isinstance(expr, And)
-    assert expr.left == Comparison(field="owner", op="=", value="alice")
-    assert expr.right == Not(expr=In(field="status", values=["CLOSED", "ARCHIVED"]))
+    assert expr.operands[0] == Equals(field="owner", value="alice")
+    assert expr.operands[1] == Not(In(field="status", values=("CLOSED", "ARCHIVED")))
 
 
 def test_parse_filter_not_in_with_or() -> None:
     expr = parse_filter("priority NOT IN ('LOW') OR owner = 'bob'")
     assert isinstance(expr, Or)
-    assert expr.left == Not(expr=In(field="priority", values=["LOW"]))
-    assert expr.right == Comparison(field="owner", op="=", value="bob")
+    assert expr.operands[0] == Not(In(field="priority", values=("LOW",)))
+    assert expr.operands[1] == Equals(field="owner", value="bob")
 
 
 def test_parse_filter_not_in_case_insensitive() -> None:
     expr = parse_filter("status not in ('CLOSED', 'ARCHIVED')")
-    assert expr == Not(expr=In(field="status", values=["CLOSED", "ARCHIVED"]))
+    assert expr == Not(In(field="status", values=("CLOSED", "ARCHIVED")))
 
 
 def test_parse_filter_not_without_in_raises() -> None:
@@ -494,65 +501,54 @@ def test_normalize_filter_field_preserves_case() -> None:
 
 
 def test_map_filter_fields_comparison() -> None:
-    expr = Comparison(field="m.foo", op="=", value="bar")
+    expr = Equals(field="m.foo", value="bar")
     result = map_filter_fields(expr, lambda f: f.upper())
-    assert result == Comparison(field="M.FOO", op="=", value="bar")
+    assert result == Equals(field="M.FOO", value="bar")
 
 
 def test_map_filter_fields_in() -> None:
-    expr = In(field="m.tag", values=["a", "b"])
+    expr = In(field="m.tag", values=("a", "b"))
     result = map_filter_fields(expr, lambda f: f.upper())
-    assert result == In(field="M.TAG", values=["a", "b"])
+    assert result == In(field="M.TAG", values=("a", "b"))
 
 
 def test_map_filter_fields_is_null() -> None:
-    expr = IsNull(field="m.note")
+    expr = IsMissing(field="m.note")
     result = map_filter_fields(expr, lambda f: f.upper())
-    assert result == IsNull(field="M.NOTE")
+    assert result == IsMissing(field="M.NOTE")
 
 
 def test_map_filter_fields_and() -> None:
-    expr = And(
-        left=Comparison(field="a", op="=", value=1),
-        right=Comparison(field="b", op="=", value=2),
-    )
+    expr = And((Equals(field="a", value=1), Equals(field="b", value=2)))
     result = map_filter_fields(expr, lambda f: f.upper())
     assert isinstance(result, And)
-    assert result.left == Comparison(field="A", op="=", value=1)
-    assert result.right == Comparison(field="B", op="=", value=2)
+    assert result.operands[0] == Equals(field="A", value=1)
+    assert result.operands[1] == Equals(field="B", value=2)
 
 
 def test_map_filter_fields_or() -> None:
-    expr = Or(
-        left=Comparison(field="x", op="=", value=1),
-        right=Comparison(field="y", op="=", value=2),
-    )
+    expr = Or((Equals(field="x", value=1), Equals(field="y", value=2)))
     result = map_filter_fields(expr, lambda f: f.upper())
     assert isinstance(result, Or)
-    assert result.left == Comparison(field="X", op="=", value=1)
-    assert result.right == Comparison(field="Y", op="=", value=2)
+    assert result.operands[0] == Equals(field="X", value=1)
+    assert result.operands[1] == Equals(field="Y", value=2)
 
 
 def test_map_filter_fields_not() -> None:
-    expr = Not(expr=Comparison(field="status", op="=", value="CLOSED"))
+    expr = Not(Equals(field="status", value="CLOSED"))
     result = map_filter_fields(expr, lambda f: f.upper())
     assert isinstance(result, Not)
-    assert result.expr == Comparison(field="STATUS", op="=", value="CLOSED")
+    assert result.operand == Equals(field="STATUS", value="CLOSED")
 
 
 def test_map_filter_fields_nested() -> None:
     # NOT (a = 1 AND b = 2)
-    expr = Not(
-        expr=And(
-            left=Comparison(field="a", op="=", value=1),
-            right=Comparison(field="b", op="=", value=2),
-        )
-    )
+    expr = Not(And((Equals(field="a", value=1), Equals(field="b", value=2))))
     result = map_filter_fields(expr, lambda f: f"prefix_{f}")
     assert isinstance(result, Not)
-    assert isinstance(result.expr, And)
-    assert result.expr.left == Comparison(field="prefix_a", op="=", value=1)
-    assert result.expr.right == Comparison(field="prefix_b", op="=", value=2)
+    assert isinstance(result.operand, And)
+    assert result.operand.operands[0] == Equals(field="prefix_a", value=1)
+    assert result.operand.operands[1] == Equals(field="prefix_b", value=2)
 
 
 def test_parse_filter_in_rejects_bool() -> None:
@@ -573,10 +569,9 @@ def test_parse_filter_in_rejects_mixed_types() -> None:
 def test_map_filter_fields_with_normalize() -> None:
     """Test map_filter_fields combined with normalize_filter_field."""
     expr = And(
-        left=Comparison(field="m.foo", op="=", value="bar"),
-        right=Comparison(field="producer_id", op="=", value="alice"),
+        (Equals(field="m.foo", value="bar"), Equals(field="producer_id", value="alice"))
     )
     result = map_filter_fields(expr, lambda f: normalize_filter_field(f)[0])
     assert isinstance(result, And)
-    assert result.left == Comparison(field="metadata.foo", op="=", value="bar")
-    assert result.right == Comparison(field="producer_id", op="=", value="alice")
+    assert result.operands[0] == Equals(field="metadata.foo", value="bar")
+    assert result.operands[1] == Equals(field="producer_id", value="alice")

--- a/packages/server/server_tests/memmachine_server/common/filter/test_sql_filter_util.py
+++ b/packages/server/server_tests/memmachine_server/common/filter/test_sql_filter_util.py
@@ -9,7 +9,6 @@ against both SQLite and PostgreSQL (via testcontainers).
 """
 
 from datetime import UTC, datetime, timedelta, timezone
-from typing import Any, cast
 
 import pytest
 import pytest_asyncio
@@ -18,13 +17,17 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Session
 
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
     And,
-    Comparison,
+    Equals,
     In,
-    IsNull,
+    IsMissing,
     Not,
+    NotEquals,
     Or,
+    Ordering,
+)
+from memmachine_server.common.filter.filter_parser import (
     parse_filter,
 )
 from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
@@ -118,6 +121,7 @@ def json_session():
 def _query_json_names(session: Session, filter_str: str) -> set[str]:
     """Parse filter, compile to SQL, execute, and return set of matching names."""
     expr = parse_filter(filter_str)
+    assert expr is not None
     clause = compile_sql_filter(expr, _resolve_json_field)
     stmt = select(_Item.name).where(clause)
     return {row[0] for row in session.execute(stmt)}
@@ -282,11 +286,6 @@ def test_unknown_field_raises(json_session):
         _query_json_names(json_session, "nonexistent = 1")
 
 
-def test_unsupported_expr_type():
-    with pytest.raises(TypeError, match="Unsupported filter expression type"):
-        compile_sql_filter("bad", _resolve_json_field)
-
-
 # ============================================================================
 # Properties JSON ("properties_json" kind) tests — async, SQLite + PostgreSQL
 # ============================================================================
@@ -392,13 +391,13 @@ class TestPropsJsonIntFilters:
     @pytest.mark.asyncio
     async def test_eq(self, properties_session):
         assert await _query_props_names(
-            properties_session, Comparison("count", "=", 10)
+            properties_session, Equals(field="count", value=10)
         ) == {"beta"}
 
     @pytest.mark.asyncio
     async def test_neq(self, properties_session):
         assert await _query_props_names(
-            properties_session, Comparison("count", "!=", 10)
+            properties_session, NotEquals(field="count", value=10)
         ) == {
             "alpha",
             "gamma",
@@ -409,7 +408,7 @@ class TestPropsJsonIntFilters:
     @pytest.mark.asyncio
     async def test_gt(self, properties_session):
         assert await _query_props_names(
-            properties_session, Comparison("count", ">", 10)
+            properties_session, Ordering(field="count", op=">", value=10)
         ) == {
             "gamma",
             "delta",
@@ -418,7 +417,7 @@ class TestPropsJsonIntFilters:
     @pytest.mark.asyncio
     async def test_gte(self, properties_session):
         assert await _query_props_names(
-            properties_session, Comparison("count", ">=", 10)
+            properties_session, Ordering(field="count", op=">=", value=10)
         ) == {
             "beta",
             "gamma",
@@ -428,7 +427,7 @@ class TestPropsJsonIntFilters:
     @pytest.mark.asyncio
     async def test_lt(self, properties_session):
         assert await _query_props_names(
-            properties_session, Comparison("count", "<", 10)
+            properties_session, Ordering(field="count", op="<", value=10)
         ) == {
             "alpha",
             "epsilon",
@@ -437,7 +436,7 @@ class TestPropsJsonIntFilters:
     @pytest.mark.asyncio
     async def test_lte(self, properties_session):
         assert await _query_props_names(
-            properties_session, Comparison("count", "<=", 10)
+            properties_session, Ordering(field="count", op="<=", value=10)
         ) == {
             "alpha",
             "beta",
@@ -449,7 +448,7 @@ class TestPropsJsonFloatFilters:
     @pytest.mark.asyncio
     async def test_gt(self, properties_session):
         assert await _query_props_names(
-            properties_session, Comparison("score", ">", 2.0)
+            properties_session, Ordering(field="score", op=">", value=2.0)
         ) == {
             "beta",
             "gamma",
@@ -459,7 +458,7 @@ class TestPropsJsonFloatFilters:
     @pytest.mark.asyncio
     async def test_lt(self, properties_session):
         assert await _query_props_names(
-            properties_session, Comparison("score", "<", 3.0)
+            properties_session, Ordering(field="score", op="<", value=3.0)
         ) == {
             "alpha",
             "beta",
@@ -470,7 +469,7 @@ class TestPropsJsonBoolFilters:
     @pytest.mark.asyncio
     async def test_true(self, properties_session):
         assert await _query_props_names(
-            properties_session, Comparison("active", "=", True)
+            properties_session, Equals(field="active", value=True)
         ) == {
             "alpha",
             "gamma",
@@ -480,7 +479,7 @@ class TestPropsJsonBoolFilters:
     @pytest.mark.asyncio
     async def test_false(self, properties_session):
         assert await _query_props_names(
-            properties_session, Comparison("active", "=", False)
+            properties_session, Equals(field="active", value=False)
         ) == {
             "beta",
             "delta",
@@ -491,13 +490,13 @@ class TestPropsJsonStringFilters:
     @pytest.mark.asyncio
     async def test_eq(self, properties_session):
         assert await _query_props_names(
-            properties_session, Comparison("tag", "=", "a")
+            properties_session, Equals(field="tag", value="a")
         ) == {"alpha"}
 
     @pytest.mark.asyncio
     async def test_neq(self, properties_session):
         assert await _query_props_names(
-            properties_session, Comparison("tag", "!=", "a")
+            properties_session, NotEquals(field="tag", value="a")
         ) == {
             "beta",
             "gamma",
@@ -510,7 +509,7 @@ class TestPropsJsonDatetimeFilters:
     async def test_gt(self, properties_session):
         cutoff = datetime(2024, 6, 1, 0, 0, 0, tzinfo=UTC)
         assert await _query_props_names(
-            properties_session, Comparison("ts", ">", cutoff)
+            properties_session, Ordering(field="ts", op=">", value=cutoff)
         ) == {
             "gamma",
             "delta",
@@ -520,7 +519,7 @@ class TestPropsJsonDatetimeFilters:
     async def test_lt(self, properties_session):
         cutoff = datetime(2024, 6, 1, 0, 0, 0, tzinfo=UTC)
         assert await _query_props_names(
-            properties_session, Comparison("ts", "<", cutoff)
+            properties_session, Ordering(field="ts", op="<", value=cutoff)
         ) == {
             "alpha",
             "beta",
@@ -531,7 +530,7 @@ class TestPropsJsonDatetimeFilters:
         jst = timezone(timedelta(hours=9))
         cutoff = datetime(2024, 3, 15, 22, 0, 0, tzinfo=jst)  # = 13:00 UTC
         assert await _query_props_names(
-            properties_session, Comparison("ts", ">=", cutoff)
+            properties_session, Ordering(field="ts", op=">=", value=cutoff)
         ) == {
             "beta",
             "gamma",
@@ -542,27 +541,28 @@ class TestPropsJsonDatetimeFilters:
 class TestPropsJsonInFilters:
     @pytest.mark.asyncio
     async def test_int_in(self, properties_session):
-        assert await _query_props_names(properties_session, In("count", [5, 15])) == {
+        assert await _query_props_names(properties_session, In("count", (5, 15))) == {
             "alpha",
             "gamma",
         }
 
     @pytest.mark.asyncio
     async def test_string_in(self, properties_session):
-        assert await _query_props_names(properties_session, In("tag", ["a", "b"])) == {
+        assert await _query_props_names(properties_session, In("tag", ("a", "b"))) == {
             "alpha",
             "beta",
         }
 
     @pytest.mark.asyncio
-    async def test_empty_in(self, properties_session):
-        assert await _query_props_names(properties_session, In("tag", [])) == set()
+    async def test_empty_in_is_not_a_predicate(self, properties_session):
+        with pytest.raises(ValueError, match="at least one value"):
+            In("tag", ())
 
 
 class TestPropsJsonIsNullFilter:
     @pytest.mark.asyncio
     async def test_is_null(self, properties_session):
-        assert await _query_props_names(properties_session, IsNull("tag")) == {
+        assert await _query_props_names(properties_session, IsMissing("tag")) == {
             "epsilon"
         }
 
@@ -570,17 +570,22 @@ class TestPropsJsonIsNullFilter:
 class TestPropsJsonLogicalFilters:
     @pytest.mark.asyncio
     async def test_and(self, properties_session):
-        expr = And(Comparison("count", ">", 10), Comparison("active", "=", True))
+        expr = And(
+            (
+                Ordering(field="count", op=">", value=10),
+                Equals(field="active", value=True),
+            )
+        )
         assert await _query_props_names(properties_session, expr) == {"gamma"}
 
     @pytest.mark.asyncio
     async def test_or(self, properties_session):
-        expr = Or(Comparison("tag", "=", "a"), Comparison("tag", "=", "c"))
+        expr = Or((Equals(field="tag", value="a"), Equals(field="tag", value="c")))
         assert await _query_props_names(properties_session, expr) == {"alpha", "gamma"}
 
     @pytest.mark.asyncio
     async def test_not(self, properties_session):
-        expr = Not(Comparison("count", ">", 10))
+        expr = Not(Ordering(field="count", op=">", value=10))
         assert await _query_props_names(properties_session, expr) == {
             "alpha",
             "beta",
@@ -589,27 +594,8 @@ class TestPropsJsonLogicalFilters:
 
     @pytest.mark.asyncio
     async def test_not_in(self, properties_session):
-        expr = Not(In("tag", ["a", "b"]))
+        expr = Not(In("tag", ("a", "b")))
         assert await _query_props_names(properties_session, expr) == {"gamma", "delta"}
-
-    @pytest.mark.asyncio
-    async def test_compound_not_and(self, properties_session):
-        inner = And(Comparison("count", ">", 10), Comparison("active", "=", True))
-        assert await _query_props_names(properties_session, Not(inner)) == {
-            "alpha",
-            "beta",
-            "delta",
-            "epsilon",
-        }
-
-
-class TestPropsJsonCompileErrors:
-    @pytest.mark.asyncio
-    async def test_unsupported_operator(self, properties_session):
-        with pytest.raises(ValueError, match="Unsupported operator"):
-            await _query_props_names(
-                properties_session, Comparison("count", cast(Any, "LIKE"), 10)
-            )
 
 
 class TestColumnDatetimeNormalization:
@@ -622,7 +608,7 @@ class TestColumnDatetimeNormalization:
         def resolve(field: str):
             return column, "column"
 
-        clause = compile_sql_filter(Comparison("ts", "<=", bound), resolve)
+        clause = compile_sql_filter(Ordering(field="ts", op="<=", value=bound), resolve)
         value = clause.right.value
         assert value.hour == 0
         assert value.utcoffset() == timedelta(0)

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
@@ -1,4 +1,5 @@
 import importlib.util
+from datetime import datetime
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -296,7 +297,7 @@ def _qdrant_only_conf() -> MagicMock:
     conf.relational_db_confs = {}
     conf.nebula_graph_confs = {}
     conf.qdrant_confs = {
-        "qdrant1": QdrantConf(host="localhost", port=6333),
+        "qdrant1": QdrantConf(request_timeout=30.0, host="localhost", port=6333),
     }
     conf.sqlite_vector_store_confs = {}
     conf.sqlite_vec_vector_store_confs = {}
@@ -308,6 +309,7 @@ async def test_qdrant_client_kwargs_forwarded():
     """host, port, grpc_port, prefer_grpc, and https are forwarded to AsyncQdrantClient."""
     conf = _qdrant_only_conf()
     conf.qdrant_confs["qdrant1"] = QdrantConf(
+        request_timeout=30.0,
         host="qdrant.example.com",
         port=7333,
         grpc_port=7334,
@@ -342,6 +344,7 @@ async def test_qdrant_client_kwargs_forwarded():
     assert call_kwargs["grpc_port"] == 7334
     assert call_kwargs["prefer_grpc"] is True
     assert call_kwargs["https"] is True
+    assert call_kwargs["timeout"] == 30.0
     assert call_kwargs["api_key"] == "secret-key"
 
 
@@ -375,11 +378,14 @@ async def test_qdrant_api_key_omitted_when_empty():
 
 @pytest.mark.asyncio
 async def test_qdrant_creates_vector_store():
-    """async_get_qdrant_client creates a QdrantVectorStore and stores it."""
+    """get_vector_store creates a QdrantVectorStore built for the service's keys."""
     conf = _qdrant_only_conf()
     conf.qdrant_confs["qdrant1"] = QdrantConf(
+        request_timeout=30.0,
         is_distributed=True,
         registry_replication_factor=3,
+        indexed_properties={"category": "str"},
+        hnsw_config={"ef_construct": 256, "payload_m": 32},
     )
 
     mock_client = AsyncMock()
@@ -399,18 +405,28 @@ async def test_qdrant_creates_vector_store():
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
-        await builder.async_get_qdrant_client("qdrant1")
+        await builder.get_vector_store(
+            "qdrant1", indexed_properties={"memmachine_event_session": str}
+        )
 
-    mock_params_cls.assert_called_once()
-    kwargs = mock_params_cls.call_args.kwargs
+    mock_params_cls.model_validate.assert_called_once()
+    kwargs = mock_params_cls.model_validate.call_args.args[0]
     assert kwargs["client"] is mock_client
     assert kwargs["is_distributed"] is True
     assert kwargs["registry_replication_factor"] == 3
+    # The configured user keys, typed, plus the service's system keys.
+    assert kwargs["indexed_properties"] == {
+        "category": str,
+        "memmachine_event_session": str,
+    }
+    assert kwargs["hnsw_config"] == {"ef_construct": 256, "payload_m": 32}
+    assert kwargs["optimizers_config"] is None
+    assert kwargs["quantization_config"] is None
     # Asserted as "not None" rather than pinned to a value: OperationTracker
     # accepts None and then discards every timing without error, so passing the
     # keyword is not the property that matters - passing a factory is.
     assert kwargs["metrics_factory"] is not None
-    mock_store_cls.assert_called_once_with(mock_params_cls.return_value)
+    mock_store_cls.assert_called_once_with(mock_params_cls.model_validate.return_value)
     mock_store_cls.return_value.startup.assert_awaited_once()
     assert "qdrant1" in builder.vector_stores
 
@@ -438,7 +454,7 @@ async def test_get_vector_store_qdrant():
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
-        store = await builder.get_vector_store("qdrant1")
+        store = await builder.get_vector_store("qdrant1", indexed_properties={})
 
     assert store is mock_store_cls.return_value
 
@@ -489,7 +505,7 @@ async def test_qdrant_close():
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        await builder.async_get_qdrant_client("qdrant1")
+        await builder.get_vector_store("qdrant1", indexed_properties={})
 
     assert "qdrant1" in builder.qdrant_clients
     assert "qdrant1" in builder.vector_stores
@@ -512,7 +528,7 @@ def _milvus_only_conf() -> MagicMock:
     conf.nebula_graph_confs = {}
     conf.qdrant_confs = {}
     conf.milvus_confs = {
-        "milvus1": MilvusConf(uri="./milvus.db"),
+        "milvus1": MilvusConf(request_timeout=30.0, uri="./milvus.db"),
     }
     conf.sqlite_vector_store_confs = {}
     conf.sqlite_vec_vector_store_confs = {}
@@ -525,6 +541,7 @@ async def test_milvus_client_kwargs_forwarded():
     """uri, token, and db_name are forwarded to MilvusClient."""
     conf = _milvus_only_conf()
     conf.milvus_confs["milvus1"] = MilvusConf(
+        request_timeout=30.0,
         uri="https://example.zillizcloud.com",
         token=SecretStr("secret-token"),
         db_name="memory",
@@ -552,6 +569,7 @@ async def test_milvus_client_kwargs_forwarded():
     assert call_kwargs["uri"] == "https://example.zillizcloud.com"
     assert call_kwargs["token"] == "secret-token"
     assert call_kwargs["db_name"] == "memory"
+    assert call_kwargs["timeout"] == 30.0
 
 
 @pytest.mark.asyncio
@@ -576,15 +594,19 @@ async def test_milvus_token_and_db_name_omitted_when_empty():
         builder = DatabaseManager(conf)
         await builder.async_get_milvus_client("milvus1")
 
-    assert mock_cls.call_args.kwargs == {"uri": "./milvus.db"}
+    assert mock_cls.call_args.kwargs == {"uri": "./milvus.db", "timeout": 30.0}
 
 
 @pytest.mark.asyncio
 @requires_pymilvus
 async def test_milvus_creates_vector_store():
-    """async_get_milvus_client creates a MilvusVectorStore and stores it."""
+    """get_vector_store creates a MilvusVectorStore built for the service's keys."""
     conf = _milvus_only_conf()
-    conf.milvus_confs["milvus1"] = MilvusConf(consistency_level="Strong")
+    conf.milvus_confs["milvus1"] = MilvusConf(
+        request_timeout=30.0,
+        consistency_level="Strong",
+        indexed_properties={"category": "str"},
+    )
 
     mock_client = MagicMock()
     mock_client.close = MagicMock()
@@ -600,11 +622,14 @@ async def test_milvus_creates_vector_store():
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
-        await builder.async_get_milvus_client("milvus1")
+        await builder.get_vector_store(
+            "milvus1", indexed_properties={"memmachine_event_session": str}
+        )
 
     mock_params_cls.assert_called_once_with(
         client=mock_client,
         consistency_level="Strong",
+        indexed_properties={"category": str, "memmachine_event_session": str},
     )
     mock_store_cls.assert_called_once_with(mock_params_cls.return_value)
     mock_store_cls.return_value.startup.assert_awaited_once()
@@ -632,7 +657,7 @@ async def test_get_vector_store_milvus():
     ):
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
-        store = await builder.get_vector_store("milvus1")
+        store = await builder.get_vector_store("milvus1", indexed_properties={})
 
     assert store is mock_store_cls.return_value
 
@@ -681,7 +706,7 @@ async def test_milvus_close():
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        await builder.async_get_milvus_client("milvus1")
+        await builder.get_vector_store("milvus1", indexed_properties={})
 
     assert "milvus1" in builder.milvus_clients
     assert "milvus1" in builder.vector_stores
@@ -713,7 +738,7 @@ def _sqlite_vector_store_only_conf(**vs_overrides) -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_sqlite_vector_store_creates_store_and_engine():
-    """async_get_sqlite_vector_store builds an engine, store, and starts it up."""
+    """get_vector_store builds an engine and a SQLiteVectorStore, and starts it up."""
     conf = _sqlite_vector_store_only_conf(
         sqlite_vector_store_confs={
             "vs1": SQLiteVectorStoreConf(
@@ -743,7 +768,7 @@ async def test_sqlite_vector_store_creates_store_and_engine():
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        store = await builder.async_get_sqlite_vector_store("vs1")
+        store = await builder.get_vector_store("vs1", indexed_properties={})
 
     assert store is mock_store_cls.return_value
     mock_create.assert_called_once()
@@ -754,6 +779,7 @@ async def test_sqlite_vector_store_creates_store_and_engine():
     assert params_kwargs["sqlalchemy_engine"] is mock_engine
     assert params_kwargs["index_directory"] == "/tmp/vs"
     assert params_kwargs["save_threshold"] == 200
+    assert params_kwargs["indexed_properties"] == {}
     assert callable(params_kwargs["vector_search_engine_factory"])
 
     mock_store_cls.return_value.startup.assert_awaited_once()
@@ -793,7 +819,7 @@ async def test_sqlite_vector_store_default_engine_is_usearch():
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        await builder.async_get_sqlite_vector_store("vs1")
+        await builder.get_vector_store("vs1", indexed_properties={})
 
         # Invoke the factory the manager passed into params and confirm it
         # routes to the USearch engine.
@@ -828,8 +854,8 @@ async def test_sqlite_vector_store_caches_after_first_call():
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        first = await builder.async_get_sqlite_vector_store("vs1")
-        second = await builder.async_get_sqlite_vector_store("vs1")
+        first = await builder.get_vector_store("vs1", indexed_properties={})
+        second = await builder.get_vector_store("vs1", indexed_properties={})
 
     assert first is second
     assert mock_create.call_count == 1
@@ -863,7 +889,7 @@ async def test_sqlite_vector_store_startup_failure_disposes_engine():
         )
         builder = DatabaseManager(conf)
         with pytest.raises(VectorStoreConfigurationError, match="failed to start"):
-            await builder.async_get_sqlite_vector_store("vs1")
+            await builder.get_vector_store("vs1", indexed_properties={})
 
     mock_engine.dispose.assert_awaited_once()
     assert "vs1" not in builder.vector_stores
@@ -874,15 +900,13 @@ async def test_sqlite_vector_store_startup_failure_disposes_engine():
 async def test_sqlite_vector_store_unknown_name_raises():
     conf = _sqlite_vector_store_only_conf()
     builder = DatabaseManager(conf)
-    with pytest.raises(
-        ValueError, match="SQLiteVectorStore config 'missing' not found"
-    ):
-        await builder.async_get_sqlite_vector_store("missing")
+    with pytest.raises(ValueError, match="VectorStore 'missing' not found"):
+        await builder.get_vector_store("missing", indexed_properties={})
 
 
 @pytest.mark.asyncio
 async def test_sqlite_vec_vector_store_creates_store_and_engine():
-    """async_get_sqlite_vec_vector_store builds an engine, store, and starts it up."""
+    """get_vector_store builds an engine and a SQLiteVecVectorStore, and starts it up."""
     conf = _sqlite_vector_store_only_conf(
         sqlite_vec_vector_store_confs={"vec1": SQLiteVecVectorStoreConf(path="vec.db")}
     )
@@ -905,7 +929,7 @@ async def test_sqlite_vec_vector_store_creates_store_and_engine():
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        store = await builder.async_get_sqlite_vec_vector_store("vec1")
+        store = await builder.get_vector_store("vec1", indexed_properties={})
 
     assert store is mock_store_cls.return_value
     create_args = mock_create.call_args
@@ -913,6 +937,7 @@ async def test_sqlite_vec_vector_store_creates_store_and_engine():
 
     params_kwargs = mock_params_cls.call_args.kwargs
     assert params_kwargs["engine"] is mock_engine
+    assert params_kwargs["indexed_properties"] == {}
 
     mock_store_cls.return_value.startup.assert_awaited_once()
     assert "vec1" in builder.vector_stores
@@ -923,10 +948,8 @@ async def test_sqlite_vec_vector_store_creates_store_and_engine():
 async def test_sqlite_vec_vector_store_unknown_name_raises():
     conf = _sqlite_vector_store_only_conf()
     builder = DatabaseManager(conf)
-    with pytest.raises(
-        ValueError, match="SQLiteVecVectorStore config 'missing' not found"
-    ):
-        await builder.async_get_sqlite_vec_vector_store("missing")
+    with pytest.raises(ValueError, match="VectorStore 'missing' not found"):
+        await builder.get_vector_store("missing", indexed_properties={})
 
 
 @pytest.mark.asyncio
@@ -963,8 +986,8 @@ async def test_get_vector_store_dispatches_to_sqlite_backends():
         mock_vec_cls.return_value.startup = AsyncMock()
         mock_vec_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        vs = await builder.get_vector_store("vs1")
-        vec = await builder.get_vector_store("vec1")
+        vs = await builder.get_vector_store("vs1", indexed_properties={})
+        vec = await builder.get_vector_store("vec1", indexed_properties={})
 
     assert vs is mock_vs_cls.return_value
     assert vec is mock_vec_cls.return_value
@@ -975,7 +998,7 @@ async def test_get_vector_store_unknown_name_raises():
     conf = _sqlite_vector_store_only_conf()
     builder = DatabaseManager(conf)
     with pytest.raises(ValueError, match="VectorStore 'missing' not found"):
-        await builder.get_vector_store("missing")
+        await builder.get_vector_store("missing", indexed_properties={})
 
 
 @pytest.mark.asyncio
@@ -1003,7 +1026,7 @@ async def test_close_disposes_vector_store_engines_and_shuts_down_stores():
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        await builder.async_get_sqlite_vector_store("vs1")
+        await builder.get_vector_store("vs1", indexed_properties={})
 
         assert "vs1" in builder.vector_stores
         assert "vs1" in builder.vector_store_sql_engines
@@ -1014,3 +1037,98 @@ async def test_close_disposes_vector_store_engines_and_shuts_down_stores():
     assert builder.vector_store_sql_engines == {}
     mock_store_cls.return_value.shutdown.assert_awaited_once()
     mock_engine.dispose.assert_awaited()
+
+
+def _sqlite_conf_with_properties(indexed_properties: dict[str, str]) -> MagicMock:
+    return _sqlite_vector_store_only_conf(
+        sqlite_vector_store_confs={
+            "vs1": SQLiteVectorStoreConf(
+                path="vs.db", indexed_properties=indexed_properties
+            )
+        }
+    )
+
+
+def _patched_sqlite_store():
+    mock_engine = MagicMock(spec=AsyncEngine)
+    mock_engine.dispose = AsyncMock()
+    return (
+        patch(
+            "memmachine_server.common.resource_manager.database_manager.create_async_engine",
+            return_value=mock_engine,
+        ),
+        patch(
+            "memmachine_server.common.vector_store.sqlite_vector_store.SQLiteVectorStoreParams",
+        ),
+        patch(
+            "memmachine_server.common.vector_store.sqlite_vector_store.SQLiteVectorStore",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_vector_store_merges_configured_and_system_keys():
+    """The store is built with the configured user keys plus the service's system keys."""
+    conf = _sqlite_conf_with_properties({"category": "str", "score": "float"})
+    engine_patch, params_patch, store_patch = _patched_sqlite_store()
+    with engine_patch, params_patch as mock_params_cls, store_patch as mock_store_cls:
+        mock_store_cls.return_value.startup = AsyncMock()
+        builder = DatabaseManager(conf)
+        await builder.get_vector_store(
+            "vs1", indexed_properties={"memmachine_event_timestamp": datetime}
+        )
+    assert mock_params_cls.call_args.kwargs["indexed_properties"] == {
+        "category": str,
+        "score": float,
+        "memmachine_event_timestamp": datetime,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_vector_store_rejects_a_configured_key_of_another_type():
+    """A configured key the service writes with another type is a configuration error."""
+    conf = _sqlite_conf_with_properties({"memmachine_event_timestamp": "str"})
+    engine_patch, params_patch, store_patch = _patched_sqlite_store()
+    with engine_patch, params_patch, store_patch as mock_store_cls:
+        mock_store_cls.return_value.startup = AsyncMock()
+        builder = DatabaseManager(conf)
+        with pytest.raises(VectorStoreConfigurationError, match="configures"):
+            await builder.get_vector_store(
+                "vs1", indexed_properties={"memmachine_event_timestamp": datetime}
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_vector_store_rejects_an_invalid_configured_key():
+    conf = _sqlite_conf_with_properties({"Bad Key": "str"})
+    engine_patch, params_patch, store_patch = _patched_sqlite_store()
+    with engine_patch, params_patch, store_patch as mock_store_cls:
+        mock_store_cls.return_value.startup = AsyncMock()
+        builder = DatabaseManager(conf)
+        with pytest.raises(VectorStoreConfigurationError, match="indexed_properties"):
+            await builder.get_vector_store("vs1", indexed_properties={})
+
+
+@pytest.mark.asyncio
+async def test_get_vector_store_is_not_shared_between_services():
+    """A second service whose keys the built store does not declare is refused."""
+    conf = _sqlite_conf_with_properties({})
+    engine_patch, params_patch, store_patch = _patched_sqlite_store()
+    with engine_patch, params_patch, store_patch as mock_store_cls:
+        mock_store_cls.return_value.startup = AsyncMock()
+        mock_store_cls.return_value.indexed_properties = {
+            "memmachine_event_session": str
+        }
+        builder = DatabaseManager(conf)
+        first = await builder.get_vector_store(
+            "vs1", indexed_properties={"memmachine_event_session": str}
+        )
+        # The same service, or one declaring a subset, gets the same store.
+        assert (
+            await builder.get_vector_store(
+                "vs1", indexed_properties={"memmachine_event_session": str}
+            )
+            is first
+        )
+        with pytest.raises(VectorStoreConfigurationError, match="another service"):
+            await builder.get_vector_store("vs1", indexed_properties={"set_id": str})

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_database_manager.py
@@ -299,6 +299,7 @@ def _qdrant_only_conf() -> MagicMock:
     conf.qdrant_confs = {
         "qdrant1": QdrantConf(request_timeout=30.0, host="localhost", port=6333),
     }
+    conf.milvus_confs = {}
     conf.sqlite_vector_store_confs = {}
     conf.sqlite_vec_vector_store_confs = {}
     return conf
@@ -334,6 +335,7 @@ async def test_qdrant_client_kwargs_forwarded():
             return_value=mock_client,
         ) as mock_cls,
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
         await builder.async_get_qdrant_client("qdrant1")
@@ -369,6 +371,7 @@ async def test_qdrant_api_key_omitted_when_empty():
             return_value=mock_client,
         ) as mock_cls,
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
         await builder.async_get_qdrant_client("qdrant1")
@@ -403,15 +406,21 @@ async def test_qdrant_creates_vector_store():
             return_value=mock_client,
         ),
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
         await builder.get_vector_store(
-            "qdrant1", indexed_properties={"memmachine_event_session": str}
+            "qdrant1",
+            collection="c",
+            vector_dimensions=3,
+            indexed_properties={"memmachine_event_session": str},
         )
 
     mock_params_cls.model_validate.assert_called_once()
     kwargs = mock_params_cls.model_validate.call_args.args[0]
     assert kwargs["client"] is mock_client
+    assert kwargs["collection"] == "c"
+    assert kwargs["vector_dimensions"] == 3
     assert kwargs["is_distributed"] is True
     assert kwargs["registry_replication_factor"] == 3
     # The configured user keys, typed, plus the service's system keys.
@@ -428,7 +437,7 @@ async def test_qdrant_creates_vector_store():
     assert kwargs["metrics_factory"] is not None
     mock_store_cls.assert_called_once_with(mock_params_cls.model_validate.return_value)
     mock_store_cls.return_value.startup.assert_awaited_once()
-    assert "qdrant1" in builder.vector_stores
+    assert ("qdrant1", "c") in builder.vector_stores
 
 
 @pytest.mark.asyncio
@@ -452,9 +461,12 @@ async def test_get_vector_store_qdrant():
             return_value=mock_client,
         ),
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
-        store = await builder.get_vector_store("qdrant1", indexed_properties={})
+        store = await builder.get_vector_store(
+            "qdrant1", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
     assert store is mock_store_cls.return_value
 
@@ -502,13 +514,16 @@ async def test_qdrant_close():
             return_value=mock_client,
         ),
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        await builder.get_vector_store("qdrant1", indexed_properties={})
+        await builder.get_vector_store(
+            "qdrant1", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
     assert "qdrant1" in builder.qdrant_clients
-    assert "qdrant1" in builder.vector_stores
+    assert ("qdrant1", "c") in builder.vector_stores
 
     await builder.close()
 
@@ -561,6 +576,7 @@ async def test_milvus_client_kwargs_forwarded():
         ) as mock_store_cls,
         patch("pymilvus.MilvusClient", return_value=mock_client) as mock_cls,
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
         await builder.async_get_milvus_client("milvus1")
@@ -590,6 +606,7 @@ async def test_milvus_token_and_db_name_omitted_when_empty():
         ) as mock_store_cls,
         patch("pymilvus.MilvusClient", return_value=mock_client) as mock_cls,
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
         await builder.async_get_milvus_client("milvus1")
@@ -620,20 +637,26 @@ async def test_milvus_creates_vector_store():
         ) as mock_store_cls,
         patch("pymilvus.MilvusClient", return_value=mock_client),
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
         await builder.get_vector_store(
-            "milvus1", indexed_properties={"memmachine_event_session": str}
+            "milvus1",
+            collection="c",
+            vector_dimensions=3,
+            indexed_properties={"memmachine_event_session": str},
         )
 
     mock_params_cls.assert_called_once_with(
         client=mock_client,
+        collection="c",
+        vector_dimensions=3,
         consistency_level="Strong",
         indexed_properties={"category": str, "memmachine_event_session": str},
     )
     mock_store_cls.assert_called_once_with(mock_params_cls.return_value)
     mock_store_cls.return_value.startup.assert_awaited_once()
-    assert "milvus1" in builder.vector_stores
+    assert ("milvus1", "c") in builder.vector_stores
 
 
 @pytest.mark.asyncio
@@ -655,9 +678,12 @@ async def test_get_vector_store_milvus():
         ) as mock_store_cls,
         patch("pymilvus.MilvusClient", return_value=mock_client),
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
-        store = await builder.get_vector_store("milvus1", indexed_properties={})
+        store = await builder.get_vector_store(
+            "milvus1", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
     assert store is mock_store_cls.return_value
 
@@ -703,13 +729,16 @@ async def test_milvus_close():
         ) as mock_store_cls,
         patch("pymilvus.MilvusClient", return_value=mock_client),
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        await builder.get_vector_store("milvus1", indexed_properties={})
+        await builder.get_vector_store(
+            "milvus1", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
     assert "milvus1" in builder.milvus_clients
-    assert "milvus1" in builder.vector_stores
+    assert ("milvus1", "c") in builder.vector_stores
 
     await builder.close()
 
@@ -765,10 +794,13 @@ async def test_sqlite_vector_store_creates_store_and_engine():
             "memmachine_server.common.vector_store.sqlite_vector_store.SQLiteVectorStore",
         ) as mock_store_cls,
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        store = await builder.get_vector_store("vs1", indexed_properties={})
+        store = await builder.get_vector_store(
+            "vs1", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
     assert store is mock_store_cls.return_value
     mock_create.assert_called_once()
@@ -777,13 +809,15 @@ async def test_sqlite_vector_store_creates_store_and_engine():
 
     params_kwargs = mock_params_cls.call_args.kwargs
     assert params_kwargs["sqlalchemy_engine"] is mock_engine
+    assert params_kwargs["collection"] == "c"
+    assert params_kwargs["vector_dimensions"] == 3
     assert params_kwargs["index_directory"] == "/tmp/vs"
     assert params_kwargs["save_threshold"] == 200
     assert params_kwargs["indexed_properties"] == {}
     assert callable(params_kwargs["vector_search_engine_factory"])
 
     mock_store_cls.return_value.startup.assert_awaited_once()
-    assert "vs1" in builder.vector_stores
+    assert ("vs1", "c") in builder.vector_stores
     assert "vs1" in builder.vector_store_sql_engines
 
 
@@ -816,10 +850,13 @@ async def test_sqlite_vector_store_default_engine_is_usearch():
             "memmachine_server.common.vector_store.vector_search_engine.usearch_engine.USearchVectorSearchEngine",
         ) as mock_usearch_cls,
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        await builder.get_vector_store("vs1", indexed_properties={})
+        await builder.get_vector_store(
+            "vs1", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
         # Invoke the factory the manager passed into params and confirm it
         # routes to the USearch engine.
@@ -851,11 +888,18 @@ async def test_sqlite_vector_store_caches_after_first_call():
             "memmachine_server.common.vector_store.sqlite_vector_store.SQLiteVectorStore",
         ) as mock_store_cls,
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
+        mock_store_cls.return_value.vector_dimensions = 3
+        mock_store_cls.return_value.indexed_properties = {}
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        first = await builder.get_vector_store("vs1", indexed_properties={})
-        second = await builder.get_vector_store("vs1", indexed_properties={})
+        first = await builder.get_vector_store(
+            "vs1", collection="c", vector_dimensions=3, indexed_properties={}
+        )
+        second = await builder.get_vector_store(
+            "vs1", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
     assert first is second
     assert mock_create.call_count == 1
@@ -889,10 +933,12 @@ async def test_sqlite_vector_store_startup_failure_disposes_engine():
         )
         builder = DatabaseManager(conf)
         with pytest.raises(VectorStoreConfigurationError, match="failed to start"):
-            await builder.get_vector_store("vs1", indexed_properties={})
+            await builder.get_vector_store(
+                "vs1", collection="c", vector_dimensions=3, indexed_properties={}
+            )
 
     mock_engine.dispose.assert_awaited_once()
-    assert "vs1" not in builder.vector_stores
+    assert ("vs1", "c") not in builder.vector_stores
     assert "vs1" not in builder.vector_store_sql_engines
 
 
@@ -901,7 +947,9 @@ async def test_sqlite_vector_store_unknown_name_raises():
     conf = _sqlite_vector_store_only_conf()
     builder = DatabaseManager(conf)
     with pytest.raises(ValueError, match="VectorStore 'missing' not found"):
-        await builder.get_vector_store("missing", indexed_properties={})
+        await builder.get_vector_store(
+            "missing", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
 
 @pytest.mark.asyncio
@@ -926,10 +974,13 @@ async def test_sqlite_vec_vector_store_creates_store_and_engine():
             "memmachine_server.common.vector_store.sqlite_vec_vector_store.SQLiteVecVectorStore",
         ) as mock_store_cls,
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        store = await builder.get_vector_store("vec1", indexed_properties={})
+        store = await builder.get_vector_store(
+            "vec1", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
     assert store is mock_store_cls.return_value
     create_args = mock_create.call_args
@@ -937,10 +988,12 @@ async def test_sqlite_vec_vector_store_creates_store_and_engine():
 
     params_kwargs = mock_params_cls.call_args.kwargs
     assert params_kwargs["engine"] is mock_engine
+    assert params_kwargs["collection"] == "c"
+    assert params_kwargs["vector_dimensions"] == 3
     assert params_kwargs["indexed_properties"] == {}
 
     mock_store_cls.return_value.startup.assert_awaited_once()
-    assert "vec1" in builder.vector_stores
+    assert ("vec1", "c") in builder.vector_stores
     assert "vec1" in builder.vector_store_sql_engines
 
 
@@ -949,7 +1002,9 @@ async def test_sqlite_vec_vector_store_unknown_name_raises():
     conf = _sqlite_vector_store_only_conf()
     builder = DatabaseManager(conf)
     with pytest.raises(ValueError, match="VectorStore 'missing' not found"):
-        await builder.get_vector_store("missing", indexed_properties={})
+        await builder.get_vector_store(
+            "missing", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
 
 @pytest.mark.asyncio
@@ -981,13 +1036,19 @@ async def test_get_vector_store_dispatches_to_sqlite_backends():
             "memmachine_server.common.vector_store.sqlite_vec_vector_store.SQLiteVecVectorStore",
         ) as mock_vec_cls,
     ):
+        mock_vs_cls.return_value.provision = AsyncMock()
         mock_vs_cls.return_value.startup = AsyncMock()
         mock_vs_cls.return_value.shutdown = AsyncMock()
+        mock_vec_cls.return_value.provision = AsyncMock()
         mock_vec_cls.return_value.startup = AsyncMock()
         mock_vec_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        vs = await builder.get_vector_store("vs1", indexed_properties={})
-        vec = await builder.get_vector_store("vec1", indexed_properties={})
+        vs = await builder.get_vector_store(
+            "vs1", collection="c", vector_dimensions=3, indexed_properties={}
+        )
+        vec = await builder.get_vector_store(
+            "vec1", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
     assert vs is mock_vs_cls.return_value
     assert vec is mock_vec_cls.return_value
@@ -998,7 +1059,9 @@ async def test_get_vector_store_unknown_name_raises():
     conf = _sqlite_vector_store_only_conf()
     builder = DatabaseManager(conf)
     with pytest.raises(ValueError, match="VectorStore 'missing' not found"):
-        await builder.get_vector_store("missing", indexed_properties={})
+        await builder.get_vector_store(
+            "missing", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
 
 @pytest.mark.asyncio
@@ -1023,12 +1086,15 @@ async def test_close_disposes_vector_store_engines_and_shuts_down_stores():
             "memmachine_server.common.vector_store.sqlite_vector_store.SQLiteVectorStore",
         ) as mock_store_cls,
     ):
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         mock_store_cls.return_value.shutdown = AsyncMock()
         builder = DatabaseManager(conf)
-        await builder.get_vector_store("vs1", indexed_properties={})
+        await builder.get_vector_store(
+            "vs1", collection="c", vector_dimensions=3, indexed_properties={}
+        )
 
-        assert "vs1" in builder.vector_stores
+        assert ("vs1", "c") in builder.vector_stores
         assert "vs1" in builder.vector_store_sql_engines
 
         await builder.close()
@@ -1072,10 +1138,14 @@ async def test_get_vector_store_merges_configured_and_system_keys():
     conf = _sqlite_conf_with_properties({"category": "str", "score": "float"})
     engine_patch, params_patch, store_patch = _patched_sqlite_store()
     with engine_patch, params_patch as mock_params_cls, store_patch as mock_store_cls:
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
         await builder.get_vector_store(
-            "vs1", indexed_properties={"memmachine_event_timestamp": datetime}
+            "vs1",
+            collection="c",
+            vector_dimensions=3,
+            indexed_properties={"memmachine_event_timestamp": datetime},
         )
     assert mock_params_cls.call_args.kwargs["indexed_properties"] == {
         "category": str,
@@ -1090,11 +1160,15 @@ async def test_get_vector_store_rejects_a_configured_key_of_another_type():
     conf = _sqlite_conf_with_properties({"memmachine_event_timestamp": "str"})
     engine_patch, params_patch, store_patch = _patched_sqlite_store()
     with engine_patch, params_patch, store_patch as mock_store_cls:
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
         with pytest.raises(VectorStoreConfigurationError, match="configures"):
             await builder.get_vector_store(
-                "vs1", indexed_properties={"memmachine_event_timestamp": datetime}
+                "vs1",
+                collection="c",
+                vector_dimensions=3,
+                indexed_properties={"memmachine_event_timestamp": datetime},
             )
 
 
@@ -1103,32 +1177,85 @@ async def test_get_vector_store_rejects_an_invalid_configured_key():
     conf = _sqlite_conf_with_properties({"Bad Key": "str"})
     engine_patch, params_patch, store_patch = _patched_sqlite_store()
     with engine_patch, params_patch, store_patch as mock_store_cls:
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
         builder = DatabaseManager(conf)
         with pytest.raises(VectorStoreConfigurationError, match="indexed_properties"):
-            await builder.get_vector_store("vs1", indexed_properties={})
+            await builder.get_vector_store(
+                "vs1", collection="c", vector_dimensions=3, indexed_properties={}
+            )
 
 
 @pytest.mark.asyncio
-async def test_get_vector_store_is_not_shared_between_services():
-    """A second service whose keys the built store does not declare is refused."""
+async def test_a_collection_is_one_store():
+    """The same collection asked for with other dimensions or keys is refused."""
     conf = _sqlite_conf_with_properties({})
     engine_patch, params_patch, store_patch = _patched_sqlite_store()
     with engine_patch, params_patch, store_patch as mock_store_cls:
+        mock_store_cls.return_value.provision = AsyncMock()
         mock_store_cls.return_value.startup = AsyncMock()
+        mock_store_cls.return_value.vector_dimensions = 3
         mock_store_cls.return_value.indexed_properties = {
             "memmachine_event_session": str
         }
         builder = DatabaseManager(conf)
         first = await builder.get_vector_store(
-            "vs1", indexed_properties={"memmachine_event_session": str}
+            "vs1",
+            collection="c",
+            vector_dimensions=3,
+            indexed_properties={"memmachine_event_session": str},
         )
-        # The same service, or one declaring a subset, gets the same store.
+        # The same cell again is the same store.
         assert (
             await builder.get_vector_store(
-                "vs1", indexed_properties={"memmachine_event_session": str}
+                "vs1",
+                collection="c",
+                vector_dimensions=3,
+                indexed_properties={"memmachine_event_session": str},
             )
             is first
         )
-        with pytest.raises(VectorStoreConfigurationError, match="another service"):
-            await builder.get_vector_store("vs1", indexed_properties={"set_id": str})
+        with pytest.raises(
+            VectorStoreConfigurationError, match="one collection is one store"
+        ):
+            await builder.get_vector_store(
+                "vs1",
+                collection="c",
+                vector_dimensions=3,
+                indexed_properties={"set_id": str},
+            )
+        with pytest.raises(
+            VectorStoreConfigurationError, match="one collection is one store"
+        ):
+            await builder.get_vector_store(
+                "vs1",
+                collection="c",
+                vector_dimensions=4,
+                indexed_properties={"memmachine_event_session": str},
+            )
+
+
+@pytest.mark.asyncio
+async def test_collections_on_one_backend_share_its_engine():
+    conf = _sqlite_conf_with_properties({})
+    engine_patch, params_patch, store_patch = _patched_sqlite_store()
+    with (
+        engine_patch as mock_create,
+        params_patch as mock_params_cls,
+        store_patch as mock_store_cls,
+    ):
+        mock_store_cls.return_value.provision = AsyncMock()
+        mock_store_cls.return_value.startup = AsyncMock()
+        builder = DatabaseManager(conf)
+        await builder.get_vector_store(
+            "vs1", collection="episodic", vector_dimensions=3, indexed_properties={}
+        )
+        await builder.get_vector_store(
+            "vs1", collection="semantic", vector_dimensions=2, indexed_properties={}
+        )
+    assert mock_create.call_count == 1
+    assert [call.kwargs["collection"] for call in mock_params_cls.call_args_list] == [
+        "episodic",
+        "semantic",
+    ]
+    assert set(builder.vector_stores) == {("vs1", "episodic"), ("vs1", "semantic")}

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_semantic_manager_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_semantic_manager_vector_store.py
@@ -10,6 +10,7 @@ from memmachine_server.common.configuration import (
     SemanticMemoryStorageBackend,
 )
 from memmachine_server.common.resource_manager.semantic_manager import (
+    _SEMANTIC_INDEXED_PROPERTIES,
     SemanticResourceManager,
 )
 from memmachine_server.semantic_memory.storage.vector_store_semantic_storage import (
@@ -48,7 +49,9 @@ async def test_semantic_manager_builds_vector_store_backend(sqlalchemy_sqlite_en
     resource_manager.get_sql_engine.assert_awaited_once_with(
         "semantic_db", validate=True
     )
-    resource_manager.get_vector_store.assert_awaited_once_with("semantic_vectors")
+    resource_manager.get_vector_store.assert_awaited_once_with(
+        "semantic_vectors", indexed_properties=_SEMANTIC_INDEXED_PROPERTIES
+    )
     vector_store.open_or_create_collection.assert_awaited_once()
 
     await storage.cleanup()

--- a/packages/server/server_tests/memmachine_server/common/resource_manager/test_semantic_manager_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/resource_manager/test_semantic_manager_vector_store.py
@@ -21,8 +21,8 @@ from memmachine_server.semantic_memory.storage.vector_store_semantic_storage imp
 @pytest.mark.asyncio
 async def test_semantic_manager_builds_vector_store_backend(sqlalchemy_sqlite_engine):
     vector_store = MagicMock()
-    vector_collection = MagicMock()
-    vector_store.open_or_create_collection = AsyncMock(return_value=vector_collection)
+    vector_partition = MagicMock()
+    vector_store.get_partition = AsyncMock(return_value=vector_partition)
 
     resource_manager = MagicMock()
     resource_manager.get_sql_engine = AsyncMock(return_value=sqlalchemy_sqlite_engine)
@@ -49,9 +49,14 @@ async def test_semantic_manager_builds_vector_store_backend(sqlalchemy_sqlite_en
     resource_manager.get_sql_engine.assert_awaited_once_with(
         "semantic_db", validate=True
     )
+    # One collection per embedder, built for semantic memory's keys.
     resource_manager.get_vector_store.assert_awaited_once_with(
-        "semantic_vectors", indexed_properties=_SEMANTIC_INDEXED_PROPERTIES
+        "semantic_vectors",
+        collection="semantic_memory__embedder",
+        vector_dimensions=2,
+        indexed_properties=_SEMANTIC_INDEXED_PROPERTIES,
     )
-    vector_store.open_or_create_collection.assert_awaited_once()
+    vector_store.get_partition.assert_awaited_once_with("semantic_memory")
+    vector_store.create_partition.assert_not_called()
 
     await storage.cleanup()

--- a/packages/server/server_tests/memmachine_server/common/test_property_keys.py
+++ b/packages/server/server_tests/memmachine_server/common/test_property_keys.py
@@ -1,0 +1,37 @@
+"""Tests for the reserved property key namespace."""
+
+import pytest
+
+from memmachine_server.common.property_keys import (
+    RESERVED_PROPERTY_KEY_PREFIX,
+    is_reserved_property_key,
+    reserved_property_key,
+    validate_caller_property_key,
+)
+
+
+def test_reserved_key_is_prefix_system_field():
+    assert reserved_property_key("event", "timestamp") == "memmachine_event_timestamp"
+    assert is_reserved_property_key("memmachine_event_timestamp")
+    assert not is_reserved_property_key("timestamp")
+
+
+def test_reserved_key_overrunning_the_budget_fails_at_build_time():
+    with pytest.raises(ValueError, match="naming contract"):
+        reserved_property_key("event", "a_field_name_far_too_long_for_it")
+
+
+def test_caller_key_in_the_reserved_namespace_is_rejected():
+    with pytest.raises(ValueError, match="reserved"):
+        validate_caller_property_key(f"{RESERVED_PROPERTY_KEY_PREFIX}mine")
+
+
+@pytest.mark.parametrize("key", ["Color", "m.color", "a" * 33, ""])
+def test_caller_key_outside_the_naming_contract_is_rejected(key):
+    with pytest.raises(ValueError, match=r"\[a-z0-9_\]"):
+        validate_caller_property_key(key)
+
+
+@pytest.mark.parametrize("key", ["color", "_episode_uid", "a" * 32])
+def test_legal_caller_key_passes(key):
+    validate_caller_property_key(key)

--- a/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_nebula_graph_vector_graph_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_nebula_graph_vector_graph_store.py
@@ -9,17 +9,12 @@ import pytest_asyncio
 # Skip all tests if nebulagraph_python is not installed
 pytest.importorskip("nebulagraph_python")
 
-from memmachine_server.common.filter.filter_parser import (
-    And as FilterAnd,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Comparison as FilterComparison,
-)
-from memmachine_server.common.filter.filter_parser import (
-    IsNull as FilterIsNull,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Or as FilterOr,
+from memmachine_server.common.filter import (
+    And,
+    Equals,
+    IsMissing,
+    Or,
+    Ordering,
 )
 from memmachine_server.common.metrics_factory.prometheus_metrics_factory import (
     PrometheusMetricsFactory,
@@ -339,7 +334,7 @@ async def test_search_similar_nodes_with_filter(vector_graph_store):
 
     # Search with filter
     query_vec = [1.0, 0.0, 0.0]
-    filter_expr = FilterComparison(field="category", op="=", value="tech")
+    filter_expr = Equals(field="category", value="tech")
 
     results = await vector_graph_store.search_similar_nodes(
         collection=collection,
@@ -463,7 +458,7 @@ async def test_search_related_nodes(vector_graph_store):
         this_node_uid=bob.uid,
         find_targets=True,
         find_sources=False,
-        node_property_filter=FilterComparison(field="industry", op="=", value="tech"),
+        node_property_filter=Equals(field="industry", value="tech"),
     )
     assert len(results) == 1
     assert results[0].properties["name"] == "Acme"
@@ -476,7 +471,7 @@ async def test_search_related_nodes(vector_graph_store):
         this_node_uid=bob.uid,
         find_targets=True,
         find_sources=False,
-        edge_property_filter=FilterComparison(field="seniority", op="=", value=2),
+        edge_property_filter=Equals(field="seniority", value=2),
     )
     assert len(results) == 1
     assert results[0].properties["name"] == "Acme"
@@ -594,7 +589,7 @@ async def test_search_directional_nodes(vector_graph_store):
         order_ascending=[True],
         include_equal_start=False,
         limit=10,
-        property_filter=FilterComparison(field="tagged", op="=", value="yes"),
+        property_filter=Equals(field="tagged", value="yes"),
     )
     assert len(results) == 2
     assert all(r.properties["tagged"] == "yes" for r in results)
@@ -648,16 +643,18 @@ async def test_search_matching_nodes(vector_graph_store):
     # is_null filter: nodes with no "price" property
     results = await vector_graph_store.search_matching_nodes(
         collection=collection,
-        property_filter=FilterIsNull(field="price"),
+        property_filter=IsMissing(field="price"),
         limit=10,
     )
     assert len(results) == 1
     assert results[0].properties["name"] == "Desk"
 
     # AND filter: electronics AND price < 100
-    filter_expr = FilterAnd(
-        left=FilterComparison(field="category", op="=", value="electronics"),
-        right=FilterComparison(field="price", op="<", value=100),
+    filter_expr = And(
+        (
+            Equals(field="category", value="electronics"),
+            Ordering(field="price", op="<", value=100),
+        )
     )
     results = await vector_graph_store.search_matching_nodes(
         collection=collection,
@@ -821,12 +818,16 @@ async def test_complex_filters(vector_graph_store):
     await vector_graph_store.add_nodes(collection=collection, nodes=nodes)
 
     # Complex filter: (category == electronics AND price < 100) OR (category == furniture)
-    filter_expr = FilterOr(
-        left=FilterAnd(
-            left=FilterComparison(field="category", op="=", value="electronics"),
-            right=FilterComparison(field="price", op="<", value=100),
-        ),
-        right=FilterComparison(field="category", op="=", value="furniture"),
+    filter_expr = Or(
+        (
+            And(
+                (
+                    Equals(field="category", value="electronics"),
+                    Ordering(field="price", op="<", value=100),
+                )
+            ),
+            Equals(field="category", value="furniture"),
+        )
     )
 
     results = await vector_graph_store.search_matching_nodes(
@@ -1165,7 +1166,7 @@ async def test_property_names_with_special_characters(vector_graph_store):
     # Filtering by special-char property names works
     filtered = await vector_graph_store.search_matching_nodes(
         collection=collection,
-        property_filter=FilterComparison(field="my-field", op="=", value="hyphen"),
+        property_filter=Equals(field="my-field", value="hyphen"),
         limit=10,
     )
     assert len(filtered) == 1

--- a/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_neo4j_vector_graph_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_graph_store/test_neo4j_vector_graph_store.py
@@ -8,23 +8,15 @@ import pytest_asyncio
 from neo4j import AsyncGraphDatabase
 from testcontainers.neo4j import Neo4jContainer
 
-from memmachine_server.common.filter.filter_parser import (
-    And as FilterAnd,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Comparison as FilterComparison,
-)
-from memmachine_server.common.filter.filter_parser import (
-    In as FilterIn,
-)
-from memmachine_server.common.filter.filter_parser import (
-    IsNull as FilterIsNull,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Not as FilterNot,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Or as FilterOr,
+from memmachine_server.common.filter import (
+    And,
+    Equals,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
 )
 from memmachine_server.common.metrics_factory.prometheus_metrics_factory import (
     PrometheusMetricsFactory,
@@ -370,11 +362,7 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         query_embedding=[1.0, 0.0],
         embedding_name="embedding1",
         limit=5,
-        property_filter=FilterComparison(
-            field="include?",
-            op="=",
-            value="yes",
-        ),
+        property_filter=Equals(field="include?", value="yes"),
     )
     assert len(results) == 1
     assert results[0].properties["name"] == "Node2"
@@ -384,15 +372,13 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         query_embedding=[1.0, 0.0],
         embedding_name="embedding1",
         limit=5,
-        property_filter=FilterOr(
-            left=FilterComparison(
-                field="include?",
-                op="=",
-                value="yes",
-            ),
-            right=FilterIsNull(
-                field="include?",
-            ),
+        property_filter=Or(
+            (
+                Equals(field="include?", value="yes"),
+                IsMissing(
+                    field="include?",
+                ),
+            )
         ),
     )
     assert len(results) == 2
@@ -412,11 +398,7 @@ async def test_search_similar_nodes(vector_graph_store, vector_graph_store_ann):
         query_embedding=[1.0, 0.0],
         embedding_name="embedding2",
         limit=5,
-        property_filter=FilterComparison(
-            field="include?",
-            op="=",
-            value="yes",
-        ),
+        property_filter=Equals(field="include?", value="yes"),
     )
     assert len(results) == 1
     assert results[0].properties["name"] == "Node2"
@@ -548,11 +530,7 @@ async def test_search_related_nodes(vector_graph_store):
         other_collection="Entity",
         this_collection="Entity",
         this_node_uid=node1_uid,
-        node_property_filter=FilterComparison(
-            field="extra!",
-            op="=",
-            value="something",
-        ),
+        node_property_filter=Equals(field="extra!", value="something"),
     )
     assert len(results) == 1
     assert results[0].properties["name"] == "Node2"
@@ -584,11 +562,7 @@ async def test_search_related_nodes(vector_graph_store):
         other_collection="Entity",
         this_collection="Entity",
         this_node_uid=node3_uid,
-        node_property_filter=FilterComparison(
-            field="marker?",
-            op="=",
-            value="A",
-        ),
+        node_property_filter=Equals(field="marker?", value="A"),
     )
     assert len(results) == 1
     assert results[0].properties["name"] == "Node3"
@@ -598,15 +572,13 @@ async def test_search_related_nodes(vector_graph_store):
         other_collection="Entity",
         this_collection="Entity",
         this_node_uid=node3_uid,
-        node_property_filter=FilterOr(
-            left=FilterComparison(
-                field="marker?",
-                op="=",
-                value="A",
-            ),
-            right=FilterIsNull(
-                field="marker?",
-            ),
+        node_property_filter=Or(
+            (
+                Equals(field="marker?", value="A"),
+                IsMissing(
+                    field="marker?",
+                ),
+            )
         ),
     )
     assert len(results) == 2
@@ -616,11 +588,7 @@ async def test_search_related_nodes(vector_graph_store):
         other_collection="Entity",
         this_collection="Entity",
         this_node_uid=node3_uid,
-        edge_property_filter=FilterComparison(
-            field="extra",
-            op="=",
-            value=1,
-        ),
+        edge_property_filter=Equals(field="extra", value=1),
     )
     assert len(results) == 1
 
@@ -629,15 +597,13 @@ async def test_search_related_nodes(vector_graph_store):
         other_collection="Entity",
         this_collection="Entity",
         this_node_uid=node3_uid,
-        edge_property_filter=FilterOr(
-            left=FilterComparison(
-                field="extra",
-                op="=",
-                value=1,
-            ),
-            right=FilterIsNull(
-                field="extra",
-            ),
+        edge_property_filter=Or(
+            (
+                Equals(field="extra", value=1),
+                IsMissing(
+                    field="extra",
+                ),
+            )
         ),
     )
     assert len(results) == 2
@@ -728,11 +694,7 @@ async def test_search_directional_nodes(vector_graph_store):
         order_ascending=[True],
         include_equal_start=True,
         limit=2,
-        property_filter=FilterComparison(
-            field="include?",
-            op="=",
-            value="yes",
-        ),
+        property_filter=Equals(field="include?", value="yes"),
     )
     assert len(results) == 2
     assert results[0].properties["name"] == "Event2"
@@ -1102,7 +1064,7 @@ async def test_search_matching_nodes(vector_graph_store):
 
     results = await vector_graph_store.search_matching_nodes(
         collection="Robot",
-        property_filter=FilterIsNull(
+        property_filter=IsMissing(
             field="none_value",
         ),
     )
@@ -1110,79 +1072,53 @@ async def test_search_matching_nodes(vector_graph_store):
 
     results = await vector_graph_store.search_matching_nodes(
         collection="Robot",
-        property_filter=FilterComparison(
-            field="none_value",
-            op="=",
-            value="something",
-        ),
+        property_filter=Equals(field="none_value", value="something"),
     )
     assert len(results) == 0
 
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterComparison(
-            field="city",
-            op="=",
-            value="New York",
-        ),
+        property_filter=Equals(field="city", value="New York"),
     )
     assert len(results) == 2
 
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterAnd(
-            left=FilterComparison(
-                field="city",
-                op="=",
-                value="San Francisco",
-            ),
-            right=FilterComparison(
-                field="age!with$pecialchars",
-                op="=",
-                value=20,
-            ),
+        property_filter=And(
+            (
+                Equals(field="city", value="San Francisco"),
+                Equals(field="age!with$pecialchars", value=20),
+            )
         ),
     )
     assert len(results) == 0
 
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterAnd(
-            left=FilterComparison(
-                field="city",
-                op="=",
-                value="New York",
-            ),
-            right=FilterComparison(
-                field="age!with$pecialchars",
-                op="=",
-                value=30,
-            ),
+        property_filter=And(
+            (
+                Equals(field="city", value="New York"),
+                Equals(field="age!with$pecialchars", value=30),
+            )
         ),
     )
     assert len(results) == 1
 
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterComparison(
-            field="age!with$pecialchars",
-            op="=",
-            value=30,
-        ),
+        property_filter=Equals(field="age!with$pecialchars", value=30),
     )
     assert len(results) == 2
 
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterOr(
-            left=FilterComparison(
-                field="age!with$pecialchars",
-                op="=",
-                value=30,
-            ),
-            right=FilterIsNull(
-                field="age!with$pecialchars",
-            ),
+        property_filter=Or(
+            (
+                Equals(field="age!with$pecialchars", value=30),
+                IsMissing(
+                    field="age!with$pecialchars",
+                ),
+            )
         ),
     )
     assert len(results) == 3
@@ -1190,26 +1126,20 @@ async def test_search_matching_nodes(vector_graph_store):
     # Should only include Alice.
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterComparison(
-            field="title",
-            op="=",
-            value="Engineer",
-        ),
+        property_filter=Equals(field="title", value="Engineer"),
     )
     assert len(results) == 1
 
     # Should include Alice and all Person nodes without the "title" property.
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterOr(
-            left=FilterComparison(
-                field="title",
-                op="=",
-                value="Engineer",
-            ),
-            right=FilterIsNull(
-                field="title",
-            ),
+        property_filter=Or(
+            (
+                Equals(field="title", value="Engineer"),
+                IsMissing(
+                    field="title",
+                ),
+            )
         ),
     )
     assert len(results) == 3
@@ -1256,64 +1186,44 @@ async def test_search_matching_nodes_extended_filters(vector_graph_store):
     # != on city
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterComparison(
-            field="city",
-            op="!=",
-            value="New York",
-        ),
+        property_filter=NotEquals(field="city", value="New York"),
     )
     assert len(results) == 2
 
     # > on age
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterComparison(
-            field="age",
-            op=">",
-            value=25,
-        ),
+        property_filter=Ordering(field="age", op=">", value=25),
     )
     assert len(results) == 2
 
     # < on age
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterComparison(
-            field="age",
-            op="<",
-            value=30,
-        ),
+        property_filter=Ordering(field="age", op="<", value=30),
     )
     assert len(results) == 1
 
     # >= on age
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterComparison(
-            field="age",
-            op=">=",
-            value=30,
-        ),
+        property_filter=Ordering(field="age", op=">=", value=30),
     )
     assert len(results) == 2
 
     # <= on age
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterComparison(
-            field="age",
-            op="<=",
-            value=25,
-        ),
+        property_filter=Ordering(field="age", op="<=", value=25),
     )
     assert len(results) == 1
 
     # In on city
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterIn(
+        property_filter=In(
             field="city",
-            values=["San Francisco", "Los Angeles"],
+            values=("San Francisco", "Los Angeles"),
         ),
     )
     assert len(results) == 2
@@ -1321,13 +1231,7 @@ async def test_search_matching_nodes_extended_filters(vector_graph_store):
     # Not
     results = await vector_graph_store.search_matching_nodes(
         collection="Person",
-        property_filter=FilterNot(
-            expr=FilterComparison(
-                field="city",
-                op="=",
-                value="New York",
-            )
-        ),
+        property_filter=Not(Equals(field="city", value="New York")),
     )
     assert len(results) == 2
 

--- a/packages/server/server_tests/memmachine_server/common/vector_store/declared_schema_contract.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/declared_schema_contract.py
@@ -1,0 +1,197 @@
+"""
+The declared-schema contract every vector store collection satisfies.
+
+Each store's test module mixes `DeclaredSchemaContract` into a test class
+and supplies the `collection` fixture: a collection of a store declaring
+`INDEXED_PROPERTIES` (`name: str`, `age: int`, `score: float`,
+`active: bool`, `created_at: datetime`). Ranking is asserted as a contract
+(which records a filtered search admits), never as an exact list.
+"""
+
+import math
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from memmachine_server.common.filter import (
+    And,
+    Equals,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
+)
+from memmachine_server.common.vector_store import (
+    PropertyTypeMismatchError,
+    Record,
+    UndeclaredPropertyKeyError,
+)
+
+_LIMIT = 100
+
+
+def _unit(vector: list[float]) -> list[float]:
+    magnitude = math.sqrt(sum(x * x for x in vector))
+    return [x / magnitude for x in vector]
+
+
+def _record(vector: list[float], **properties) -> Record:
+    return Record(uuid=uuid4(), vector=_unit(vector), properties=properties)
+
+
+async def _admitted(collection, property_filter, *, limit=_LIMIT) -> set:
+    [result] = await collection.query(
+        query_vectors=[_unit([1.0, 0.0, 0.0])],
+        limit=limit,
+        property_filter=property_filter,
+    )
+    return {match.record_uuid for match in result.matches}
+
+
+class DeclaredSchemaContract:
+    """Mix into a store's test class; requires an async `collection` fixture."""
+
+    @pytest.mark.asyncio
+    async def test_upsert_rejects_an_undeclared_key(self, collection):
+        with pytest.raises(UndeclaredPropertyKeyError, match="color"):
+            await collection.upsert(records=[_record([1.0, 0.0, 0.0], color="red")])
+
+    @pytest.mark.asyncio
+    async def test_upsert_rejects_a_value_of_another_type(self, collection):
+        with pytest.raises(PropertyTypeMismatchError, match="age"):
+            await collection.upsert(records=[_record([1.0, 0.0, 0.0], age="5")])
+        # A bool is an int at runtime and is still not one here.
+        with pytest.raises(PropertyTypeMismatchError, match="age"):
+            await collection.upsert(records=[_record([1.0, 0.0, 0.0], age=True)])
+
+    @pytest.mark.asyncio
+    async def test_query_rejects_an_undeclared_key(self, collection):
+        with pytest.raises(UndeclaredPropertyKeyError, match="color"):
+            await _admitted(collection, Equals(field="color", value="red"))
+        with pytest.raises(UndeclaredPropertyKeyError, match="color"):
+            await _admitted(
+                collection,
+                And((Equals(field="name", value="a"), IsMissing(field="color"))),
+            )
+
+    @pytest.mark.asyncio
+    async def test_every_supported_node_evaluates_during_a_search(self, collection):
+        held = _record([1.0, 0.0, 0.0], name="alice", age=30, score=1.5, active=True)
+        other = _record([0.0, 1.0, 0.0], name="bob", age=40)
+        lacking = _record([0.0, 0.0, 1.0])
+        await collection.upsert(records=[held, other, lacking])
+
+        expected = {
+            Equals: (Equals(field="name", value="alice"), {held.uuid}),
+            NotEquals: (NotEquals(field="name", value="alice"), {other.uuid}),
+            Ordering: (Ordering(field="age", op=">", value=35), {other.uuid}),
+            In: (In(field="name", values=("alice", "carol")), {held.uuid}),
+            IsMissing: (IsMissing(field="name"), {lacking.uuid}),
+            And: (
+                And(
+                    (Equals(field="name", value="alice"), Equals(field="age", value=30))
+                ),
+                {held.uuid},
+            ),
+            Or: (
+                Or(
+                    (
+                        Equals(field="name", value="alice"),
+                        Equals(field="name", value="bob"),
+                    )
+                ),
+                {held.uuid, other.uuid},
+            ),
+            Not: (Not(Equals(field="name", value="bob")), {held.uuid, lacking.uuid}),
+        }
+        assert set(expected) >= collection.supported_filter_nodes
+        for node, (property_filter, admitted) in expected.items():
+            assert node in collection.supported_filter_nodes
+            assert await _admitted(collection, property_filter) == admitted, node
+
+    @pytest.mark.asyncio
+    async def test_not_equals_excludes_absence_and_not_equals_includes_it(
+        self, collection
+    ):
+        holding = _record([1.0, 0.0, 0.0], name="alice")
+        differing = _record([0.0, 1.0, 0.0], name="bob")
+        lacking = _record([0.0, 0.0, 1.0])
+        await collection.upsert(records=[holding, differing, lacking])
+
+        assert await _admitted(collection, NotEquals(field="name", value="alice")) == {
+            differing.uuid
+        }
+        assert await _admitted(
+            collection, Not(Equals(field="name", value="alice"))
+        ) == {
+            differing.uuid,
+            lacking.uuid,
+        }
+
+    @pytest.mark.asyncio
+    async def test_is_missing_matches_absence(self, collection):
+        holding = _record([1.0, 0.0, 0.0], name="alice", age=30)
+        lacking = _record([0.0, 1.0, 0.0], age=31)
+        await collection.upsert(records=[holding, lacking])
+
+        assert await _admitted(collection, IsMissing(field="name")) == {lacking.uuid}
+        assert await _admitted(collection, Not(IsMissing(field="name"))) == {
+            holding.uuid
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_predicate_of_another_type_matches_nothing(self, collection):
+        held = _record([1.0, 0.0, 0.0], name="5", age=5)
+        await collection.upsert(records=[held])
+
+        assert await _admitted(collection, Equals(field="age", value="5")) == set()
+        assert await _admitted(collection, Equals(field="name", value=5)) == set()
+        assert await _admitted(collection, Equals(field="age", value=5)) == {held.uuid}
+
+    @pytest.mark.asyncio
+    async def test_datetime_bounds_hold_at_microsecond_precision(self, collection):
+        base = datetime(2024, 3, 1, 12, 0, 0, tzinfo=UTC)
+        instants = [base + timedelta(microseconds=offset) for offset in range(3)]
+        records = [
+            _record([1.0, 0.0, 0.0], created_at=instants[0]),
+            _record([0.0, 1.0, 0.0], created_at=instants[1]),
+            _record([0.0, 0.0, 1.0], created_at=instants[2]),
+        ]
+        await collection.upsert(records=records)
+
+        assert await _admitted(
+            collection, Ordering(field="created_at", op=">=", value=instants[1])
+        ) == {records[1].uuid, records[2].uuid}
+        assert await _admitted(
+            collection, Ordering(field="created_at", op="<", value=instants[1])
+        ) == {records[0].uuid}
+        assert await _admitted(
+            collection, Equals(field="created_at", value=instants[1])
+        ) == {records[1].uuid}
+
+    @pytest.mark.asyncio
+    async def test_a_bound_in_another_zone_is_the_same_instant(self, collection):
+        instant = datetime(2024, 3, 1, 12, 0, 0, tzinfo=UTC)
+        record = _record([1.0, 0.0, 0.0], created_at=instant)
+        await collection.upsert(records=[record])
+
+        from datetime import timezone
+
+        same_instant = instant.astimezone(timezone(timedelta(hours=-8)))
+        assert await _admitted(
+            collection, Equals(field="created_at", value=same_instant)
+        ) == {record.uuid}
+
+    @pytest.mark.asyncio
+    async def test_the_filter_is_evaluated_during_the_search(self, collection):
+        """A filtered search finds an admitted record behind nearer excluded ones."""
+        near = [_record([1.0, 0.01 * i, 0.0], name="near") for i in range(1, 6)]
+        far = _record([0.0, 1.0, 0.0], name="far")
+        await collection.upsert(records=[*near, far])
+
+        assert await _admitted(
+            collection, Equals(field="name", value="far"), limit=1
+        ) == {far.uuid}

--- a/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_collection.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_collection.py
@@ -2,19 +2,24 @@
 
 import math
 import operator
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
+from datetime import datetime
+from typing import override
 from uuid import UUID
 
-from memmachine_server.common.data_types import PropertyValue
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.data_types import PropertyType, PropertyValue
+from memmachine_server.common.filter import (
     And,
-    Comparison,
+    Equals,
     FilterExpr,
     In,
-    IsNull,
+    IsMissing,
     Not,
+    NotEquals,
     Or,
+    Ordering,
 )
+from memmachine_server.common.utils import ensure_tz_aware
 from memmachine_server.common.vector_store import VectorStoreCollection
 from memmachine_server.common.vector_store.data_types import (
     QueryMatch,
@@ -22,14 +27,16 @@ from memmachine_server.common.vector_store.data_types import (
     Record,
     VectorStoreCollectionConfig,
 )
+from memmachine_server.common.vector_store.declared_properties import (
+    require_declared_properties,
+    require_supported_filter,
+)
 
 # ---------------------------------------------------------------------------
 # Filter evaluation
 # ---------------------------------------------------------------------------
 
-_COMPARISON_OPS = {
-    "=": operator.eq,
-    "!=": operator.ne,
+_ORDERING_OPS = {
     ">": operator.gt,
     "<": operator.lt,
     ">=": operator.ge,
@@ -37,37 +44,49 @@ _COMPARISON_OPS = {
 }
 
 
-def _evaluate_comparison(prop: PropertyValue, op: str, value: PropertyValue) -> bool:
-    fn = _COMPARISON_OPS.get(op)
-    if fn is None:
-        raise ValueError(f"Unknown comparison op: {op!r}")
-    return bool(fn(prop, value))
+def _comparable(value: PropertyValue) -> PropertyValue:
+    return ensure_tz_aware(value) if isinstance(value, datetime) else value
 
 
-def evaluate_filter(expr: FilterExpr, properties: dict[str, PropertyValue]) -> bool:
-    """Evaluate a FilterExpr against a properties dict."""
+def _same_type(held: PropertyValue, value: PropertyValue) -> bool:
+    # A predicate matches only a value of the compared type; `bool` is an
+    # `int` at runtime and its own type here.
+    return type(held) is type(value)
+
+
+def evaluate_filter(expr: FilterExpr, properties: Mapping[str, PropertyValue]) -> bool:
+    """Evaluate a FilterExpr against a properties mapping, by the language's semantics."""
     match expr:
-        case Comparison(field=field, op=op, value=value):
-            prop = properties.get(field)
-            if prop is None:
+        case Equals(field, value):
+            held = properties.get(field)
+            return (
+                held is not None
+                and _same_type(held, value)
+                and _comparable(held) == _comparable(value)
+            )
+        case NotEquals(field, value):
+            held = properties.get(field)
+            return (
+                held is not None
+                and _same_type(held, value)
+                and _comparable(held) != _comparable(value)
+            )
+        case Ordering(field, op, value):
+            held = properties.get(field)
+            if held is None or not _same_type(held, value):
                 return False
-            return _evaluate_comparison(prop, op, value)
-        case In(field=field, values=values):
-            return properties.get(field) in values
-        case IsNull(field=field):
+            return bool(_ORDERING_OPS[op](_comparable(held), _comparable(value)))
+        case In(field, values):
+            held = properties.get(field)
+            return held is not None and _same_type(held, values[0]) and held in values
+        case IsMissing(field):
             return field not in properties
-        case And(left=left, right=right):
-            return evaluate_filter(left, properties) and evaluate_filter(
-                right, properties
-            )
-        case Or(left=left, right=right):
-            return evaluate_filter(left, properties) or evaluate_filter(
-                right, properties
-            )
-        case Not(expr=inner):
-            return not evaluate_filter(inner, properties)
-        case _:
-            raise TypeError(f"Unknown filter expression type: {type(expr)}")
+        case And(operands):
+            return all(evaluate_filter(o, properties) for o in operands)
+        case Or(operands):
+            return any(evaluate_filter(o, properties) for o in operands)
+        case Not(operand):
+            return not evaluate_filter(operand, properties)
 
 
 # ---------------------------------------------------------------------------
@@ -96,42 +115,80 @@ def _cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
 class InMemoryVectorStoreCollection(VectorStoreCollection):
     """In-memory VectorStoreCollection for testing.
 
-    Scores by cosine similarity and evaluates FilterExpr on record properties.
+    Scores by cosine similarity, evaluates FilterExpr on record properties,
+    and enforces the declared schema the way a real store does.
     """
 
-    def __init__(self, collection_config: VectorStoreCollectionConfig) -> None:
+    _SUPPORTED_FILTER_NODES = frozenset(
+        {Equals, NotEquals, Ordering, In, IsMissing, And, Or, Not}
+    )
+
+    def __init__(
+        self,
+        collection_config: VectorStoreCollectionConfig,
+        indexed_properties: Mapping[str, PropertyType],
+        *,
+        supported_filter_nodes: Iterable[type] | None = None,
+    ) -> None:
         self.collection_config = collection_config
+        self._indexed_properties = dict(indexed_properties)
+        self._supported_filter_nodes = (
+            frozenset(supported_filter_nodes)
+            if supported_filter_nodes is not None
+            else InMemoryVectorStoreCollection._SUPPORTED_FILTER_NODES
+        )
         self.records: dict[UUID, Record] = {}
+        self.queries: list[FilterExpr | None] = []
+        """The property filter of each query, in order, for tests that assert routing."""
 
     @property
+    @override
     def config(self) -> VectorStoreCollectionConfig:
         return self.collection_config
 
+    @property
+    @override
+    def indexed_properties(self) -> Mapping[str, PropertyType]:
+        return self._indexed_properties
+
+    @property
+    @override
+    def supported_filter_nodes(self) -> frozenset[type]:
+        return self._supported_filter_nodes
+
+    @override
     async def upsert(self, *, records: Iterable[Record]) -> None:
+        records = list(records)
+        for record in records:
+            require_declared_properties(record.properties, self._indexed_properties)
         for record in records:
             self.records[record.uuid] = Record(
                 uuid=record.uuid,
-                vector=list(record.vector) if record.vector is not None else None,
-                properties=dict(record.properties) if record.properties else {},
+                vector=list(record.vector),
+                properties=dict(record.properties),
             )
 
+    @override
     async def query(
         self,
         *,
         query_vectors: Iterable[Sequence[float]],
+        limit: int,
         min_cosine_similarity: float | None = None,
-        limit: int | None = None,
         property_filter: FilterExpr | None = None,
     ) -> list[QueryResult]:
+        if property_filter is not None:
+            require_supported_filter(
+                property_filter, self._indexed_properties, self._supported_filter_nodes
+            )
+        self.queries.append(property_filter)
         results: list[QueryResult] = []
         for query_vector in query_vectors:
             qv = list(query_vector)
             matches: list[QueryMatch] = []
             for record in self.records.values():
-                if record.vector is None:
-                    continue
                 if property_filter is not None and not evaluate_filter(
-                    property_filter, record.properties or {}
+                    property_filter, record.properties
                 ):
                     continue
                 cosine_similarity = _cosine_similarity(qv, record.vector)
@@ -147,11 +204,10 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
                     )
                 )
             matches.sort(key=lambda m: m.cosine_similarity, reverse=True)
-            if limit is not None:
-                matches = matches[:limit]
-            results.append(QueryResult(matches=matches))
+            results.append(QueryResult(matches=matches[:limit]))
         return results
 
+    @override
     async def delete(self, *, record_uuids: Iterable[UUID]) -> None:
         for uid in record_uuids:
             self.records.pop(uid, None)

--- a/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_partition.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/in_memory_vector_store_partition.py
@@ -1,4 +1,4 @@
-"""In-memory VectorStoreCollection implementation for testing."""
+"""In-memory VectorStorePartition implementation for testing."""
 
 import math
 import operator
@@ -20,12 +20,11 @@ from memmachine_server.common.filter import (
     Ordering,
 )
 from memmachine_server.common.utils import ensure_tz_aware
-from memmachine_server.common.vector_store import VectorStoreCollection
+from memmachine_server.common.vector_store import VectorStorePartition
 from memmachine_server.common.vector_store.data_types import (
     QueryMatch,
     QueryResult,
     Record,
-    VectorStoreCollectionConfig,
 )
 from memmachine_server.common.vector_store.declared_properties import (
     require_declared_properties,
@@ -108,12 +107,12 @@ def _cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
 
 
 # ---------------------------------------------------------------------------
-# InMemoryVectorStoreCollection
+# InMemoryVectorStorePartition
 # ---------------------------------------------------------------------------
 
 
-class InMemoryVectorStoreCollection(VectorStoreCollection):
-    """In-memory VectorStoreCollection for testing.
+class InMemoryVectorStorePartition(VectorStorePartition):
+    """In-memory VectorStorePartition for testing.
 
     Scores by cosine similarity, evaluates FilterExpr on record properties,
     and enforces the declared schema the way a real store does.
@@ -125,17 +124,17 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
 
     def __init__(
         self,
-        collection_config: VectorStoreCollectionConfig,
+        partition_key: str,
         indexed_properties: Mapping[str, PropertyType],
         *,
         supported_filter_nodes: Iterable[type] | None = None,
     ) -> None:
-        self.collection_config = collection_config
+        self._partition_key = partition_key
         self._indexed_properties = dict(indexed_properties)
         self._supported_filter_nodes = (
             frozenset(supported_filter_nodes)
             if supported_filter_nodes is not None
-            else InMemoryVectorStoreCollection._SUPPORTED_FILTER_NODES
+            else InMemoryVectorStorePartition._SUPPORTED_FILTER_NODES
         )
         self.records: dict[UUID, Record] = {}
         self.queries: list[FilterExpr | None] = []
@@ -143,8 +142,8 @@ class InMemoryVectorStoreCollection(VectorStoreCollection):
 
     @property
     @override
-    def config(self) -> VectorStoreCollectionConfig:
-        return self.collection_config
+    def partition_key(self) -> str:
+        return self._partition_key
 
     @property
     @override

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -15,13 +15,14 @@ DataType = pymilvus.DataType
 MilvusClient = pymilvus.MilvusClient
 
 from memmachine_server.common.data_types import PropertyValue
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
     And,
-    Comparison,
+    Equals,
     In,
-    IsNull,
+    IsMissing,
     Not,
     Or,
+    Ordering,
 )
 from memmachine_server.common.vector_store.data_types import (
     Record,
@@ -34,10 +35,22 @@ from memmachine_server.common.vector_store.milvus_vector_store import (
     MilvusVectorStoreCollection,
     MilvusVectorStoreParams,
 )
+from server_tests.memmachine_server.common.filter.nodes import comparison
+from server_tests.memmachine_server.common.vector_store.declared_schema_contract import (
+    DeclaredSchemaContract,
+)
 
 NAMESPACE = "test_namespace"
 NAME = "test_name"
 VECTOR_DIM = 3
+
+INDEXED_PROPERTIES: dict[str, type[PropertyValue]] = {
+    "name": str,
+    "age": int,
+    "score": float,
+    "active": bool,
+    "created_at": datetime,
+}
 
 
 def _normalize(vector: list[float]) -> list[float]:
@@ -82,7 +95,11 @@ def _make_record(
 async def store(tmp_path):
     client = MilvusClient(uri=str(tmp_path / "test_milvus.db"))
     vector_store = MilvusVectorStore(
-        MilvusVectorStoreParams(client=client, consistency_level="Session")
+        MilvusVectorStoreParams(
+            indexed_properties=INDEXED_PROPERTIES,
+            client=client,
+            consistency_level="Session",
+        )
     )
     await vector_store.startup()
     yield vector_store
@@ -97,13 +114,6 @@ async def collection(store):
         name=NAME,
         config=VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            indexed_properties_schema={
-                "name": str,
-                "age": int,
-                "score": float,
-                "active": bool,
-                "created_at": datetime,
-            },
         ),
     )
     coll = await store.open_collection(namespace=NAMESPACE, name=NAME)
@@ -179,10 +189,8 @@ class TestCollectionLifecycle:
 
     @pytest.mark.asyncio
     async def test_same_config_shares_native_collection(self, store):
-        schema: dict[str, type[PropertyValue]] = {"name": str}
         config = VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            indexed_properties_schema=schema,
         )
         await store.create_collection(namespace=NAMESPACE, name="coll_a", config=config)
         await store.create_collection(namespace=NAMESPACE, name="coll_b", config=config)
@@ -215,7 +223,6 @@ class TestCollectionLifecycle:
         assert fields["partition_key"]["is_partition_key"] is True
         assert fields["vector"]["type"] == DataType.FLOAT_VECTOR
         assert fields["vector"]["params"]["dim"] == VECTOR_DIM
-        assert fields["properties"]["type"] == DataType.JSON
 
         await store.delete_collection(namespace=NAMESPACE, name="schema")
 
@@ -334,7 +341,7 @@ class TestUpsertAndQuery:
         results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=IsNull(field="name"),
+            property_filter=IsMissing(field="name"),
         )
         assert {match.record_uuid for match in results[0].matches} == {record.uuid}
 
@@ -370,6 +377,10 @@ class TestUpsertAndQuery:
         assert results[0].matches[0].cosine_similarity == pytest.approx(1.0, abs=0.01)
 
 
+class TestDeclaredSchema(DeclaredSchemaContract):
+    """The declared-schema contract, against this store."""
+
+
 class TestFilters:
     async def _setup(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
@@ -394,7 +405,7 @@ class TestFilters:
         all_results = await collection.query(
             query_vectors=[query_vec],
             limit=10,
-            property_filter=Comparison(field=field, op=op, value=value),
+            property_filter=comparison(field, op, value),
         )
         return {match.record_uuid for match in all_results[0].matches}
 
@@ -450,14 +461,14 @@ class TestFilters:
         null_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=IsNull(field="name"),
+            property_filter=IsMissing(field="name"),
         )
         assert {m.record_uuid for m in null_results[0].matches} == {r_missing.uuid}
 
         not_null_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Not(expr=IsNull(field="name")),
+            property_filter=Not(IsMissing(field="name")),
         )
         assert {m.record_uuid for m in not_null_results[0].matches} == {
             r_has_value.uuid
@@ -470,7 +481,7 @@ class TestFilters:
         in_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=In(field="name", values=["alice", "carol"]),
+            property_filter=In(field="name", values=("alice", "carol")),
         )
         assert {m.record_uuid for m in in_results[0].matches} == {r1.uuid, r3.uuid}
 
@@ -478,8 +489,10 @@ class TestFilters:
             query_vectors=[v1],
             limit=10,
             property_filter=And(
-                left=Comparison(field="active", op="=", value=True),
-                right=Comparison(field="age", op=">", value=30),
+                (
+                    Equals(field="active", value=True),
+                    Ordering(field="age", op=">", value=30),
+                )
             ),
         )
         assert {m.record_uuid for m in and_results[0].matches} == {r3.uuid}
@@ -488,8 +501,7 @@ class TestFilters:
             query_vectors=[v1],
             limit=10,
             property_filter=Or(
-                left=Comparison(field="name", op="=", value="alice"),
-                right=Comparison(field="name", op="=", value="bob"),
+                (Equals(field="name", value="alice"), Equals(field="name", value="bob"))
             ),
         )
         assert {m.record_uuid for m in or_results[0].matches} == {r1.uuid, r2.uuid}
@@ -524,12 +536,12 @@ class TestPartitionIsolation:
         [only_a] = await coll_a.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Comparison(field="name", op="=", value="a"),
+            property_filter=Equals(field="name", value="a"),
         )
         [only_b] = await coll_b.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Comparison(field="name", op="=", value="b"),
+            property_filter=Equals(field="name", value="b"),
         )
         assert [m.record_uuid for m in only_a.matches] == [record_uuid]
         assert [m.record_uuid for m in only_b.matches] == [record_uuid]

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_milvus_vector_store.py
@@ -26,21 +26,19 @@ from memmachine_server.common.filter import (
 )
 from memmachine_server.common.vector_store.data_types import (
     Record,
-    VectorStoreCollectionAlreadyExistsError,
-    VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
+    VectorStorePartitionAlreadyExistsError,
 )
 from memmachine_server.common.vector_store.milvus_vector_store import (
     MilvusVectorStore,
-    MilvusVectorStoreCollection,
     MilvusVectorStoreParams,
+    MilvusVectorStorePartition,
 )
 from server_tests.memmachine_server.common.filter.nodes import comparison
 from server_tests.memmachine_server.common.vector_store.declared_schema_contract import (
     DeclaredSchemaContract,
 )
 
-NAMESPACE = "test_namespace"
+COLLECTION = "test_namespace"
 NAME = "test_name"
 VECTOR_DIM = 3
 
@@ -71,7 +69,7 @@ async def _present_uuids(collection, record_uuids) -> list[UUID]:
     record_uuids = list(record_uuids)
     if not record_uuids:
         return []
-    dimensions = collection.config.vector_dimensions
+    dimensions = VECTOR_DIM
     probe = [1.0] + [0.0] * (dimensions - 1)
     [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
     present = {match.record_uuid for match in result.matches}
@@ -96,11 +94,14 @@ async def store(tmp_path):
     client = MilvusClient(uri=str(tmp_path / "test_milvus.db"))
     vector_store = MilvusVectorStore(
         MilvusVectorStoreParams(
+            collection=COLLECTION,
+            vector_dimensions=VECTOR_DIM,
             indexed_properties=INDEXED_PROPERTIES,
             client=client,
             consistency_level="Session",
         )
     )
+    await vector_store.provision()
     await vector_store.startup()
     yield vector_store
     await vector_store.shutdown()
@@ -109,38 +110,24 @@ async def store(tmp_path):
 
 @pytest_asyncio.fixture
 async def collection(store):
-    await store.create_collection(
-        namespace=NAMESPACE,
-        name=NAME,
-        config=VectorStoreCollectionConfig(
-            vector_dimensions=VECTOR_DIM,
-        ),
-    )
-    coll = await store.open_collection(namespace=NAMESPACE, name=NAME)
+    await store.create_partition(NAME)
+    coll = await store.get_partition(NAME)
     assert coll is not None
     yield coll
-    await store.delete_collection(namespace=NAMESPACE, name=NAME)
+    await store.delete_partition(NAME)
 
 
 class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_create_open_delete(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="lifecycle",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        coll = await store.open_collection(namespace=NAMESPACE, name="lifecycle")
-        assert isinstance(coll, MilvusVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="lifecycle")
+        await store.create_partition("lifecycle")
+        coll = await store.get_partition("lifecycle")
+        assert isinstance(coll, MilvusVectorStorePartition)
+        await store.delete_partition("lifecycle")
 
     @pytest.mark.asyncio
     async def test_registry_lookup_requests_primary_key(self, store, monkeypatch):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="registry_fields",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
+        await store.create_partition("registry_fields")
 
         captured_output_fields = None
         original_get = MilvusClient.get
@@ -151,67 +138,42 @@ class TestCollectionLifecycle:
             return original_get(self, *args, **kwargs)
 
         monkeypatch.setattr(MilvusClient, "get", tracked_get)
-        coll = await store.open_collection(namespace=NAMESPACE, name="registry_fields")
+        coll = await store.get_partition("registry_fields")
 
         assert coll is not None
         assert captured_output_fields is not None
         assert "id" in captured_output_fields
-        assert "config" in captured_output_fields
-        await store.delete_collection(namespace=NAMESPACE, name="registry_fields")
+        assert "schema" in captured_output_fields
+        await store.delete_partition("registry_fields")
 
     @pytest.mark.asyncio
     async def test_duplicate_name_raises(self, store, collection):
-        with pytest.raises(VectorStoreCollectionAlreadyExistsError):
-            await store.create_collection(
-                namespace=NAMESPACE,
-                name=NAME,
-                config=collection.config,
-            )
+        with pytest.raises(VectorStorePartitionAlreadyExistsError):
+            await store.create_partition(NAME)
 
     @pytest.mark.asyncio
     async def test_delete_nonexistent_is_idempotent(self, store):
-        await store.delete_collection(namespace=NAMESPACE, name="nonexistent")
+        await store.delete_partition("nonexistent")
 
     @pytest.mark.asyncio
-    async def test_open_or_create_raises_on_config_mismatch(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="mismatch",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        with pytest.raises(VectorStoreCollectionConfigMismatchError):
-            await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name="mismatch",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1),
-            )
-        await store.delete_collection(namespace=NAMESPACE, name="mismatch")
+    async def test_partitions_share_the_native_collection(self, store):
+        """Every partition lives in the store's one native collection."""
+        await store.create_partition("coll_a")
+        await store.create_partition("coll_b")
 
-    @pytest.mark.asyncio
-    async def test_same_config_shares_native_collection(self, store):
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=VECTOR_DIM,
-        )
-        await store.create_collection(namespace=NAMESPACE, name="coll_a", config=config)
-        await store.create_collection(namespace=NAMESPACE, name="coll_b", config=config)
-
-        coll_a = await store.open_collection(namespace=NAMESPACE, name="coll_a")
-        coll_b = await store.open_collection(namespace=NAMESPACE, name="coll_b")
+        coll_a = await store.get_partition("coll_a")
+        coll_b = await store.get_partition("coll_b")
         assert coll_a is not None
         assert coll_b is not None
         assert coll_a._collection_name == coll_b._collection_name
 
-        await store.delete_collection(namespace=NAMESPACE, name="coll_a")
-        await store.delete_collection(namespace=NAMESPACE, name="coll_b")
+        await store.delete_partition("coll_a")
+        await store.delete_partition("coll_b")
 
     @pytest.mark.asyncio
     async def test_native_collection_schema(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="schema",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        coll = await store.open_collection(namespace=NAMESPACE, name="schema")
+        await store.create_partition("schema")
+        coll = await store.get_partition("schema")
         assert coll is not None
 
         schema = store._client.describe_collection(coll._collection_name)
@@ -224,7 +186,7 @@ class TestCollectionLifecycle:
         assert fields["vector"]["type"] == DataType.FLOAT_VECTOR
         assert fields["vector"]["params"]["dim"] == VECTOR_DIM
 
-        await store.delete_collection(namespace=NAMESPACE, name="schema")
+        await store.delete_partition("schema")
 
 
 class TestUpsertAndQuery:
@@ -510,15 +472,10 @@ class TestFilters:
 class TestPartitionIsolation:
     @pytest.mark.asyncio
     async def test_same_uuid_can_exist_in_different_logical_collections(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_a", config=config
-        )
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_b", config=config
-        )
-        coll_a = await store.open_collection(namespace=NAMESPACE, name="tenant_a")
-        coll_b = await store.open_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.create_partition("tenant_a")
+        await store.create_partition("tenant_b")
+        coll_a = await store.get_partition("tenant_a")
+        coll_b = await store.get_partition("tenant_b")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -546,5 +503,5 @@ class TestPartitionIsolation:
         assert [m.record_uuid for m in only_a.matches] == [record_uuid]
         assert [m.record_uuid for m in only_b.matches] == [record_uuid]
 
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.delete_partition("tenant_a")
+        await store.delete_partition("tenant_b")

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -3,21 +3,23 @@
 import asyncio
 import math
 from datetime import UTC, datetime, timedelta, timezone
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
 import pytest_asyncio
+from pydantic import ValidationError
 from qdrant_client import AsyncQdrantClient, models
 
 from memmachine_server.common.data_types import PropertyValue
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
     And,
-    Comparison,
+    Equals,
     In,
-    IsNull,
+    IsMissing,
     Not,
     Or,
+    Ordering,
 )
 from memmachine_server.common.metrics_factory import MetricsFactory
 from memmachine_server.common.vector_store.data_types import (
@@ -32,10 +34,22 @@ from memmachine_server.common.vector_store.qdrant_vector_store import (
     QdrantVectorStoreCollection,
     QdrantVectorStoreParams,
 )
+from server_tests.memmachine_server.common.filter.nodes import comparison
+from server_tests.memmachine_server.common.vector_store.declared_schema_contract import (
+    DeclaredSchemaContract,
+)
 
 NAMESPACE = "test_namespace"
 NAME = "test_name"
 VECTOR_DIM = 3
+
+INDEXED_PROPERTIES: dict[str, type[PropertyValue]] = {
+    "name": str,
+    "age": int,
+    "score": float,
+    "active": bool,
+    "created_at": datetime,
+}
 
 
 @pytest.fixture
@@ -56,7 +70,9 @@ def any_qdrant_client(request):
 
 @pytest_asyncio.fixture
 async def store(any_qdrant_client):
-    params = QdrantVectorStoreParams(client=any_qdrant_client)
+    params = QdrantVectorStoreParams(
+        indexed_properties=INDEXED_PROPERTIES, client=any_qdrant_client
+    )
     s = QdrantVectorStore(params)
     await s.startup()
     yield s
@@ -69,13 +85,6 @@ async def collection(store):
         name=NAME,
         config=VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            indexed_properties_schema={
-                "name": str,
-                "age": int,
-                "score": float,
-                "active": bool,
-                "created_at": datetime,
-            },
         ),
     )
     coll = await store.open_collection(namespace=NAMESPACE, name=NAME)
@@ -150,13 +159,6 @@ class TestCollectionLifecycle:
                 name=NAME,
                 config=VectorStoreCollectionConfig(
                     vector_dimensions=VECTOR_DIM,
-                    indexed_properties_schema={
-                        "name": str,
-                        "age": int,
-                        "score": float,
-                        "active": bool,
-                        "created_at": datetime,
-                    },
                 ),
             )
 
@@ -203,10 +205,8 @@ class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_same_config_shares_native_collection(self, store):
         """Two logical collections with the same config share one native collection."""
-        schema: dict[str, type[PropertyValue]] = {"name": str}
         config = VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            indexed_properties_schema=schema,
         )
         await store.create_collection(namespace=NAMESPACE, name="coll_a", config=config)
         await store.create_collection(namespace=NAMESPACE, name="coll_b", config=config)
@@ -323,6 +323,10 @@ class TestUpsertAndQuery:
 # ── Filters ──
 
 
+class TestDeclaredSchema(DeclaredSchemaContract):
+    """The declared-schema contract, against this store."""
+
+
 class TestFilters:
     # alice=30/9.5/True, bob=25/7.0/False, carol=35/8.0/True
     async def _setup(self, collection):
@@ -377,7 +381,7 @@ class TestFilters:
             await collection.query(
                 query_vectors=[query_vec],
                 limit=10,
-                property_filter=Comparison(field=field, op=op, value=value),
+                property_filter=comparison(field, op, value),
             )
         )
         return {m.record_uuid for m in all_results[0].matches}
@@ -391,7 +395,7 @@ class TestFilters:
             await collection.query(
                 query_vectors=[v1],
                 limit=10,
-                property_filter=Comparison(field="name", op="=", value="alice"),
+                property_filter=Equals(field="name", value="alice"),
             )
         )
         matches = query_results[0].matches
@@ -413,7 +417,7 @@ class TestFilters:
             await collection.query(
                 query_vectors=[v1],
                 limit=10,
-                property_filter=Comparison(field="age", op=">", value=30),
+                property_filter=Ordering(field="age", op=">", value=30),
             )
         )
         matches = query_results[0].matches
@@ -435,7 +439,7 @@ class TestFilters:
             await collection.query(
                 query_vectors=[v1],
                 limit=10,
-                property_filter=Comparison(field="age", op="<", value=30),
+                property_filter=Ordering(field="age", op="<", value=30),
             )
         )
         matches = query_results[0].matches
@@ -593,7 +597,7 @@ class TestFilters:
         [result] = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Comparison(field="created_at", op="=", value=dt),
+            property_filter=Equals(field="created_at", value=dt),
         )
         assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
@@ -610,7 +614,7 @@ class TestFilters:
         [result] = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Comparison(field="created_at", op="=", value=dt),
+            property_filter=Equals(field="created_at", value=dt),
         )
         assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
@@ -754,10 +758,8 @@ class TestFilters:
         [result] = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Comparison(
-                field="created_at",
-                op="=",
-                value=datetime(2024, 6, 15, 12, 30, 0, tzinfo=UTC),
+            property_filter=Equals(
+                field="created_at", value=datetime(2024, 6, 15, 12, 30, 0, tzinfo=UTC)
             ),
         )
         assert [m.record_uuid for m in result.matches] == [r1.uuid]
@@ -821,7 +823,7 @@ class TestFilters:
         assert r1.uuid in uuids
         assert r2.uuid not in uuids
 
-    # ── IsNull ──
+    # ── IsMissing ──
 
     @pytest.mark.asyncio
     async def test_is_null(self, collection):
@@ -841,7 +843,7 @@ class TestFilters:
             await collection.query(
                 query_vectors=[v1],
                 limit=10,
-                property_filter=IsNull(field="name"),
+                property_filter=IsMissing(field="name"),
             )
         )
         uuids = {m.record_uuid for m in query_results[0].matches}
@@ -868,7 +870,7 @@ class TestFilters:
             await collection.query(
                 query_vectors=[v1],
                 limit=10,
-                property_filter=Not(expr=IsNull(field="name")),
+                property_filter=Not(IsMissing(field="name")),
             )
         )
         uuids = {m.record_uuid for m in query_results[0].matches}
@@ -886,7 +888,7 @@ class TestFilters:
             await collection.query(
                 query_vectors=[v1],
                 limit=10,
-                property_filter=In(field="name", values=["alice", "carol"]),
+                property_filter=In(field="name", values=("alice", "carol")),
             )
         )
         matches = query_results[0].matches
@@ -903,8 +905,10 @@ class TestFilters:
                 query_vectors=[v1],
                 limit=10,
                 property_filter=And(
-                    left=Comparison(field="active", op="=", value=True),
-                    right=Comparison(field="age", op=">", value=30),
+                    (
+                        Equals(field="active", value=True),
+                        Ordering(field="age", op=">", value=30),
+                    )
                 ),
             )
         )
@@ -920,8 +924,10 @@ class TestFilters:
                 query_vectors=[v1],
                 limit=10,
                 property_filter=Or(
-                    left=Comparison(field="name", op="=", value="alice"),
-                    right=Comparison(field="name", op="=", value="carol"),
+                    (
+                        Equals(field="name", value="alice"),
+                        Equals(field="name", value="carol"),
+                    )
                 ),
             )
         )
@@ -938,7 +944,7 @@ class TestFilters:
             await collection.query(
                 query_vectors=[v1],
                 limit=10,
-                property_filter=Not(expr=Comparison(field="age", op=">", value=30)),
+                property_filter=Not(Ordering(field="age", op=">", value=30)),
             )
         )
         matches = query_results[0].matches
@@ -1085,6 +1091,7 @@ class TestMetrics:
         mock_factory.get_histogram.return_value = mock_histogram
 
         params = QdrantVectorStoreParams(
+            indexed_properties=INDEXED_PROPERTIES,
             client=qdrant_client,
             metrics_factory=mock_factory,
         )
@@ -1124,7 +1131,9 @@ class TestMetrics:
 @pytest_asyncio.fixture
 async def distributed_store(distributed_qdrant_client):
     params = QdrantVectorStoreParams(
-        client=distributed_qdrant_client, is_distributed=True
+        indexed_properties=INDEXED_PROPERTIES,
+        client=distributed_qdrant_client,
+        is_distributed=True,
     )
     s = QdrantVectorStore(params)
     await s.startup()
@@ -1146,7 +1155,6 @@ class TestDistributedSharding:
             name=name,
             config=VectorStoreCollectionConfig(
                 vector_dimensions=VECTOR_DIM,
-                indexed_properties_schema={"name": str},
             ),
         )
         coll = await store.open_collection(namespace=ns, name=name)
@@ -1229,7 +1237,6 @@ class TestCollectionLifecycleAcrossWorkers:
     def _config() -> VectorStoreCollectionConfig:
         return VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            indexed_properties_schema={"name": str},
         )
 
     @pytest.mark.asyncio
@@ -1262,7 +1269,11 @@ class TestCollectionLifecycleAcrossWorkers:
             ),
         )
 
-        store = QdrantVectorStore(QdrantVectorStoreParams(client=qdrant_client))
+        store = QdrantVectorStore(
+            QdrantVectorStoreParams(
+                indexed_properties=INDEXED_PROPERTIES, client=qdrant_client
+            )
+        )
         await store.startup()
         try:
             await store.open_or_create_collection(
@@ -1298,8 +1309,16 @@ class TestCollectionLifecycleAcrossWorkers:
         config = self._config()
         native = QdrantVectorStore._build_native_collection_name(namespace, config)
 
-        store_a = QdrantVectorStore(QdrantVectorStoreParams(client=client_a))
-        store_b = QdrantVectorStore(QdrantVectorStoreParams(client=client_b))
+        store_a = QdrantVectorStore(
+            QdrantVectorStoreParams(
+                indexed_properties=INDEXED_PROPERTIES, client=client_a
+            )
+        )
+        store_b = QdrantVectorStore(
+            QdrantVectorStoreParams(
+                indexed_properties=INDEXED_PROPERTIES, client=client_b
+            )
+        )
         await store_a.startup()
         await store_b.startup()
 
@@ -1331,3 +1350,155 @@ class TestCollectionLifecycleAcrossWorkers:
             await store_a.delete_collection(namespace=namespace, name=name)
             await client_a.close()
             await client_b.close()
+
+
+# ── Index / quantization configuration ──
+
+
+class TestIndexAndQuantizationParams:
+    """Native-collection HNSW, quantization, and optimizer configuration."""
+
+    def test_dict_configs_are_coerced_to_qdrant_models(self, in_memory_qdrant_client):
+        """Plain dicts (the YAML form) coerce into qdrant's own model types."""
+        params = QdrantVectorStoreParams.model_validate(
+            {
+                "client": in_memory_qdrant_client,
+                "indexed_properties": {"name": "str", "created_at": "datetime"},
+                "hnsw_config": {"ef_construct": 256, "payload_m": 32},
+                "optimizers_config": {"default_segment_number": 4},
+                "quantization_config": {"turbo": {"always_ram": True, "bits": "bits2"}},
+            }
+        )
+        assert params.indexed_properties == {"name": str, "created_at": datetime}
+        assert isinstance(params.hnsw_config, models.HnswConfigDiff)
+        assert params.hnsw_config.ef_construct == 256
+        assert isinstance(params.optimizers_config, models.OptimizersConfigDiff)
+        assert params.optimizers_config.default_segment_number == 4
+        assert isinstance(params.quantization_config, models.TurboQuantization)
+        assert params.quantization_config.turbo.bits == models.TurboQuantBitSize.BITS2
+
+    @pytest.mark.parametrize("m", [None, 0])
+    def test_hnsw_config_zero_or_unset_m_accepted(self, in_memory_qdrant_client, m):
+        params = QdrantVectorStoreParams(
+            indexed_properties=INDEXED_PROPERTIES,
+            client=in_memory_qdrant_client,
+            hnsw_config=models.HnswConfigDiff(m=m, ef_construct=200),
+        )
+        assert isinstance(params.hnsw_config, models.HnswConfigDiff)
+        assert params.hnsw_config.m == m
+
+    def test_hnsw_config_nonzero_m_rejected(self, in_memory_qdrant_client):
+        """Native collections require m=0; a positive global m is rejected."""
+        with pytest.raises(ValidationError, match="payload_m"):
+            QdrantVectorStoreParams(
+                indexed_properties=INDEXED_PROPERTIES,
+                client=in_memory_qdrant_client,
+                hnsw_config=models.HnswConfigDiff(m=16),
+            )
+
+    def test_native_hnsw_config_defaults_to_tenant_indexing(
+        self, in_memory_qdrant_client
+    ):
+        """With no override, the native graph is disabled with a default payload_m."""
+        store = QdrantVectorStore(
+            QdrantVectorStoreParams(
+                indexed_properties=INDEXED_PROPERTIES, client=in_memory_qdrant_client
+            )
+        )
+        cfg = store._native_hnsw_config()
+        assert cfg.m == 0
+        assert cfg.payload_m == QdrantVectorStore._DEFAULT_NATIVE_PAYLOAD_M
+
+    def test_native_hnsw_config_merges_overrides_but_pins_m(
+        self, in_memory_qdrant_client
+    ):
+        """Caller fields layer on top, but m stays pinned at 0 for tenant isolation."""
+        store = QdrantVectorStore(
+            QdrantVectorStoreParams(
+                indexed_properties=INDEXED_PROPERTIES,
+                client=in_memory_qdrant_client,
+                hnsw_config=models.HnswConfigDiff(ef_construct=222, payload_m=32),
+            )
+        )
+        cfg = store._native_hnsw_config()
+        assert cfg.m == 0
+        assert cfg.payload_m == 32
+        assert cfg.ef_construct == 222
+
+    @pytest.mark.asyncio
+    async def test_native_collection_creation_forwards_configs(
+        self, in_memory_qdrant_client
+    ):
+        """The native (not registry) create_collection call carries the configs."""
+        opt = models.OptimizersConfigDiff(default_segment_number=3)
+        quant = models.TurboQuantization(
+            turbo=models.TurboQuantQuantizationConfig(
+                always_ram=True, bits=models.TurboQuantBitSize.BITS2
+            )
+        )
+        params = QdrantVectorStoreParams(
+            indexed_properties=INDEXED_PROPERTIES,
+            client=in_memory_qdrant_client,
+            hnsw_config=models.HnswConfigDiff(ef_construct=222, payload_m=32),
+            optimizers_config=opt,
+            quantization_config=quant,
+        )
+        store = QdrantVectorStore(params)
+        await store.startup()
+
+        spy = AsyncMock(wraps=in_memory_qdrant_client.create_collection)
+        with patch.object(in_memory_qdrant_client, "create_collection", new=spy):
+            await store.create_collection(
+                namespace=NAMESPACE,
+                name="quant_test",
+                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
+            )
+
+        # The registry collection is created without quantization; the native
+        # (data) collection is the one carrying the new settings.
+        native_calls = [
+            c
+            for c in spy.call_args_list
+            if c.kwargs.get("quantization_config") is not None
+        ]
+        assert len(native_calls) == 1
+        kwargs = native_calls[0].kwargs
+        assert kwargs["hnsw_config"].m == 0
+        assert kwargs["hnsw_config"].payload_m == 32
+        assert kwargs["hnsw_config"].ef_construct == 222
+        assert kwargs["optimizers_config"] == opt
+        assert kwargs["quantization_config"] == quant
+
+        await store.delete_collection(namespace=NAMESPACE, name="quant_test")
+
+
+@pytest.mark.integration
+class TestDeclaredPayloadIndexes:
+    """Local mode accepts payload indexes but reports no schema, so this needs a server."""
+
+    @pytest.mark.asyncio
+    async def test_every_declared_key_gets_a_payload_index(self, qdrant_client):
+        store = QdrantVectorStore(
+            QdrantVectorStoreParams(
+                indexed_properties=INDEXED_PROPERTIES, client=qdrant_client
+            )
+        )
+        await store.startup()
+        await store.create_collection(
+            namespace=NAMESPACE,
+            name="declared_indexes",
+            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
+        )
+        collection = await store.open_collection(
+            namespace=NAMESPACE, name="declared_indexes"
+        )
+        assert collection is not None
+        info = await store._client.get_collection(collection._collection_name)
+        indexed = set(info.payload_schema or {})
+        assert set(INDEXED_PROPERTIES) <= indexed
+        assert (
+            info.payload_schema["created_at"].data_type
+            == models.PayloadSchemaType.DATETIME
+        )
+        assert info.payload_schema["age"].data_type == models.PayloadSchemaType.INTEGER
+        await store.delete_collection(namespace=NAMESPACE, name="declared_indexes")

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_qdrant_vector_store.py
@@ -22,24 +22,23 @@ from memmachine_server.common.filter import (
     Ordering,
 )
 from memmachine_server.common.metrics_factory import MetricsFactory
+from memmachine_server.common.vector_store import get_or_create_partition
 from memmachine_server.common.vector_store.data_types import (
     Record,
-    VectorStoreCollectionAlreadyExistsError,
-    VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
+    VectorStorePartitionAlreadyExistsError,
 )
 from memmachine_server.common.vector_store.qdrant_vector_store import (
     _PAYLOAD_PARTITION_KEY,
     QdrantVectorStore,
-    QdrantVectorStoreCollection,
     QdrantVectorStoreParams,
+    QdrantVectorStorePartition,
 )
 from server_tests.memmachine_server.common.filter.nodes import comparison
 from server_tests.memmachine_server.common.vector_store.declared_schema_contract import (
     DeclaredSchemaContract,
 )
 
-NAMESPACE = "test_namespace"
+COLLECTION = "test_namespace"
 NAME = "test_name"
 VECTOR_DIM = 3
 
@@ -71,26 +70,24 @@ def any_qdrant_client(request):
 @pytest_asyncio.fixture
 async def store(any_qdrant_client):
     params = QdrantVectorStoreParams(
-        indexed_properties=INDEXED_PROPERTIES, client=any_qdrant_client
+        collection=COLLECTION,
+        vector_dimensions=VECTOR_DIM,
+        indexed_properties=INDEXED_PROPERTIES,
+        client=any_qdrant_client,
     )
     s = QdrantVectorStore(params)
+    await s.provision()
     await s.startup()
     yield s
 
 
 @pytest_asyncio.fixture
 async def collection(store):
-    await store.create_collection(
-        namespace=NAMESPACE,
-        name=NAME,
-        config=VectorStoreCollectionConfig(
-            vector_dimensions=VECTOR_DIM,
-        ),
-    )
-    coll = await store.open_collection(namespace=NAMESPACE, name=NAME)
+    await store.create_partition(NAME)
+    coll = await store.get_partition(NAME)
     assert coll is not None
     yield coll
-    await store.delete_collection(namespace=NAMESPACE, name=NAME)
+    await store.delete_partition(NAME)
 
 
 def _normalize(v: list[float]) -> list[float]:
@@ -111,7 +108,7 @@ async def _present_uuids(collection, record_uuids) -> list[UUID]:
     record_uuids = list(record_uuids)
     if not record_uuids:
         return []
-    dimensions = collection.config.vector_dimensions
+    dimensions = VECTOR_DIM
     probe = [1.0] + [0.0] * (dimensions - 1)
     [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
     present = {match.record_uuid for match in result.matches}
@@ -131,94 +128,58 @@ def _make_record(
     )
 
 
-# ── Collection lifecycle ──
+# ── Partition lifecycle ──
 
 
 class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_create_get_delete(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="lifecycle",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        coll = await store.open_collection(namespace=NAMESPACE, name="lifecycle")
-        assert isinstance(coll, QdrantVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="lifecycle")
+        await store.create_partition("lifecycle")
+        coll = await store.get_partition("lifecycle")
+        assert isinstance(coll, QdrantVectorStorePartition)
+        await store.delete_partition("lifecycle")
 
     @pytest.mark.asyncio
     async def test_open_collection_returns_qdrant_collection(self, store, collection):
-        coll = await store.open_collection(namespace=NAMESPACE, name=NAME)
-        assert isinstance(coll, QdrantVectorStoreCollection)
+        coll = await store.get_partition(NAME)
+        assert isinstance(coll, QdrantVectorStorePartition)
 
     @pytest.mark.asyncio
     async def test_duplicate_name_raises(self, store, collection):
-        with pytest.raises(VectorStoreCollectionAlreadyExistsError):
-            await store.create_collection(
-                namespace=NAMESPACE,
-                name=NAME,
-                config=VectorStoreCollectionConfig(
-                    vector_dimensions=VECTOR_DIM,
-                ),
-            )
+        with pytest.raises(VectorStorePartitionAlreadyExistsError):
+            await store.create_partition(NAME)
 
     @pytest.mark.asyncio
     async def test_delete_nonexistent_is_idempotent(self, store):
-        await store.delete_collection(namespace=NAMESPACE, name="nonexistent")
+        await store.delete_partition("nonexistent")
 
     @pytest.mark.asyncio
     async def test_open_or_create_creates_when_missing(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="new", config=config
-        )
-        assert isinstance(coll, QdrantVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="new")
+        coll = await get_or_create_partition(store, "new")
+        assert isinstance(coll, QdrantVectorStorePartition)
+        await store.delete_partition("new")
 
     @pytest.mark.asyncio
     async def test_open_or_create_opens_when_exists(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        assert isinstance(coll, QdrantVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="existing")
+        await store.create_partition("existing")
+        coll = await get_or_create_partition(store, "existing")
+        assert isinstance(coll, QdrantVectorStorePartition)
+        await store.delete_partition("existing")
 
     @pytest.mark.asyncio
-    async def test_open_or_create_raises_on_config_mismatch(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="mismatch",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        with pytest.raises(VectorStoreCollectionConfigMismatchError):
-            await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name="mismatch",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1),
-            )
-        await store.delete_collection(namespace=NAMESPACE, name="mismatch")
+    async def test_partitions_share_the_native_collection(self, store):
+        """Every partition lives in the store's one native collection."""
+        await store.create_partition("coll_a")
+        await store.create_partition("coll_b")
 
-    @pytest.mark.asyncio
-    async def test_same_config_shares_native_collection(self, store):
-        """Two logical collections with the same config share one native collection."""
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=VECTOR_DIM,
-        )
-        await store.create_collection(namespace=NAMESPACE, name="coll_a", config=config)
-        await store.create_collection(namespace=NAMESPACE, name="coll_b", config=config)
-
-        coll_a = await store.open_collection(namespace=NAMESPACE, name="coll_a")
-        coll_b = await store.open_collection(namespace=NAMESPACE, name="coll_b")
+        coll_a = await store.get_partition("coll_a")
+        coll_b = await store.get_partition("coll_b")
         assert coll_a is not None
         assert coll_b is not None
         assert coll_a._collection_name == coll_b._collection_name
 
-        await store.delete_collection(namespace=NAMESPACE, name="coll_a")
-        await store.delete_collection(namespace=NAMESPACE, name="coll_b")
+        await store.delete_partition("coll_a")
+        await store.delete_partition("coll_b")
 
 
 # ── Upsert + Query ──
@@ -974,24 +935,16 @@ class TestDelete:
         assert results[0] == r2.uuid
 
 
-# ── Partition isolation (via separate logical collections) ──
+# ── Partition isolation ──
 
 
 class TestPartitionIsolation:
     @pytest.mark.asyncio
     async def test_query_only_returns_own_partition(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="tenant_a",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="tenant_b",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        coll_a = await store.open_collection(namespace=NAMESPACE, name="tenant_a")
-        coll_b = await store.open_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.create_partition("tenant_a")
+        await store.create_partition("tenant_b")
+        coll_a = await store.get_partition("tenant_a")
+        coll_b = await store.get_partition("tenant_b")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -1010,23 +963,15 @@ class TestPartitionIsolation:
         assert uuids_a == {r1.uuid}
         assert uuids_b == {r2.uuid}
 
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.delete_partition("tenant_a")
+        await store.delete_partition("tenant_b")
 
     @pytest.mark.asyncio
     async def test_get_only_returns_own_partition(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="tenant_a",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="tenant_b",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        coll_a = await store.open_collection(namespace=NAMESPACE, name="tenant_a")
-        coll_b = await store.open_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.create_partition("tenant_a")
+        await store.create_partition("tenant_b")
+        coll_a = await store.get_partition("tenant_a")
+        coll_b = await store.get_partition("tenant_b")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -1041,23 +986,15 @@ class TestPartitionIsolation:
         assert len(results) == 1
         assert results[0] == r1.uuid
 
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.delete_partition("tenant_a")
+        await store.delete_partition("tenant_b")
 
     @pytest.mark.asyncio
     async def test_delete_only_affects_own_partition(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="tenant_a",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="tenant_b",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        coll_a = await store.open_collection(namespace=NAMESPACE, name="tenant_a")
-        coll_b = await store.open_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.create_partition("tenant_a")
+        await store.create_partition("tenant_b")
+        coll_a = await store.get_partition("tenant_a")
+        coll_b = await store.get_partition("tenant_b")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -1075,8 +1012,8 @@ class TestPartitionIsolation:
         assert len(results) == 1
         assert results[0] == r2.uuid
 
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.delete_partition("tenant_a")
+        await store.delete_partition("tenant_b")
 
 
 # ── Metrics ──
@@ -1091,18 +1028,17 @@ class TestMetrics:
         mock_factory.get_histogram.return_value = mock_histogram
 
         params = QdrantVectorStoreParams(
+            collection=COLLECTION,
+            vector_dimensions=VECTOR_DIM,
             indexed_properties=INDEXED_PROPERTIES,
             client=qdrant_client,
             metrics_factory=mock_factory,
         )
         store = QdrantVectorStore(params)
+        await store.provision()
         await store.startup()
 
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="metrics_test",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
+        await store.create_partition("metrics_test")
 
         assert mock_histogram.observe.called
         call_labels = mock_histogram.observe.call_args
@@ -1111,7 +1047,7 @@ class TestMetrics:
 
         mock_histogram.reset_mock()
 
-        coll = await store.open_collection(namespace=NAMESPACE, name="metrics_test")
+        coll = await store.get_partition("metrics_test")
         assert coll is not None
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1)
@@ -1122,7 +1058,7 @@ class TestMetrics:
         assert call_labels[1]["labels"]["operation"] == "upsert"
         assert call_labels[1]["labels"]["status"] == "ok"
 
-        await store.delete_collection(namespace=NAMESPACE, name="metrics_test")
+        await store.delete_partition("metrics_test")
 
 
 # ── Distributed sharding ──
@@ -1131,11 +1067,14 @@ class TestMetrics:
 @pytest_asyncio.fixture
 async def distributed_store(distributed_qdrant_client):
     params = QdrantVectorStoreParams(
+        collection=COLLECTION,
+        vector_dimensions=VECTOR_DIM,
         indexed_properties=INDEXED_PROPERTIES,
         client=distributed_qdrant_client,
         is_distributed=True,
     )
     s = QdrantVectorStore(params)
+    await s.provision()
     await s.startup()
     yield s
 
@@ -1148,16 +1087,10 @@ class TestDistributedSharding:
     async def test_crud_lifecycle(self, distributed_store):
         """Full create → upsert → query → get → delete records → delete collection."""
         store = distributed_store
-        ns, name = NAMESPACE, "distributed_crud"
+        name = "distributed_crud"
 
-        await store.create_collection(
-            namespace=ns,
-            name=name,
-            config=VectorStoreCollectionConfig(
-                vector_dimensions=VECTOR_DIM,
-            ),
-        )
-        coll = await store.open_collection(namespace=ns, name=name)
+        await store.create_partition(name)
+        coll = await store.get_partition(name)
         assert coll is not None
 
         v1 = _normalize([1.0, 0.0, 0.0])
@@ -1174,21 +1107,16 @@ class TestDistributedSharding:
         got = await _present_uuids(coll, [r1.uuid])
         assert len(got) == 0
 
-        await store.delete_collection(namespace=ns, name=name)
+        await store.delete_partition(name)
 
     async def test_shard_drop_isolates_logical_collections(self, distributed_store):
-        """Dropping one logical collection's shard must not affect another's data."""
+        """Dropping one partition's shard must not affect another's data."""
         store = distributed_store
-        ns = NAMESPACE
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=VECTOR_DIM,
-        )
+        await store.create_partition("tenant_a")
+        await store.create_partition("tenant_b")
 
-        await store.create_collection(namespace=ns, name="tenant_a", config=config)
-        await store.create_collection(namespace=ns, name="tenant_b", config=config)
-
-        coll_a = await store.open_collection(namespace=ns, name="tenant_a")
-        coll_b = await store.open_collection(namespace=ns, name="tenant_b")
+        coll_a = await store.get_partition("tenant_a")
+        coll_b = await store.get_partition("tenant_b")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -1200,44 +1128,36 @@ class TestDistributedSharding:
         await coll_b.upsert(records=[r_b])
 
         # Delete tenant_a's shard.
-        await store.delete_collection(namespace=ns, name="tenant_a")
+        await store.delete_partition("tenant_a")
 
         # tenant_b data should be untouched.
         assert await _present_uuids(coll_b, [r_b.uuid]) == [r_b.uuid]
 
-        await store.delete_collection(namespace=ns, name="tenant_b")
+        await store.delete_partition("tenant_b")
 
     async def test_idempotent_delete(self, distributed_store):
         """Deleting an already-deleted collection should be a no-op."""
         store = distributed_store
-        ns, name = NAMESPACE, "distributed_idem"
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
+        name = "distributed_idem"
 
-        await store.create_collection(namespace=ns, name=name, config=config)
-        await store.delete_collection(namespace=ns, name=name)
+        await store.create_partition(name)
+        await store.delete_partition(name)
         # Second delete should not raise.
-        await store.delete_collection(namespace=ns, name=name)
+        await store.delete_partition(name)
 
 
 @pytest.mark.integration
-class TestCollectionLifecycleAcrossWorkers:
-    """Collection creation has to survive more than one creator.
+class TestCollectionProvisioningAcrossWorkers:
+    """Provisioning has to survive more than one provisioner.
 
-    The store serialises creation with an asyncio.Lock keyed on the client
-    object, which serialises callers inside one process and nothing else. Run
-    the server with MEMMACHINE_WORKERS above 1 and each worker gets its own
-    client, its own lock, and no mutual exclusion - so two workers can decide to
-    create the same collection at the same moment.
+    Run the server with MEMMACHINE_WORKERS above 1 and each worker builds its
+    own store over its own client, so two workers can provision the same
+    collection at the same moment, and one can find the collection already
+    there without its indexes.
 
     These need a real server: payload indexes have no effect in local-mode
     Qdrant, so the thing under test is invisible there.
     """
-
-    @staticmethod
-    def _config() -> VectorStoreCollectionConfig:
-        return VectorStoreCollectionConfig(
-            vector_dimensions=VECTOR_DIM,
-        )
 
     @pytest.mark.asyncio
     async def test_indexes_are_created_when_the_collection_already_exists(
@@ -1245,11 +1165,10 @@ class TestCollectionLifecycleAcrossWorkers:
     ):
         """A collection that exists without its indexes must still get them.
 
-        _create_native_collection creates the collection and its payload indexes
-        in one try block and swallows "already exists" for the whole block. So a
-        second creator - another worker, or a retry after one died between the
-        two calls - takes the exception path and never creates an index. Its
-        docstring claims it creates both idempotently; this pins that claim.
+        The collection and its payload indexes are created in separate steps,
+        each swallowing "already exists" on its own, so a provisioner that
+        finds the collection there, left by another worker or by a crash
+        between the two steps, still creates the indexes.
 
         The partition key is declared is_tenant. Verified against Qdrant 1.19:
         filtering stays correct without the index - a filtered query on an
@@ -1257,13 +1176,11 @@ class TestCollectionLifecycleAcrossWorkers:
         is lost is the multitenant storage layout and query speed, not
         isolation.
         """
-        namespace, name = "raced_ns", "raced_name"
-        config = self._config()
-        native = QdrantVectorStore._build_native_collection_name(namespace, config)
+        collection = "raced_collection"
 
-        # Stand in for a creator that got as far as the collection and no further.
+        # Stand in for a provisioner that got as far as the collection and no further.
         await qdrant_client.create_collection(
-            collection_name=native,
+            collection_name=collection,
             vectors_config=models.VectorParams(
                 size=VECTOR_DIM, distance=models.Distance.COSINE
             ),
@@ -1271,15 +1188,16 @@ class TestCollectionLifecycleAcrossWorkers:
 
         store = QdrantVectorStore(
             QdrantVectorStoreParams(
-                indexed_properties=INDEXED_PROPERTIES, client=qdrant_client
+                collection=collection,
+                vector_dimensions=VECTOR_DIM,
+                indexed_properties=INDEXED_PROPERTIES,
+                client=qdrant_client,
             )
         )
-        await store.startup()
         try:
-            await store.open_or_create_collection(
-                namespace=namespace, name=name, config=config
-            )
-            info = await qdrant_client.get_collection(native)
+            await store.provision()
+            await store.startup()
+            info = await qdrant_client.get_collection(collection)
             indexed = set(info.payload_schema or {})
             assert _PAYLOAD_PARTITION_KEY in indexed, (
                 "the tenant partition index is missing: a collection that already "
@@ -1290,64 +1208,71 @@ class TestCollectionLifecycleAcrossWorkers:
                 f"declared property index absent. present: {sorted(indexed)}"
             )
         finally:
-            await store.delete_collection(namespace=namespace, name=name)
+            await qdrant_client.delete_collection(collection)
+            await qdrant_client.delete_collection(store._registry_collection_name)
 
     @pytest.mark.asyncio
-    async def test_two_workers_creating_at_once_both_succeed_and_index(
+    async def test_two_workers_provisioning_at_once_both_succeed_and_index(
         self, qdrant_container
     ):
         """Two clients, no shared lock - the multi-worker shape, in one process.
 
-        The lock is keyed on the client object, so two stores holding separate
-        clients are exactly two workers as far as mutual exclusion goes. Both
-        calls must return a usable handle, and the collection they agree on must
-        end up indexed.
+        Both provisioners must return, and the collection they agree on must
+        end up indexed; then both must be able to create partitions in it.
         """
         client_a = qdrant_container.get_async_client()
         client_b = qdrant_container.get_async_client()
-        namespace, name = "race_two_ns", "race_two_name"
-        config = self._config()
-        native = QdrantVectorStore._build_native_collection_name(namespace, config)
+        collection = "race_two_collection"
 
         store_a = QdrantVectorStore(
             QdrantVectorStoreParams(
-                indexed_properties=INDEXED_PROPERTIES, client=client_a
+                collection=collection,
+                vector_dimensions=VECTOR_DIM,
+                indexed_properties=INDEXED_PROPERTIES,
+                client=client_a,
             )
         )
         store_b = QdrantVectorStore(
             QdrantVectorStoreParams(
-                indexed_properties=INDEXED_PROPERTIES, client=client_b
+                collection=collection,
+                vector_dimensions=VECTOR_DIM,
+                indexed_properties=INDEXED_PROPERTIES,
+                client=client_b,
             )
         )
-        await store_a.startup()
-        await store_b.startup()
 
-        assert store_a._client_name_locks is not store_b._client_name_locks, (
+        assert store_a._client_partition_locks is not store_b._client_partition_locks, (
             "separate clients must not share a lock, or this does not test anything"
         )
 
         try:
             results = await asyncio.gather(
-                store_a.open_or_create_collection(
-                    namespace=namespace, name=name, config=config
-                ),
-                store_b.open_or_create_collection(
-                    namespace=namespace, name=name, config=config
-                ),
-                return_exceptions=True,
+                store_a.provision(), store_b.provision(), return_exceptions=True
             )
             failures = [r for r in results if isinstance(r, BaseException)]
-            assert not failures, f"a concurrent creator raised: {failures!r}"
+            assert not failures, f"a concurrent provisioner raised: {failures!r}"
+            await store_a.startup()
+            await store_b.startup()
 
-            info = await client_a.get_collection(native)
+            info = await client_a.get_collection(collection)
             indexed = set(info.payload_schema or {})
             assert _PAYLOAD_PARTITION_KEY in indexed, (
                 "two workers raced and the tenant partition index was lost: the "
                 "loser skips index creation entirely. present: "
                 f"{sorted(indexed)}"
             )
+
+            results = await asyncio.gather(
+                get_or_create_partition(store_a, "race_two_key"),
+                get_or_create_partition(store_b, "race_two_key"),
+                return_exceptions=True,
+            )
+            failures = [r for r in results if isinstance(r, BaseException)]
+            assert not failures, f"a concurrent creator raised: {failures!r}"
         finally:
-            await store_a.delete_collection(namespace=namespace, name=name)
+            await store_a.delete_partition("race_two_key")
+            await client_a.delete_collection(collection)
+            await client_a.delete_collection(store_a._registry_collection_name)
             await client_a.close()
             await client_b.close()
 
@@ -1363,6 +1288,8 @@ class TestIndexAndQuantizationParams:
         params = QdrantVectorStoreParams.model_validate(
             {
                 "client": in_memory_qdrant_client,
+                "collection": COLLECTION,
+                "vector_dimensions": VECTOR_DIM,
                 "indexed_properties": {"name": "str", "created_at": "datetime"},
                 "hnsw_config": {"ef_construct": 256, "payload_m": 32},
                 "optimizers_config": {"default_segment_number": 4},
@@ -1380,6 +1307,8 @@ class TestIndexAndQuantizationParams:
     @pytest.mark.parametrize("m", [None, 0])
     def test_hnsw_config_zero_or_unset_m_accepted(self, in_memory_qdrant_client, m):
         params = QdrantVectorStoreParams(
+            collection=COLLECTION,
+            vector_dimensions=VECTOR_DIM,
             indexed_properties=INDEXED_PROPERTIES,
             client=in_memory_qdrant_client,
             hnsw_config=models.HnswConfigDiff(m=m, ef_construct=200),
@@ -1391,6 +1320,8 @@ class TestIndexAndQuantizationParams:
         """Native collections require m=0; a positive global m is rejected."""
         with pytest.raises(ValidationError, match="payload_m"):
             QdrantVectorStoreParams(
+                collection=COLLECTION,
+                vector_dimensions=VECTOR_DIM,
                 indexed_properties=INDEXED_PROPERTIES,
                 client=in_memory_qdrant_client,
                 hnsw_config=models.HnswConfigDiff(m=16),
@@ -1402,7 +1333,10 @@ class TestIndexAndQuantizationParams:
         """With no override, the native graph is disabled with a default payload_m."""
         store = QdrantVectorStore(
             QdrantVectorStoreParams(
-                indexed_properties=INDEXED_PROPERTIES, client=in_memory_qdrant_client
+                collection=COLLECTION,
+                vector_dimensions=VECTOR_DIM,
+                indexed_properties=INDEXED_PROPERTIES,
+                client=in_memory_qdrant_client,
             )
         )
         cfg = store._native_hnsw_config()
@@ -1415,6 +1349,8 @@ class TestIndexAndQuantizationParams:
         """Caller fields layer on top, but m stays pinned at 0 for tenant isolation."""
         store = QdrantVectorStore(
             QdrantVectorStoreParams(
+                collection=COLLECTION,
+                vector_dimensions=VECTOR_DIM,
                 indexed_properties=INDEXED_PROPERTIES,
                 client=in_memory_qdrant_client,
                 hnsw_config=models.HnswConfigDiff(ef_construct=222, payload_m=32),
@@ -1437,6 +1373,8 @@ class TestIndexAndQuantizationParams:
             )
         )
         params = QdrantVectorStoreParams(
+            collection=COLLECTION,
+            vector_dimensions=VECTOR_DIM,
             indexed_properties=INDEXED_PROPERTIES,
             client=in_memory_qdrant_client,
             hnsw_config=models.HnswConfigDiff(ef_construct=222, payload_m=32),
@@ -1444,15 +1382,12 @@ class TestIndexAndQuantizationParams:
             quantization_config=quant,
         )
         store = QdrantVectorStore(params)
-        await store.startup()
 
+        # The native collection is created by provisioning, not per partition.
         spy = AsyncMock(wraps=in_memory_qdrant_client.create_collection)
         with patch.object(in_memory_qdrant_client, "create_collection", new=spy):
-            await store.create_collection(
-                namespace=NAMESPACE,
-                name="quant_test",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-            )
+            await store.provision()
+        await store.startup()
 
         # The registry collection is created without quantization; the native
         # (data) collection is the one carrying the new settings.
@@ -1469,8 +1404,6 @@ class TestIndexAndQuantizationParams:
         assert kwargs["optimizers_config"] == opt
         assert kwargs["quantization_config"] == quant
 
-        await store.delete_collection(namespace=NAMESPACE, name="quant_test")
-
 
 @pytest.mark.integration
 class TestDeclaredPayloadIndexes:
@@ -1480,18 +1413,16 @@ class TestDeclaredPayloadIndexes:
     async def test_every_declared_key_gets_a_payload_index(self, qdrant_client):
         store = QdrantVectorStore(
             QdrantVectorStoreParams(
-                indexed_properties=INDEXED_PROPERTIES, client=qdrant_client
+                collection=COLLECTION,
+                vector_dimensions=VECTOR_DIM,
+                indexed_properties=INDEXED_PROPERTIES,
+                client=qdrant_client,
             )
         )
+        await store.provision()
         await store.startup()
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="declared_indexes",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        collection = await store.open_collection(
-            namespace=NAMESPACE, name="declared_indexes"
-        )
+        await store.create_partition("declared_indexes")
+        collection = await store.get_partition("declared_indexes")
         assert collection is not None
         info = await store._client.get_collection(collection._collection_name)
         indexed = set(info.payload_schema or {})
@@ -1501,4 +1432,4 @@ class TestDeclaredPayloadIndexes:
             == models.PayloadSchemaType.DATETIME
         )
         assert info.payload_schema["age"].data_type == models.PayloadSchemaType.INTEGER
-        await store.delete_collection(namespace=NAMESPACE, name="declared_indexes")
+        await store.delete_partition("declared_indexes")

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -10,14 +10,17 @@ import pytest_asyncio
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.data_types import PropertyValue
+from memmachine_server.common.filter import (
     And,
-    Comparison,
+    Equals,
     In,
     Not,
     Or,
+    Ordering,
 )
 from memmachine_server.common.vector_store.data_types import (
+    IndexedPropertiesMismatchError,
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
@@ -28,6 +31,10 @@ from memmachine_server.common.vector_store.sqlite_vec_vector_store import (
     SQLiteVecVectorStoreCollection,
     SQLiteVecVectorStoreParams,
 )
+from server_tests.memmachine_server.common.filter.nodes import comparison
+from server_tests.memmachine_server.common.vector_store.declared_schema_contract import (
+    DeclaredSchemaContract,
+)
 
 pytestmark = pytest.mark.skipif(
     not hasattr(sqlite3.Connection, "enable_load_extension"),
@@ -37,6 +44,14 @@ pytestmark = pytest.mark.skipif(
 NAMESPACE = "test_namespace"
 NAME = "test_name"
 VECTOR_DIM = 3
+
+INDEXED_PROPERTIES: dict[str, type[PropertyValue]] = {
+    "name": str,
+    "age": int,
+    "score": float,
+    "active": bool,
+    "created_at": datetime,
+}
 
 
 def _normalize(vector: list[float]) -> list[float]:
@@ -81,7 +96,9 @@ def _make_record(
 async def store(tmp_path):
     db_path = tmp_path / "test.db"
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
-    params = SQLiteVecVectorStoreParams(engine=engine)
+    params = SQLiteVecVectorStoreParams(
+        indexed_properties=INDEXED_PROPERTIES, engine=engine
+    )
     vector_store = SQLiteVecVectorStore(params)
     await vector_store.startup()
     yield vector_store
@@ -96,13 +113,6 @@ async def collection(store):
         name=NAME,
         config=VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            indexed_properties_schema={
-                "name": str,
-                "age": int,
-                "score": float,
-                "active": bool,
-                "created_at": datetime,
-            },
         ),
     )
     coll = await store.open_collection(namespace=NAMESPACE, name=NAME)
@@ -139,13 +149,6 @@ class TestCollectionLifecycle:
                 name=NAME,
                 config=VectorStoreCollectionConfig(
                     vector_dimensions=VECTOR_DIM,
-                    indexed_properties_schema={
-                        "name": str,
-                        "age": int,
-                        "score": float,
-                        "active": bool,
-                        "created_at": datetime,
-                    },
                 ),
             )
 
@@ -257,7 +260,7 @@ class TestUpsertAndQuery:
         [result] = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Comparison(field="name", op="=", value="updated"),
+            property_filter=Equals(field="name", value="updated"),
         )
         assert [m.record_uuid for m in result.matches] == [record.uuid]
 
@@ -334,6 +337,10 @@ class TestUpsertAndQuery:
 # ── Filters ──
 
 
+class TestDeclaredSchema(DeclaredSchemaContract):
+    """The declared-schema contract, against this store."""
+
+
 class TestFilters:
     async def _setup(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
@@ -387,7 +394,7 @@ class TestFilters:
         all_results = await collection.query(
             query_vectors=[query_vector],
             limit=10,
-            property_filter=Comparison(field=field, op=op, value=value),
+            property_filter=comparison(field, op, value),
         )
         return {match.record_uuid for match in all_results[0].matches}
 
@@ -495,7 +502,7 @@ class TestFilters:
         [result] = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Comparison(field="created_at", op="=", value=dt),
+            property_filter=Equals(field="created_at", value=dt),
         )
         assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
@@ -560,9 +567,7 @@ class TestFilters:
         [result] = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Comparison(
-                field="created_at", op="=", value=dt.astimezone(UTC)
-            ),
+            property_filter=Equals(field="created_at", value=dt.astimezone(UTC)),
         )
         assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
@@ -574,7 +579,7 @@ class TestFilters:
         query_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=In(field="name", values=["alice", "carol"]),
+            property_filter=In(field="name", values=("alice", "carol")),
         )
         uuids = {match.record_uuid for match in query_results[0].matches}
         assert r1.uuid in uuids
@@ -588,8 +593,10 @@ class TestFilters:
             query_vectors=[v1],
             limit=10,
             property_filter=And(
-                left=Comparison(field="active", op="=", value=True),
-                right=Comparison(field="age", op=">", value=30),
+                (
+                    Equals(field="active", value=True),
+                    Ordering(field="age", op=">", value=30),
+                )
             ),
         )
         matches = query_results[0].matches
@@ -603,8 +610,10 @@ class TestFilters:
             query_vectors=[v1],
             limit=10,
             property_filter=Or(
-                left=Comparison(field="name", op="=", value="alice"),
-                right=Comparison(field="name", op="=", value="carol"),
+                (
+                    Equals(field="name", value="alice"),
+                    Equals(field="name", value="carol"),
+                )
             ),
         )
         uuids = {match.record_uuid for match in query_results[0].matches}
@@ -618,7 +627,7 @@ class TestFilters:
         query_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Not(expr=Comparison(field="age", op=">", value=30)),
+            property_filter=Not(Ordering(field="age", op=">", value=30)),
         )
         uuids = {match.record_uuid for match in query_results[0].matches}
         assert r1.uuid in uuids
@@ -890,7 +899,7 @@ class TestUpsertBehavior:
         [named_bob] = await collection.query(
             query_vectors=[v2],
             limit=10,
-            property_filter=Comparison(field="name", op="=", value="bob"),
+            property_filter=Equals(field="name", value="bob"),
         )
         assert [m.record_uuid for m in named_bob.matches] == [record_uuid]
 
@@ -916,11 +925,43 @@ class TestFilterEdgeCases:
             query_vectors=[v1],
             limit=10,
             property_filter=Or(
-                left=Comparison(field="name", op="=", value="alice"),
-                right=Comparison(field="name", op="=", value="carol"),
+                (
+                    Equals(field="name", value="alice"),
+                    Equals(field="name", value="carol"),
+                )
             ),
         )
         uuids = {m.record_uuid for m in results[0].matches}
         assert r1.uuid in uuids
         assert r3.uuid in uuids
         assert r2.uuid not in uuids
+
+
+class TestDeclaredSchemaIsFixed:
+    @pytest.mark.asyncio
+    async def test_a_store_with_another_schema_cannot_open_the_collection(
+        self, tmp_path
+    ):
+        db_path = tmp_path / "fixed.db"
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+        first = SQLiteVecVectorStore(
+            SQLiteVecVectorStoreParams(
+                indexed_properties=INDEXED_PROPERTIES, engine=engine
+            )
+        )
+        await first.startup()
+        await first.create_collection(
+            namespace=NAMESPACE,
+            name="fixed",
+            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
+        )
+        await first.shutdown()
+
+        second = SQLiteVecVectorStore(
+            SQLiteVecVectorStoreParams(indexed_properties={"name": str}, engine=engine)
+        )
+        await second.startup()
+        with pytest.raises(IndexedPropertiesMismatchError, match="fixed"):
+            await second.open_collection(namespace=NAMESPACE, name="fixed")
+        await second.shutdown()
+        await engine.dispose()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vec_vector_store.py
@@ -19,17 +19,16 @@ from memmachine_server.common.filter import (
     Or,
     Ordering,
 )
+from memmachine_server.common.vector_store import get_or_create_partition
 from memmachine_server.common.vector_store.data_types import (
-    IndexedPropertiesMismatchError,
     Record,
-    VectorStoreCollectionAlreadyExistsError,
-    VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
+    VectorStorePartitionAlreadyExistsError,
+    VectorStorePartitionSchemaMismatchError,
 )
 from memmachine_server.common.vector_store.sqlite_vec_vector_store import (
     SQLiteVecVectorStore,
-    SQLiteVecVectorStoreCollection,
     SQLiteVecVectorStoreParams,
+    SQLiteVecVectorStorePartition,
 )
 from server_tests.memmachine_server.common.filter.nodes import comparison
 from server_tests.memmachine_server.common.vector_store.declared_schema_contract import (
@@ -41,7 +40,7 @@ pytestmark = pytest.mark.skipif(
     reason="sqlite3 built without extension loading support",
 )
 
-NAMESPACE = "test_namespace"
+COLLECTION = "test_namespace"
 NAME = "test_name"
 VECTOR_DIM = 3
 
@@ -72,7 +71,7 @@ async def _present_uuids(collection, record_uuids) -> list[UUID]:
     record_uuids = list(record_uuids)
     if not record_uuids:
         return []
-    dimensions = collection.config.vector_dimensions
+    dimensions = VECTOR_DIM
     probe = [1.0] + [0.0] * (dimensions - 1)
     [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
     present = {match.record_uuid for match in result.matches}
@@ -97,9 +96,13 @@ async def store(tmp_path):
     db_path = tmp_path / "test.db"
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
     params = SQLiteVecVectorStoreParams(
-        indexed_properties=INDEXED_PROPERTIES, engine=engine
+        collection=COLLECTION,
+        vector_dimensions=VECTOR_DIM,
+        indexed_properties=INDEXED_PROPERTIES,
+        engine=engine,
     )
     vector_store = SQLiteVecVectorStore(params)
+    await vector_store.provision()
     await vector_store.startup()
     yield vector_store
     await vector_store.shutdown()
@@ -108,111 +111,59 @@ async def store(tmp_path):
 
 @pytest_asyncio.fixture
 async def collection(store):
-    await store.create_collection(
-        namespace=NAMESPACE,
-        name=NAME,
-        config=VectorStoreCollectionConfig(
-            vector_dimensions=VECTOR_DIM,
-        ),
-    )
-    coll = await store.open_collection(namespace=NAMESPACE, name=NAME)
+    await store.create_partition(NAME)
+    coll = await store.get_partition(NAME)
     assert coll is not None
     yield coll
-    await store.delete_collection(namespace=NAMESPACE, name=NAME)
+    await store.delete_partition(NAME)
 
 
-# ── Collection lifecycle ──
+# ── Partition lifecycle ──
 
 
 class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_create_open_delete(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="lifecycle",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        coll = await store.open_collection(namespace=NAMESPACE, name="lifecycle")
-        assert isinstance(coll, SQLiteVecVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="lifecycle")
+        await store.create_partition("lifecycle")
+        coll = await store.get_partition("lifecycle")
+        assert isinstance(coll, SQLiteVecVectorStorePartition)
+        await store.delete_partition("lifecycle")
 
     @pytest.mark.asyncio
     async def test_open_returns_correct_type(self, store, collection):
-        coll = await store.open_collection(namespace=NAMESPACE, name=NAME)
-        assert isinstance(coll, SQLiteVecVectorStoreCollection)
+        coll = await store.get_partition(NAME)
+        assert isinstance(coll, SQLiteVecVectorStorePartition)
 
     @pytest.mark.asyncio
     async def test_duplicate_name_raises(self, store, collection):
-        with pytest.raises(VectorStoreCollectionAlreadyExistsError):
-            await store.create_collection(
-                namespace=NAMESPACE,
-                name=NAME,
-                config=VectorStoreCollectionConfig(
-                    vector_dimensions=VECTOR_DIM,
-                ),
-            )
+        with pytest.raises(VectorStorePartitionAlreadyExistsError):
+            await store.create_partition(NAME)
 
     @pytest.mark.asyncio
     async def test_delete_nonexistent_is_idempotent(self, store):
-        await store.delete_collection(namespace=NAMESPACE, name="nonexistent")
+        await store.delete_partition("nonexistent")
 
     @pytest.mark.asyncio
     async def test_open_or_create_creates_when_missing(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="new", config=config
-        )
-        assert isinstance(coll, SQLiteVecVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="new")
+        coll = await get_or_create_partition(store, "new")
+        assert isinstance(coll, SQLiteVecVectorStorePartition)
+        await store.delete_partition("new")
 
     @pytest.mark.asyncio
     async def test_open_or_create_opens_when_exists(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        assert isinstance(coll, SQLiteVecVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="existing")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_raises_on_config_mismatch(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="mismatch",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        with pytest.raises(VectorStoreCollectionConfigMismatchError):
-            await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name="mismatch",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1),
-            )
-        await store.delete_collection(namespace=NAMESPACE, name="mismatch")
+        await store.create_partition("existing")
+        coll = await get_or_create_partition(store, "existing")
+        assert isinstance(coll, SQLiteVecVectorStorePartition)
+        await store.delete_partition("existing")
 
     @pytest.mark.asyncio
     async def test_open_nonexistent_returns_none(self, store):
-        assert await store.open_collection(namespace=NAMESPACE, name="nope") is None
-
-    @pytest.mark.asyncio
-    async def test_invalid_namespace_raises(self, store):
-        with pytest.raises(ValueError, match="Invalid namespace"):
-            await store.create_collection(
-                namespace="INVALID",
-                name="test",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-            )
+        assert await store.get_partition("nope") is None
 
     @pytest.mark.asyncio
     async def test_invalid_name_raises(self, store):
-        with pytest.raises(ValueError, match="Invalid namespace"):
-            await store.create_collection(
-                namespace="valid",
-                name="INVALID",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-            )
+        with pytest.raises(ValueError, match="Invalid partition key"):
+            await store.create_partition("INVALID")
 
 
 # ── Upsert + Query ──
@@ -679,15 +630,10 @@ class TestDelete:
 class TestPartitionIsolation:
     @pytest.mark.asyncio
     async def test_query_only_returns_own_collection(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_a", config=config
-        )
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_b", config=config
-        )
-        coll_a = await store.open_collection(namespace=NAMESPACE, name="tenant_a")
-        coll_b = await store.open_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.create_partition("tenant_a")
+        await store.create_partition("tenant_b")
+        coll_a = await store.get_partition("tenant_a")
+        coll_b = await store.get_partition("tenant_b")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -706,20 +652,15 @@ class TestPartitionIsolation:
         assert uuids_a == {r1.uuid}
         assert uuids_b == {r2.uuid}
 
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.delete_partition("tenant_a")
+        await store.delete_partition("tenant_b")
 
     @pytest.mark.asyncio
     async def test_get_only_returns_own_collection(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_a", config=config
-        )
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_b", config=config
-        )
-        coll_a = await store.open_collection(namespace=NAMESPACE, name="tenant_a")
-        coll_b = await store.open_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.create_partition("tenant_a")
+        await store.create_partition("tenant_b")
+        coll_a = await store.get_partition("tenant_a")
+        coll_b = await store.get_partition("tenant_b")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -734,20 +675,15 @@ class TestPartitionIsolation:
         assert len(results) == 1
         assert results[0] == r1.uuid
 
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.delete_partition("tenant_a")
+        await store.delete_partition("tenant_b")
 
     @pytest.mark.asyncio
     async def test_delete_only_affects_own_collection(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_a", config=config
-        )
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_b", config=config
-        )
-        coll_a = await store.open_collection(namespace=NAMESPACE, name="tenant_a")
-        coll_b = await store.open_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.create_partition("tenant_a")
+        await store.create_partition("tenant_b")
+        coll_a = await store.get_partition("tenant_a")
+        coll_b = await store.get_partition("tenant_b")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -764,20 +700,26 @@ class TestPartitionIsolation:
         assert len(results) == 1
         assert results[0] == r2.uuid
 
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.delete_partition("tenant_a")
+        await store.delete_partition("tenant_b")
 
     @pytest.mark.asyncio
-    async def test_namespace_isolation(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace="namespace_a", name="coll", config=config
+    async def test_collections_on_one_engine_are_isolated(self, store):
+        """Two stores over one engine, named differently, never see each other's rows."""
+        other = SQLiteVecVectorStore(
+            SQLiteVecVectorStoreParams(
+                collection="other_collection",
+                vector_dimensions=VECTOR_DIM,
+                indexed_properties=INDEXED_PROPERTIES,
+                engine=store._engine,
+            )
         )
-        await store.create_collection(
-            namespace="namespace_b", name="coll", config=config
-        )
-        coll_a = await store.open_collection(namespace="namespace_a", name="coll")
-        coll_b = await store.open_collection(namespace="namespace_b", name="coll")
+        await other.provision()
+        await other.startup()
+        await store.create_partition("coll")
+        await other.create_partition("coll")
+        coll_a = await store.get_partition("coll")
+        coll_b = await other.get_partition("coll")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -791,19 +733,16 @@ class TestPartitionIsolation:
         results_a = await coll_a.query(query_vectors=[v1], limit=10)
         assert {match.record_uuid for match in results_a[0].matches} == {r1.uuid}
 
-        await store.delete_collection(namespace="namespace_a", name="coll")
-        await store.delete_collection(namespace="namespace_b", name="coll")
+        await store.delete_partition("coll")
+        assert await other.get_partition("coll") is not None
+        await other.delete_partition("coll")
+        await other.shutdown()
 
     @pytest.mark.asyncio
     async def test_delete_collection_does_not_affect_sibling(self, store):
         """Deleting one collection doesn't break a sibling sharing tables."""
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll_a = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="sibling_a", config=config
-        )
-        coll_b = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="sibling_b", config=config
-        )
+        coll_a = await get_or_create_partition(store, "sibling_a")
+        coll_b = await get_or_create_partition(store, "sibling_b")
 
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1)
@@ -811,29 +750,27 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        await store.delete_collection(namespace=NAMESPACE, name="sibling_a")
+        await store.delete_partition("sibling_a")
 
         results = await coll_b.query(query_vectors=[v1], limit=10)
         assert len(results[0].matches) == 1
         assert results[0].matches[0].record_uuid == r2.uuid
 
-        await store.delete_collection(namespace=NAMESPACE, name="sibling_b")
+        await store.delete_partition("sibling_b")
 
 
 class TestNoProperties:
     @pytest.mark.asyncio
     async def test_collection_without_properties(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=2)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="no_props", config=config
-        )
-        r1 = _make_record(vector=[1.0, 0.0])
+        coll = await get_or_create_partition(store, "no_props")
+        v1 = _normalize([1.0, 0.0, 0.0])
+        r1 = _make_record(vector=v1)
         await coll.upsert(records=[r1])
 
-        results = await coll.query(query_vectors=[[1.0, 0.0]], limit=1)
+        results = await coll.query(query_vectors=[v1], limit=1)
         assert len(results[0].matches) == 1
 
-        await store.delete_collection(namespace=NAMESPACE, name="no_props")
+        await store.delete_partition("no_props")
 
 
 # ── Input validation ──
@@ -946,22 +883,28 @@ class TestDeclaredSchemaIsFixed:
         engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
         first = SQLiteVecVectorStore(
             SQLiteVecVectorStoreParams(
-                indexed_properties=INDEXED_PROPERTIES, engine=engine
+                collection=COLLECTION,
+                vector_dimensions=VECTOR_DIM,
+                indexed_properties=INDEXED_PROPERTIES,
+                engine=engine,
             )
         )
+        await first.provision()
         await first.startup()
-        await first.create_collection(
-            namespace=NAMESPACE,
-            name="fixed",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
+        await first.create_partition("fixed")
         await first.shutdown()
 
         second = SQLiteVecVectorStore(
-            SQLiteVecVectorStoreParams(indexed_properties={"name": str}, engine=engine)
+            SQLiteVecVectorStoreParams(
+                collection=COLLECTION,
+                vector_dimensions=VECTOR_DIM,
+                indexed_properties={"name": str},
+                engine=engine,
+            )
         )
+        await second.provision()
         await second.startup()
-        with pytest.raises(IndexedPropertiesMismatchError, match="fixed"):
-            await second.open_collection(namespace=NAMESPACE, name="fixed")
+        with pytest.raises(VectorStorePartitionSchemaMismatchError, match="fixed"):
+            await second.get_partition("fixed")
         await second.shutdown()
         await engine.dispose()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -10,14 +10,17 @@ from pydantic import ValidationError
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.data_types import PropertyValue
+from memmachine_server.common.filter import (
     And,
-    Comparison,
+    Equals,
     In,
     Not,
     Or,
+    Ordering,
 )
 from memmachine_server.common.vector_store.data_types import (
+    IndexedPropertiesMismatchError,
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
@@ -34,10 +37,22 @@ from memmachine_server.common.vector_store.sqlite_vector_store import (
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
     USearchVectorSearchEngine,
 )
+from server_tests.memmachine_server.common.filter.nodes import comparison
+from server_tests.memmachine_server.common.vector_store.declared_schema_contract import (
+    DeclaredSchemaContract,
+)
 
 NAMESPACE = "test_namespace"
 NAME = "test_name"
 VECTOR_DIM = 3
+
+INDEXED_PROPERTIES: dict[str, type[PropertyValue]] = {
+    "name": str,
+    "age": int,
+    "score": float,
+    "active": bool,
+    "created_at": datetime,
+}
 
 
 def _normalize(vector: list[float]) -> list[float]:
@@ -83,6 +98,7 @@ async def store(tmp_path):
     db_path = tmp_path / "test.db"
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
     params = SQLiteVectorStoreParams(
+        indexed_properties=INDEXED_PROPERTIES,
         sqlalchemy_engine=engine,
         vector_search_engine_factory=lambda ndim: USearchVectorSearchEngine(
             num_dimensions=ndim
@@ -102,13 +118,6 @@ async def collection(store):
         name=NAME,
         config=VectorStoreCollectionConfig(
             vector_dimensions=VECTOR_DIM,
-            indexed_properties_schema={
-                "name": str,
-                "age": int,
-                "score": float,
-                "active": bool,
-                "created_at": datetime,
-            },
         ),
     )
     coll = await store.open_collection(namespace=NAMESPACE, name=NAME)
@@ -145,13 +154,6 @@ class TestCollectionLifecycle:
                 name=NAME,
                 config=VectorStoreCollectionConfig(
                     vector_dimensions=VECTOR_DIM,
-                    indexed_properties_schema={
-                        "name": str,
-                        "age": int,
-                        "score": float,
-                        "active": bool,
-                        "created_at": datetime,
-                    },
                 ),
             )
 
@@ -263,7 +265,7 @@ class TestUpsertAndQuery:
         [result] = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Comparison(field="name", op="=", value="updated"),
+            property_filter=Equals(field="name", value="updated"),
         )
         assert [m.record_uuid for m in result.matches] == [record.uuid]
 
@@ -340,6 +342,10 @@ class TestUpsertAndQuery:
 # ── Filters ──
 
 
+class TestDeclaredSchema(DeclaredSchemaContract):
+    """The declared-schema contract, against this store."""
+
+
 class TestFilters:
     async def _setup(self, collection):
         v1 = _normalize([1.0, 0.0, 0.0])
@@ -393,7 +399,7 @@ class TestFilters:
         all_results = await collection.query(
             query_vectors=[query_vector],
             limit=10,
-            property_filter=Comparison(field=field, op=op, value=value),
+            property_filter=comparison(field, op, value),
         )
         return {match.record_uuid for match in all_results[0].matches}
 
@@ -501,7 +507,7 @@ class TestFilters:
         [result] = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Comparison(field="created_at", op="=", value=dt),
+            property_filter=Equals(field="created_at", value=dt),
         )
         assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
@@ -566,9 +572,7 @@ class TestFilters:
         [result] = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Comparison(
-                field="created_at", op="=", value=dt.astimezone(UTC)
-            ),
+            property_filter=Equals(field="created_at", value=dt.astimezone(UTC)),
         )
         assert [m.record_uuid for m in result.matches] == [r1.uuid]
 
@@ -580,7 +584,7 @@ class TestFilters:
         query_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=In(field="name", values=["alice", "carol"]),
+            property_filter=In(field="name", values=("alice", "carol")),
         )
         uuids = {match.record_uuid for match in query_results[0].matches}
         assert r1.uuid in uuids
@@ -594,8 +598,10 @@ class TestFilters:
             query_vectors=[v1],
             limit=10,
             property_filter=And(
-                left=Comparison(field="active", op="=", value=True),
-                right=Comparison(field="age", op=">", value=30),
+                (
+                    Equals(field="active", value=True),
+                    Ordering(field="age", op=">", value=30),
+                )
             ),
         )
         matches = query_results[0].matches
@@ -609,8 +615,10 @@ class TestFilters:
             query_vectors=[v1],
             limit=10,
             property_filter=Or(
-                left=Comparison(field="name", op="=", value="alice"),
-                right=Comparison(field="name", op="=", value="carol"),
+                (
+                    Equals(field="name", value="alice"),
+                    Equals(field="name", value="carol"),
+                )
             ),
         )
         uuids = {match.record_uuid for match in query_results[0].matches}
@@ -624,7 +632,7 @@ class TestFilters:
         query_results = await collection.query(
             query_vectors=[v1],
             limit=10,
-            property_filter=Not(expr=Comparison(field="age", op=">", value=30)),
+            property_filter=Not(Ordering(field="age", op=">", value=30)),
         )
         uuids = {match.record_uuid for match in query_results[0].matches}
         assert r1.uuid in uuids
@@ -899,7 +907,7 @@ class TestUpsertBehavior:
         [named_bob] = await collection.query(
             query_vectors=[v2],
             limit=10,
-            property_filter=Comparison(field="name", op="=", value="bob"),
+            property_filter=Equals(field="name", value="bob"),
         )
         assert [m.record_uuid for m in named_bob.matches] == [record_uuid]
 
@@ -979,6 +987,7 @@ async def _fresh_store(db_path, tmp_path, *, save_threshold=1000):
     """Create a new SQLiteVectorStore against the same DB file."""
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
     params = SQLiteVectorStoreParams(
+        indexed_properties=INDEXED_PROPERTIES,
         sqlalchemy_engine=engine,
         vector_search_engine_factory=_engine_factory,
         index_directory=str(tmp_path / "indexes"),
@@ -1207,6 +1216,7 @@ class TestCrashRecovery:
         engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
         store = SQLiteVectorStore(
             SQLiteVectorStoreParams(
+                indexed_properties=INDEXED_PROPERTIES,
                 sqlalchemy_engine=engine,
                 vector_search_engine_factory=_engine_factory,
             )
@@ -1438,3 +1448,43 @@ class TestIndexFileDurability:
 
         await store2.shutdown()
         await engine2.dispose()
+
+
+class TestDeclaredSchemaIsFixed:
+    @pytest.mark.asyncio
+    async def test_a_store_with_another_schema_cannot_open_the_collection(
+        self, tmp_path
+    ):
+        db_path = tmp_path / "fixed.db"
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+        first = SQLiteVectorStore(
+            SQLiteVectorStoreParams(
+                indexed_properties=INDEXED_PROPERTIES,
+                sqlalchemy_engine=engine,
+                vector_search_engine_factory=lambda ndim: USearchVectorSearchEngine(
+                    num_dimensions=ndim
+                ),
+            )
+        )
+        await first.startup()
+        await first.create_collection(
+            namespace=NAMESPACE,
+            name="fixed",
+            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
+        )
+        await first.shutdown()
+
+        second = SQLiteVectorStore(
+            SQLiteVectorStoreParams(
+                indexed_properties={"name": str},
+                sqlalchemy_engine=engine,
+                vector_search_engine_factory=lambda ndim: USearchVectorSearchEngine(
+                    num_dimensions=ndim
+                ),
+            )
+        )
+        await second.startup()
+        with pytest.raises(IndexedPropertiesMismatchError, match="fixed"):
+            await second.open_collection(namespace=NAMESPACE, name="fixed")
+        await second.shutdown()
+        await engine.dispose()

--- a/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
+++ b/packages/server/server_tests/memmachine_server/common/vector_store/test_sqlite_vector_store.py
@@ -19,19 +19,18 @@ from memmachine_server.common.filter import (
     Or,
     Ordering,
 )
+from memmachine_server.common.vector_store import get_or_create_partition
 from memmachine_server.common.vector_store.data_types import (
-    IndexedPropertiesMismatchError,
     Record,
-    VectorStoreCollectionAlreadyExistsError,
-    VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
+    VectorStorePartitionAlreadyExistsError,
+    VectorStorePartitionSchemaMismatchError,
 )
 from memmachine_server.common.vector_store.sqlite_vector_store import (
     IndexLoadError,
     SQLiteVectorStore,
-    SQLiteVectorStoreCollection,
     SQLiteVectorStoreParams,
-    _CollectionRow,
+    SQLiteVectorStorePartition,
+    _PartitionRow,
     _PendingOperationRow,
 )
 from memmachine_server.common.vector_store.vector_search_engine.usearch_engine import (
@@ -42,7 +41,7 @@ from server_tests.memmachine_server.common.vector_store.declared_schema_contract
     DeclaredSchemaContract,
 )
 
-NAMESPACE = "test_namespace"
+COLLECTION = "test_namespace"
 NAME = "test_name"
 VECTOR_DIM = 3
 
@@ -73,7 +72,7 @@ async def _present_uuids(collection, record_uuids) -> list[UUID]:
     record_uuids = list(record_uuids)
     if not record_uuids:
         return []
-    dimensions = collection.config.vector_dimensions
+    dimensions = VECTOR_DIM
     probe = [1.0] + [0.0] * (dimensions - 1)
     [result] = await collection.query(query_vectors=[probe], limit=_FETCH_LIMIT)
     present = {match.record_uuid for match in result.matches}
@@ -98,6 +97,8 @@ async def store(tmp_path):
     db_path = tmp_path / "test.db"
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
     params = SQLiteVectorStoreParams(
+        collection=COLLECTION,
+        vector_dimensions=VECTOR_DIM,
         indexed_properties=INDEXED_PROPERTIES,
         sqlalchemy_engine=engine,
         vector_search_engine_factory=lambda ndim: USearchVectorSearchEngine(
@@ -105,6 +106,7 @@ async def store(tmp_path):
         ),
     )
     vector_store = SQLiteVectorStore(params)
+    await vector_store.provision()
     await vector_store.startup()
     yield vector_store
     await vector_store.shutdown()
@@ -113,111 +115,59 @@ async def store(tmp_path):
 
 @pytest_asyncio.fixture
 async def collection(store):
-    await store.create_collection(
-        namespace=NAMESPACE,
-        name=NAME,
-        config=VectorStoreCollectionConfig(
-            vector_dimensions=VECTOR_DIM,
-        ),
-    )
-    coll = await store.open_collection(namespace=NAMESPACE, name=NAME)
+    await store.create_partition(NAME)
+    coll = await store.get_partition(NAME)
     assert coll is not None
     yield coll
-    await store.delete_collection(namespace=NAMESPACE, name=NAME)
+    await store.delete_partition(NAME)
 
 
-# ── Collection lifecycle ──
+# ── Partition lifecycle ──
 
 
 class TestCollectionLifecycle:
     @pytest.mark.asyncio
     async def test_create_open_delete(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="lifecycle",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        coll = await store.open_collection(namespace=NAMESPACE, name="lifecycle")
-        assert isinstance(coll, SQLiteVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="lifecycle")
+        await store.create_partition("lifecycle")
+        coll = await store.get_partition("lifecycle")
+        assert isinstance(coll, SQLiteVectorStorePartition)
+        await store.delete_partition("lifecycle")
 
     @pytest.mark.asyncio
     async def test_open_returns_correct_type(self, store, collection):
-        coll = await store.open_collection(namespace=NAMESPACE, name=NAME)
-        assert isinstance(coll, SQLiteVectorStoreCollection)
+        coll = await store.get_partition(NAME)
+        assert isinstance(coll, SQLiteVectorStorePartition)
 
     @pytest.mark.asyncio
     async def test_duplicate_name_raises(self, store, collection):
-        with pytest.raises(VectorStoreCollectionAlreadyExistsError):
-            await store.create_collection(
-                namespace=NAMESPACE,
-                name=NAME,
-                config=VectorStoreCollectionConfig(
-                    vector_dimensions=VECTOR_DIM,
-                ),
-            )
+        with pytest.raises(VectorStorePartitionAlreadyExistsError):
+            await store.create_partition(NAME)
 
     @pytest.mark.asyncio
     async def test_delete_nonexistent_is_idempotent(self, store):
-        await store.delete_collection(namespace=NAMESPACE, name="nonexistent")
+        await store.delete_partition("nonexistent")
 
     @pytest.mark.asyncio
     async def test_open_or_create_creates_when_missing(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="new", config=config
-        )
-        assert isinstance(coll, SQLiteVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="new")
+        coll = await get_or_create_partition(store, "new")
+        assert isinstance(coll, SQLiteVectorStorePartition)
+        await store.delete_partition("new")
 
     @pytest.mark.asyncio
     async def test_open_or_create_opens_when_exists(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="existing", config=config
-        )
-        assert isinstance(coll, SQLiteVectorStoreCollection)
-        await store.delete_collection(namespace=NAMESPACE, name="existing")
-
-    @pytest.mark.asyncio
-    async def test_open_or_create_raises_on_config_mismatch(self, store):
-        await store.create_collection(
-            namespace=NAMESPACE,
-            name="mismatch",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
-        with pytest.raises(VectorStoreCollectionConfigMismatchError):
-            await store.open_or_create_collection(
-                namespace=NAMESPACE,
-                name="mismatch",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM + 1),
-            )
-        await store.delete_collection(namespace=NAMESPACE, name="mismatch")
+        await store.create_partition("existing")
+        coll = await get_or_create_partition(store, "existing")
+        assert isinstance(coll, SQLiteVectorStorePartition)
+        await store.delete_partition("existing")
 
     @pytest.mark.asyncio
     async def test_open_nonexistent_returns_none(self, store):
-        assert await store.open_collection(namespace=NAMESPACE, name="nope") is None
-
-    @pytest.mark.asyncio
-    async def test_invalid_namespace_raises(self, store):
-        with pytest.raises(ValueError, match="Invalid namespace"):
-            await store.create_collection(
-                namespace="INVALID",
-                name="test",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-            )
+        assert await store.get_partition("nope") is None
 
     @pytest.mark.asyncio
     async def test_invalid_name_raises(self, store):
-        with pytest.raises(ValueError, match="Invalid namespace"):
-            await store.create_collection(
-                namespace="valid",
-                name="INVALID",
-                config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-            )
+        with pytest.raises(ValueError, match="Invalid partition key"):
+            await store.create_partition("INVALID")
 
 
 # ── Upsert + Query ──
@@ -684,15 +634,10 @@ class TestDelete:
 class TestPartitionIsolation:
     @pytest.mark.asyncio
     async def test_query_only_returns_own_collection(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_a", config=config
-        )
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_b", config=config
-        )
-        coll_a = await store.open_collection(namespace=NAMESPACE, name="tenant_a")
-        coll_b = await store.open_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.create_partition("tenant_a")
+        await store.create_partition("tenant_b")
+        coll_a = await store.get_partition("tenant_a")
+        coll_b = await store.get_partition("tenant_b")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -711,20 +656,15 @@ class TestPartitionIsolation:
         assert uuids_a == {r1.uuid}
         assert uuids_b == {r2.uuid}
 
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.delete_partition("tenant_a")
+        await store.delete_partition("tenant_b")
 
     @pytest.mark.asyncio
     async def test_get_only_returns_own_collection(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_a", config=config
-        )
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_b", config=config
-        )
-        coll_a = await store.open_collection(namespace=NAMESPACE, name="tenant_a")
-        coll_b = await store.open_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.create_partition("tenant_a")
+        await store.create_partition("tenant_b")
+        coll_a = await store.get_partition("tenant_a")
+        coll_b = await store.get_partition("tenant_b")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -739,20 +679,15 @@ class TestPartitionIsolation:
         assert len(results) == 1
         assert results[0] == r1.uuid
 
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.delete_partition("tenant_a")
+        await store.delete_partition("tenant_b")
 
     @pytest.mark.asyncio
     async def test_delete_only_affects_own_collection(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_a", config=config
-        )
-        await store.create_collection(
-            namespace=NAMESPACE, name="tenant_b", config=config
-        )
-        coll_a = await store.open_collection(namespace=NAMESPACE, name="tenant_a")
-        coll_b = await store.open_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.create_partition("tenant_a")
+        await store.create_partition("tenant_b")
+        coll_a = await store.get_partition("tenant_a")
+        coll_b = await store.get_partition("tenant_b")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -769,20 +704,29 @@ class TestPartitionIsolation:
         assert len(results) == 1
         assert results[0] == r2.uuid
 
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_a")
-        await store.delete_collection(namespace=NAMESPACE, name="tenant_b")
+        await store.delete_partition("tenant_a")
+        await store.delete_partition("tenant_b")
 
     @pytest.mark.asyncio
-    async def test_namespace_isolation(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        await store.create_collection(
-            namespace="namespace_a", name="coll", config=config
+    async def test_collections_on_one_engine_are_isolated(self, store):
+        """Two stores over one engine, named differently, never see each other's rows."""
+        other = SQLiteVectorStore(
+            SQLiteVectorStoreParams(
+                collection="other_collection",
+                vector_dimensions=VECTOR_DIM,
+                indexed_properties=INDEXED_PROPERTIES,
+                sqlalchemy_engine=store._sqlalchemy_engine,
+                vector_search_engine_factory=lambda ndim: USearchVectorSearchEngine(
+                    num_dimensions=ndim
+                ),
+            )
         )
-        await store.create_collection(
-            namespace="namespace_b", name="coll", config=config
-        )
-        coll_a = await store.open_collection(namespace="namespace_a", name="coll")
-        coll_b = await store.open_collection(namespace="namespace_b", name="coll")
+        await other.provision()
+        await other.startup()
+        await store.create_partition("coll")
+        await other.create_partition("coll")
+        coll_a = await store.get_partition("coll")
+        coll_b = await other.get_partition("coll")
         assert coll_a is not None
         assert coll_b is not None
 
@@ -796,19 +740,16 @@ class TestPartitionIsolation:
         results_a = await coll_a.query(query_vectors=[v1], limit=10)
         assert {match.record_uuid for match in results_a[0].matches} == {r1.uuid}
 
-        await store.delete_collection(namespace="namespace_a", name="coll")
-        await store.delete_collection(namespace="namespace_b", name="coll")
+        await store.delete_partition("coll")
+        assert await other.get_partition("coll") is not None
+        await other.delete_partition("coll")
+        await other.shutdown()
 
     @pytest.mark.asyncio
     async def test_delete_collection_does_not_affect_sibling(self, store):
         """Deleting one collection doesn't break a sibling sharing tables."""
-        config = VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM)
-        coll_a = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="sibling_a", config=config
-        )
-        coll_b = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="sibling_b", config=config
-        )
+        coll_a = await get_or_create_partition(store, "sibling_a")
+        coll_b = await get_or_create_partition(store, "sibling_b")
 
         v1 = _normalize([1.0, 0.0, 0.0])
         r1 = _make_record(vector=v1)
@@ -816,13 +757,13 @@ class TestPartitionIsolation:
         await coll_a.upsert(records=[r1])
         await coll_b.upsert(records=[r2])
 
-        await store.delete_collection(namespace=NAMESPACE, name="sibling_a")
+        await store.delete_partition("sibling_a")
 
         results = await coll_b.query(query_vectors=[v1], limit=10)
         assert len(results[0].matches) == 1
         assert results[0].matches[0].record_uuid == r2.uuid
 
-        await store.delete_collection(namespace=NAMESPACE, name="sibling_b")
+        await store.delete_partition("sibling_b")
 
 
 # ── No-properties collection ──
@@ -831,17 +772,15 @@ class TestPartitionIsolation:
 class TestNoProperties:
     @pytest.mark.asyncio
     async def test_collection_without_properties(self, store):
-        config = VectorStoreCollectionConfig(vector_dimensions=2)
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name="no_props", config=config
-        )
-        r1 = _make_record(vector=[1.0, 0.0])
+        coll = await get_or_create_partition(store, "no_props")
+        v1 = _normalize([1.0, 0.0, 0.0])
+        r1 = _make_record(vector=v1)
         await coll.upsert(records=[r1])
 
-        results = await coll.query(query_vectors=[[1.0, 0.0]], limit=1)
+        results = await coll.query(query_vectors=[v1], limit=1)
         assert len(results[0].matches) == 1
 
-        await store.delete_collection(namespace=NAMESPACE, name="no_props")
+        await store.delete_partition("no_props")
 
 
 # ── Input validation ──
@@ -978,15 +917,12 @@ def _engine_factory(ndim):
     return USearchVectorSearchEngine(num_dimensions=ndim)
 
 
-CONFIG = VectorStoreCollectionConfig(
-    vector_dimensions=VECTOR_DIM,
-)
-
-
 async def _fresh_store(db_path, tmp_path, *, save_threshold=1000):
     """Create a new SQLiteVectorStore against the same DB file."""
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
     params = SQLiteVectorStoreParams(
+        collection=COLLECTION,
+        vector_dimensions=VECTOR_DIM,
         indexed_properties=INDEXED_PROPERTIES,
         sqlalchemy_engine=engine,
         vector_search_engine_factory=_engine_factory,
@@ -994,6 +930,7 @@ async def _fresh_store(db_path, tmp_path, *, save_threshold=1000):
         save_threshold=save_threshold,
     )
     store = SQLiteVectorStore(params)
+    await store.provision()
     await store.startup()
     return store, engine
 
@@ -1004,7 +941,7 @@ async def _stored_record_uuids(engine, store) -> set[UUID]:
     The collection contract cannot see a record whose vector the index lost, so
     a test about surviving that loss has to look past the contract at the row.
     """
-    records_table = store._records_table(NAMESPACE, NAME)
+    records_table = store._records_table(NAME)
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     async with session_factory() as session:
         rows = (await session.execute(select(records_table.c.uuid))).all()
@@ -1038,9 +975,7 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        coll = await get_or_create_partition(store1, NAME)
         records = [
             _make_record(vector=_normalize([1.0, 0.0, 0.0])),
             _make_record(vector=_normalize([0.0, 1.0, 0.0])),
@@ -1052,7 +987,7 @@ class TestCrashRecovery:
 
         # Restart with fresh in-memory engines.
         store2, engine2 = await _fresh_store(db_path, tmp_path)
-        coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        coll2 = await store2.get_partition(NAME)
         assert coll2 is not None
 
         results = await coll2.query(
@@ -1069,9 +1004,7 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        coll = await get_or_create_partition(store1, NAME)
         records = [
             _make_record(vector=_normalize([1.0, 0.0, 0.0])),
             _make_record(vector=_normalize([0.0, 1.0, 0.0])),
@@ -1085,7 +1018,7 @@ class TestCrashRecovery:
 
         # Restart: replay should re-apply unapplied ops to the engine.
         store2, engine2 = await _fresh_store(db_path, tmp_path)
-        coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        coll2 = await store2.get_partition(NAME)
         assert coll2 is not None
 
         results = await coll2.query(
@@ -1102,9 +1035,7 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        coll = await get_or_create_partition(store1, NAME)
         r1 = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
         r2 = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
         await coll.upsert(records=[r1, r2])
@@ -1114,7 +1045,7 @@ class TestCrashRecovery:
         await engine1.dispose()
 
         store2, engine2 = await _fresh_store(db_path, tmp_path)
-        coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        coll2 = await store2.get_partition(NAME)
         assert coll2 is not None
 
         results = await coll2.query(
@@ -1134,9 +1065,7 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        coll = await get_or_create_partition(store1, NAME)
         r1 = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
         r2 = _make_record(vector=_normalize([0.0, 1.0, 0.0]))
         r3 = _make_record(vector=_normalize([0.0, 0.0, 1.0]))
@@ -1147,7 +1076,7 @@ class TestCrashRecovery:
         await engine1.dispose()
 
         store2, engine2 = await _fresh_store(db_path, tmp_path)
-        coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        coll2 = await store2.get_partition(NAME)
         assert coll2 is not None
 
         results = await coll2.query(
@@ -1170,9 +1099,7 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=2)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        coll = await get_or_create_partition(store1, NAME)
 
         # Upsert 1 record: below threshold, pending op should remain.
         r1 = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
@@ -1193,9 +1120,7 @@ class TestCrashRecovery:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        coll = await get_or_create_partition(store1, NAME)
         records = [
             _make_record(vector=_normalize([1.0, 0.0, 0.0])),
             _make_record(vector=_normalize([0.0, 1.0, 0.0])),
@@ -1203,7 +1128,7 @@ class TestCrashRecovery:
         await coll.upsert(records=records)
         assert await _pending_operation_count(engine1) == 2
 
-        await store1.delete_collection(namespace=NAMESPACE, name=NAME)
+        await store1.delete_partition(NAME)
         assert await _pending_operation_count(engine1) == 0
 
         await store1.shutdown()
@@ -1216,6 +1141,8 @@ class TestCrashRecovery:
         engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
         store = SQLiteVectorStore(
             SQLiteVectorStoreParams(
+                collection=COLLECTION,
+                vector_dimensions=VECTOR_DIM,
                 indexed_properties=INDEXED_PROPERTIES,
                 sqlalchemy_engine=engine,
                 vector_search_engine_factory=_engine_factory,
@@ -1223,13 +1150,13 @@ class TestCrashRecovery:
         )
 
         with pytest.raises(RuntimeError, match="startup"):
-            await store.open_collection(namespace=NAMESPACE, name=NAME)
+            await store.get_partition(NAME)
 
         with pytest.raises(RuntimeError, match="startup"):
-            await store.create_collection(namespace=NAMESPACE, name=NAME, config=CONFIG)
+            await store.create_partition(NAME)
 
         with pytest.raises(RuntimeError, match="startup"):
-            await store.delete_collection(namespace=NAMESPACE, name=NAME)
+            await store.delete_partition(NAME)
 
         await engine.dispose()
 
@@ -1237,14 +1164,14 @@ class TestCrashRecovery:
 # ── Index file durability contract ──
 
 
-async def _get_index_saved(engine, namespace, name) -> bool | None:
+async def _get_index_saved(engine, name) -> bool | None:
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     async with session_factory() as session:
         return (
             await session.execute(
-                select(_CollectionRow.index_saved).where(
-                    _CollectionRow.namespace == namespace,
-                    _CollectionRow.name == name,
+                select(_PartitionRow.index_saved).where(
+                    _PartitionRow.collection == COLLECTION,
+                    _PartitionRow.partition_key == name,
                 )
             )
         ).scalar_one_or_none()
@@ -1258,11 +1185,9 @@ class TestIndexFileDurability:
         """A freshly created collection has index_saved=False."""
         db_path = tmp_path / "test.db"
         store, engine = await _fresh_store(db_path, tmp_path)
-        await store.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        await get_or_create_partition(store, NAME)
 
-        assert await _get_index_saved(engine, NAMESPACE, NAME) is False
+        assert await _get_index_saved(engine, NAME) is False
 
         await store.shutdown()
         await engine.dispose()
@@ -1273,12 +1198,10 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store, engine = await _fresh_store(db_path, tmp_path, save_threshold=1)
 
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        coll = await get_or_create_partition(store, NAME)
         await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
 
-        assert await _get_index_saved(engine, NAMESPACE, NAME) is True
+        assert await _get_index_saved(engine, NAME) is True
 
         await store.shutdown()
         await engine.dispose()
@@ -1289,16 +1212,14 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store, engine = await _fresh_store(db_path, tmp_path, save_threshold=1000)
 
-        coll = await store.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        coll = await get_or_create_partition(store, NAME)
         await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
 
         # Below save_threshold, so _maybe_save_index has not flipped the flag yet.
-        assert await _get_index_saved(engine, NAMESPACE, NAME) is False
+        assert await _get_index_saved(engine, NAME) is False
 
         await store.shutdown()
-        assert await _get_index_saved(engine, NAMESPACE, NAME) is True
+        assert await _get_index_saved(engine, NAME) is True
 
         await engine.dispose()
 
@@ -1308,9 +1229,7 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        coll = await get_or_create_partition(store1, NAME)
         await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
         await store1.shutdown()
         await engine1.dispose()
@@ -1325,9 +1244,9 @@ class TestIndexFileDurability:
         # engine silently rebuilt empty.
         store2, engine2 = await _fresh_store(db_path, tmp_path)
         with pytest.raises(IndexLoadError) as exc_info:
-            await store2.open_collection(namespace=NAMESPACE, name=NAME)
-        assert exc_info.value.namespace == NAMESPACE
-        assert exc_info.value.name == NAME
+            await store2.get_partition(NAME)
+        assert exc_info.value.collection == COLLECTION
+        assert exc_info.value.partition_key == NAME
         assert exc_info.value.__cause__ is not None
 
         await store2.shutdown()
@@ -1339,9 +1258,7 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        coll = await get_or_create_partition(store1, NAME)
         await coll.upsert(records=[_make_record(vector=_normalize([1.0, 0.0, 0.0]))])
         await store1.shutdown()
         await engine1.dispose()
@@ -1353,9 +1270,9 @@ class TestIndexFileDurability:
 
         store2, engine2 = await _fresh_store(db_path, tmp_path)
         with pytest.raises(IndexLoadError) as exc_info:
-            await store2.open_collection(namespace=NAMESPACE, name=NAME)
-        assert exc_info.value.namespace == NAMESPACE
-        assert exc_info.value.name == NAME
+            await store2.get_partition(NAME)
+        assert exc_info.value.collection == COLLECTION
+        assert exc_info.value.partition_key == NAME
         assert exc_info.value.__cause__ is not None
 
         await store2.shutdown()
@@ -1367,9 +1284,7 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=1000)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        coll = await get_or_create_partition(store1, NAME)
         await coll.upsert(
             records=[
                 _make_record(vector=_normalize([1.0, 0.0, 0.0])),
@@ -1384,7 +1299,7 @@ class TestIndexFileDurability:
         )
 
         store2, engine2 = await _fresh_store(db_path, tmp_path)
-        coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        coll2 = await store2.get_partition(NAME)
         assert coll2 is not None
 
         results = await coll2.query(
@@ -1413,9 +1328,7 @@ class TestIndexFileDurability:
         db_path = tmp_path / "test.db"
         store1, engine1 = await _fresh_store(db_path, tmp_path, save_threshold=1)
 
-        coll = await store1.open_or_create_collection(
-            namespace=NAMESPACE, name=NAME, config=CONFIG
-        )
+        coll = await get_or_create_partition(store1, NAME)
         r1 = _make_record(vector=_normalize([1.0, 0.0, 0.0]))
         await coll.upsert(records=[r1])
 
@@ -1436,7 +1349,7 @@ class TestIndexFileDurability:
         idx_files[0].write_bytes(published_without_r2)
 
         store2, engine2 = await _fresh_store(db_path, tmp_path)
-        coll2 = await store2.open_collection(namespace=NAMESPACE, name=NAME)
+        coll2 = await store2.get_partition(NAME)
         assert coll2 is not None
 
         # The record is still a row.
@@ -1459,6 +1372,8 @@ class TestDeclaredSchemaIsFixed:
         engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
         first = SQLiteVectorStore(
             SQLiteVectorStoreParams(
+                collection=COLLECTION,
+                vector_dimensions=VECTOR_DIM,
                 indexed_properties=INDEXED_PROPERTIES,
                 sqlalchemy_engine=engine,
                 vector_search_engine_factory=lambda ndim: USearchVectorSearchEngine(
@@ -1466,16 +1381,15 @@ class TestDeclaredSchemaIsFixed:
                 ),
             )
         )
+        await first.provision()
         await first.startup()
-        await first.create_collection(
-            namespace=NAMESPACE,
-            name="fixed",
-            config=VectorStoreCollectionConfig(vector_dimensions=VECTOR_DIM),
-        )
+        await first.create_partition("fixed")
         await first.shutdown()
 
         second = SQLiteVectorStore(
             SQLiteVectorStoreParams(
+                collection=COLLECTION,
+                vector_dimensions=VECTOR_DIM,
                 indexed_properties={"name": str},
                 sqlalchemy_engine=engine,
                 vector_search_engine_factory=lambda ndim: USearchVectorSearchEngine(
@@ -1483,8 +1397,9 @@ class TestDeclaredSchemaIsFixed:
                 ),
             )
         )
+        await second.provision()
         await second.startup()
-        with pytest.raises(IndexedPropertiesMismatchError, match="fixed"):
-            await second.open_collection(namespace=NAMESPACE, name="fixed")
+        with pytest.raises(VectorStorePartitionSchemaMismatchError, match="fixed"):
+            await second.get_partition("fixed")
         await second.shutdown()
         await engine.dispose()

--- a/packages/server/server_tests/memmachine_server/episodic_memory/declarative_memory/test_declarative_memory.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/declarative_memory/test_declarative_memory.py
@@ -6,23 +6,14 @@ import pytest_asyncio
 from neo4j import AsyncGraphDatabase
 from testcontainers.neo4j import Neo4jContainer
 
-from memmachine_server.common.filter.filter_parser import (
-    And as FilterAnd,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Comparison as FilterComparison,
-)
-from memmachine_server.common.filter.filter_parser import (
-    In as FilterIn,
-)
-from memmachine_server.common.filter.filter_parser import (
-    IsNull as FilterIsNull,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Not as FilterNot,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Or as FilterOr,
+from memmachine_server.common.filter import (
+    And,
+    Equals,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
 )
 from memmachine_server.common.vector_graph_store.neo4j_vector_graph_store import (
     Neo4jVectorGraphStore,
@@ -395,11 +386,7 @@ async def test_search(declarative_memory):
     results = await declarative_memory.search(
         query="Who wrote the test?",
         max_num_episodes=10,
-        property_filter=FilterComparison(
-            field="project",
-            op="=",
-            value="memmachine",
-        ),
+        property_filter=Equals(field="project", value="memmachine"),
     )
     assert len(results) == 10
     assert "episode1" in [result.uid for result in results]
@@ -408,11 +395,7 @@ async def test_search(declarative_memory):
     results = await declarative_memory.search(
         query="Who wrote the test?",
         max_num_episodes=4,
-        property_filter=FilterComparison(
-            field="length",
-            op="=",
-            value="short",
-        ),
+        property_filter=Equals(field="length", value="short"),
     )
 
     assert len(results) == 3
@@ -656,49 +639,33 @@ async def test_get_matching_episodes(declarative_memory):
     await declarative_memory.add_episodes(episodes)
 
     results = await declarative_memory.get_matching_episodes(
-        property_filter=FilterComparison(
-            field="project",
-            op="=",
-            value="memmachine",
-        ),
+        property_filter=Equals(field="project", value="memmachine"),
     )
     assert len(results) == 22
 
     results = await declarative_memory.get_matching_episodes(
-        property_filter=FilterAnd(
-            left=FilterComparison(
-                field="project",
-                op="=",
-                value="memmachine",
-            ),
-            right=FilterIsNull(
-                field="length",
-            ),
+        property_filter=And(
+            (
+                Equals(field="project", value="memmachine"),
+                IsMissing(
+                    field="length",
+                ),
+            )
         ),
     )
     assert len(results) == 1
 
     results = await declarative_memory.get_matching_episodes(
-        property_filter=FilterComparison(
-            field="length",
-            op="=",
-            value="short",
-        )
+        property_filter=Equals(field="length", value="short")
     )
     assert len(results) == 2
 
     results = await declarative_memory.get_matching_episodes(
-        property_filter=FilterAnd(
-            left=FilterComparison(
-                field="project",
-                op="=",
-                value="memmachine",
-            ),
-            right=FilterComparison(
-                field="length",
-                op="=",
-                value="short",
-            ),
+        property_filter=And(
+            (
+                Equals(field="project", value="memmachine"),
+                Equals(field="length", value="short"),
+            )
         ),
     )
     assert len(results) == 1
@@ -915,11 +882,7 @@ async def test_get_matching_episodes_extended_filters(declarative_memory):
 
     # != on project: != 'memmachine' → episodes with project=other, testing
     results = await declarative_memory.get_matching_episodes(
-        property_filter=FilterComparison(
-            field="project",
-            op="!=",
-            value="memmachine",
-        ),
+        property_filter=NotEquals(field="project", value="memmachine"),
     )
     result_uids = {r.uid for r in results}
     assert "episode2" in result_uids
@@ -929,9 +892,9 @@ async def test_get_matching_episodes_extended_filters(declarative_memory):
 
     # In on project
     results = await declarative_memory.get_matching_episodes(
-        property_filter=FilterIn(
+        property_filter=In(
             field="project",
-            values=["memmachine", "other"],
+            values=("memmachine", "other"),
         ),
     )
     result_uids = {r.uid for r in results}
@@ -941,13 +904,7 @@ async def test_get_matching_episodes_extended_filters(declarative_memory):
 
     # Not: NOT length = 'short'
     results = await declarative_memory.get_matching_episodes(
-        property_filter=FilterNot(
-            expr=FilterComparison(
-                field="length",
-                op="=",
-                value="short",
-            )
-        ),
+        property_filter=Not(Equals(field="length", value="short")),
     )
     result_uids = {r.uid for r in results}
     assert "episode1" not in result_uids
@@ -956,17 +913,11 @@ async def test_get_matching_episodes_extended_filters(declarative_memory):
 
     # Or: project = 'other' OR length = 'short'
     results = await declarative_memory.get_matching_episodes(
-        property_filter=FilterOr(
-            left=FilterComparison(
-                field="project",
-                op="=",
-                value="other",
-            ),
-            right=FilterComparison(
-                field="length",
-                op="=",
-                value="short",
-            ),
+        property_filter=Or(
+            (
+                Equals(field="project", value="other"),
+                Equals(field="length", value="short"),
+            )
         ),
     )
     result_uids = {r.uid for r in results}

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/conftest.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/conftest.py
@@ -9,10 +9,12 @@ from uuid import UUID
 
 import pytest
 
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
     FilterExpr,
-    demangle_user_metadata_key,
     map_filter_fields,
+)
+from memmachine_server.common.filter.filter_parser import (
+    demangle_user_metadata_key,
     normalize_filter_field,
 )
 from memmachine_server.common.reranker import Reranker
@@ -386,13 +388,8 @@ class AngleEmbedder(FakeEmbedder):
 def make_collection(embedder: FakeEmbedder) -> InMemoryVectorStoreCollection:
     """A collection declaring EventMemory's reserved keys and a `color` property."""
     return InMemoryVectorStoreCollection(
-        VectorStoreCollectionConfig(
-            vector_dimensions=embedder.dimensions,
-            indexed_properties_schema={
-                **EventMemory.expected_vector_store_collection_schema(),
-                "color": str,
-            },
-        )
+        VectorStoreCollectionConfig(vector_dimensions=embedder.dimensions),
+        {**EventMemory.expected_vector_store_collection_schema(), "color": str},
     )
 
 

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/conftest.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/conftest.py
@@ -1,8 +1,10 @@
 """Shared fakes and fixtures for event memory tests."""
 
+import math
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
-from typing import override
+from datetime import datetime
+from typing import Any, override
 from uuid import UUID
 
 import pytest
@@ -17,7 +19,11 @@ from memmachine_server.common.reranker import Reranker
 from memmachine_server.common.vector_store.data_types import (
     VectorStoreCollectionConfig,
 )
-from memmachine_server.episodic_memory.event_memory.data_types import Segment
+from memmachine_server.episodic_memory.event_memory.data_types import (
+    EvictionOptions,
+    Neighborhood,
+    Segment,
+)
 from memmachine_server.episodic_memory.event_memory.deriver.text_deriver import (
     SentenceTextDeriver,
     WholeTextDeriver,
@@ -46,8 +52,25 @@ from server_tests.memmachine_server.common.vector_store.in_memory_vector_store_c
 # ---------------------------------------------------------------------------
 
 
+def _order_key(segment: Segment) -> tuple:
+    # The store's total order, with the ungrouped (null session) stream first.
+    return (
+        segment.session_id is not None,
+        segment.session_id or "",
+        segment.timestamp,
+        segment.event_uuid,
+        segment.index,
+        segment.offset,
+    )
+
+
 class InMemorySegmentStorePartition(SegmentStorePartition):
-    """Minimal in-memory segment store partition for testing."""
+    """Minimal in-memory segment store partition for testing.
+
+    Mirrors the SQLAlchemy store's reads: one total order per session,
+    windows confined to the seed's session, the seed filtered for a
+    context and never returned for a neighborhood.
+    """
 
     def __init__(
         self,
@@ -55,7 +78,6 @@ class InMemorySegmentStorePartition(SegmentStorePartition):
     ) -> None:
         self._config = config or SegmentStorePartitionConfig()
         self.segments: dict[UUID, Segment] = {}
-        self.segment_order: list[UUID] = []
         self.event_to_segments: dict[UUID, list[UUID]] = defaultdict(list)
         self.segment_to_derivatives: dict[UUID, list[UUID]] = {}
 
@@ -71,58 +93,160 @@ class InMemorySegmentStorePartition(SegmentStorePartition):
     ) -> None:
         for segment, derivative_uuids in segments_to_derivative_uuids.items():
             self.segments[segment.uuid] = segment
-            self.segment_order.append(segment.uuid)
             self.event_to_segments[segment.event_uuid].append(segment.uuid)
             self.segment_to_derivatives[segment.uuid] = list(derivative_uuids)
+
+    def _ordered(self) -> list[Segment]:
+        return sorted(self.segments.values(), key=_order_key)
+
+    @staticmethod
+    def _passes(
+        segment: Segment,
+        *,
+        since: datetime | None,
+        until: datetime | None,
+        source_ids: list[str] | None,
+        block_kinds: list[str] | None,
+        normalized_filter: FilterExpr | None,
+    ) -> bool:
+        if since is not None and segment.timestamp < since:
+            return False
+        if until is not None and segment.timestamp >= until:
+            return False
+        if source_ids is not None and segment.source_id not in source_ids:
+            return False
+        if block_kinds is not None and segment.block.kind not in block_kinds:
+            return False
+        if normalized_filter is not None:
+            evaluated = {**segment.properties, "timestamp": segment.timestamp}
+            return evaluate_filter(normalized_filter, evaluated)
+        return True
+
+    def _window(
+        self,
+        seed: Segment,
+        before: int,
+        after: int,
+        passes: Any,
+    ) -> tuple[list[Segment], list[Segment]]:
+        ordered = [s for s in self._ordered() if s.session_id == seed.session_id]
+        position = next(i for i, s in enumerate(ordered) if s.uuid == seed.uuid)
+        backward = (
+            [s for s in ordered[:position] if passes(s)][-before:] if before > 0 else []
+        )
+        forward = [s for s in ordered[position + 1 :] if passes(s)][:after]
+        return backward, forward
+
+    def _read(
+        self,
+        seed_segment_uuids: Iterable[UUID],
+        *,
+        before: int,
+        after: int,
+        since: datetime | None,
+        until: datetime | None,
+        source_ids: Iterable[str] | None,
+        block_kinds: Iterable[str] | None,
+        property_filter: FilterExpr | None,
+        seed_must_pass: bool,
+    ) -> dict[UUID, tuple[list[Segment], Segment, list[Segment]]]:
+        normalized_filter = (
+            map_filter_fields(property_filter, self._normalize_segment_field)
+            if property_filter is not None
+            else None
+        )
+        source_ids = list(source_ids) if source_ids is not None else None
+        block_kinds = list(block_kinds) if block_kinds is not None else None
+
+        def passes(segment: Segment) -> bool:
+            return self._passes(
+                segment,
+                since=since,
+                until=until,
+                source_ids=source_ids,
+                block_kinds=block_kinds,
+                normalized_filter=normalized_filter,
+            )
+
+        result: dict[UUID, tuple[list[Segment], Segment, list[Segment]]] = {}
+        for seed_uuid in seed_segment_uuids:
+            seed = self.segments.get(seed_uuid)
+            if seed is None or (seed_must_pass and not passes(seed)):
+                continue
+            backward, forward = self._window(seed, before, after, passes)
+            result[seed_uuid] = (backward, seed, forward)
+        return result
 
     @override
     async def get_segment_contexts(
         self,
         seed_segment_uuids: Iterable[UUID],
         *,
-        max_backward_segments: int = 0,
-        max_forward_segments: int = 0,
+        before: int = 0,
+        after: int = 0,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        source_ids: Iterable[str] | None = None,
+        block_kinds: Iterable[str] | None = None,
         property_filter: FilterExpr | None = None,
     ) -> dict[UUID, list[Segment]]:
-        # Normalize canonical field names (e.g. "m.color" → "color") to
-        # match the raw keys stored in segment.properties.
-        normalized_filter = (
-            map_filter_fields(property_filter, self._normalize_segment_field)
-            if property_filter is not None
-            else None
+        windows = self._read(
+            seed_segment_uuids,
+            before=before,
+            after=after,
+            since=since,
+            until=until,
+            source_ids=source_ids,
+            block_kinds=block_kinds,
+            property_filter=property_filter,
+            seed_must_pass=True,
         )
-        result: dict[UUID, list[Segment]] = {}
-        for seed_uuid in seed_segment_uuids:
-            if seed_uuid not in self.segments:
-                continue
-            try:
-                pos = self.segment_order.index(seed_uuid)
-            except ValueError:
-                continue
-            start = max(0, pos - max_backward_segments)
-            end = min(len(self.segment_order), pos + max_forward_segments + 1)
-            context = [
-                self.segments[uid]
-                for uid in self.segment_order[start:end]
-                if uid in self.segments
-                and (
-                    normalized_filter is None
-                    or evaluate_filter(normalized_filter, self.segments[uid].properties)
-                )
-            ]
-            if context:
-                result[seed_uuid] = context
-        return result
+        return {
+            seed_uuid: [*backward, seed, *forward]
+            for seed_uuid, (backward, seed, forward) in windows.items()
+        }
+
+    @override
+    async def get_neighbourhoods(
+        self,
+        seed_segment_uuids: Iterable[UUID],
+        *,
+        before: int = 0,
+        after: int = 0,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        source_ids: Iterable[str] | None = None,
+        block_kinds: Iterable[str] | None = None,
+        property_filter: FilterExpr | None = None,
+    ) -> dict[UUID, Neighborhood]:
+        windows = self._read(
+            seed_segment_uuids,
+            before=before,
+            after=after,
+            since=since,
+            until=until,
+            source_ids=source_ids,
+            block_kinds=block_kinds,
+            property_filter=property_filter,
+            seed_must_pass=False,
+        )
+        return {
+            seed_uuid: Neighborhood(before=backward, after=forward)
+            for seed_uuid, (backward, _, forward) in windows.items()
+        }
 
     @staticmethod
     def _normalize_segment_field(field: str) -> str:
         """Translate canonical filter field names to raw segment property keys.
 
         Mirrors SQLAlchemySegmentStorePartition._resolve_segment_field:
-        - `m.<key>` / `metadata.<key>` → user metadata, bare key.
-        - any other bare name → system field, `_<field>` (matches the
+        - `timestamp` -> the segment's own timestamp.
+        - `m.<key>` / `metadata.<key>` -> user metadata, bare key.
+        - any other bare name -> system field, `_<field>` (matches the
           LongTermMemory event-backend property layout).
         """
+        if field == "timestamp":
+            return field
         internal_name, is_user_metadata = normalize_filter_field(field)
         if is_user_metadata:
             return demangle_user_metadata_key(internal_name)
@@ -137,7 +261,13 @@ class InMemorySegmentStorePartition(SegmentStorePartition):
         for event_uuid in event_uuids:
             segment_uuids = self.event_to_segments.get(event_uuid)
             if segment_uuids:
-                result[event_uuid] = list(segment_uuids)
+                result[event_uuid] = sorted(
+                    segment_uuids,
+                    key=lambda uid: (
+                        self.segments[uid].index,
+                        self.segments[uid].offset,
+                    ),
+                )
         return result
 
     @override
@@ -174,15 +304,23 @@ class InMemorySegmentStorePartition(SegmentStorePartition):
             segment = self.segments.pop(segment_uuid, None)
             if segment is None:
                 continue
-            self.segment_order = [
-                uid for uid in self.segment_order if uid != segment_uuid
-            ]
             event_list = self.event_to_segments.get(segment.event_uuid)
             if event_list is not None:
                 event_list[:] = [uid for uid in event_list if uid != segment_uuid]
                 if not event_list:
                     del self.event_to_segments[segment.event_uuid]
             self.segment_to_derivatives.pop(segment_uuid, None)
+
+    @override
+    async def delete_derivatives(
+        self,
+        derivative_uuids: Iterable[UUID],
+    ) -> None:
+        derivative_uuids = set(derivative_uuids)
+        for segment_uuid, linked in self.segment_to_derivatives.items():
+            self.segment_to_derivatives[segment_uuid] = [
+                uid for uid in linked if uid not in derivative_uuids
+            ]
 
 
 class FakeReranker(Reranker):
@@ -192,9 +330,70 @@ class FakeReranker(Reranker):
         return [float(len(c)) for c in candidates]
 
 
+class AngleEmbedder(FakeEmbedder):
+    """Embeds a text on the unit circle at the angle of the first token it carries.
+
+    `FakeEmbedder` maps every text onto one direction, so under cosine every
+    score is 1.0 and an ordering assertion is vacuous. This fake gives a
+    text its own angle by a token it contains, so two texts sharing a token
+    are one cluster (cosine 1.0), texts a quarter turn apart are unrelated
+    (cosine 0.0), and a query ranks texts by angular distance.
+    """
+
+    def __init__(
+        self,
+        token_angles: Mapping[str, float],
+        *,
+        default_angle: float = math.pi / 4,
+    ) -> None:
+        super().__init__()
+        self._token_angles = dict(token_angles)
+        self._default_angle = default_angle
+
+    def _vector(self, text: Any) -> list[float]:
+        angle = next(
+            (
+                angle
+                for token, angle in self._token_angles.items()
+                if token in str(text)
+            ),
+            self._default_angle,
+        )
+        return [math.cos(angle), math.sin(angle)]
+
+    @override
+    async def _ingest_embed(
+        self,
+        inputs: list[Any],
+        max_attempts: int = 1,
+    ) -> list[list[float]]:
+        return [self._vector(text) for text in inputs]
+
+    @override
+    async def _search_embed(
+        self,
+        queries: list[Any],
+        max_attempts: int = 1,
+    ) -> list[list[float]]:
+        return [self._vector(query) for query in queries]
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+def make_collection(embedder: FakeEmbedder) -> InMemoryVectorStoreCollection:
+    """A collection declaring EventMemory's reserved keys and a `color` property."""
+    return InMemoryVectorStoreCollection(
+        VectorStoreCollectionConfig(
+            vector_dimensions=embedder.dimensions,
+            indexed_properties_schema={
+                **EventMemory.expected_vector_store_collection_schema(),
+                "color": str,
+            },
+        )
+    )
 
 
 @pytest.fixture
@@ -209,14 +408,7 @@ def fake_segment_store_partition():
 
 @pytest.fixture
 def fake_vector_store_collection(fake_embedder):
-    config = VectorStoreCollectionConfig(
-        vector_dimensions=fake_embedder.dimensions,
-        indexed_properties_schema={
-            **EventMemory.expected_vector_store_collection_schema(),
-            "color": str,
-        },
-    )
-    return InMemoryVectorStoreCollection(config)
+    return make_collection(fake_embedder)
 
 
 @pytest.fixture
@@ -237,24 +429,6 @@ def event_memory(
 
 
 @pytest.fixture
-def event_memory_with_reranker(
-    fake_vector_store_collection,
-    fake_segment_store_partition,
-    fake_embedder,
-):
-    return EventMemory(
-        EventMemoryParams(
-            segment_store_partition=fake_segment_store_partition,
-            vector_store_collection=fake_vector_store_collection,
-            segmenter=TextSegmenter(),
-            deriver=WholeTextDeriver(),
-            embedder=fake_embedder,
-            reranker=FakeReranker(),
-        )
-    )
-
-
-@pytest.fixture
 def event_memory_with_sentences(
     fake_vector_store_collection,
     fake_segment_store_partition,
@@ -267,5 +441,27 @@ def event_memory_with_sentences(
             segmenter=TextSegmenter(),
             deriver=SentenceTextDeriver(),
             embedder=fake_embedder,
+        )
+    )
+
+
+@pytest.fixture
+def event_memory_with_eviction(
+    fake_vector_store_collection,
+    fake_segment_store_partition,
+    fake_embedder,
+):
+    # FakeEmbedder maps every text onto one direction, so all derivatives
+    # are cosine-similar (1.0): any batch forms a single eviction cluster.
+    return EventMemory(
+        EventMemoryParams(
+            segment_store_partition=fake_segment_store_partition,
+            vector_store_collection=fake_vector_store_collection,
+            segmenter=TextSegmenter(),
+            deriver=WholeTextDeriver(),
+            embedder=fake_embedder,
+            eviction=EvictionOptions(
+                similarity_threshold=0.5, search_limit=100, target_size=5
+            ),
         )
     )

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/conftest.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/conftest.py
@@ -18,9 +18,6 @@ from memmachine_server.common.filter.filter_parser import (
     normalize_filter_field,
 )
 from memmachine_server.common.reranker import Reranker
-from memmachine_server.common.vector_store.data_types import (
-    VectorStoreCollectionConfig,
-)
 from memmachine_server.episodic_memory.event_memory.data_types import (
     EvictionOptions,
     Neighborhood,
@@ -44,8 +41,8 @@ from memmachine_server.episodic_memory.event_memory.segmenter.text_segmenter imp
 from server_tests.memmachine_server.common.reranker.fake_embedder import (
     FakeEmbedder,
 )
-from server_tests.memmachine_server.common.vector_store.in_memory_vector_store_collection import (
-    InMemoryVectorStoreCollection,
+from server_tests.memmachine_server.common.vector_store.in_memory_vector_store_partition import (
+    InMemoryVectorStorePartition,
     evaluate_filter,
 )
 
@@ -385,10 +382,10 @@ class AngleEmbedder(FakeEmbedder):
 # ---------------------------------------------------------------------------
 
 
-def make_collection(embedder: FakeEmbedder) -> InMemoryVectorStoreCollection:
+def make_collection(embedder: FakeEmbedder) -> InMemoryVectorStorePartition:
     """A collection declaring EventMemory's reserved keys and a `color` property."""
-    return InMemoryVectorStoreCollection(
-        VectorStoreCollectionConfig(vector_dimensions=embedder.dimensions),
+    return InMemoryVectorStorePartition(
+        "test",
         {**EventMemory.expected_vector_store_collection_schema(), "color": str},
     )
 
@@ -404,20 +401,20 @@ def fake_segment_store_partition():
 
 
 @pytest.fixture
-def fake_vector_store_collection(fake_embedder):
+def fake_vector_store_partition(fake_embedder):
     return make_collection(fake_embedder)
 
 
 @pytest.fixture
 def event_memory(
-    fake_vector_store_collection,
+    fake_vector_store_partition,
     fake_segment_store_partition,
     fake_embedder,
 ):
     return EventMemory(
         EventMemoryParams(
             segment_store_partition=fake_segment_store_partition,
-            vector_store_collection=fake_vector_store_collection,
+            vector_store_partition=fake_vector_store_partition,
             segmenter=TextSegmenter(),
             deriver=WholeTextDeriver(),
             embedder=fake_embedder,
@@ -427,14 +424,14 @@ def event_memory(
 
 @pytest.fixture
 def event_memory_with_sentences(
-    fake_vector_store_collection,
+    fake_vector_store_partition,
     fake_segment_store_partition,
     fake_embedder,
 ):
     return EventMemory(
         EventMemoryParams(
             segment_store_partition=fake_segment_store_partition,
-            vector_store_collection=fake_vector_store_collection,
+            vector_store_partition=fake_vector_store_partition,
             segmenter=TextSegmenter(),
             deriver=SentenceTextDeriver(),
             embedder=fake_embedder,
@@ -444,7 +441,7 @@ def event_memory_with_sentences(
 
 @pytest.fixture
 def event_memory_with_eviction(
-    fake_vector_store_collection,
+    fake_vector_store_partition,
     fake_segment_store_partition,
     fake_embedder,
 ):
@@ -453,7 +450,7 @@ def event_memory_with_eviction(
     return EventMemory(
         EventMemoryParams(
             segment_store_partition=fake_segment_store_partition,
-            vector_store_collection=fake_vector_store_collection,
+            vector_store_partition=fake_vector_store_partition,
             segmenter=TextSegmenter(),
             deriver=WholeTextDeriver(),
             embedder=fake_embedder,

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/deriver/test_text_deriver.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/deriver/test_text_deriver.py
@@ -8,10 +8,9 @@ import pytest
 from pydantic import BaseModel
 
 from memmachine_server.episodic_memory.event_memory.data_types import (
+    Author,
     Block,
     FormatOptions,
-    NullContext,
-    ProducerContext,
     Segment,
     TextBlock,
 )
@@ -37,7 +36,7 @@ def _make_segment(
         index=0,
         offset=0,
         timestamp=_TS,
-        context=context if context is not None else NullContext(),
+        context=context if context is not None else {},
         block=block,
         properties=properties or {},
     )
@@ -47,7 +46,7 @@ def _make_segment_with_unsupported_block() -> Segment:
     """Bypass discriminated-union validation to exercise the deriver's fallback arm."""
 
     class _OtherBlock(BaseModel):
-        block_type: str = "other"
+        kind: str = "other"
 
     return Segment.model_construct(
         uuid=uuid4(),
@@ -55,7 +54,7 @@ def _make_segment_with_unsupported_block() -> Segment:
         index=0,
         offset=0,
         timestamp=_TS,
-        context=NullContext(),
+        context={},
         block=cast(Block, _OtherBlock()),
         properties={},
     )
@@ -87,7 +86,7 @@ class TestWholeTextDeriver:
     async def test_producer_context_prefixes_text(self):
         seg = _make_segment(
             block=TextBlock(text="hi there"),
-            context=ProducerContext(producer="Alice"),
+            context={"author": Author(name="Alice")},
         )
 
         result = await WholeTextDeriver().derive(seg)
@@ -100,7 +99,7 @@ class TestWholeTextDeriver:
     async def test_format_options_with_time_includes_time(self):
         seg = _make_segment(
             block=TextBlock(text="hi there"),
-            context=ProducerContext(producer="Alice"),
+            context={"author": Author(name="Alice")},
         )
 
         result = await WholeTextDeriver().derive(
@@ -136,7 +135,7 @@ class TestWholeTextDeriver:
     async def test_non_text_block_raises(self):
         seg = _make_segment_with_unsupported_block()
 
-        with pytest.raises(NotImplementedError, match="Unsupported block type"):
+        with pytest.raises(NotImplementedError, match="Unsupported block kind"):
             await WholeTextDeriver().derive(seg)
 
     async def test_each_derive_call_emits_unique_uuid(self):
@@ -177,7 +176,7 @@ class TestSentenceTextDeriver:
     async def test_producer_context_prefixes_each_sentence(self):
         seg = _make_segment(
             block=TextBlock(text="One. Two."),
-            context=ProducerContext(producer="Bob"),
+            context={"author": Author(name="Bob")},
         )
 
         result = await SentenceTextDeriver().derive(seg)
@@ -205,5 +204,5 @@ class TestSentenceTextDeriver:
     async def test_non_text_block_raises(self):
         seg = _make_segment_with_unsupported_block()
 
-        with pytest.raises(NotImplementedError, match="Unsupported block type"):
+        with pytest.raises(NotImplementedError, match="Unsupported block kind"):
             await SentenceTextDeriver().derive(seg)

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
@@ -38,7 +38,6 @@ from memmachine_server.episodic_memory.event_memory.segment_store import (
     SegmentStoreAttemptsExhaustedError,
     SegmentStorePartitionAlreadyExistsError,
     SegmentStorePartitionConfig,
-    SegmentStorePartitionConfigMismatchError,
     SegmentStorePartitionHandleStaleError,
     sqlalchemy_segment_store,
 )
@@ -104,6 +103,21 @@ async def _drop_schema(engine: AsyncEngine) -> None:
 def _links(*segments: Segment) -> dict[Segment, list[UUID]]:
     """Build a segment-to-derivative-UUIDs mapping with one derivative per segment."""
     return {seg: [uuid4()] for seg in segments}
+
+
+async def _get_or_create_partition(
+    store: SQLAlchemySegmentStore,
+    partition_key: str,
+    config: SegmentStorePartitionConfig,
+) -> SQLAlchemySegmentStorePartition:
+    """Create-if-absent then get, as the composition root does."""
+    partition = await store.get_partition(partition_key)
+    if partition is None:
+        with contextlib.suppress(SegmentStorePartitionAlreadyExistsError):
+            await store.create_partition(partition_key, config)
+        partition = await store.get_partition(partition_key)
+    assert partition is not None
+    return partition
 
 
 def _plaintext_partition_config() -> SegmentStorePartitionConfig:
@@ -209,7 +223,8 @@ def recorded_statements(
 async def partition(
     store: SQLAlchemySegmentStore,
 ) -> SQLAlchemySegmentStorePartition:
-    return await store.open_or_create_partition(
+    return await _get_or_create_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -634,13 +649,15 @@ async def test_contexts_session_isolation(store: SQLAlchemySegmentStore) -> None
     s_seed = _seg(event_uuid=ep, offset=1, ts_offset_seconds=1)
     s_after = _seg(event_uuid=ep, offset=2, ts_offset_seconds=2)
 
-    other_partition = await store.open_or_create_partition(
+    other_partition = await _get_or_create_partition(
+        store,
         "other_session",
         _plaintext_partition_config(),
     )
     await other_partition.add_segments(_links(s_other))
 
-    partition = await store.open_or_create_partition(
+    partition = await _get_or_create_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -829,7 +846,8 @@ async def test_get_segment_uuids_by_derivative_uuids_session_isolation(
     store: SQLAlchemySegmentStore,
 ) -> None:
     """A derivative another partition owns is invisible here."""
-    other_partition = await store.open_or_create_partition(
+    other_partition = await _get_or_create_partition(
+        store,
         "other_derivatives",
         _plaintext_partition_config(),
     )
@@ -837,7 +855,8 @@ async def test_get_segment_uuids_by_derivative_uuids_session_isolation(
     other_derivative = uuid4()
     await other_partition.add_segments({other_seg: [other_derivative]})
 
-    partition = await store.open_or_create_partition(
+    partition = await _get_or_create_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -934,7 +953,8 @@ async def test_delete_segments_partial(
 async def _get_partition(engine: AsyncEngine) -> SQLAlchemySegmentStorePartition:
     """Create a partition handle that shares the engine."""
     store = SQLAlchemySegmentStore(SQLAlchemySegmentStoreParams(engine=engine))
-    return await store.open_or_create_partition(
+    return await _get_or_create_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -972,7 +992,8 @@ async def test_concurrent_reads_during_writes(
 ) -> None:
     """Reads should not fail or block indefinitely while writes are happening."""
     engine = store._engine
-    partition = await store.open_or_create_partition(
+    partition = await _get_or_create_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -1010,7 +1031,8 @@ async def test_concurrent_context_reads_during_deletes(
 ) -> None:
     """get_segment_contexts should not crash if segments are deleted concurrently."""
     engine = store._engine
-    partition = await store.open_or_create_partition(
+    partition = await _get_or_create_partition(
+        store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -1056,7 +1078,8 @@ async def test_concurrent_context_reads_during_deletes(
 async def test_open_or_create_partition_defaults_to_plaintext_config(
     store: SQLAlchemySegmentStore,
 ) -> None:
-    partition = await store.open_or_create_partition(
+    partition = await _get_or_create_partition(
+        store,
         "plaintext_default",
         _plaintext_partition_config(),
     )
@@ -1066,7 +1089,7 @@ async def test_open_or_create_partition_defaults_to_plaintext_config(
 @pytest.mark.asyncio
 async def test_create_partition(store: SQLAlchemySegmentStore) -> None:
     await store.create_partition("new_partition", _plaintext_partition_config())
-    partition = await store.open_partition("new_partition")
+    partition = await store.get_partition("new_partition")
     assert partition is not None
 
 
@@ -1078,45 +1101,22 @@ async def test_create_partition_already_exists(store: SQLAlchemySegmentStore) ->
 
 
 @pytest.mark.asyncio
-async def test_open_partition_nonexistent(store: SQLAlchemySegmentStore) -> None:
-    result = await store.open_partition("nonexistent")
+async def test_get_partition_nonexistent(store: SQLAlchemySegmentStore) -> None:
+    result = await store.get_partition("nonexistent")
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_open_partition_existing(store: SQLAlchemySegmentStore) -> None:
+async def test_get_partition_existing(store: SQLAlchemySegmentStore) -> None:
     await store.create_partition("existing", _plaintext_partition_config())
-    partition = await store.open_partition("existing")
-    assert partition is not None
-
-
-@pytest.mark.asyncio
-async def test_open_or_create_partition_creates(store: SQLAlchemySegmentStore) -> None:
-    partition = await store.open_or_create_partition(
-        "fresh",
-        _plaintext_partition_config(),
-    )
-    assert partition is not None
-    # Verify it was actually created.
-    opened = await store.open_partition("fresh")
-    assert opened is not None
-
-
-@pytest.mark.asyncio
-async def test_open_or_create_partition_idempotent(
-    store: SQLAlchemySegmentStore,
-) -> None:
-    await store.create_partition("idem", _plaintext_partition_config())
-    partition = await store.open_or_create_partition(
-        "idem",
-        _plaintext_partition_config(),
-    )
+    partition = await store.get_partition("existing")
     assert partition is not None
 
 
 @pytest.mark.asyncio
 async def test_delete_partition_removes_data(store: SQLAlchemySegmentStore) -> None:
-    partition = await store.open_or_create_partition(
+    partition = await _get_or_create_partition(
+        store,
         "to_delete",
         _plaintext_partition_config(),
     )
@@ -1126,7 +1126,7 @@ async def test_delete_partition_removes_data(store: SQLAlchemySegmentStore) -> N
     await store.delete_partition("to_delete")
 
     # Partition no longer exists.
-    assert await store.open_partition("to_delete") is None
+    assert await store.get_partition("to_delete") is None
 
 
 @pytest.mark.integration
@@ -1136,10 +1136,10 @@ async def test_delete_partition_keeps_foreign_key_enforced(
     sqlalchemy_pg_engine: AsyncEngine,
 ) -> None:
     """Deleting one partition must not drop the derivative-link foreign key."""
-    keeper = await pg_store.open_or_create_partition(
-        "keeper_fk", _plaintext_partition_config()
+    keeper = await _get_or_create_partition(
+        pg_store, "keeper_fk", _plaintext_partition_config()
     )
-    await pg_store.open_or_create_partition("doomed_fk", _plaintext_partition_config())
+    await _get_or_create_partition(pg_store, "doomed_fk", _plaintext_partition_config())
 
     await pg_store.delete_partition("doomed_fk")
 
@@ -1166,11 +1166,13 @@ async def test_delete_partition_keeps_other_partitions_cascading(
     store: SQLAlchemySegmentStore,
 ) -> None:
     """Deleting one partition must not disable the derivative-link cascade."""
-    keeper = await store.open_or_create_partition(
+    keeper = await _get_or_create_partition(
+        store,
         "keeper",
         _plaintext_partition_config(),
     )
-    await store.open_or_create_partition(
+    await _get_or_create_partition(
+        store,
         "doomed",
         _plaintext_partition_config(),
     )
@@ -1190,7 +1192,8 @@ async def test_delete_partition_keeps_other_partitions_cascading(
 async def test_delete_partition_cascades_segments(
     store: SQLAlchemySegmentStore,
 ) -> None:
-    partition = await store.open_or_create_partition(
+    partition = await _get_or_create_partition(
+        store,
         "cascade_test",
         _plaintext_partition_config(),
     )
@@ -1201,7 +1204,8 @@ async def test_delete_partition_cascades_segments(
     await store.delete_partition("cascade_test")
 
     # Re-create the partition and verify data is gone.
-    new_partition = await store.open_or_create_partition(
+    new_partition = await _get_or_create_partition(
+        store,
         "cascade_test",
         _plaintext_partition_config(),
     )
@@ -1242,7 +1246,8 @@ async def test_pg_context_preserved_via_lateral_join(
     pg_store: SQLAlchemySegmentStore,
 ) -> None:
     """Context is preserved when retrieved via the LATERAL join path (multiple seeds)."""
-    partition = await pg_store.open_or_create_partition(
+    partition = await _get_or_create_partition(
+        pg_store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -1279,7 +1284,8 @@ async def test_pg_mixed_context_types(
     pg_store: SQLAlchemySegmentStore,
 ) -> None:
     """Different context types (producer, None) round-trip correctly on PG."""
-    partition = await pg_store.open_or_create_partition(
+    partition = await _get_or_create_partition(
+        pg_store,
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
@@ -1316,8 +1322,8 @@ async def test_stale_handle_raises_after_delete(
     store: SQLAlchemySegmentStore,
 ) -> None:
     """A handle held across deletion must fail loudly, not act."""
-    partition = await store.open_or_create_partition(
-        "fenced", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        store, "fenced", _plaintext_partition_config()
     )
     seg = _seg()
     await partition.add_segments(_links(seg))
@@ -1350,8 +1356,8 @@ async def test_reads_check_liveness_inside_the_data_statement(
     Only a read that finds nothing pays a second statement, to tell an
     empty partition from a stale handle.
     """
-    partition = await pg_store.open_or_create_partition(
-        "folded", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        pg_store, "folded", _plaintext_partition_config()
     )
     seg = _seg()
     derivative_uuids = [uuid4()]
@@ -1377,12 +1383,12 @@ async def test_stale_handle_raises_after_recreate(
     store: SQLAlchemySegmentStore,
 ) -> None:
     """Re-creating the key must not let an old handle act on the successor."""
-    old_handle = await store.open_or_create_partition(
-        "reborn", _plaintext_partition_config()
+    old_handle = await _get_or_create_partition(
+        store, "reborn", _plaintext_partition_config()
     )
     await store.delete_partition("reborn")
-    new_handle = await store.open_or_create_partition(
-        "reborn", _plaintext_partition_config()
+    new_handle = await _get_or_create_partition(
+        store, "reborn", _plaintext_partition_config()
     )
 
     with pytest.raises(SegmentStorePartitionHandleStaleError):
@@ -1395,16 +1401,16 @@ async def test_recreated_partition_is_isolated_from_old_rows(
     store: SQLAlchemySegmentStore,
 ) -> None:
     """Old-incarnation rows are invisible to the successor before purging."""
-    partition = await store.open_or_create_partition(
-        "isolated", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        store, "isolated", _plaintext_partition_config()
     )
     seg = _seg()
     await partition.add_segments(_links(seg))
     old_incarnation = partition._incarnation
 
     await store.delete_partition("isolated")
-    successor = await store.open_or_create_partition(
-        "isolated", _plaintext_partition_config()
+    successor = await _get_or_create_partition(
+        store, "isolated", _plaintext_partition_config()
     )
 
     assert await successor.get_segment_contexts([seg.uuid]) == {}
@@ -1429,12 +1435,14 @@ async def test_purge_reclaims_only_dead_incarnations(
     # Small default bound, so draining takes the caller's loop.
     monkeypatch.setattr(store, "_purge_max_segments", 2)
 
-    live = await store.open_or_create_partition("live_p", _plaintext_partition_config())
+    live = await _get_or_create_partition(
+        store, "live_p", _plaintext_partition_config()
+    )
     live_seg = _seg()
     await live.add_segments(_links(live_seg))
 
-    doomed = await store.open_or_create_partition(
-        "doomed_p", _plaintext_partition_config()
+    doomed = await _get_or_create_partition(
+        store, "doomed_p", _plaintext_partition_config()
     )
     doomed_incarnation = doomed._incarnation
     await doomed.add_segments(_links(_seg(), _seg(), _seg()))
@@ -1476,8 +1484,8 @@ async def test_concurrent_purges_reclaim_everything(
     monkeypatch.setattr(store, "_purge_max_segments", 2)
     incarnations = []
     for index in range(3):
-        partition = await store.open_or_create_partition(
-            f"gc_race_{index}", _plaintext_partition_config()
+        partition = await _get_or_create_partition(
+            store, f"gc_race_{index}", _plaintext_partition_config()
         )
         incarnations.append(partition._incarnation)
         await partition.add_segments(_links(_seg(), _seg(), _seg()))
@@ -1520,8 +1528,8 @@ async def test_purge_skips_entries_claimed_by_concurrent_purger(
     """
     partitions = {}
     for key in ("gc_held", "gc_free"):
-        partition = await pg_store.open_or_create_partition(
-            key, _plaintext_partition_config()
+        partition = await _get_or_create_partition(
+            pg_store, key, _plaintext_partition_config()
         )
         partitions[key] = partition._incarnation
         await partition.add_segments(_links(_seg()))
@@ -1586,8 +1594,8 @@ async def test_write_landing_during_delete_is_never_orphaned(
     flight, and the write then lands rows under an incarnation the queue
     no longer tracks: garbage no purge will ever reclaim.
     """
-    partition = await pg_store.open_or_create_partition(
-        "orphan_race", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        pg_store, "orphan_race", _plaintext_partition_config()
     )
     incarnation = partition._incarnation
 
@@ -1658,8 +1666,8 @@ async def test_concurrent_remote_delete_yields_single_queue_entry(
     observe the registry row gone and no-op -- one queue entry, no
     integrity error surfacing to the caller.
     """
-    partition = await pg_store.open_or_create_partition(
-        "remote_del", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        pg_store, "remote_del", _plaintext_partition_config()
     )
     incarnation = partition._incarnation
 
@@ -1699,7 +1707,7 @@ async def test_concurrent_remote_delete_yields_single_queue_entry(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "create_via",
-    ["create_partition", "open_or_create_partition"],
+    ["create_partition"],
 )
 async def test_incarnation_with_garbage_left_is_never_reused(
     store: SQLAlchemySegmentStore,
@@ -1713,8 +1721,8 @@ async def test_incarnation_with_garbage_left_is_never_reused(
     the purger. The mint transaction re-checks the purge queue and retries
     with a fresh uuid instead.
     """
-    doomed = await store.open_or_create_partition(
-        "gc_reuse", _plaintext_partition_config()
+    doomed = await _get_or_create_partition(
+        store, "gc_reuse", _plaintext_partition_config()
     )
     dead_incarnation = doomed._incarnation
     await doomed.add_segments(_links(_seg()))
@@ -1732,10 +1740,10 @@ async def test_incarnation_with_garbage_left_is_never_reused(
 
     if create_via == "create_partition":
         await store.create_partition("fresh_p", _plaintext_partition_config())
-        fresh = await store.open_partition("fresh_p")
+        fresh = await store.get_partition("fresh_p")
     else:
-        fresh = await store.open_or_create_partition(
-            "fresh_p", _plaintext_partition_config()
+        fresh = await _get_or_create_partition(
+            store, "fresh_p", _plaintext_partition_config()
         )
     assert fresh is not None
     assert offered, "the colliding uuid was never offered to the mint"
@@ -1760,7 +1768,7 @@ async def test_incarnation_with_garbage_left_is_never_reused(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "create_via",
-    ["create_partition", "open_or_create_partition"],
+    ["create_partition"],
 )
 async def test_incarnation_colliding_with_live_partition_is_never_reused(
     store: SQLAlchemySegmentStore,
@@ -1774,8 +1782,8 @@ async def test_incarnation_colliding_with_live_partition_is_never_reused(
     fresh uuid, and succeed -- not misreport the partition as already
     existing.
     """
-    live = await store.open_or_create_partition(
-        "live_src", _plaintext_partition_config()
+    live = await _get_or_create_partition(
+        store, "live_src", _plaintext_partition_config()
     )
     live_incarnation = live._incarnation
 
@@ -1791,17 +1799,17 @@ async def test_incarnation_colliding_with_live_partition_is_never_reused(
 
     if create_via == "create_partition":
         await store.create_partition("fresh_p", _plaintext_partition_config())
-        fresh = await store.open_partition("fresh_p")
+        fresh = await store.get_partition("fresh_p")
     else:
-        fresh = await store.open_or_create_partition(
-            "fresh_p", _plaintext_partition_config()
+        fresh = await _get_or_create_partition(
+            store, "fresh_p", _plaintext_partition_config()
         )
     assert fresh is not None
     assert offered, "the colliding uuid was never offered to the mint"
     assert fresh._incarnation != live_incarnation
 
     # The live partition is unharmed.
-    reopened = await store.open_partition("live_src")
+    reopened = await store.get_partition("live_src")
     assert reopened is not None
     assert reopened._incarnation == live_incarnation
 
@@ -1819,8 +1827,8 @@ async def test_purge_bound_comes_from_params(
     )
     await store.startup()
     try:
-        partition = await store.open_or_create_partition(
-            "bound_p", _plaintext_partition_config()
+        partition = await _get_or_create_partition(
+            store, "bound_p", _plaintext_partition_config()
         )
         await partition.add_segments(_links(_seg(), _seg(), _seg()))
         await store.delete_partition("bound_p")
@@ -1850,8 +1858,8 @@ async def test_mint_detects_collision_with_concurrent_deletion(
     whose incarnation is on the purge queue, handing its rows to the
     purger.
     """
-    victim = await pg_store.open_or_create_partition(
-        "mint_victim", _plaintext_partition_config()
+    victim = await _get_or_create_partition(
+        pg_store, "mint_victim", _plaintext_partition_config()
     )
     victim_incarnation = victim._incarnation
     await victim.add_segments(_links(_seg()))
@@ -1899,7 +1907,7 @@ async def test_mint_detects_collision_with_concurrent_deletion(
     # Deletion committed on exiting begin().
     await asyncio.wait_for(creator, 30)
 
-    fresh = await pg_store.open_partition("mint_fresh")
+    fresh = await pg_store.get_partition("mint_fresh")
     assert fresh is not None
     assert offered, "the colliding uuid was never offered to the mint"
     assert fresh._incarnation != victim_incarnation, (
@@ -1919,7 +1927,7 @@ async def test_mint_detects_collision_with_concurrent_deletion(
             )
         ).scalar_one()
     assert dead_rows == 0
-    assert await pg_store.open_partition("mint_fresh") is not None
+    assert await pg_store.get_partition("mint_fresh") is not None
 
 
 @pytest.mark.integration
@@ -1937,8 +1945,8 @@ async def test_purge_claims_queue_entries_incrementally(
     concurrent purgers.
     """
     for index in range(3):
-        partition = await pg_store.open_or_create_partition(
-            f"inc_claim_{index}", _plaintext_partition_config()
+        partition = await _get_or_create_partition(
+            pg_store, f"inc_claim_{index}", _plaintext_partition_config()
         )
         await partition.add_segments(_links(_seg(), _seg(), _seg()))
         await pg_store.delete_partition(f"inc_claim_{index}")
@@ -1981,8 +1989,8 @@ async def test_sqlite_write_racing_delete_cannot_orphan_rows(
     registry UPDATE opens the write transaction first, so the racing
     deletion must wait for the writer and the rows stay reclaimable.
     """
-    partition = await sqlite_store.open_or_create_partition(
-        "sqlite_fence", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        sqlite_store, "sqlite_fence", _plaintext_partition_config()
     )
     incarnation = partition._incarnation
 
@@ -2077,20 +2085,7 @@ async def test_persistent_mint_failure_raises_instead_of_looping(
 
     attempts.clear()
     with pytest.raises(SegmentStoreAttemptsExhaustedError):
-        await store.open_or_create_partition("mint_cap", _plaintext_partition_config())
-    assert len(attempts) == sqlalchemy_segment_store._MAX_MINT_ATTEMPTS
-
-    # The lost-race arm is bounded by the same cap: an insert that keeps
-    # losing to a winner that keeps vanishing must not livelock.
-    attempts.clear()
-
-    async def always_losing(partition_key, incarnation, config) -> None:
-        attempts.append(incarnation)
-        raise SegmentStorePartitionAlreadyExistsError(partition_key)
-
-    monkeypatch.setattr(store, "_insert_partition_row", always_losing)
-    with pytest.raises(SegmentStoreAttemptsExhaustedError):
-        await store.open_or_create_partition("mint_cap", _plaintext_partition_config())
+        await _get_or_create_partition(store, "mint_cap", _plaintext_partition_config())
     assert len(attempts) == sqlalchemy_segment_store._MAX_MINT_ATTEMPTS
 
 
@@ -2109,7 +2104,7 @@ async def test_persistent_integrity_error_surfaces_with_cause(
     """
     monkeypatch.setattr(sqlalchemy_segment_store, "uuid4", lambda: None)
 
-    for create in (store.create_partition, store.open_or_create_partition):
+    for create in (store.create_partition,):
         with pytest.raises(SegmentStoreAttemptsExhaustedError) as exc_info:
             await create("not_null", _plaintext_partition_config())
         cause: BaseException | None = exc_info.value.__cause__
@@ -2166,8 +2161,8 @@ async def test_empty_incarnations_do_not_consume_row_budget(
     for index in range(3):
         await store.create_partition(f"noop_{index}", _plaintext_partition_config())
         await store.delete_partition(f"noop_{index}")
-    rowful = await store.open_or_create_partition(
-        "rowful", _plaintext_partition_config()
+    rowful = await _get_or_create_partition(
+        store, "rowful", _plaintext_partition_config()
     )
     await rowful.add_segments(_links(_seg(), _seg()))
     await store.delete_partition("rowful")
@@ -2191,8 +2186,8 @@ async def test_purge_reclaims_oldest_garbage_first(
     incarnations = {}
     partition = None
     for key in ("fifo_a", "fifo_b", "fifo_c"):
-        partition = await store.open_or_create_partition(
-            key, _plaintext_partition_config()
+        partition = await _get_or_create_partition(
+            store, key, _plaintext_partition_config()
         )
         incarnations[key] = partition._incarnation
         await partition.add_segments(_links(_seg()))
@@ -2243,8 +2238,8 @@ async def test_purge_batches_links_that_escaped_integrity(
     foreign_keys pragma can insert orphan link rows; the batching under
     test is dialect-independent.
     """
-    partition = await sqlite_store.open_or_create_partition(
-        "leaky", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        sqlite_store, "leaky", _plaintext_partition_config()
     )
     incarnation = partition._incarnation
     await sqlite_store.delete_partition("leaky")
@@ -2314,27 +2309,7 @@ class _ForeignPayloadCodecConfig(PlaintextPayloadCodecConfig):
 
 
 @pytest.mark.asyncio
-async def test_open_or_create_with_different_config_raises_mismatch(
-    store: SQLAlchemySegmentStore,
-) -> None:
-    """Reopening a key under a different config is refused, not adapted."""
-    await store.create_partition("cfg_guard", _plaintext_partition_config())
-
-    requested = SegmentStorePartitionConfig(
-        payload_codec_config=_ForeignPayloadCodecConfig()
-    )
-    with pytest.raises(SegmentStorePartitionConfigMismatchError) as exc_info:
-        await store.open_or_create_partition("cfg_guard", requested)
-    assert exc_info.value.partition_key == "cfg_guard"
-    assert exc_info.value.existing_config == _plaintext_partition_config()
-    assert exc_info.value.requested_config == requested
-
-    # The partition itself is untouched and still opens.
-    assert await store.open_partition("cfg_guard") is not None
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("create", ["create_partition", "open_or_create_partition"])
+@pytest.mark.parametrize("create", ["create_partition"])
 async def test_unloadable_codec_config_commits_no_registry_row(
     store: SQLAlchemySegmentStore,
     monkeypatch: pytest.MonkeyPatch,
@@ -2394,8 +2369,8 @@ async def test_windowed_read_raises_when_partition_dies_between_statements(
     would return nothing; the read must raise rather than hand back
     seeds with silently empty context.
     """
-    partition = await store.open_or_create_partition(
-        "mid_read", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        store, "mid_read", _plaintext_partition_config()
     )
     segs = [_seg(ts_offset_seconds=i) for i in range(3)]
     await partition.add_segments(_links(*segs))
@@ -2432,8 +2407,8 @@ async def test_delete_partition_touches_only_registry_and_queue(
     recorded_statements: list[str],
 ) -> None:
     """Deletion is O(1): no data-table statements, regardless of size."""
-    partition = await pg_store.open_or_create_partition(
-        "big_delete", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        pg_store, "big_delete", _plaintext_partition_config()
     )
     await partition.add_segments(
         _links(*(_seg(ts_offset_seconds=i) for i in range(20)))
@@ -2490,8 +2465,8 @@ async def test_write_pin_blocks_partition_delete(
     without the pin it proceeds immediately and the write lands in a
     partition that no longer exists.
     """
-    partition = await pg_store.open_or_create_partition(
-        "lk_write_pin", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        pg_store, "lk_write_pin", _plaintext_partition_config()
     )
 
     reached_pause = asyncio.Event()
@@ -2528,7 +2503,7 @@ async def test_write_pin_blocks_partition_delete(
 
     await writer
     await deleter
-    assert await pg_store.open_partition("lk_write_pin") is None
+    assert await pg_store.get_partition("lk_write_pin") is None
 
 
 @pytest.mark.asyncio
@@ -2546,8 +2521,8 @@ async def test_overlapping_segment_deletes_do_not_deadlock(
     deliberately; this test catches the AB/BA cycle wherever an engine or
     plan change ever produces divergent orders.
     """
-    partition = await store.open_or_create_partition(
-        "lk_row_order", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        store, "lk_row_order", _plaintext_partition_config()
     )
 
     async def round_trip(rng: random.Random) -> None:
@@ -2592,15 +2567,12 @@ async def test_lifecycle_churn_completes_without_database_errors(
                 if operation == 0:
                     await store.create_partition(key, config)
                 elif operation == 1:
-                    await store.open_or_create_partition(key, config)
+                    await _get_or_create_partition(store, key, config)
                 elif operation == 2:
-                    await store.open_partition(key)
+                    await store.get_partition(key)
                 else:
                     await store.delete_partition(key)
-            except (
-                SegmentStorePartitionAlreadyExistsError,
-                SegmentStorePartitionConfigMismatchError,
-            ):
+            except SegmentStorePartitionAlreadyExistsError:
                 pass
 
     await asyncio.wait_for(
@@ -2626,7 +2598,7 @@ async def test_concurrent_partition_deletes_are_clean(
             asyncio.gather(*(store.delete_partition("lk_del_race") for _ in range(4))),
             30,
         )
-        assert await store.open_partition("lk_del_race") is None
+        assert await store.get_partition("lk_del_race") is None
         async with store._create_session() as session:
             queue_depth = (
                 await session.execute(select(func.count()).select_from(PurgeQueueRow))
@@ -2650,8 +2622,8 @@ async def test_sqlite_delete_partition_touches_only_registry_and_queue(
     sqlite_recorded_statements: list[str],
 ) -> None:
     """Deletion is O(1) on SQLite too: no data-table statements."""
-    partition = await sqlite_store.open_or_create_partition(
-        "sqlite_big_delete", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        sqlite_store, "sqlite_big_delete", _plaintext_partition_config()
     )
     await partition.add_segments(
         _links(*(_seg(ts_offset_seconds=i) for i in range(20)))
@@ -2681,8 +2653,8 @@ async def test_sqlite_mint_detects_collision_with_concurrent_deletion(
     deletion commits, the post-insert queue re-check sees the entry and
     re-mints.
     """
-    victim = await sqlite_store.open_or_create_partition(
-        "sq_mint_victim", _plaintext_partition_config()
+    victim = await _get_or_create_partition(
+        sqlite_store, "sq_mint_victim", _plaintext_partition_config()
     )
     victim_incarnation = victim._incarnation
     await victim.add_segments(_links(_seg()))
@@ -2738,14 +2710,14 @@ async def test_sqlite_mint_detects_collision_with_concurrent_deletion(
     # Deletion committed on exiting begin().
     await asyncio.wait_for(creator, 30)
 
-    fresh = await sqlite_store.open_partition("sq_mint_fresh")
+    fresh = await sqlite_store.get_partition("sq_mint_fresh")
     assert fresh is not None
     assert offered
     assert fresh._incarnation != victim_incarnation
 
     while await sqlite_store.purge_deleted_partitions():
         pass
-    assert (await sqlite_store.open_partition("sq_mint_fresh")) is not None
+    assert (await sqlite_store.get_partition("sq_mint_fresh")) is not None
 
 
 def test_empty_partition_key_is_named_as_empty() -> None:
@@ -3081,8 +3053,8 @@ async def test_delete_derivatives_empty(
 async def test_delete_derivatives_on_a_stale_handle_raises(
     store: SQLAlchemySegmentStore,
 ) -> None:
-    partition = await store.open_or_create_partition(
-        "unlink_fenced", _plaintext_partition_config()
+    partition = await _get_or_create_partition(
+        store, "unlink_fenced", _plaintext_partition_config()
     )
     seg = _seg()
     derivative = uuid4()

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
@@ -17,7 +17,12 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlalchemy.pool import StaticPool
 
-from memmachine_server.common.filter.filter_parser import Comparison, parse_filter
+from memmachine_server.common.filter import (
+    Equals,
+)
+from memmachine_server.common.filter.filter_parser import (
+    parse_filter,
+)
 from memmachine_server.common.payload_codec.payload_codec_config import (
     PlaintextPayloadCodecConfig,
 )
@@ -530,7 +535,7 @@ async def test_contexts_property_filter(
     s3 = _seg(event_uuid=ep, offset=3, ts_offset_seconds=3, properties={"tag": "a"})
     await partition.add_segments(_links(s0, s1, s2, s3))
 
-    filt = Comparison(field="m.tag", op="=", value="a")
+    filt = Equals(field="m.tag", value="a")
     result = await partition.get_segment_contexts(
         [s2.uuid],
         before=5,
@@ -575,7 +580,7 @@ async def test_contexts_filter_by_context_producer(
     )
     await partition.add_segments(_links(s0, s1, s2))
 
-    filt = Comparison(field="context.producer", op="=", value="Alice")
+    filt = Equals(field="context.producer", value="Alice")
     contexts = await partition.get_segment_contexts(
         [s0.uuid],
         before=5,
@@ -611,7 +616,7 @@ async def test_contexts_filter_by_context_type(
     )
     await partition.add_segments(_links(s0, s1, s2))
 
-    filt = Comparison(field="context.context_type", op="=", value="producer")
+    filt = Equals(field="context.context_type", value="producer")
     contexts = await partition.get_segment_contexts(
         [s0.uuid],
         before=5,

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segment_store/test_sqlalchemy_segment_store.py
@@ -22,10 +22,12 @@ from memmachine_server.common.payload_codec.payload_codec_config import (
     PlaintextPayloadCodecConfig,
 )
 from memmachine_server.episodic_memory.event_memory.data_types import (
-    NullContext,
-    ProducerContext,
+    Author,
+    Context,
+    Neighborhood,
     Segment,
     TextBlock,
+    with_part,
 )
 from memmachine_server.episodic_memory.event_memory.segment_store import (
     SegmentStoreAttemptsExhaustedError,
@@ -51,12 +53,15 @@ from memmachine_server.episodic_memory.event_memory.segment_store.utils import (
 
 PARTITION_KEY = "test_partition"
 BASE_TIME = datetime(2024, 1, 1, tzinfo=UTC)
-_NULL_CONTEXT = NullContext()
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _author(name: str) -> Context:
+    return with_part({}, Author(name=name))
 
 
 def _seg(
@@ -66,7 +71,9 @@ def _seg(
     offset: int = 0,
     ts_offset_seconds: int = 0,
     text: str = "hello",
-    context: ProducerContext | NullContext = _NULL_CONTEXT,
+    session_id: str | None = None,
+    source_id: str | None = None,
+    context: Context | None = None,
     properties: dict | None = None,
 ) -> Segment:
     return Segment(
@@ -75,10 +82,18 @@ def _seg(
         index=index,
         offset=offset,
         timestamp=BASE_TIME + timedelta(seconds=ts_offset_seconds),
+        session_id=session_id,
+        source_id=source_id,
         block=TextBlock(text=text),
-        context=context,
+        context=context if context is not None else {},
         properties=properties or {},
     )
+
+
+async def _drop_schema(engine: AsyncEngine) -> None:
+    """Drop the store's tables, so the next startup starts clean."""
+    async with engine.begin() as conn:
+        await conn.run_sync(BaseSegmentStore.metadata.drop_all)
 
 
 def _links(*segments: Segment) -> dict[Segment, list[UUID]]:
@@ -137,8 +152,7 @@ async def sqlite_store(
     )
     await store.startup()
     yield store
-    async with sqlalchemy_sqlite_engine.begin() as conn:
-        await conn.run_sync(BaseSegmentStore.metadata.drop_all)
+    await _drop_schema(sqlalchemy_sqlite_engine)
 
 
 @pytest_asyncio.fixture
@@ -150,8 +164,7 @@ async def pg_store(
     )
     await store.startup()
     yield store
-    async with sqlalchemy_pg_engine.begin() as conn:
-        await conn.run_sync(BaseSegmentStore.metadata.drop_all)
+    await _drop_schema(sqlalchemy_pg_engine)
 
 
 @pytest.fixture(
@@ -231,7 +244,7 @@ async def test_add_segments_with_properties(
 async def test_add_segments_with_producer_context(
     partition: SQLAlchemySegmentStorePartition,
 ) -> None:
-    ctx = ProducerContext(producer="User")
+    ctx = _author("User")
     seg = _seg(context=ctx)
     await partition.add_segments(_links(seg))
 
@@ -242,8 +255,8 @@ async def test_add_segments_with_producer_context(
         row = (
             await session.execute(select(SegmentRow).where(SegmentRow.uuid == seg.uuid))
         ).scalar_one()
-    assert json.loads(row.context) == {"context_type": "producer", "producer": "User"}
-    assert json.loads(row.block) == {"block_type": "text", "text": "hello"}
+    assert json.loads(row.context) == {"author": {"name": "User"}}
+    assert json.loads(row.block) == {"kind": "text", "text": "hello"}
 
 
 @pytest.mark.asyncio
@@ -257,10 +270,10 @@ async def test_add_segments_with_no_context(
         row = (
             await session.execute(select(SegmentRow).where(SegmentRow.uuid == seg.uuid))
         ).scalar_one()
-    assert json.loads(row.context) == {"context_type": "null"}
+    assert json.loads(row.context) == {}
 
     result = await partition.get_segment_contexts([seg.uuid])
-    assert result[seg.uuid][0].context == NullContext()
+    assert result[seg.uuid][0].context == {}
 
 
 @pytest.mark.asyncio
@@ -290,7 +303,7 @@ async def test_timestamp_roundtrips_with_timezone(
         offset=0,
         timestamp=ts,
         block=TextBlock(text="tz"),
-        context=_NULL_CONTEXT,
+        context={},
         properties={},
     )
     await partition.add_segments(_links(seg))
@@ -329,7 +342,7 @@ async def test_timestamp_filter_compares_instants_not_wall_clocks(
 
     result = await partition.get_segment_contexts(
         [early.uuid],
-        max_forward_segments=5,
+        after=5,
         property_filter=parse_filter(f"timestamp <= date('{bound}')"),
     )
     assert [s.uuid for s in result[early.uuid]] == [early.uuid]
@@ -372,9 +385,7 @@ async def test_contexts_empty_seeds(
 async def test_contexts_unknown_seed(
     partition: SQLAlchemySegmentStorePartition,
 ) -> None:
-    result = await partition.get_segment_contexts(
-        [uuid4()], max_backward_segments=2, max_forward_segments=2
-    )
+    result = await partition.get_segment_contexts([uuid4()], before=2, after=2)
     assert result == {}
 
 
@@ -382,7 +393,7 @@ async def test_contexts_unknown_seed(
 async def test_contexts_seed_only(
     partition: SQLAlchemySegmentStorePartition,
 ) -> None:
-    """When max_backward=0 and max_forward=0, return just the seed."""
+    """When before=0 and after=0, return just the seed."""
     seg = _seg()
     await partition.add_segments(_links(seg))
 
@@ -402,7 +413,7 @@ async def test_contexts_backward(
     await partition.add_segments(_links(*segs))
 
     seed = segs[3]
-    result = await partition.get_segment_contexts([seed.uuid], max_backward_segments=2)
+    result = await partition.get_segment_contexts([seed.uuid], before=2)
     ctx = result[seed.uuid]
     # backward(2) + seed = 3 segments
     assert len(ctx) == 3
@@ -419,7 +430,7 @@ async def test_contexts_forward(
     await partition.add_segments(_links(*segs))
 
     seed = segs[1]
-    result = await partition.get_segment_contexts([seed.uuid], max_forward_segments=2)
+    result = await partition.get_segment_contexts([seed.uuid], after=2)
     ctx = result[seed.uuid]
     # seed + forward(2) = 3 segments
     assert len(ctx) == 3
@@ -436,9 +447,7 @@ async def test_contexts_backward_and_forward(
     await partition.add_segments(_links(*segs))
 
     seed = segs[3]
-    result = await partition.get_segment_contexts(
-        [seed.uuid], max_backward_segments=2, max_forward_segments=2
-    )
+    result = await partition.get_segment_contexts([seed.uuid], before=2, after=2)
     ctx = result[seed.uuid]
     assert len(ctx) == 5
     uuids = [s.uuid for s in ctx]
@@ -461,9 +470,7 @@ async def test_contexts_clamp_at_boundaries(
     await partition.add_segments(_links(*segs))
 
     seed = segs[0]
-    result = await partition.get_segment_contexts(
-        [seed.uuid], max_backward_segments=10, max_forward_segments=10
-    )
+    result = await partition.get_segment_contexts([seed.uuid], before=10, after=10)
     ctx = result[seed.uuid]
     assert len(ctx) == 3
     uuids = [s.uuid for s in ctx]
@@ -481,8 +488,8 @@ async def test_contexts_multiple_seeds(
     seed_a, seed_b = segs[2], segs[7]
     result = await partition.get_segment_contexts(
         [seed_a.uuid, seed_b.uuid],
-        max_backward_segments=1,
-        max_forward_segments=1,
+        before=1,
+        after=1,
     )
     assert seed_a.uuid in result
     assert seed_b.uuid in result
@@ -503,9 +510,7 @@ async def test_contexts_with_properties(
     s2 = _seg(event_uuid=ep, offset=2, ts_offset_seconds=2, properties={"k": "v2"})
     await partition.add_segments(_links(s0, s1, s2))
 
-    result = await partition.get_segment_contexts(
-        [s1.uuid], max_backward_segments=1, max_forward_segments=1
-    )
+    result = await partition.get_segment_contexts([s1.uuid], before=1, after=1)
     ctx = result[s1.uuid]
     assert len(ctx) == 3
     assert ctx[0].properties == {"k": "v0"}
@@ -528,8 +533,8 @@ async def test_contexts_property_filter(
     filt = Comparison(field="m.tag", op="=", value="a")
     result = await partition.get_segment_contexts(
         [s2.uuid],
-        max_backward_segments=5,
-        max_forward_segments=5,
+        before=5,
+        after=5,
         property_filter=filt,
     )
     ctx = result[s2.uuid]
@@ -554,27 +559,27 @@ async def test_contexts_filter_by_context_producer(
         event_uuid=ep,
         offset=0,
         ts_offset_seconds=0,
-        context=ProducerContext(producer="Alice"),
+        context=_author("Alice"),
     )
     s1 = _seg(
         event_uuid=ep,
         offset=1,
         ts_offset_seconds=1,
-        context=ProducerContext(producer="Bob"),
+        context=_author("Bob"),
     )
     s2 = _seg(
         event_uuid=ep,
         offset=2,
         ts_offset_seconds=2,
-        context=ProducerContext(producer="Alice"),
+        context=_author("Alice"),
     )
     await partition.add_segments(_links(s0, s1, s2))
 
     filt = Comparison(field="context.producer", op="=", value="Alice")
     contexts = await partition.get_segment_contexts(
         [s0.uuid],
-        max_backward_segments=5,
-        max_forward_segments=5,
+        before=5,
+        after=5,
         property_filter=filt,
     )
     assert contexts == {}
@@ -590,27 +595,27 @@ async def test_contexts_filter_by_context_type(
         event_uuid=ep,
         offset=0,
         ts_offset_seconds=0,
-        context=ProducerContext(producer="Alice"),
+        context=_author("Alice"),
     )
     s1 = _seg(
         event_uuid=ep,
         offset=1,
         ts_offset_seconds=1,
-        context=NullContext(),
+        context={},
     )
     s2 = _seg(
         event_uuid=ep,
         offset=2,
         ts_offset_seconds=2,
-        context=ProducerContext(producer="Bob"),
+        context=_author("Bob"),
     )
     await partition.add_segments(_links(s0, s1, s2))
 
     filt = Comparison(field="context.context_type", op="=", value="producer")
     contexts = await partition.get_segment_contexts(
         [s0.uuid],
-        max_backward_segments=5,
-        max_forward_segments=5,
+        before=5,
+        after=5,
         property_filter=filt,
     )
     assert contexts == {}
@@ -636,9 +641,7 @@ async def test_contexts_session_isolation(store: SQLAlchemySegmentStore) -> None
     )
     await partition.add_segments(_links(s_seed, s_after))
 
-    result = await partition.get_segment_contexts(
-        [s_seed.uuid], max_backward_segments=5, max_forward_segments=5
-    )
+    result = await partition.get_segment_contexts([s_seed.uuid], before=5, after=5)
     ctx = result[s_seed.uuid]
     uuids = [s.uuid for s in ctx]
     assert s_other.uuid not in uuids
@@ -654,9 +657,7 @@ async def test_contexts_chronological_order(
     segs = [_seg(event_uuid=ep, offset=i, ts_offset_seconds=i) for i in range(5)]
     await partition.add_segments(_links(*segs))
 
-    result = await partition.get_segment_contexts(
-        [segs[2].uuid], max_backward_segments=10, max_forward_segments=10
-    )
+    result = await partition.get_segment_contexts([segs[2].uuid], before=10, after=10)
     ctx = result[segs[2].uuid]
     timestamps = [s.timestamp for s in ctx]
     assert timestamps == sorted(timestamps)
@@ -668,16 +669,14 @@ async def test_context_preserved_in_segment_contexts(
 ) -> None:
     """Context is preserved when retrieving segment contexts (backward/forward)."""
     ep = uuid4()
-    ctx_user = ProducerContext(producer="User")
-    ctx_assistant = ProducerContext(producer="Assistant")
+    ctx_user = _author("User")
+    ctx_assistant = _author("Assistant")
     s0 = _seg(event_uuid=ep, offset=0, ts_offset_seconds=0, context=ctx_user)
     s1 = _seg(event_uuid=ep, offset=1, ts_offset_seconds=1, context=ctx_assistant)
     s2 = _seg(event_uuid=ep, offset=2, ts_offset_seconds=2, context=ctx_user)
     await partition.add_segments(_links(s0, s1, s2))
 
-    result = await partition.get_segment_contexts(
-        [s1.uuid], max_backward_segments=1, max_forward_segments=1
-    )
+    result = await partition.get_segment_contexts([s1.uuid], before=1, after=1)
     ctx = result[s1.uuid]
     assert len(ctx) == 3
     assert ctx[0].context == ctx_user
@@ -983,9 +982,7 @@ async def test_concurrent_reads_during_writes(
     async def reader() -> None:
         part = await _get_partition(engine)
         for _ in range(5):
-            result = await part.get_segment_contexts(
-                [segs[5].uuid], max_backward_segments=5, max_forward_segments=5
-            )
+            result = await part.get_segment_contexts([segs[5].uuid], before=5, after=5)
             if segs[5].uuid in result:
                 read_results.append(len(result[segs[5].uuid]))
             await asyncio.sleep(0.01)
@@ -1028,9 +1025,7 @@ async def test_concurrent_context_reads_during_deletes(
         part = await _get_partition(engine)
         for seg in all_segs[::3]:
             try:
-                await part.get_segment_contexts(
-                    [seg.uuid], max_backward_segments=2, max_forward_segments=2
-                )
+                await part.get_segment_contexts([seg.uuid], before=2, after=2)
             except Exception as e:
                 errors.append(e)
             await asyncio.sleep(0.01)
@@ -1247,8 +1242,8 @@ async def test_pg_context_preserved_via_lateral_join(
         _plaintext_partition_config(),
     )
     ep = uuid4()
-    ctx_user = ProducerContext(producer="User")
-    ctx_assistant = ProducerContext(producer="Assistant")
+    ctx_user = _author("User")
+    ctx_assistant = _author("Assistant")
     s0 = _seg(event_uuid=ep, offset=0, ts_offset_seconds=0, context=ctx_user)
     s1 = _seg(event_uuid=ep, offset=1, ts_offset_seconds=1, context=ctx_assistant)
     s2 = _seg(event_uuid=ep, offset=2, ts_offset_seconds=2, context=ctx_user)
@@ -1258,9 +1253,7 @@ async def test_pg_context_preserved_via_lateral_join(
     await partition.add_segments(_links(*all_segs))
 
     # Two seeds exercises the LATERAL join code path.
-    result = await partition.get_segment_contexts(
-        [s1.uuid, s3.uuid], max_backward_segments=1, max_forward_segments=1
-    )
+    result = await partition.get_segment_contexts([s1.uuid, s3.uuid], before=1, after=1)
 
     ctx_a = result[s1.uuid]
     assert len(ctx_a) == 3
@@ -1285,7 +1278,7 @@ async def test_pg_mixed_context_types(
         PARTITION_KEY,
         _plaintext_partition_config(),
     )
-    ctx_msg = ProducerContext(producer="User")
+    ctx_msg = _author("User")
 
     s_msg = _seg(ts_offset_seconds=0, context=ctx_msg)
     s_none = _seg(ts_offset_seconds=1)
@@ -1299,13 +1292,13 @@ async def test_pg_mixed_context_types(
                 select(SegmentRow).where(SegmentRow.uuid == s_none.uuid)
             )
         ).scalar_one()
-    assert json.loads(row.context) == {"context_type": "null"}
+    assert json.loads(row.context) == {}
 
     result = await partition.get_segment_contexts([s_msg.uuid])
     assert result[s_msg.uuid][0].context == ctx_msg
 
     result = await partition.get_segment_contexts([s_none.uuid])
-    assert result[s_none.uuid][0].context == NullContext()
+    assert result[s_none.uuid][0].context == {}
 
 
 # ===================================================================
@@ -1830,8 +1823,7 @@ async def test_purge_bound_comes_from_params(
         assert await store.purge_deleted_partitions() is True
         assert await store.purge_deleted_partitions() is False
     finally:
-        async with sqlalchemy_sqlite_engine.begin() as conn:
-            await conn.run_sync(BaseSegmentStore.metadata.drop_all)
+        await _drop_schema(sqlalchemy_sqlite_engine)
 
 
 @pytest.mark.integration
@@ -2156,8 +2148,7 @@ async def test_purge_bounds_entries_processed_per_call(
         while await store.purge_deleted_partitions():
             pass
     finally:
-        async with sqlalchemy_sqlite_engine.begin() as conn:
-            await conn.run_sync(BaseSegmentStore.metadata.drop_all)
+        await _drop_schema(sqlalchemy_sqlite_engine)
 
 
 @pytest.mark.asyncio
@@ -2417,9 +2408,7 @@ async def test_windowed_read_raises_when_partition_dies_between_statements(
 
     monkeypatch.setattr(partition, context_method, delete_then_read)
     with pytest.raises(SegmentStorePartitionHandleStaleError):
-        await partition.get_segment_contexts(
-            [segs[1].uuid], max_backward_segments=1, max_forward_segments=1
-        )
+        await partition.get_segment_contexts([segs[1].uuid], before=1, after=1)
 
 
 @pytest.mark.asyncio
@@ -2758,3 +2747,342 @@ def test_empty_partition_key_is_named_as_empty() -> None:
     """An empty key is reported as empty, not as containing invalid characters."""
     with pytest.raises(ValueError, match="must not be empty"):
         validate_partition_key("")
+
+
+# ===================================================================
+# get_neighbourhoods -- the seed is an address
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_neighbourhoods_are_two_lists_without_the_seed(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    ep = uuid4()
+    segs = [_seg(event_uuid=ep, offset=i, ts_offset_seconds=i) for i in range(5)]
+    await partition.add_segments(_links(*segs))
+
+    result = await partition.get_neighbourhoods([segs[2].uuid], before=2, after=2)
+
+    neighborhood = result[segs[2].uuid]
+    # Other chunks of the seed's own event are ordinary neighbors; only the
+    # seed itself is withheld, and its place is between the two lists.
+    assert [s.uuid for s in neighborhood.before] == [segs[0].uuid, segs[1].uuid]
+    assert [s.uuid for s in neighborhood.after] == [segs[3].uuid, segs[4].uuid]
+    assert segs[2].uuid not in {
+        s.uuid for s in [*neighborhood.before, *neighborhood.after]
+    }
+
+
+@pytest.mark.asyncio
+async def test_neighbourhoods_keep_the_window_when_the_seed_fails_the_filter(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    """The seed is located whether or not it passes; the filter is about neighbors.
+
+    During a search the same seed is dropped before a window is built.
+    """
+    ep = uuid4()
+    s0 = _seg(event_uuid=ep, offset=0, ts_offset_seconds=0, properties={"tag": "a"})
+    s1 = _seg(event_uuid=ep, offset=1, ts_offset_seconds=1, properties={"tag": "b"})
+    s2 = _seg(event_uuid=ep, offset=2, ts_offset_seconds=2, properties={"tag": "a"})
+    await partition.add_segments(_links(s0, s1, s2))
+    only_a = parse_filter("m.tag = 'a'")
+
+    neighborhoods = await partition.get_neighbourhoods(
+        [s1.uuid], before=5, after=5, property_filter=only_a
+    )
+    contexts = await partition.get_segment_contexts(
+        [s1.uuid], before=5, after=5, property_filter=only_a
+    )
+
+    assert [s.uuid for s in neighborhoods[s1.uuid].before] == [s0.uuid]
+    assert [s.uuid for s in neighborhoods[s1.uuid].after] == [s2.uuid]
+    assert contexts == {}
+
+
+@pytest.mark.asyncio
+async def test_neighbourhoods_of_a_lone_seed_are_empty_lists(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    seed = _seg()
+    await partition.add_segments(_links(seed))
+
+    result = await partition.get_neighbourhoods([seed.uuid], before=5, after=5)
+
+    assert result == {seed.uuid: Neighborhood(before=[], after=[])}
+
+
+@pytest.mark.asyncio
+async def test_neighbourhoods_omit_an_unknown_seed(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    await partition.add_segments(_links(_seg()))
+
+    assert await partition.get_neighbourhoods([uuid4()], before=1, after=1) == {}
+
+
+@pytest.mark.asyncio
+async def test_neighbourhoods_with_zero_counts_still_locate_the_seed(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    seed = _seg()
+    await partition.add_segments(_links(seed, _seg(ts_offset_seconds=1)))
+
+    assert await partition.get_neighbourhoods([seed.uuid]) == {
+        seed.uuid: Neighborhood(before=[], after=[])
+    }
+
+
+# ===================================================================
+# The one total order: sessions
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_windows_stay_in_the_seeds_session(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    """Two conversations interleaved in time never appear in each other's windows."""
+    a0 = _seg(session_id="a", ts_offset_seconds=0)
+    b0 = _seg(session_id="b", ts_offset_seconds=1)
+    a1 = _seg(session_id="a", ts_offset_seconds=2)
+    b1 = _seg(session_id="b", ts_offset_seconds=3)
+    a2 = _seg(session_id="a", ts_offset_seconds=4)
+    await partition.add_segments(_links(a0, b0, a1, b1, a2))
+
+    contexts = await partition.get_segment_contexts([a1.uuid], before=5, after=5)
+    neighborhoods = await partition.get_neighbourhoods([b0.uuid], before=5, after=5)
+
+    assert [s.uuid for s in contexts[a1.uuid]] == [a0.uuid, a1.uuid, a2.uuid]
+    assert neighborhoods[b0.uuid].before == []
+    assert [s.uuid for s in neighborhoods[b0.uuid].after] == [b1.uuid]
+
+
+@pytest.mark.asyncio
+async def test_null_session_is_one_stream(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    """A null session id compares equal to a null session id and to nothing else."""
+    n0 = _seg(session_id=None, ts_offset_seconds=0)
+    s0 = _seg(session_id="s", ts_offset_seconds=1)
+    n1 = _seg(session_id=None, ts_offset_seconds=2)
+    await partition.add_segments(_links(n0, s0, n1))
+
+    neighborhoods = await partition.get_neighbourhoods([n0.uuid], after=5)
+    contexts = await partition.get_segment_contexts([n1.uuid], before=5)
+
+    assert [s.uuid for s in neighborhoods[n0.uuid].after] == [n1.uuid]
+    assert [s.uuid for s in contexts[n1.uuid]] == [n0.uuid, n1.uuid]
+
+
+@pytest.mark.asyncio
+async def test_multiple_seeds_across_sessions(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    """Seeds of different sessions in one call each get their own session's window."""
+    a0 = _seg(session_id="a", ts_offset_seconds=0)
+    b0 = _seg(session_id="b", ts_offset_seconds=1)
+    a1 = _seg(session_id="a", ts_offset_seconds=2)
+    b1 = _seg(session_id="b", ts_offset_seconds=3)
+    n0 = _seg(session_id=None, ts_offset_seconds=4)
+    await partition.add_segments(_links(a0, b0, a1, b1, n0))
+
+    result = await partition.get_segment_contexts(
+        [a0.uuid, b0.uuid, n0.uuid], before=2, after=2
+    )
+
+    assert [s.uuid for s in result[a0.uuid]] == [a0.uuid, a1.uuid]
+    assert [s.uuid for s in result[b0.uuid]] == [b0.uuid, b1.uuid]
+    assert [s.uuid for s in result[n0.uuid]] == [n0.uuid]
+
+
+# ===================================================================
+# since / until, source_ids, block_kinds
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_since_and_until_meet_without_overlap(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    """`since` is inclusive and `until` exclusive on a boundary timestamp."""
+    s0 = _seg(ts_offset_seconds=0)
+    s1 = _seg(ts_offset_seconds=60)
+    s2 = _seg(ts_offset_seconds=120)
+    await partition.add_segments(_links(s0, s1, s2))
+    boundary = BASE_TIME + timedelta(seconds=60)
+
+    from_boundary = await partition.get_segment_contexts(
+        [s1.uuid], before=5, after=5, since=boundary
+    )
+    to_boundary = await partition.get_segment_contexts(
+        [s1.uuid], before=5, after=5, until=boundary
+    )
+    around = await partition.get_neighbourhoods(
+        [s1.uuid], before=5, after=5, since=BASE_TIME, until=boundary
+    )
+
+    assert [s.uuid for s in from_boundary[s1.uuid]] == [s1.uuid, s2.uuid]
+    # The seed sits on the exclusive bound, so as a result it is out...
+    assert to_boundary == {}
+    # ...and as an address it still anchors, and the bound admits only s0.
+    assert [s.uuid for s in around[s1.uuid].before] == [s0.uuid]
+    assert around[s1.uuid].after == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bound",
+    [
+        "2024-01-01T00:00:30+00:00",
+        "2024-01-01T08:00:30+08:00",  # the same instant, named in another zone
+        "2023-12-31T16:00:30-08:00",  # and another
+    ],
+)
+async def test_time_bounds_compare_instants_not_wall_clocks(
+    partition: SQLAlchemySegmentStorePartition,
+    bound: str,
+) -> None:
+    """A bound means an instant, whatever zone it is written in.
+
+    Timestamps are stored as the UTC instant; a bound compared with its own
+    offset on SQLite would be compared on its wall-clock digits.
+    """
+    early = _seg(ts_offset_seconds=0)
+    late = _seg(ts_offset_seconds=60)
+    await partition.add_segments(_links(early, late))
+    instant = datetime.fromisoformat(bound)
+
+    before_bound = await partition.get_segment_contexts(
+        [early.uuid], after=5, until=instant
+    )
+    from_bound = await partition.get_neighbourhoods(
+        [early.uuid], after=5, since=instant
+    )
+
+    assert [s.uuid for s in before_bound[early.uuid]] == [early.uuid]
+    assert [s.uuid for s in from_bound[early.uuid].after] == [late.uuid]
+
+
+@pytest.mark.asyncio
+async def test_source_ids_select_rows(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    s0 = _seg(source_id="alice", ts_offset_seconds=0)
+    s1 = _seg(source_id="bob", ts_offset_seconds=1)
+    s2 = _seg(source_id="alice", ts_offset_seconds=2)
+    s3 = _seg(source_id=None, ts_offset_seconds=3)
+    await partition.add_segments(_links(s0, s1, s2, s3))
+
+    alice = await partition.get_segment_contexts(
+        [s0.uuid], after=5, source_ids=["alice"]
+    )
+    bob_around_alice = await partition.get_neighbourhoods(
+        [s0.uuid], after=5, source_ids=["bob"]
+    )
+    nobody = await partition.get_segment_contexts([s0.uuid], after=5, source_ids=[])
+
+    assert [s.uuid for s in alice[s0.uuid]] == [s0.uuid, s2.uuid]
+    assert [s.uuid for s in bob_around_alice[s0.uuid].after] == [s1.uuid]
+    assert nobody == {}
+    assert alice[s0.uuid][0].source_id == "alice"
+
+
+@pytest.mark.asyncio
+async def test_block_kinds_select_rows(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    s0 = _seg(ts_offset_seconds=0)
+    s1 = _seg(ts_offset_seconds=1)
+    await partition.add_segments(_links(s0, s1))
+
+    text = await partition.get_segment_contexts(
+        [s0.uuid], after=5, block_kinds=["text"]
+    )
+    image = await partition.get_segment_contexts(
+        [s0.uuid], after=5, block_kinds=["image"]
+    )
+    around = await partition.get_neighbourhoods(
+        [s0.uuid], after=5, block_kinds=["image"]
+    )
+
+    assert [s.uuid for s in text[s0.uuid]] == [s0.uuid, s1.uuid]
+    assert image == {}
+    assert around == {s0.uuid: Neighborhood(before=[], after=[])}
+
+
+@pytest.mark.asyncio
+async def test_row_projections_are_derived_from_the_segment(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    seg = _seg(session_id="s1", source_id="alice")
+    await partition.add_segments(_links(seg))
+
+    async with partition._create_session() as session:
+        row = (
+            await session.execute(select(SegmentRow).where(SegmentRow.uuid == seg.uuid))
+        ).scalar_one()
+    assert (row.session_id, row.source_id, row.block_kind) == ("s1", "alice", "text")
+
+    [returned] = (await partition.get_segment_contexts([seg.uuid]))[seg.uuid]
+    assert (returned.session_id, returned.source_id) == ("s1", "alice")
+
+
+@pytest.mark.asyncio
+async def test_segment_uuids_by_event_are_in_the_events_order(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    ep = uuid4()
+    later_block = _seg(event_uuid=ep, index=1, offset=0)
+    second_chunk = _seg(event_uuid=ep, index=0, offset=1)
+    first_chunk = _seg(event_uuid=ep, index=0, offset=0)
+    await partition.add_segments(_links(later_block, second_chunk, first_chunk))
+
+    result = await partition.get_segment_uuids_by_event_uuids([ep])
+
+    assert result[ep] == [first_chunk.uuid, second_chunk.uuid, later_block.uuid]
+
+
+# ===================================================================
+# delete_derivatives
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_derivatives_unlinks_and_keeps_the_segment(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    seg = _seg()
+    d1, d2 = uuid4(), uuid4()
+    await partition.add_segments({seg: [d1, d2]})
+
+    await partition.delete_derivatives([d1, uuid4()])
+
+    assert await partition.get_derivative_uuids_by_segment_uuids([seg.uuid]) == {
+        seg.uuid: [d2]
+    }
+    assert seg.uuid in await partition.get_segment_contexts([seg.uuid])
+
+
+@pytest.mark.asyncio
+async def test_delete_derivatives_empty(
+    partition: SQLAlchemySegmentStorePartition,
+) -> None:
+    await partition.delete_derivatives([])
+
+
+@pytest.mark.asyncio
+async def test_delete_derivatives_on_a_stale_handle_raises(
+    store: SQLAlchemySegmentStore,
+) -> None:
+    partition = await store.open_or_create_partition(
+        "unlink_fenced", _plaintext_partition_config()
+    )
+    seg = _seg()
+    derivative = uuid4()
+    await partition.add_segments({seg: [derivative]})
+    await store.delete_partition("unlink_fenced")
+
+    with pytest.raises(SegmentStorePartitionHandleStaleError):
+        await partition.delete_derivatives([derivative])

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segmenter/test_passthrough_segmenter.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segmenter/test_passthrough_segmenter.py
@@ -6,9 +6,8 @@ from uuid import uuid4
 import pytest
 
 from memmachine_server.episodic_memory.event_memory.data_types import (
+    Author,
     Event,
-    NullContext,
-    ProducerContext,
     TextBlock,
 )
 from memmachine_server.episodic_memory.event_memory.segmenter.passthrough_segmenter import (
@@ -24,7 +23,7 @@ async def test_passthrough_emits_one_segment_per_block():
     event = Event(
         uuid=uuid4(),
         timestamp=_TS,
-        context=ProducerContext(producer="alice"),
+        context={"author": Author(name="alice")},
         blocks=[
             TextBlock(text="first block"),
             TextBlock(text="second block"),
@@ -53,7 +52,7 @@ async def test_passthrough_does_not_split_long_text():
     event = Event(
         uuid=uuid4(),
         timestamp=_TS,
-        context=NullContext(),
+        context={},
         blocks=[TextBlock(text=long_text)],
     )
     segmenter = PassthroughSegmenter()
@@ -68,7 +67,7 @@ async def test_passthrough_empty_blocks_yields_no_segments():
     event = Event(
         uuid=uuid4(),
         timestamp=_TS,
-        context=NullContext(),
+        context={},
         blocks=[],
     )
     segmenter = PassthroughSegmenter()
@@ -82,7 +81,7 @@ async def test_passthrough_each_segment_has_unique_uuid():
     event = Event(
         uuid=uuid4(),
         timestamp=_TS,
-        context=NullContext(),
+        context={},
         blocks=[TextBlock(text="a"), TextBlock(text="b")],
     )
     segmenter = PassthroughSegmenter()

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segmenter/test_text_segmenter.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/segmenter/test_text_segmenter.py
@@ -8,10 +8,9 @@ import pytest
 from pydantic import BaseModel
 
 from memmachine_server.episodic_memory.event_memory.data_types import (
+    Author,
     Block,
     Event,
-    NullContext,
-    ProducerContext,
     TextBlock,
 )
 from memmachine_server.episodic_memory.event_memory.segmenter.text_segmenter import (
@@ -32,7 +31,7 @@ def _make_event(
     return Event(
         uuid=uuid4(),
         timestamp=_TS,
-        context=context if context is not None else NullContext(),
+        context=context if context is not None else {},
         blocks=blocks,
         properties=properties or {},
     )
@@ -42,12 +41,12 @@ def _make_event_with_unsupported_block() -> Event:
     """Bypass discriminated-union validation to exercise the segmenter's fallback arm."""
 
     class _OtherBlock(BaseModel):
-        block_type: str = "other"
+        kind: str = "other"
 
     return Event.model_construct(
         uuid=uuid4(),
         timestamp=_TS,
-        context=NullContext(),
+        context={},
         blocks=[cast(Block, _OtherBlock())],
         properties={},
     )
@@ -109,12 +108,12 @@ class TestTextSegmenter:
     async def test_propagates_event_context(self):
         event = _make_event(
             blocks=[TextBlock(text="hi")],
-            context=ProducerContext(producer="Alice"),
+            context={"author": Author(name="Alice")},
         )
 
         result = await TextSegmenter().segment(event)
 
-        assert result[0].context == ProducerContext(producer="Alice")
+        assert result[0].context == {"author": Author(name="Alice")}
 
     async def test_propagates_event_properties(self):
         event = _make_event(
@@ -144,5 +143,5 @@ class TestTextSegmenter:
     async def test_non_text_block_raises(self):
         event = _make_event_with_unsupported_block()
 
-        with pytest.raises(NotImplementedError, match="Unsupported block type"):
+        with pytest.raises(NotImplementedError, match="Unsupported block kind"):
             await TextSegmenter().segment(event)

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_data_types.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_data_types.py
@@ -7,15 +7,20 @@ import pytest
 from pydantic import ValidationError
 
 from memmachine_server.episodic_memory.event_memory.data_types import (
+    Author,
     Derivative,
     Event,
-    ProducerContext,
+    FormatOptions,
     Segment,
     TextBlock,
+    UnknownPart,
     decode_block,
     decode_context,
     encode_block,
     encode_context,
+    get_part,
+    with_part,
+    without_part,
 )
 
 SAMPLE_PROPERTIES = {
@@ -74,12 +79,36 @@ class TestSegmentRoundTrip:
             index=0,
             offset=0,
             timestamp=datetime(2026, 1, 15, 10, 30, tzinfo=UTC),
-            context=ProducerContext(producer="user"),
+            context=with_part({}, Author(name="user")),
             block=TextBlock(text="hello"),
         )
         seg2 = Segment.model_validate(seg.model_dump(mode="json"))
-        assert isinstance(seg2.context, ProducerContext)
-        assert seg2.context.producer == "user"
+        assert get_part(seg2.context, Author) == Author(name="user")
+
+    def test_session_and_source_round_trip(self):
+        seg = Segment(
+            uuid=uuid4(),
+            event_uuid=uuid4(),
+            index=0,
+            offset=0,
+            timestamp=datetime(2026, 1, 15, 10, 30, tzinfo=UTC),
+            session_id="s1",
+            source_id="alice",
+            block=TextBlock(text="hello"),
+        )
+        seg2 = Segment.model_validate(seg.model_dump(mode="json"))
+        assert (seg2.session_id, seg2.source_id) == ("s1", "alice")
+
+    def test_session_and_source_default_to_none(self):
+        seg = Segment(
+            uuid=uuid4(),
+            event_uuid=uuid4(),
+            index=0,
+            offset=0,
+            timestamp=datetime(2026, 1, 15, 10, 30, tzinfo=UTC),
+            block=TextBlock(text="hello"),
+        )
+        assert (seg.session_id, seg.source_id, seg.context) == (None, None, {})
 
 
 class TestEventRoundTrip:
@@ -120,7 +149,7 @@ class TestDeserializationErrors:
             "index": 0,
             "offset": 0,
             "timestamp": "2026-01-15T10:30:00Z",
-            "block": {"block_type": "text", "text": "hi"},
+            "block": {"kind": "text", "text": "hi"},
             "properties": {"key": {"not_tagged": "value"}},
         }
         with pytest.raises(ValidationError):
@@ -133,7 +162,7 @@ class TestDeserializationErrors:
             "index": 0,
             "offset": 0,
             "timestamp": "2026-01-15T10:30:00Z",
-            "block": {"block_type": "text", "text": "hi"},
+            "block": {"kind": "text", "text": "hi"},
             "properties": {"n": {"t": "int", "v": 42, "extra": "junk"}},
         }
         with pytest.raises(ValidationError):
@@ -146,7 +175,7 @@ class TestDeserializationErrors:
             "index": 0,
             "offset": 0,
             "timestamp": "2026-01-15T10:30:00Z",
-            "block": {"block_type": "text", "text": "hi"},
+            "block": {"kind": "text", "text": "hi"},
             "properties": {
                 "dt": {"t": "datetime", "v": "2026-01-15T00:00:00+00:00"},
             },
@@ -155,22 +184,73 @@ class TestDeserializationErrors:
             Segment.model_validate(data)
 
 
-class TestContextModels:
+class TestContextParts:
     def test_context_models_do_not_declare_index_hints(self):
-        assert not hasattr(ProducerContext, "indexed_properties")
+        assert not hasattr(Author, "indexed_properties")
+
+    def test_get_part_of_an_absent_kind_is_none(self):
+        assert get_part({}, Author) is None
+
+    def test_with_part_replaces_the_part_of_that_kind(self):
+        context = with_part({}, Author(name="user"))
+        replaced = with_part(context, Author(name="other"))
+        assert get_part(context, Author) == Author(name="user")
+        assert get_part(replaced, Author) == Author(name="other")
+        assert list(replaced) == ["author"]
+
+    def test_without_part_removes_the_kind(self):
+        context = with_part({}, Author(name="user"))
+        assert without_part(context, Author) == {}
+        assert context == {"author": Author(name="user")}
+
+    def test_author_renders_its_name_and_unknown_renders_nothing(self):
+        unknown = UnknownPart(kind_name="plugin", data={"x": 1})
+        assert Author(name="user").render(FormatOptions()) == "user"
+        assert unknown.render(FormatOptions()) is None
 
 
 class TestContextAndBlockSerialization:
     def test_context_round_trip(self):
-        context = ProducerContext(producer="user")
+        context = with_part({}, Author(name="user"))
 
         serialized = encode_context(context)
         deserialized = decode_context(serialized)
 
+        assert serialized == {"author": {"name": "user"}}
         assert deserialized == context
 
-    def test_context_none_round_trip(self):
-        assert decode_context(encode_context(None)) is None
+    def test_empty_context_round_trip(self):
+        assert encode_context({}) == {}
+        assert decode_context({}) == {}
+
+    def test_unregistered_kind_round_trips_unchanged(self):
+        encoded = {"author": {"name": "user"}, "plugin": {"x": 1, "y": "z"}}
+
+        decoded = decode_context(encoded)
+
+        assert decoded["plugin"] == UnknownPart(
+            kind_name="plugin", data={"x": 1, "y": "z"}
+        )
+        assert get_part(decoded, Author) == Author(name="user")
+        assert encode_context(decoded) == encoded
+
+    def test_part_that_is_not_an_object_is_rejected(self):
+        with pytest.raises(TypeError, match="object"):
+            decode_context({"author": "user"})
+
+    def test_model_dump_encodes_parts_by_kind(self):
+        seg = Segment(
+            uuid=uuid4(),
+            event_uuid=uuid4(),
+            index=0,
+            offset=0,
+            timestamp=datetime(2026, 1, 15, 10, 30, tzinfo=UTC),
+            context=with_part({}, Author(name="user")),
+            block=TextBlock(text="hello"),
+        )
+        dumped = seg.model_dump(mode="json")
+        assert dumped["context"] == {"author": {"name": "user"}}
+        assert dumped["block"] == {"kind": "text", "text": "hello"}
 
     def test_block_round_trip(self):
         block = TextBlock(text="hello")

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_event_memory.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_event_memory.py
@@ -9,13 +9,16 @@ from uuid import UUID, uuid4
 import pytest
 
 from memmachine_server.common.data_types import PropertyValue
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
     And,
-    Comparison,
+    Equals,
     In,
-    IsNull,
+    IsMissing,
     Not,
+    NotEquals,
     Or,
+    Ordering,
+    filter_fields,
 )
 from memmachine_server.common.vector_store.data_types import (
     Record,
@@ -26,6 +29,7 @@ from memmachine_server.episodic_memory.event_memory.data_types import (
     Context,
     Event,
     EvictionOptions,
+    FilterOptions,
     FormatOptions,
     SearchHit,
     Segment,
@@ -41,6 +45,7 @@ from memmachine_server.episodic_memory.event_memory.event_memory import (
     ID_MAX_BYTES,
     EventMemory,
     EventMemoryParams,
+    InvalidCollectionSchemaError,
 )
 from memmachine_server.episodic_memory.event_memory.segmenter.text_segmenter import (
     TextSegmenter,
@@ -303,14 +308,9 @@ class TestEncodeEvents:
         schema = EventMemory.expected_vector_store_collection_schema()
         del schema[EVENT_SESSION_KEY]
         collection = InMemoryVectorStoreCollection(
-            VectorStoreCollectionConfig(
-                vector_dimensions=2, indexed_properties_schema=schema
-            )
+            VectorStoreCollectionConfig(vector_dimensions=2), schema
         )
-        with pytest.raises(
-            ValueError,
-            match="Collection schema missing fields required by EventMemory",
-        ):
+        with pytest.raises(InvalidCollectionSchemaError, match=EVENT_SESSION_KEY):
             EventMemory(
                 EventMemoryParams(
                     vector_store_collection=collection,
@@ -494,7 +494,7 @@ class TestQuerySystemFilters:
 
         hits = await event_memory.query(
             "x",
-            property_filter=Comparison(field="timestamp", op=">=", value=_ts(5)),
+            property_filter=Ordering(field="timestamp", op=">=", value=_ts(5)),
             expand_context=6,
         )
 
@@ -563,7 +563,7 @@ class TestExpand:
             anchor,
             before=5,
             after=5,
-            property_filter=Comparison(field="m.color", op="=", value="green"),
+            property_filter=Equals(field="m.color", value="green"),
         )
 
         assert neighborhood.before == []
@@ -864,7 +864,7 @@ class TestQueryWithFilter:
 
         hits = await event_memory.query(
             "thing",
-            property_filter=Comparison(field="m.color", op="=", value="red"),
+            property_filter=Equals(field="m.color", value="red"),
         )
         assert _texts(hits) == {"red thing"}
 
@@ -875,7 +875,7 @@ class TestQueryWithFilter:
 
         hits = await event_memory.query(
             "thing",
-            property_filter=Comparison(field="m.color", op="!=", value="red"),
+            property_filter=NotEquals(field="m.color", value="red"),
         )
         assert _texts(hits) == {"blue thing"}
 
@@ -887,7 +887,7 @@ class TestQueryWithFilter:
 
         hits = await event_memory.query(
             "thing",
-            property_filter=In(field="m.color", values=["red", "green"]),
+            property_filter=In(field="m.color", values=("red", "green")),
         )
         assert _texts(hits) == {"red thing", "green thing"}
 
@@ -898,7 +898,7 @@ class TestQueryWithFilter:
 
         hits = await event_memory.query(
             "thing",
-            property_filter=IsNull(field="m.color"),
+            property_filter=IsMissing(field="m.color"),
         )
         assert _texts(hits) == {"no color"}
 
@@ -910,8 +910,7 @@ class TestQueryWithFilter:
         hits = await event_memory.query(
             "thing",
             property_filter=And(
-                left=Comparison(field="m.color", op="=", value="red"),
-                right=Not(expr=IsNull(field="m.color")),
+                (Equals(field="m.color", value="red"), Not(IsMissing(field="m.color")))
             ),
         )
         assert _texts(hits) == {"red small"}
@@ -925,8 +924,10 @@ class TestQueryWithFilter:
         hits = await event_memory.query(
             "thing",
             property_filter=Or(
-                left=Comparison(field="m.color", op="=", value="red"),
-                right=Comparison(field="m.color", op="=", value="blue"),
+                (
+                    Equals(field="m.color", value="red"),
+                    Equals(field="m.color", value="blue"),
+                )
             ),
         )
         assert _texts(hits) == {"red thing", "blue thing"}
@@ -938,7 +939,7 @@ class TestQueryWithFilter:
 
         hits = await event_memory.query(
             "thing",
-            property_filter=Not(expr=Comparison(field="m.color", op="=", value="red")),
+            property_filter=Not(Equals(field="m.color", value="red")),
         )
         assert _texts(hits) == {"blue thing"}
 
@@ -951,7 +952,7 @@ class TestQueryWithFilter:
 
         hits = await event_memory.query(
             "thing",
-            property_filter=Comparison(field="m.color", op="=", value="purple"),
+            property_filter=Equals(field="m.color", value="purple"),
         )
         assert hits == []
 
@@ -961,9 +962,147 @@ class TestQueryWithFilter:
 
         hits = await event_memory.query(
             "hi",
-            property_filter=Comparison(field="context.author", op="=", value="Alice"),
+            property_filter=Equals(field="context.author", value="Alice"),
         )
         assert hits == []
+
+
+# ===================================================================
+# Filter routing between the vector store and the segment store
+# ===================================================================
+
+
+def _routing_memory(
+    embedder: FakeEmbedder,
+    collection: InMemoryVectorStoreCollection,
+    *,
+    max_overfetch_factor: int,
+) -> EventMemory:
+    return EventMemory(
+        EventMemoryParams(
+            segment_store_partition=InMemorySegmentStorePartition(),
+            vector_store_collection=collection,
+            segmenter=TextSegmenter(),
+            deriver=WholeTextDeriver(),
+            embedder=embedder,
+            filter=FilterOptions(max_overfetch_factor=max_overfetch_factor),
+        )
+    )
+
+
+def _sized(index: int, size: str) -> Event:
+    return _make_event(
+        f"{size} thing {index}",
+        timestamp=_ts(index),
+        properties={"color": "red", "size": size},
+    )
+
+
+@_async
+class TestFilterRouting:
+    """The declared part of a filter is the vector store's; the rest is the segment store's.
+
+    The collection declares `color` and not `size`, so a predicate on
+    `size` can only be applied by the segment store, after the search.
+    """
+
+    async def test_an_undeclared_predicate_never_reaches_the_vector_store(
+        self, fake_embedder
+    ):
+        collection = make_collection(fake_embedder)
+        memory = _routing_memory(fake_embedder, collection, max_overfetch_factor=4)
+        await memory.encode_events([_sized(0, "big"), _sized(1, "small")])
+
+        hits = await memory.query(
+            "thing",
+            property_filter=And(
+                (
+                    Equals(field="m.color", value="red"),
+                    Equals(field="m.size", value="big"),
+                )
+            ),
+        )
+
+        assert _texts(hits) == {"big thing 0"}
+        # The declared part alone went to the vector store; `size` was
+        # neither scanned for nor stored there.
+        [vector_filter] = collection.queries
+        assert vector_filter is not None
+        assert filter_fields(vector_filter) == {"color"}
+        assert all("size" not in r.properties for r in collection.records.values())
+
+    async def test_a_fully_declared_filter_issues_one_query(self, fake_embedder):
+        collection = make_collection(fake_embedder)
+        memory = _routing_memory(fake_embedder, collection, max_overfetch_factor=4)
+        await memory.encode_events([_sized(index, "big") for index in range(8)])
+
+        hits = await memory.query(
+            "thing", limit=2, property_filter=Equals(field="m.color", value="red")
+        )
+
+        assert len(hits) == 2
+        assert len(collection.queries) == 1
+
+    async def test_the_search_widens_to_make_up_for_dropped_seeds(self, fake_embedder):
+        collection = make_collection(fake_embedder)
+        memory = _routing_memory(fake_embedder, collection, max_overfetch_factor=4)
+        sizes = ["big", "small", "small", "small", "big", "small", "small", "big"]
+        await memory.encode_events([_sized(i, size) for i, size in enumerate(sizes)])
+
+        hits = await memory.query(
+            "thing", limit=2, property_filter=Equals(field="m.size", value="big")
+        )
+
+        # Two seeds fetched, one survived, so the fetch widened once to the
+        # cap of eight, where three survive and the limit is met.
+        assert len(hits) == 2
+        assert _texts(hits) <= {"big thing 0", "big thing 4", "big thing 7"}
+        assert len(collection.queries) == 2
+
+    async def test_widening_stops_at_the_cap_and_returns_what_survived(
+        self, fake_embedder
+    ):
+        collection = make_collection(fake_embedder)
+        memory = _routing_memory(fake_embedder, collection, max_overfetch_factor=2)
+        sizes = ["small", "small", "small", "big", "small", "small", "small", "small"]
+        await memory.encode_events([_sized(i, size) for i, size in enumerate(sizes)])
+
+        hits = await memory.query(
+            "thing", limit=2, property_filter=Equals(field="m.size", value="big")
+        )
+
+        # limit * max_overfetch_factor is four: the fetch of two found no
+        # survivor, the fetch of four found one, and the cap ends the search.
+        assert _texts(hits) == {"big thing 3"}
+        assert len(collection.queries) == 2
+
+    async def test_every_count_is_a_maximum(self, fake_embedder):
+        collection = make_collection(fake_embedder)
+        memory = _routing_memory(fake_embedder, collection, max_overfetch_factor=4)
+        await memory.encode_events([_sized(0, "big"), _sized(1, "small")])
+
+        hits = await memory.query(
+            "thing", limit=5, property_filter=Equals(field="m.size", value="big")
+        )
+        assert len(hits) == 1
+
+    async def test_an_empty_id_list_admits_nothing_without_a_query(self, fake_embedder):
+        collection = make_collection(fake_embedder)
+        memory = _routing_memory(fake_embedder, collection, max_overfetch_factor=4)
+        await memory.encode_events([_sized(0, "big")])
+
+        assert await memory.query("thing", session_ids=[]) == []
+        assert await memory.query("thing", source_ids=[]) == []
+        assert await memory.query("thing", block_kinds=[]) == []
+        assert collection.queries == []
+
+    async def test_a_declared_value_of_another_type_is_rejected_at_ingest(
+        self, fake_embedder
+    ):
+        collection = make_collection(fake_embedder)
+        memory = _routing_memory(fake_embedder, collection, max_overfetch_factor=4)
+        with pytest.raises(ValueError, match="declares it as str"):
+            await memory.encode_events([_make_event("hi", properties={"color": 7})])
 
 
 # ===================================================================

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_event_memory.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_event_memory.py
@@ -20,10 +20,7 @@ from memmachine_server.common.filter import (
     Ordering,
     filter_fields,
 )
-from memmachine_server.common.vector_store.data_types import (
-    Record,
-    VectorStoreCollectionConfig,
-)
+from memmachine_server.common.vector_store.data_types import Record
 from memmachine_server.episodic_memory.event_memory.data_types import (
     Author,
     Context,
@@ -64,7 +61,7 @@ from .conftest import (
     AngleEmbedder,
     FakeReranker,
     InMemorySegmentStorePartition,
-    InMemoryVectorStoreCollection,
+    InMemoryVectorStorePartition,
     make_collection,
 )
 
@@ -126,13 +123,13 @@ def _build(
     embedder: FakeEmbedder,
     *,
     partition: InMemorySegmentStorePartition | None = None,
-    collection: InMemoryVectorStoreCollection | None = None,
+    collection: InMemoryVectorStorePartition | None = None,
     format_options: FormatOptions | None = None,
     eviction: EvictionOptions | None = None,
 ) -> EventMemory:
     params = {
         "segment_store_partition": partition or InMemorySegmentStorePartition(),
-        "vector_store_collection": collection or make_collection(embedder),
+        "vector_store_partition": collection or make_collection(embedder),
         "segmenter": TextSegmenter(),
         "deriver": WholeTextDeriver(),
         "embedder": embedder,
@@ -173,7 +170,7 @@ class TestEncodeEvents:
         self,
         event_memory: EventMemory,
         fake_segment_store_partition: InMemorySegmentStorePartition,
-        fake_vector_store_collection: InMemoryVectorStoreCollection,
+        fake_vector_store_partition: InMemoryVectorStorePartition,
     ):
         event = _make_event("hello world")
         await event_memory.encode_events([event])
@@ -188,8 +185,8 @@ class TestEncodeEvents:
 
         # One derivative record in vector store, with every filterable
         # system value under its reserved key.
-        assert len(fake_vector_store_collection.records) == 1
-        record = next(iter(fake_vector_store_collection.records.values()))
+        assert len(fake_vector_store_partition.records) == 1
+        record = next(iter(fake_vector_store_partition.records.values()))
         props = _record_properties(record)
         assert props[EVENT_TIMESTAMP_KEY] == event.timestamp
         assert props[BLOCK_KIND_KEY] == "text"
@@ -206,12 +203,12 @@ class TestEncodeEvents:
         self,
         event_memory: EventMemory,
         fake_segment_store_partition: InMemorySegmentStorePartition,
-        fake_vector_store_collection: InMemoryVectorStoreCollection,
+        fake_vector_store_partition: InMemoryVectorStorePartition,
     ):
         event = _make_event("hi", session_id="s1", source_id="alice")
         await event_memory.encode_events([event])
 
-        record = next(iter(fake_vector_store_collection.records.values()))
+        record = next(iter(fake_vector_store_partition.records.values()))
         props = _record_properties(record)
         assert props[EVENT_SESSION_KEY] == "s1"
         assert props[EVENT_SOURCE_KEY] == "alice"
@@ -221,12 +218,12 @@ class TestEncodeEvents:
     async def test_context_is_not_a_property(
         self,
         event_memory: EventMemory,
-        fake_vector_store_collection: InMemoryVectorStoreCollection,
+        fake_vector_store_partition: InMemoryVectorStorePartition,
     ):
         event = _make_event("hi", context=_author("Alice"))
         await event_memory.encode_events([event])
 
-        record = next(iter(fake_vector_store_collection.records.values()))
+        record = next(iter(fake_vector_store_partition.records.values()))
         props = _record_properties(record)
         assert not any("author" in key or "context" in key for key in props)
 
@@ -275,12 +272,12 @@ class TestEncodeEvents:
     async def test_user_properties_propagate(
         self,
         event_memory: EventMemory,
-        fake_vector_store_collection: InMemoryVectorStoreCollection,
+        fake_vector_store_partition: InMemoryVectorStorePartition,
     ):
         event = _make_event("hi", properties={"color": "red"})
         await event_memory.encode_events([event])
 
-        record = next(iter(fake_vector_store_collection.records.values()))
+        record = next(iter(fake_vector_store_partition.records.values()))
         assert _record_properties(record)["color"] == "red"
 
     async def test_reserved_property_key_is_rejected(self, event_memory: EventMemory):
@@ -307,13 +304,11 @@ class TestEncodeEvents:
     async def test_init_raises_on_missing_reserved_field(self, fake_embedder):
         schema = EventMemory.expected_vector_store_collection_schema()
         del schema[EVENT_SESSION_KEY]
-        collection = InMemoryVectorStoreCollection(
-            VectorStoreCollectionConfig(vector_dimensions=2), schema
-        )
+        collection = InMemoryVectorStorePartition("test", schema)
         with pytest.raises(InvalidCollectionSchemaError, match=EVENT_SESSION_KEY):
             EventMemory(
                 EventMemoryParams(
-                    vector_store_collection=collection,
+                    vector_store_partition=collection,
                     segment_store_partition=InMemorySegmentStorePartition(),
                     segmenter=TextSegmenter(),
                     embedder=fake_embedder,
@@ -325,16 +320,16 @@ class TestEncodeEvents:
         self,
         event_memory: EventMemory,
         fake_segment_store_partition: InMemorySegmentStorePartition,
-        fake_vector_store_collection: InMemoryVectorStoreCollection,
+        fake_vector_store_partition: InMemoryVectorStorePartition,
     ):
         await event_memory.encode_events([])
         assert len(fake_segment_store_partition.segments) == 0
-        assert len(fake_vector_store_collection.records) == 0
+        assert len(fake_vector_store_partition.records) == 0
 
     async def test_derive_sentences(
         self,
         event_memory_with_sentences: EventMemory,
-        fake_vector_store_collection: InMemoryVectorStoreCollection,
+        fake_vector_store_partition: InMemoryVectorStorePartition,
         fake_segment_store_partition: InMemorySegmentStorePartition,
     ):
         event = _make_event("Hello there. How are you? I am fine.")
@@ -342,20 +337,20 @@ class TestEncodeEvents:
 
         # One segment, but multiple derivatives (one per sentence).
         assert len(fake_segment_store_partition.segments) == 1
-        assert len(fake_vector_store_collection.records) > 1
+        assert len(fake_vector_store_partition.records) > 1
 
     async def test_repeated_batch_leaves_one_copy(
         self,
         event_memory: EventMemory,
         fake_segment_store_partition: InMemorySegmentStorePartition,
-        fake_vector_store_collection: InMemoryVectorStoreCollection,
+        fake_vector_store_partition: InMemoryVectorStorePartition,
     ):
         event = _make_event("hello world")
         await event_memory.encode_events([event])
         await event_memory.encode_events([event])
 
         assert len(fake_segment_store_partition.segments) == 1
-        assert len(fake_vector_store_collection.records) == 1
+        assert len(fake_vector_store_partition.records) == 1
         assert len(await event_memory.query("hello")) == 1
 
 
@@ -599,14 +594,14 @@ class TestForgetEvents:
         self,
         event_memory: EventMemory,
         fake_segment_store_partition: InMemorySegmentStorePartition,
-        fake_vector_store_collection: InMemoryVectorStoreCollection,
+        fake_vector_store_partition: InMemoryVectorStorePartition,
     ):
         e1 = _make_event("keep me", timestamp=_ts(0))
         e2 = _make_event("forget me", timestamp=_ts(1))
         await event_memory.encode_events([e1, e2])
 
         assert len(fake_segment_store_partition.segments) == 2
-        assert len(fake_vector_store_collection.records) == 2
+        assert len(fake_vector_store_partition.records) == 2
 
         await event_memory.forget_events([e2.uuid])
 
@@ -614,7 +609,7 @@ class TestForgetEvents:
         assert len(fake_segment_store_partition.segments) == 1
         remaining_segment = next(iter(fake_segment_store_partition.segments.values()))
         assert remaining_segment.event_uuid == e1.uuid
-        assert len(fake_vector_store_collection.records) == 1
+        assert len(fake_vector_store_partition.records) == 1
 
     async def test_forget_empty_set(
         self,
@@ -974,14 +969,14 @@ class TestQueryWithFilter:
 
 def _routing_memory(
     embedder: FakeEmbedder,
-    collection: InMemoryVectorStoreCollection,
+    collection: InMemoryVectorStorePartition,
     *,
     max_overfetch_factor: int,
 ) -> EventMemory:
     return EventMemory(
         EventMemoryParams(
             segment_store_partition=InMemorySegmentStorePartition(),
-            vector_store_collection=collection,
+            vector_store_partition=collection,
             segmenter=TextSegmenter(),
             deriver=WholeTextDeriver(),
             embedder=embedder,
@@ -1145,7 +1140,7 @@ class TestQueryDeduplication:
         memory = EventMemory(
             EventMemoryParams(
                 segment_store_partition=InMemorySegmentStorePartition(),
-                vector_store_collection=make_collection(embedder),
+                vector_store_partition=make_collection(embedder),
                 segmenter=TextSegmenter(),
                 deriver=SentenceTextDeriver(),
                 embedder=embedder,
@@ -1228,7 +1223,7 @@ class TestIngestFormatOptions:
 # ===================================================================
 
 
-async def _stored_minutes(collection: InMemoryVectorStoreCollection) -> list[int]:
+async def _stored_minutes(collection: InMemoryVectorStorePartition) -> list[int]:
     """Minute-offsets (from _T0) of every derivative currently in the store."""
     [result] = await collection.query(query_vectors=[[1.0, 0.0]], limit=1000)
     minutes: list[int] = []
@@ -1257,43 +1252,43 @@ class TestEviction:
 
     @_async
     async def test_disabled_keeps_all_and_issues_no_query(
-        self, event_memory, fake_vector_store_collection, monkeypatch
+        self, event_memory, fake_vector_store_partition, monkeypatch
     ):
         queries: list[int] = []
-        original_query = fake_vector_store_collection.query
+        original_query = fake_vector_store_partition.query
 
         async def counting_query(**kwargs):
             queries.append(1)
             return await original_query(**kwargs)
 
-        monkeypatch.setattr(fake_vector_store_collection, "query", counting_query)
+        monkeypatch.setattr(fake_vector_store_partition, "query", counting_query)
         events = [_make_event(f"msg {i}", timestamp=_ts(i)) for i in range(20)]
 
         await event_memory.encode_events(events)
 
-        assert len(await _stored_minutes(fake_vector_store_collection)) == 20
+        assert len(await _stored_minutes(fake_vector_store_partition)) == 20
         assert queries == [1]  # the one query _stored_minutes made
 
     @_async
     async def test_cluster_within_target_keeps_all(
-        self, event_memory_with_eviction, fake_vector_store_collection
+        self, event_memory_with_eviction, fake_vector_store_partition
     ):
         events = [_make_event(f"msg {i}", timestamp=_ts(i)) for i in range(5)]
         await event_memory_with_eviction.encode_events(events)
-        assert await _stored_minutes(fake_vector_store_collection) == [0, 1, 2, 3, 4]
+        assert await _stored_minutes(fake_vector_store_partition) == [0, 1, 2, 3, 4]
 
     @_async
     async def test_intra_batch_caps_and_keeps_temporal_extremes(
-        self, event_memory_with_eviction, fake_vector_store_collection
+        self, event_memory_with_eviction, fake_vector_store_partition
     ):
         events = [_make_event(f"msg {i}", timestamp=_ts(i)) for i in range(20)]
         await event_memory_with_eviction.encode_events(events)
         # target=5 -> keep 2 earliest + 3 latest, evict the middle.
-        assert await _stored_minutes(fake_vector_store_collection) == [0, 1, 17, 18, 19]
+        assert await _stored_minutes(fake_vector_store_partition) == [0, 1, 17, 18, 19]
 
     @_async
     async def test_batch_order_mimics_serial_ingestion(
-        self, fake_vector_store_collection
+        self, fake_vector_store_partition
     ):
         """A batch evicts what encoding its events one at a time would."""
         events = [_make_event(f"msg {i}", timestamp=_ts(i)) for i in range(12)]
@@ -1345,14 +1340,14 @@ class TestEviction:
     async def test_cross_batch_displaces_stored_records_and_their_links(
         self,
         event_memory_with_eviction,
-        fake_vector_store_collection,
+        fake_vector_store_partition,
         fake_segment_store_partition,
     ):
         await event_memory_with_eviction.encode_events(
             [_make_event(f"a{i}", timestamp=_ts(i)) for i in range(5)]
         )
-        assert await _stored_minutes(fake_vector_store_collection) == [0, 1, 2, 3, 4]
-        stored_before = set(fake_vector_store_collection.records)
+        assert await _stored_minutes(fake_vector_store_partition) == [0, 1, 2, 3, 4]
+        stored_before = set(fake_vector_store_partition.records)
 
         # A second batch grows the cluster past target: stored records from the
         # temporal middle are displaced, from the vector store and the links.
@@ -1360,12 +1355,12 @@ class TestEviction:
             [_make_event(f"b{i}", timestamp=_ts(5 + i)) for i in range(5)]
         )
 
-        assert await _stored_minutes(fake_vector_store_collection) == [0, 1, 7, 8, 9]
-        displaced = stored_before - set(fake_vector_store_collection.records)
+        assert await _stored_minutes(fake_vector_store_partition) == [0, 1, 7, 8, 9]
+        displaced = stored_before - set(fake_vector_store_partition.records)
         assert displaced
         assert not (displaced & _linked(fake_segment_store_partition))
         assert _linked(fake_segment_store_partition) == set(
-            fake_vector_store_collection.records
+            fake_vector_store_partition.records
         )
         # Segments are untouched: every event is still expandable.
         assert len(fake_segment_store_partition.segments) == 10

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_event_memory.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_event_memory.py
@@ -2,8 +2,9 @@
 
 import datetime
 import json
+import math
 from datetime import UTC
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -21,32 +22,45 @@ from memmachine_server.common.vector_store.data_types import (
     VectorStoreCollectionConfig,
 )
 from memmachine_server.episodic_memory.event_memory.data_types import (
+    Author,
+    Context,
     Event,
+    EvictionOptions,
     FormatOptions,
-    NullContext,
-    ProducerContext,
-    QueryResult,
-    ScoredSegmentContext,
+    SearchHit,
     Segment,
     TextBlock,
+    get_part,
+    with_part,
 )
 from memmachine_server.episodic_memory.event_memory.deriver.text_deriver import (
+    SentenceTextDeriver,
     WholeTextDeriver,
 )
 from memmachine_server.episodic_memory.event_memory.event_memory import (
+    ID_MAX_BYTES,
     EventMemory,
     EventMemoryParams,
 )
 from memmachine_server.episodic_memory.event_memory.segmenter.text_segmenter import (
     TextSegmenter,
 )
+from memmachine_server.episodic_memory.event_memory.system_filters import (
+    BLOCK_KIND_KEY,
+    EVENT_SESSION_KEY,
+    EVENT_SOURCE_KEY,
+    EVENT_TIMESTAMP_KEY,
+)
 from server_tests.memmachine_server.common.reranker.fake_embedder import (
     FakeEmbedder,
 )
 
 from .conftest import (
+    AngleEmbedder,
+    FakeReranker,
     InMemorySegmentStorePartition,
     InMemoryVectorStoreCollection,
+    make_collection,
 )
 
 _async = pytest.mark.asyncio
@@ -56,7 +70,7 @@ _async = pytest.mark.asyncio
 # ---------------------------------------------------------------------------
 
 _T0 = datetime.datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
-_NULL_CONTEXT = NullContext()
+_SHORT_TIME = FormatOptions(time_style="short")
 
 
 def _record_properties(record: Record) -> dict[str, PropertyValue]:
@@ -65,17 +79,25 @@ def _record_properties(record: Record) -> dict[str, PropertyValue]:
     return record.properties
 
 
+def _author(name: str) -> Context:
+    return with_part({}, Author(name=name))
+
+
 def _make_event(
     text: str,
     *,
     timestamp: datetime.datetime = _T0,
-    context: ProducerContext | NullContext = _NULL_CONTEXT,
+    session_id: str | None = None,
+    source_id: str | None = None,
+    context: Context | None = None,
     properties=None,
 ) -> Event:
     return Event(
         uuid=uuid4(),
         timestamp=timestamp,
-        context=context,
+        session_id=session_id,
+        source_id=source_id,
+        context=context if context is not None else {},
         blocks=[TextBlock(text=text)],
         properties=properties or {},
     )
@@ -86,16 +108,53 @@ def _ts(minutes: int) -> datetime.datetime:
     return _T0 + datetime.timedelta(minutes=minutes)
 
 
+def _texts(hits: list[SearchHit]) -> set[str]:
+    return {
+        seg.block.text
+        for hit in hits
+        for seg in hit.segments
+        if isinstance(seg.block, TextBlock)
+    }
+
+
+def _build(
+    embedder: FakeEmbedder,
+    *,
+    partition: InMemorySegmentStorePartition | None = None,
+    collection: InMemoryVectorStoreCollection | None = None,
+    format_options: FormatOptions | None = None,
+    eviction: EvictionOptions | None = None,
+) -> EventMemory:
+    params = {
+        "segment_store_partition": partition or InMemorySegmentStorePartition(),
+        "vector_store_collection": collection or make_collection(embedder),
+        "segmenter": TextSegmenter(),
+        "deriver": WholeTextDeriver(),
+        "embedder": embedder,
+        "eviction": eviction,
+    }
+    if format_options is not None:
+        params["format_options"] = format_options
+    return EventMemory(EventMemoryParams(**params))
+
+
 # ===================================================================
 # schema
 # ===================================================================
 
 
 class TestSchema:
-    def test_expected_vector_store_collection_schema_only_has_base_fields(self):
+    def test_expected_vector_store_collection_schema_declares_the_reserved_keys(self):
         assert EventMemory.expected_vector_store_collection_schema() == {
-            "_timestamp": datetime.datetime,
+            EVENT_TIMESTAMP_KEY: datetime.datetime,
+            EVENT_SESSION_KEY: str,
+            EVENT_SOURCE_KEY: str,
+            BLOCK_KIND_KEY: str,
         }
+        assert all(
+            key.startswith("memmachine_")
+            for key in EventMemory.expected_vector_store_collection_schema()
+        )
 
 
 # ===================================================================
@@ -122,42 +181,49 @@ class TestEncodeEvents:
         assert segment.offset == 0
         assert segment.block == TextBlock(text="hello world")
 
-        # One derivative record in vector store.
+        # One derivative record in vector store, with every filterable
+        # system value under its reserved key.
         assert len(fake_vector_store_collection.records) == 1
         record = next(iter(fake_vector_store_collection.records.values()))
         props = _record_properties(record)
-        assert props["_timestamp"] == event.timestamp
+        assert props[EVENT_TIMESTAMP_KEY] == event.timestamp
+        assert props[BLOCK_KIND_KEY] == "text"
+        assert EVENT_SESSION_KEY not in props
+        assert EVENT_SOURCE_KEY not in props
         # The derivative's segment is not copied here; the segment store owns
         # that mapping and answers it from the derivative's own row.
-        assert "_segment_uuid" not in props
+        assert not any("uuid" in key for key in props)
         assert await fake_segment_store_partition.get_segment_uuids_by_derivative_uuids(
             [record.uuid]
         ) == {record.uuid: segment.uuid}
 
-    async def test_producer_context(
+    async def test_session_and_source_are_recorded(
         self,
         event_memory: EventMemory,
+        fake_segment_store_partition: InMemorySegmentStorePartition,
         fake_vector_store_collection: InMemoryVectorStoreCollection,
     ):
-        event = _make_event("hi", context=ProducerContext(producer="Alice"))
+        event = _make_event("hi", session_id="s1", source_id="alice")
         await event_memory.encode_events([event])
 
         record = next(iter(fake_vector_store_collection.records.values()))
         props = _record_properties(record)
-        assert "_context_type" not in props
-        assert "_context_producer" not in props
+        assert props[EVENT_SESSION_KEY] == "s1"
+        assert props[EVENT_SOURCE_KEY] == "alice"
+        segment = next(iter(fake_segment_store_partition.segments.values()))
+        assert (segment.session_id, segment.source_id) == ("s1", "alice")
 
-    async def test_no_context(
+    async def test_context_is_not_a_property(
         self,
         event_memory: EventMemory,
         fake_vector_store_collection: InMemoryVectorStoreCollection,
     ):
-        event = _make_event("bare text")
+        event = _make_event("hi", context=_author("Alice"))
         await event_memory.encode_events([event])
 
         record = next(iter(fake_vector_store_collection.records.values()))
         props = _record_properties(record)
-        assert "_context_type" not in props
+        assert not any("author" in key or "context" in key for key in props)
 
     async def test_long_text_chunking(
         self,
@@ -212,47 +278,35 @@ class TestEncodeEvents:
         record = next(iter(fake_vector_store_collection.records.values()))
         assert _record_properties(record)["color"] == "red"
 
-    async def test_missing_context_schema_fields_still_allows_ingest(
-        self, fake_embedder
-    ):
-        # Collection without context fields.
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=2,
-            indexed_properties_schema={
-                "_segment_uuid": str,
-                "_timestamp": datetime.datetime,
-            },
+    async def test_reserved_property_key_is_rejected(self, event_memory: EventMemory):
+        event = _make_event("hi", properties={EVENT_SESSION_KEY: "spoofed"})
+        with pytest.raises(ValueError, match="reserved"):
+            await event_memory.encode_events([event])
+
+    async def test_illegal_property_key_is_rejected(self, event_memory: EventMemory):
+        event = _make_event("hi", properties={"Color": "red"})
+        with pytest.raises(ValueError, match=r"\[a-z0-9_\]"):
+            await event_memory.encode_events([event])
+
+    @pytest.mark.parametrize("field", ["session_id", "source_id"])
+    async def test_overlong_id_is_rejected(self, event_memory: EventMemory, field):
+        overlong = "x" * (ID_MAX_BYTES + 1)
+        event = (
+            _make_event("hi", session_id=overlong)
+            if field == "session_id"
+            else _make_event("hi", source_id=overlong)
         )
-        collection = InMemoryVectorStoreCollection(config)
-        partition = InMemorySegmentStorePartition()
-        em = EventMemory(
-            EventMemoryParams(
-                segment_store_partition=partition,
-                vector_store_collection=collection,
-                segmenter=TextSegmenter(),
-                deriver=WholeTextDeriver(),
-                embedder=fake_embedder,
+        with pytest.raises(ValueError, match=field):
+            await event_memory.encode_events([event])
+
+    async def test_init_raises_on_missing_reserved_field(self, fake_embedder):
+        schema = EventMemory.expected_vector_store_collection_schema()
+        del schema[EVENT_SESSION_KEY]
+        collection = InMemoryVectorStoreCollection(
+            VectorStoreCollectionConfig(
+                vector_dimensions=2, indexed_properties_schema=schema
             )
         )
-        event = _make_event("hi", context=ProducerContext(producer="Alice"))
-        await em.encode_events([event])
-
-        assert len(collection.records) == 1
-        record = next(iter(collection.records.values()))
-        props = _record_properties(record)
-        assert "_context_type" not in props
-        assert "_context_producer" not in props
-
-    async def test_init_raises_on_missing_base_field(self, fake_embedder):
-        # Collection without _timestamp — base field required at init.
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=2,
-            indexed_properties_schema={
-                "_segment_uuid": str,
-            },
-        )
-        collection = InMemoryVectorStoreCollection(config)
-        partition = InMemorySegmentStorePartition()
         with pytest.raises(
             ValueError,
             match="Collection schema missing fields required by EventMemory",
@@ -260,7 +314,7 @@ class TestEncodeEvents:
             EventMemory(
                 EventMemoryParams(
                     vector_store_collection=collection,
-                    segment_store_partition=partition,
+                    segment_store_partition=InMemorySegmentStorePartition(),
                     segmenter=TextSegmenter(),
                     embedder=fake_embedder,
                     deriver=WholeTextDeriver(),
@@ -290,6 +344,20 @@ class TestEncodeEvents:
         assert len(fake_segment_store_partition.segments) == 1
         assert len(fake_vector_store_collection.records) > 1
 
+    async def test_repeated_batch_leaves_one_copy(
+        self,
+        event_memory: EventMemory,
+        fake_segment_store_partition: InMemorySegmentStorePartition,
+        fake_vector_store_collection: InMemoryVectorStoreCollection,
+    ):
+        event = _make_event("hello world")
+        await event_memory.encode_events([event])
+        await event_memory.encode_events([event])
+
+        assert len(fake_segment_store_partition.segments) == 1
+        assert len(fake_vector_store_collection.records) == 1
+        assert len(await event_memory.query("hello")) == 1
+
 
 # ===================================================================
 # query
@@ -303,63 +371,221 @@ class TestQuery:
         e2 = _make_event("a longer sentence here", timestamp=_ts(1))
         await event_memory.encode_events([e1, e2])
 
-        result = await event_memory.query("test query")
-        assert isinstance(result, QueryResult)
-        assert len(result.scored_segment_contexts) > 0
+        hits = await event_memory.query("test query")
+        assert len(hits) == 2
+        for hit in hits:
+            assert isinstance(hit, SearchHit)
+            assert hit.segments[hit.seed].uuid in {s.uuid for s in hit.segments}
 
-        # Each scored context has segments.
-        for scored in result.scored_segment_contexts:
-            assert len(scored.segments) > 0
-
-    async def test_vector_search_limit(self, event_memory: EventMemory):
+    async def test_limit_is_a_maximum(self, event_memory: EventMemory):
         events = [_make_event(f"event {i}", timestamp=_ts(i)) for i in range(10)]
         await event_memory.encode_events(events)
 
-        result = await event_memory.query("test", vector_search_limit=2)
-        assert len(result.scored_segment_contexts) <= 2
+        assert len(await event_memory.query("test", limit=2)) <= 2
 
-    async def test_expand_context(
+    async def test_expand_context_marks_the_seed(self, event_memory: EventMemory):
+        events = [_make_event(f"event {i}", timestamp=_ts(i)) for i in range(5)]
+        await event_memory.encode_events(events)
+
+        hits = await event_memory.query("test query", limit=1, expand_context=6)
+
+        # With expand_context=6: before=2, after=4.
+        [hit] = hits
+        assert len(hit.segments) > 1
+        assert len({seg.event_uuid for seg in hit.segments}) > 1
+        assert hit.segments[hit.seed].uuid == hit.segments[hit.seed].uuid
+        timestamps = [seg.timestamp for seg in hit.segments]
+        assert timestamps == sorted(timestamps)
+
+    async def test_empty_memory(self, event_memory: EventMemory):
+        assert await event_memory.query("anything") == []
+
+    async def test_scores_are_cosine_similarities(self, event_memory: EventMemory):
+        await event_memory.encode_events([_make_event("hello")])
+        [hit] = await event_memory.query("hello")
+        # FakeEmbedder: all vectors same direction -> cosine 1.0.
+        assert hit.score == pytest.approx(1.0, abs=0.01)
+
+    async def test_hits_rank_by_similarity_and_a_threshold_excludes(self):
+        # Angles from the query: "near" 0.1 rad, "far" 1.2 rad, the query 0.
+        embedder = AngleEmbedder({"near": 0.1, "far": 1.2, "query": 0.0})
+        memory = _build(embedder)
+        far = _make_event("far", timestamp=_ts(0))
+        near = _make_event("near", timestamp=_ts(1))
+        await memory.encode_events([far, near])
+
+        ranked = await memory.query("query")
+        thresholded = await memory.query("query", min_cosine_similarity=0.9)
+
+        assert [hit.segments[hit.seed].event_uuid for hit in ranked] == [
+            near.uuid,
+            far.uuid,
+        ]
+        assert [hit.score for hit in ranked] == sorted(
+            (hit.score for hit in ranked), reverse=True
+        )
+        assert [hit.segments[hit.seed].event_uuid for hit in thresholded] == [near.uuid]
+
+    async def test_a_neighbor_in_the_window_is_not_a_hit(self):
+        embedder = AngleEmbedder({"match": 0.0, "other": 1.4, "query": 0.0})
+        memory = _build(embedder)
+        other = _make_event("other", timestamp=_ts(0))
+        match = _make_event("match", timestamp=_ts(1))
+        await memory.encode_events([other, match])
+
+        hits = await memory.query("query", limit=1, expand_context=3)
+
+        [hit] = hits
+        assert hit.segments[hit.seed].event_uuid == match.uuid
+        assert {seg.event_uuid for seg in hit.segments} == {other.uuid, match.uuid}
+
+
+@_async
+class TestQuerySystemFilters:
+    async def test_session_ids_select_events_and_confine_windows(
+        self, event_memory: EventMemory
+    ):
+        a0 = _make_event("a0", timestamp=_ts(0), session_id="a")
+        b0 = _make_event("b0", timestamp=_ts(1), session_id="b")
+        a1 = _make_event("a1", timestamp=_ts(2), session_id="a")
+        n0 = _make_event("n0", timestamp=_ts(3))
+        await event_memory.encode_events([a0, b0, a1, n0])
+
+        hits = await event_memory.query("x", session_ids=["a"], expand_context=6)
+
+        assert {hit.segments[hit.seed].event_uuid for hit in hits} == {a0.uuid, a1.uuid}
+        for hit in hits:
+            assert {seg.session_id for seg in hit.segments} == {"a"}
+
+    async def test_source_ids_select_events(self, event_memory: EventMemory):
+        alice = _make_event("alice says", timestamp=_ts(0), source_id="alice")
+        bob = _make_event("bob says", timestamp=_ts(1), source_id="bob")
+        await event_memory.encode_events([alice, bob])
+
+        hits = await event_memory.query("says", source_ids=["bob"], expand_context=6)
+
+        assert _texts(hits) == {"bob says"}
+
+    async def test_since_and_until_bound_hits_and_windows(
+        self, event_memory: EventMemory
+    ):
+        events = [_make_event(f"event {i}", timestamp=_ts(i)) for i in range(5)]
+        await event_memory.encode_events(events)
+
+        hits = await event_memory.query(
+            "event", since=_ts(1), until=_ts(3), expand_context=6
+        )
+
+        assert _texts(hits) == {"event 1", "event 2"}
+
+    async def test_block_kinds_select_segments(self, event_memory: EventMemory):
+        await event_memory.encode_events([_make_event("hi")])
+
+        assert len(await event_memory.query("hi", block_kinds=["text"])) == 1
+        assert await event_memory.query("hi", block_kinds=["image"]) == []
+
+    async def test_timestamp_filter_field_reaches_the_reserved_key(
+        self, event_memory: EventMemory
+    ):
+        """A caller's bare `timestamp` names the event timestamp on both stores."""
+        early = _make_event("early", timestamp=_ts(0))
+        late = _make_event("late", timestamp=_ts(10))
+        await event_memory.encode_events([early, late])
+
+        hits = await event_memory.query(
+            "x",
+            property_filter=Comparison(field="timestamp", op=">=", value=_ts(5)),
+            expand_context=6,
+        )
+
+        assert _texts(hits) == {"late"}
+
+
+# ===================================================================
+# expand
+# ===================================================================
+
+
+@_async
+class TestExpand:
+    async def test_expand_around_a_segment(
         self,
         event_memory: EventMemory,
         fake_segment_store_partition: InMemorySegmentStorePartition,
     ):
         events = [_make_event(f"event {i}", timestamp=_ts(i)) for i in range(5)]
         await event_memory.encode_events(events)
+        [anchor] = fake_segment_store_partition.event_to_segments[events[2].uuid]
 
-        result = await event_memory.query("test query", expand_context=3)
+        neighborhood = await event_memory.expand(anchor, before=1, after=2)
 
-        # With expand_context=3, backward=1, forward=2.
-        # Context windows should include neighbors.
-        for scored in result.scored_segment_contexts:
-            assert len(scored.segments) >= 1
+        assert [s.event_uuid for s in neighborhood.before] == [events[1].uuid]
+        assert [s.event_uuid for s in neighborhood.after] == [
+            events[3].uuid,
+            events[4].uuid,
+        ]
+        assert anchor not in {s.uuid for s in neighborhood.before + neighborhood.after}
 
-    async def test_empty_memory(self, event_memory: EventMemory):
-        result = await event_memory.query("anything")
-        assert result.scored_segment_contexts == []
-
-    async def test_without_reranker_uses_embedding_scores(
-        self, event_memory: EventMemory
+    async def test_expand_around_an_event_uses_its_first_segment(
+        self,
+        event_memory: EventMemory,
     ):
-        await event_memory.encode_events([_make_event("hello")])
-        result = await event_memory.query("hello")
+        events = [_make_event(f"event {i}", timestamp=_ts(i)) for i in range(3)]
+        long = Event(
+            uuid=uuid4(),
+            timestamp=_ts(1),
+            blocks=[TextBlock(text="first block"), TextBlock(text="second block")],
+        )
+        events[1] = long
+        await event_memory.encode_events(events)
 
-        # FakeEmbedder: all vectors same direction → cosine ≈ 1.0.
-        for scored in result.scored_segment_contexts:
-            assert scored.score == pytest.approx(1.0, abs=0.01)
+        neighborhood = await event_memory.expand(long.uuid, before=1, after=5)
 
-    async def test_with_reranker(self, event_memory_with_reranker: EventMemory):
-        e1 = _make_event("short", timestamp=_ts(0))
-        e2 = _make_event("a much longer text", timestamp=_ts(1))
-        await event_memory_with_reranker.encode_events([e1, e2])
+        assert [s.event_uuid for s in neighborhood.before] == [events[0].uuid]
+        # The anchor is the event's first segment; its second block is a neighbor.
+        assert [s.block.render(_SHORT_TIME) for s in neighborhood.after] == [
+            "second block",
+            "event 2",
+        ]
 
-        result = await event_memory_with_reranker.query("anything")
+    async def test_expand_filters_neighbors_but_not_the_anchor(
+        self,
+        event_memory: EventMemory,
+        fake_segment_store_partition: InMemorySegmentStorePartition,
+    ):
+        red = _make_event("red", timestamp=_ts(0), properties={"color": "red"})
+        blue = _make_event("blue", timestamp=_ts(1), properties={"color": "blue"})
+        green = _make_event("green", timestamp=_ts(2), properties={"color": "green"})
+        await event_memory.encode_events([red, blue, green])
+        [anchor] = fake_segment_store_partition.event_to_segments[blue.uuid]
 
-        # FakeReranker scores by string length (higher is better).
-        # The result with the longer formatted context should come first.
-        scores = [sc.score for sc in result.scored_segment_contexts]
-        assert scores == sorted(scores, reverse=True)
-        assert len(scores) == 2
-        assert scores[0] > scores[1]
+        neighborhood = await event_memory.expand(
+            anchor,
+            before=5,
+            after=5,
+            property_filter=Comparison(field="m.color", op="=", value="green"),
+        )
+
+        assert neighborhood.before == []
+        assert [s.event_uuid for s in neighborhood.after] == [green.uuid]
+
+    async def test_expand_walks_further_from_an_edge(
+        self,
+        event_memory: EventMemory,
+    ):
+        events = [_make_event(f"event {i}", timestamp=_ts(i)) for i in range(5)]
+        await event_memory.encode_events(events)
+
+        first = await event_memory.expand(events[0].uuid, after=2)
+        second = await event_memory.expand(first.after[-1].uuid, after=2)
+
+        assert [s.event_uuid for s in first.after] == [events[1].uuid, events[2].uuid]
+        assert [s.event_uuid for s in second.after] == [events[3].uuid, events[4].uuid]
+
+    async def test_unknown_anchor_raises(self, event_memory: EventMemory):
+        await event_memory.encode_events([_make_event("hi")])
+        with pytest.raises(LookupError):
+            await event_memory.expand(uuid4(), before=1, after=1)
 
 
 # ===================================================================
@@ -410,7 +636,7 @@ class TestForgetEvents:
 
 
 # ===================================================================
-# build_query_result_context (static, sync)
+# render (static, sync)
 # ===================================================================
 
 
@@ -421,7 +647,7 @@ def _make_segment(
     offset: int = 0,
     timestamp: datetime.datetime = _T0,
     text: str = "text",
-    context: ProducerContext | NullContext = _NULL_CONTEXT,
+    context: Context | None = None,
 ) -> Segment:
     return Segment(
         uuid=uuid4(),
@@ -430,158 +656,116 @@ def _make_segment(
         offset=offset,
         timestamp=timestamp,
         block=TextBlock(text=text),
-        context=context,
+        context=context if context is not None else {},
     )
 
 
-class TestBuildQueryResultContext:
-    def test_under_limit(self):
-        s1 = _make_segment(timestamp=_ts(0))
-        s2 = _make_segment(timestamp=_ts(1))
-        s3 = _make_segment(timestamp=_ts(2))
-
-        qr = QueryResult(
-            scored_segment_contexts=[
-                ScoredSegmentContext(
-                    score=1.0, seed_segment_uuid=s1.uuid, segments=[s1]
-                ),
-                ScoredSegmentContext(
-                    score=0.5, seed_segment_uuid=s2.uuid, segments=[s2, s3]
-                ),
-            ]
-        )
-        result = EventMemory.build_query_result_context(qr, max_num_segments=10)
-        assert len(result) == 3
-        # Sorted chronologically.
-        assert result == sorted(
-            result,
-            key=lambda s: (s.timestamp, s.event_uuid, s.index, s.offset),
-        )
-
-    def test_over_limit_prioritizes_seed(self):
-        # 5 segments, seed in the middle (index 2).
-        event_uuid = uuid4()
-        segments = [
-            _make_segment(
-                event_uuid=event_uuid, index=i, timestamp=_ts(i), text=f"seg{i}"
-            )
-            for i in range(5)
-        ]
-        seed = segments[2]
-
-        qr = QueryResult(
-            scored_segment_contexts=[
-                ScoredSegmentContext(
-                    score=1.0,
-                    seed_segment_uuid=seed.uuid,
-                    segments=segments,
-                ),
-            ]
-        )
-        result = EventMemory.build_query_result_context(qr, max_num_segments=3)
-        assert len(result) == 3
-        # Seed must be included.
-        result_uuids = {s.uuid for s in result}
-        assert seed.uuid in result_uuids
-
-    def test_deduplicates_across_contexts(self):
-        shared = _make_segment(timestamp=_ts(0))
-        s1 = _make_segment(timestamp=_ts(1))
-        s2 = _make_segment(timestamp=_ts(2))
-
-        qr = QueryResult(
-            scored_segment_contexts=[
-                ScoredSegmentContext(
-                    score=1.0,
-                    seed_segment_uuid=shared.uuid,
-                    segments=[shared, s1],
-                ),
-                ScoredSegmentContext(
-                    score=0.5,
-                    seed_segment_uuid=shared.uuid,
-                    segments=[shared, s2],
-                ),
-            ]
-        )
-        result = EventMemory.build_query_result_context(qr, max_num_segments=10)
-        uuids = [s.uuid for s in result]
-        assert len(uuids) == len(set(uuids))  # No duplicates.
-        assert len(result) == 3  # shared, s1, s2
-
-    def test_empty_result(self):
-        qr = QueryResult(scored_segment_contexts=[])
-        result = EventMemory.build_query_result_context(qr, max_num_segments=10)
-        assert result == []
-
-    def test_budget_exhaustion_across_contexts(self):
-        # First context: 3 segments. Second context: 4 segments. Budget: 5.
-        ctx1_segs = [_make_segment(timestamp=_ts(i)) for i in range(3)]
-        ctx2_segs = [_make_segment(timestamp=_ts(10 + i)) for i in range(4)]
-
-        qr = QueryResult(
-            scored_segment_contexts=[
-                ScoredSegmentContext(
-                    score=1.0,
-                    seed_segment_uuid=ctx1_segs[1].uuid,
-                    segments=ctx1_segs,
-                ),
-                ScoredSegmentContext(
-                    score=0.5,
-                    seed_segment_uuid=ctx2_segs[1].uuid,
-                    segments=ctx2_segs,
-                ),
-            ]
-        )
-        result = EventMemory.build_query_result_context(qr, max_num_segments=5)
-        assert len(result) == 5
-        # First context fully included.
-        result_uuids = {s.uuid for s in result}
-        for seg in ctx1_segs:
-            assert seg.uuid in result_uuids
-
-
-# ===================================================================
-# string_from_segment_context (static, sync)
-# ===================================================================
-
-
-class TestStringFromSegmentContext:
+class TestRender:
     def test_no_context(self):
         segment = _make_segment(text="hello world")
-        result = EventMemory.string_from_segment_context([segment])
+        result = EventMemory.render([segment], format_options=_SHORT_TIME)
         assert json.dumps("hello world") in result
         assert "[" in result  # Timestamp bracket.
 
-    def test_message_context(self):
-        segment = _make_segment(text="hi", context=ProducerContext(producer="Alice"))
-        result = EventMemory.string_from_segment_context([segment])
+    def test_author_renders_its_name(self):
+        segment = _make_segment(text="hi", context=_author("Alice"))
+        result = EventMemory.render([segment], format_options=_SHORT_TIME)
         assert "Alice:" in result
         assert json.dumps("hi") in result
 
-    def test_continuation_segments(self):
+    def test_adjacent_pieces_share_a_header(self):
         event_uuid = uuid4()
         s1 = _make_segment(event_uuid=event_uuid, index=0, offset=0, text="part1")
-        s2 = Segment(
-            uuid=uuid4(),
-            event_uuid=event_uuid,
-            index=0,
-            offset=1,
-            timestamp=_T0,
-            block=TextBlock(text="part2"),
-        )
-        result = EventMemory.string_from_segment_context([s1, s2])
+        s2 = _make_segment(event_uuid=event_uuid, index=0, offset=1, text="part2")
+        s3 = _make_segment(event_uuid=event_uuid, index=1, offset=0, text="part3")
+        result = EventMemory.render([s1, s2, s3], format_options=_SHORT_TIME)
         # Text content is accumulated into one JSON string.
-        assert json.dumps("part1part2") in result
+        assert json.dumps("part1part2part3") in result
         # Only one timestamp line.
         assert result.count("[") == 1
 
+    def test_a_missing_piece_starts_a_new_header(self):
+        event_uuid = uuid4()
+        first = _make_segment(event_uuid=event_uuid, index=0, offset=0, text="A")
+        third = _make_segment(event_uuid=event_uuid, index=2, offset=0, text="C")
+        result = EventMemory.render([first, third], format_options=_SHORT_TIME)
+        assert result.count("[") == 2
+        assert json.dumps("AC") not in result
+
+    def test_no_timestamp_when_both_styles_are_off(self):
+        segment = _make_segment(text="hi", context=_author("Alice"))
+        result = EventMemory.render(
+            [segment], format_options=FormatOptions(date_style=None, time_style=None)
+        )
+        assert result == 'Alice: "hi"'
+
     def test_empty_list(self):
-        result = EventMemory.string_from_segment_context([])
-        assert result == ""
+        assert EventMemory.render([], format_options=_SHORT_TIME) == ""
 
 
 # ===================================================================
-# Round-trip tests (encode → query/forget → verify via public API)
+# rerank (static)
+# ===================================================================
+
+
+@_async
+class TestRerank:
+    async def test_scores_are_replaced_and_ordered(self, event_memory: EventMemory):
+        e1 = _make_event("short", timestamp=_ts(0))
+        e2 = _make_event("a much longer text", timestamp=_ts(1))
+        await event_memory.encode_events([e1, e2])
+        hits = await event_memory.query("anything")
+
+        reranked = await EventMemory.rerank(
+            "anything",
+            hits,
+            reranker=FakeReranker(),
+            limit=10,
+            format_options=_SHORT_TIME,
+        )
+
+        # FakeReranker scores by rendered length: the longer text first.
+        assert [hit.segments[hit.seed].event_uuid for hit in reranked] == [
+            e2.uuid,
+            e1.uuid,
+        ]
+        assert reranked[0].score > reranked[1].score > 1.0
+
+    async def test_limit_and_min_score_cut(self, event_memory: EventMemory):
+        events = [_make_event("x" * (i + 1), timestamp=_ts(i)) for i in range(4)]
+        await event_memory.encode_events(events)
+        hits = await event_memory.query("anything")
+
+        limited = await EventMemory.rerank(
+            "anything",
+            hits,
+            reranker=FakeReranker(),
+            limit=2,
+            format_options=_SHORT_TIME,
+        )
+        thresholded = await EventMemory.rerank(
+            "anything",
+            hits,
+            reranker=FakeReranker(),
+            limit=10,
+            min_score=limited[-1].score,
+            format_options=_SHORT_TIME,
+        )
+
+        assert len(limited) == 2
+        assert [hit.score for hit in thresholded] == [hit.score for hit in limited]
+
+    async def test_empty(self):
+        assert (
+            await EventMemory.rerank(
+                "q", [], reranker=FakeReranker(), limit=5, format_options=_SHORT_TIME
+            )
+            == []
+        )
+
+
+# ===================================================================
+# Round-trip tests (encode -> query/forget -> verify via public API)
 # ===================================================================
 
 
@@ -593,40 +777,27 @@ class TestRoundTrips:
         """Encoded events should be retrievable through query."""
         e1 = _make_event(
             "The quick brown fox",
-            context=ProducerContext(producer="Alice"),
+            context=_author("Alice"),
             timestamp=_ts(0),
         )
         e2 = _make_event(
             "jumps over the lazy dog",
-            context=ProducerContext(producer="Bob"),
+            context=_author("Bob"),
             timestamp=_ts(1),
         )
         await event_memory.encode_events([e1, e2])
 
-        result = await event_memory.query("test query")
-        assert len(result.scored_segment_contexts) == 2
-
-        # Verify the actual content is present in the returned segments.
-        all_segments = [
-            seg for scored in result.scored_segment_contexts for seg in scored.segments
-        ]
-        all_texts = {
-            seg.block.text for seg in all_segments if isinstance(seg.block, TextBlock)
-        }
-        assert "The quick brown fox" in all_texts
-        assert "jumps over the lazy dog" in all_texts
+        hits = await event_memory.query("test query")
+        assert len(hits) == 2
+        assert _texts(hits) == {"The quick brown fox", "jumps over the lazy dog"}
 
     async def test_encode_then_query_preserves_context(self, event_memory: EventMemory):
         """Query results should carry the original context."""
-        event = _make_event(
-            "hello", context=ProducerContext(producer="Alice"), timestamp=_ts(0)
-        )
+        event = _make_event("hello", context=_author("Alice"), timestamp=_ts(0))
         await event_memory.encode_events([event])
 
-        result = await event_memory.query("test")
-        segment = result.scored_segment_contexts[0].segments[0]
-        assert isinstance(segment.context, ProducerContext)
-        assert segment.context.producer == "Alice"
+        [hit] = await event_memory.query("test")
+        assert get_part(hit.segments[hit.seed].context, Author) == Author(name="Alice")
 
     async def test_forget_then_query_excludes_forgotten(
         self, event_memory: EventMemory
@@ -638,76 +809,42 @@ class TestRoundTrips:
 
         await event_memory.forget_events([e2.uuid])
 
-        result = await event_memory.query("test query")
-        all_texts = {
-            seg.block.text
-            for scored in result.scored_segment_contexts
-            for seg in scored.segments
-            if isinstance(seg.block, TextBlock)
-        }
-        assert "keep this one" in all_texts
-        assert "forget this one" not in all_texts
+        texts = _texts(await event_memory.query("test query"))
+        assert "keep this one" in texts
+        assert "forget this one" not in texts
 
     async def test_forget_all_then_query_returns_empty(self, event_memory: EventMemory):
-        """After forgetting all events, query should return nothing."""
         e1 = _make_event("first", timestamp=_ts(0))
         e2 = _make_event("second", timestamp=_ts(1))
         await event_memory.encode_events([e1, e2])
 
         await event_memory.forget_events([e1.uuid, e2.uuid])
 
-        result = await event_memory.query("test")
-        assert result.scored_segment_contexts == []
+        assert await event_memory.query("test") == []
 
     async def test_multiple_encode_calls_are_additive(self, event_memory: EventMemory):
-        """Successive encode_events calls should accumulate data."""
         e1 = _make_event("batch one", timestamp=_ts(0))
         e2 = _make_event("batch two", timestamp=_ts(1))
 
         await event_memory.encode_events([e1])
         await event_memory.encode_events([e2])
 
-        result = await event_memory.query("test query")
-        all_texts = {
-            seg.block.text
-            for scored in result.scored_segment_contexts
-            for seg in scored.segments
-            if isinstance(seg.block, TextBlock)
+        assert _texts(await event_memory.query("test query")) == {
+            "batch one",
+            "batch two",
         }
-        assert "batch one" in all_texts
-        assert "batch two" in all_texts
 
-    async def test_expand_context_includes_neighbors(self, event_memory: EventMemory):
-        """Query with expand_context should return neighboring segments."""
-        events = [_make_event(f"event {i}", timestamp=_ts(i)) for i in range(5)]
-        await event_memory.encode_events(events)
-
-        result = await event_memory.query(
-            "test query", vector_search_limit=1, expand_context=6
-        )
-
-        # With expand_context=6: backward=2, forward=4.
-        # Even with only 1 seed, context window should include neighbors.
-        assert len(result.scored_segment_contexts) == 1
-        context_segments = result.scored_segment_contexts[0].segments
-        assert len(context_segments) > 1
-
-        # Context segments should be from distinct events.
-        event_uuids = {seg.event_uuid for seg in context_segments}
-        assert len(event_uuids) > 1
-
-    async def test_query_result_formatted_as_string(self, event_memory: EventMemory):
-        """End-to-end: encode, query, format as string."""
+    async def test_query_result_rendered_as_string(self, event_memory: EventMemory):
+        """End-to-end: encode, query, render."""
         event = _make_event(
             "The mitochondria is the powerhouse of the cell.",
-            context=ProducerContext(producer="textbook"),
+            context=_author("textbook"),
             timestamp=_ts(0),
         )
         await event_memory.encode_events([event])
 
-        result = await event_memory.query("biology")
-        segments = EventMemory.build_query_result_context(result, max_num_segments=10)
-        context_string = EventMemory.string_from_segment_context(segments)
+        [hit] = await event_memory.query("biology")
+        context_string = EventMemory.render(hit.segments, format_options=_SHORT_TIME)
 
         assert "textbook:" in context_string
         assert "The mitochondria is the powerhouse of the cell." in context_string
@@ -721,175 +858,112 @@ class TestRoundTrips:
 @_async
 class TestQueryWithFilter:
     async def test_equality_filter(self, event_memory: EventMemory):
-        """Filter by user property equality."""
         e1 = _make_event("red thing", timestamp=_ts(0), properties={"color": "red"})
         e2 = _make_event("blue thing", timestamp=_ts(1), properties={"color": "blue"})
         await event_memory.encode_events([e1, e2])
 
-        result = await event_memory.query(
+        hits = await event_memory.query(
             "thing",
             property_filter=Comparison(field="m.color", op="=", value="red"),
         )
-        all_texts = {
-            seg.block.text
-            for scored in result.scored_segment_contexts
-            for seg in scored.segments
-            if isinstance(seg.block, TextBlock)
-        }
-        assert "red thing" in all_texts
-        assert "blue thing" not in all_texts
+        assert _texts(hits) == {"red thing"}
 
     async def test_inequality_filter(self, event_memory: EventMemory):
-        """Filter by != excludes matching events."""
         e1 = _make_event("red thing", timestamp=_ts(0), properties={"color": "red"})
         e2 = _make_event("blue thing", timestamp=_ts(1), properties={"color": "blue"})
         await event_memory.encode_events([e1, e2])
 
-        result = await event_memory.query(
+        hits = await event_memory.query(
             "thing",
             property_filter=Comparison(field="m.color", op="!=", value="red"),
         )
-        all_texts = {
-            seg.block.text
-            for scored in result.scored_segment_contexts
-            for seg in scored.segments
-            if isinstance(seg.block, TextBlock)
-        }
-        assert "blue thing" in all_texts
-        assert "red thing" not in all_texts
+        assert _texts(hits) == {"blue thing"}
 
     async def test_in_filter(self, event_memory: EventMemory):
-        """Filter by IN membership."""
         e1 = _make_event("red thing", timestamp=_ts(0), properties={"color": "red"})
         e2 = _make_event("blue thing", timestamp=_ts(1), properties={"color": "blue"})
         e3 = _make_event("green thing", timestamp=_ts(2), properties={"color": "green"})
         await event_memory.encode_events([e1, e2, e3])
 
-        result = await event_memory.query(
+        hits = await event_memory.query(
             "thing",
             property_filter=In(field="m.color", values=["red", "green"]),
         )
-        all_texts = {
-            seg.block.text
-            for scored in result.scored_segment_contexts
-            for seg in scored.segments
-            if isinstance(seg.block, TextBlock)
-        }
-        assert "red thing" in all_texts
-        assert "green thing" in all_texts
-        assert "blue thing" not in all_texts
+        assert _texts(hits) == {"red thing", "green thing"}
 
     async def test_is_null_filter(self, event_memory: EventMemory):
-        """Filter by IS NULL matches events missing the property."""
         e1 = _make_event("has color", timestamp=_ts(0), properties={"color": "red"})
         e2 = _make_event("no color", timestamp=_ts(1))
         await event_memory.encode_events([e1, e2])
 
-        result = await event_memory.query(
+        hits = await event_memory.query(
             "thing",
             property_filter=IsNull(field="m.color"),
         )
-        all_texts = {
-            seg.block.text
-            for scored in result.scored_segment_contexts
-            for seg in scored.segments
-            if isinstance(seg.block, TextBlock)
-        }
-        assert "no color" in all_texts
-        assert "has color" not in all_texts
+        assert _texts(hits) == {"no color"}
 
     async def test_and_filter(self, event_memory: EventMemory):
-        """Filter by AND conjunction."""
         e1 = _make_event("red small", timestamp=_ts(0), properties={"color": "red"})
         e2 = _make_event("blue small", timestamp=_ts(1), properties={"color": "blue"})
         await event_memory.encode_events([e1, e2])
 
-        result = await event_memory.query(
+        hits = await event_memory.query(
             "thing",
             property_filter=And(
                 left=Comparison(field="m.color", op="=", value="red"),
                 right=Not(expr=IsNull(field="m.color")),
             ),
         )
-        all_texts = {
-            seg.block.text
-            for scored in result.scored_segment_contexts
-            for seg in scored.segments
-            if isinstance(seg.block, TextBlock)
-        }
-        assert "red small" in all_texts
-        assert "blue small" not in all_texts
+        assert _texts(hits) == {"red small"}
 
     async def test_or_filter(self, event_memory: EventMemory):
-        """Filter by OR disjunction."""
         e1 = _make_event("red thing", timestamp=_ts(0), properties={"color": "red"})
         e2 = _make_event("blue thing", timestamp=_ts(1), properties={"color": "blue"})
         e3 = _make_event("green thing", timestamp=_ts(2), properties={"color": "green"})
         await event_memory.encode_events([e1, e2, e3])
 
-        result = await event_memory.query(
+        hits = await event_memory.query(
             "thing",
             property_filter=Or(
                 left=Comparison(field="m.color", op="=", value="red"),
                 right=Comparison(field="m.color", op="=", value="blue"),
             ),
         )
-        all_texts = {
-            seg.block.text
-            for scored in result.scored_segment_contexts
-            for seg in scored.segments
-            if isinstance(seg.block, TextBlock)
-        }
-        assert "red thing" in all_texts
-        assert "blue thing" in all_texts
-        assert "green thing" not in all_texts
+        assert _texts(hits) == {"red thing", "blue thing"}
 
     async def test_not_filter(self, event_memory: EventMemory):
-        """Filter by NOT negation."""
         e1 = _make_event("red thing", timestamp=_ts(0), properties={"color": "red"})
         e2 = _make_event("blue thing", timestamp=_ts(1), properties={"color": "blue"})
         await event_memory.encode_events([e1, e2])
 
-        result = await event_memory.query(
+        hits = await event_memory.query(
             "thing",
             property_filter=Not(expr=Comparison(field="m.color", op="=", value="red")),
         )
-        all_texts = {
-            seg.block.text
-            for scored in result.scored_segment_contexts
-            for seg in scored.segments
-            if isinstance(seg.block, TextBlock)
-        }
-        assert "blue thing" in all_texts
-        assert "red thing" not in all_texts
+        assert _texts(hits) == {"blue thing"}
 
     async def test_filter_returns_empty_when_nothing_matches(
         self, event_memory: EventMemory
     ):
-        """Filter that matches nothing returns empty results."""
-        e1 = _make_event("red thing", timestamp=_ts(0), properties={"color": "red"})
-        await event_memory.encode_events([e1])
+        await event_memory.encode_events(
+            [_make_event("red thing", timestamp=_ts(0), properties={"color": "red"})]
+        )
 
-        result = await event_memory.query(
+        hits = await event_memory.query(
             "thing",
             property_filter=Comparison(field="m.color", op="=", value="purple"),
         )
-        assert result.scored_segment_contexts == []
+        assert hits == []
 
     async def test_context_filter_returns_no_results(self, event_memory: EventMemory):
-        """Context fields are no longer filterable."""
-        event = _make_event("hi", context=ProducerContext(producer="Alice"))
-        await event_memory.encode_events([event])
+        """Context is never filterable."""
+        await event_memory.encode_events([_make_event("hi", context=_author("Alice"))])
 
-        result = await event_memory.query(
+        hits = await event_memory.query(
             "hi",
-            property_filter=Comparison(
-                field="context.producer",
-                op="=",
-                value="Alice",
-            ),
+            property_filter=Comparison(field="context.author", op="=", value="Alice"),
         )
-        assert result.scored_segment_contexts == []
+        assert hits == []
 
 
 # ===================================================================
@@ -903,57 +977,48 @@ class TestQueryDeduplication:
         self,
         event_memory_with_sentences: EventMemory,
     ):
-        """Multiple derivatives from the same segment should produce one scored context."""
         event = _make_event(
             "First sentence. Second sentence. Third sentence.",
             timestamp=_ts(0),
         )
         await event_memory_with_sentences.encode_events([event])
 
-        result = await event_memory_with_sentences.query("sentence")
+        hits = await event_memory_with_sentences.query("sentence")
 
         # All derivatives map to the same segment, so deduplication
-        # should collapse them into a single scored context.
-        assert len(result.scored_segment_contexts) == 1
-        assert len(result.scored_segment_contexts[0].segments) == 1
+        # should collapse them into a single hit.
+        assert len(hits) == 1
+        assert len(hits[0].segments) == 1
 
     async def test_derivatives_from_different_segments_not_collapsed(
         self,
         event_memory_with_sentences: EventMemory,
     ):
-        """Derivatives from different segments should remain separate scored contexts."""
-        e1 = _make_event(
-            "Alpha sentence. Beta sentence.",
-            timestamp=_ts(0),
-        )
-        e2 = _make_event(
-            "Gamma sentence. Delta sentence.",
-            timestamp=_ts(1),
-        )
+        e1 = _make_event("Alpha sentence. Beta sentence.", timestamp=_ts(0))
+        e2 = _make_event("Gamma sentence. Delta sentence.", timestamp=_ts(1))
         await event_memory_with_sentences.encode_events([e1, e2])
 
-        result = await event_memory_with_sentences.query("sentence")
+        assert len(await event_memory_with_sentences.query("sentence")) == 2
 
-        # Two events → two segments → two scored contexts.
-        assert len(result.scored_segment_contexts) == 2
-
-    async def test_dedup_uses_best_derivative_score(
-        self,
-        event_memory_with_sentences: EventMemory,
-    ):
+    async def test_dedup_uses_best_derivative_score(self):
         """When multiple derivatives map to one segment, the best score wins."""
-        event = _make_event(
-            "Short. A much longer second sentence here.",
-            timestamp=_ts(0),
+        embedder = AngleEmbedder({"Close": 0.1, "Distant": 1.0, "query": 0.0})
+        memory = EventMemory(
+            EventMemoryParams(
+                segment_store_partition=InMemorySegmentStorePartition(),
+                vector_store_collection=make_collection(embedder),
+                segmenter=TextSegmenter(),
+                deriver=SentenceTextDeriver(),
+                embedder=embedder,
+            )
         )
-        await event_memory_with_sentences.encode_events([event])
+        await memory.encode_events(
+            [_make_event("Distant sentence. Close sentence.", timestamp=_ts(0))]
+        )
 
-        result = await event_memory_with_sentences.query("test")
+        [hit] = await memory.query("query")
 
-        # Cosine sim ≈ 1.0 for all (FakeEmbedder), but the key point
-        # is that we get exactly one context with a valid score.
-        assert len(result.scored_segment_contexts) == 1
-        assert result.scored_segment_contexts[0].score == pytest.approx(1.0, abs=0.01)
+        assert hit.score == pytest.approx(math.cos(0.1))
 
 
 # ===================================================================
@@ -975,27 +1040,9 @@ class _RecordingEmbedder(FakeEmbedder):
 
 @_async
 class TestIngestFormatOptions:
-    @staticmethod
-    def _build(embedder: FakeEmbedder) -> EventMemory:
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=embedder.dimensions,
-            indexed_properties_schema=(
-                EventMemory.expected_vector_store_collection_schema()
-            ),
-        )
-        return EventMemory(
-            EventMemoryParams(
-                segment_store_partition=InMemorySegmentStorePartition(),
-                vector_store_collection=InMemoryVectorStoreCollection(config),
-                segmenter=TextSegmenter(),
-                deriver=WholeTextDeriver(),
-                embedder=embedder,
-            )
-        )
-
     async def test_default_bakes_full_date_into_embedding(self):
         embedder = _RecordingEmbedder()
-        event_memory = self._build(embedder)
+        event_memory = _build(embedder)
 
         await event_memory.encode_events([_make_event("hello world")])
 
@@ -1003,38 +1050,193 @@ class TestIngestFormatOptions:
         # and the message text is JSON-dumped (ensure_ascii=False).
         assert embedder.ingested == ['[Sunday, June 1, 2025] "hello world"']
 
-    async def test_format_options_can_disable_timestamp(self):
+    async def test_format_options_are_fixed_per_memory(self):
         embedder = _RecordingEmbedder()
-        event_memory = self._build(embedder)
-
-        await event_memory.encode_events(
-            [_make_event("hello world")],
-            format_options=FormatOptions(date_style=None, time_style=None),
+        event_memory = _build(
+            embedder, format_options=FormatOptions(date_style=None, time_style=None)
         )
 
+        await event_memory.encode_events([_make_event("hello world")])
+
         assert embedder.ingested == ['"hello world"']
+
+    async def test_author_is_embedded_by_name(self):
+        embedder = _RecordingEmbedder()
+        event_memory = _build(
+            embedder, format_options=FormatOptions(date_style=None, time_style=None)
+        )
+
+        await event_memory.encode_events(
+            [_make_event("hello", context=_author("Alice"), source_id="u-1")]
+        )
+
+        assert embedder.ingested == ['Alice: "hello"']
 
     async def test_segment_text_stays_structured(self):
         """The baked timestamp lives only in the embedding, not the segment."""
         embedder = _RecordingEmbedder()
         partition = InMemorySegmentStorePartition()
-        config = VectorStoreCollectionConfig(
-            vector_dimensions=embedder.dimensions,
-            indexed_properties_schema=(
-                EventMemory.expected_vector_store_collection_schema()
-            ),
-        )
-        event_memory = EventMemory(
-            EventMemoryParams(
-                segment_store_partition=partition,
-                vector_store_collection=InMemoryVectorStoreCollection(config),
-                segmenter=TextSegmenter(),
-                deriver=WholeTextDeriver(),
-                embedder=embedder,
-            )
-        )
+        event_memory = _build(embedder, partition=partition)
 
         await event_memory.encode_events([_make_event("hello world")])
 
         (segment,) = partition.segments.values()
         assert segment.block == TextBlock(text="hello world")
+
+
+# ===================================================================
+# eviction
+# ===================================================================
+
+
+async def _stored_minutes(collection: InMemoryVectorStoreCollection) -> list[int]:
+    """Minute-offsets (from _T0) of every derivative currently in the store."""
+    [result] = await collection.query(query_vectors=[[1.0, 0.0]], limit=1000)
+    minutes: list[int] = []
+    for match in result.matches:
+        timestamp = _record_properties(collection.records[match.record_uuid])[
+            EVENT_TIMESTAMP_KEY
+        ]
+        assert isinstance(timestamp, datetime.datetime)
+        minutes.append(int((timestamp - _T0).total_seconds() // 60))
+    return sorted(minutes)
+
+
+def _linked(partition: InMemorySegmentStorePartition) -> set[UUID]:
+    return {
+        uid for linked in partition.segment_to_derivatives.values() for uid in linked
+    }
+
+
+class TestEviction:
+    """Eviction caps a similarity cluster at `target_size` by dropping its
+    temporally middle members.
+
+    The FakeEmbedder maps every text onto one direction (cosine 1.0), so
+    each batch below forms a single cluster regardless of the text.
+    """
+
+    @_async
+    async def test_disabled_keeps_all_and_issues_no_query(
+        self, event_memory, fake_vector_store_collection, monkeypatch
+    ):
+        queries: list[int] = []
+        original_query = fake_vector_store_collection.query
+
+        async def counting_query(**kwargs):
+            queries.append(1)
+            return await original_query(**kwargs)
+
+        monkeypatch.setattr(fake_vector_store_collection, "query", counting_query)
+        events = [_make_event(f"msg {i}", timestamp=_ts(i)) for i in range(20)]
+
+        await event_memory.encode_events(events)
+
+        assert len(await _stored_minutes(fake_vector_store_collection)) == 20
+        assert queries == [1]  # the one query _stored_minutes made
+
+    @_async
+    async def test_cluster_within_target_keeps_all(
+        self, event_memory_with_eviction, fake_vector_store_collection
+    ):
+        events = [_make_event(f"msg {i}", timestamp=_ts(i)) for i in range(5)]
+        await event_memory_with_eviction.encode_events(events)
+        assert await _stored_minutes(fake_vector_store_collection) == [0, 1, 2, 3, 4]
+
+    @_async
+    async def test_intra_batch_caps_and_keeps_temporal_extremes(
+        self, event_memory_with_eviction, fake_vector_store_collection
+    ):
+        events = [_make_event(f"msg {i}", timestamp=_ts(i)) for i in range(20)]
+        await event_memory_with_eviction.encode_events(events)
+        # target=5 -> keep 2 earliest + 3 latest, evict the middle.
+        assert await _stored_minutes(fake_vector_store_collection) == [0, 1, 17, 18, 19]
+
+    @_async
+    async def test_batch_order_mimics_serial_ingestion(
+        self, fake_vector_store_collection
+    ):
+        """A batch evicts what encoding its events one at a time would."""
+        events = [_make_event(f"msg {i}", timestamp=_ts(i)) for i in range(12)]
+        eviction = EvictionOptions(
+            similarity_threshold=0.5, search_limit=100, target_size=5
+        )
+        batched_collection = make_collection(FakeEmbedder())
+        serial_collection = make_collection(FakeEmbedder())
+        batched = _build(
+            FakeEmbedder(), collection=batched_collection, eviction=eviction
+        )
+        serial = _build(FakeEmbedder(), collection=serial_collection, eviction=eviction)
+
+        await batched.encode_events(list(reversed(events)))
+        for event in events:
+            await serial.encode_events([event])
+
+        assert await _stored_minutes(batched_collection) == await _stored_minutes(
+            serial_collection
+        )
+
+    @_async
+    async def test_clusters_are_trimmed_independently(self):
+        embedder = AngleEmbedder({"alpha": 0.0, "beta": math.pi / 2})
+        collection = make_collection(embedder)
+        memory = _build(
+            embedder,
+            collection=collection,
+            eviction=EvictionOptions(
+                similarity_threshold=0.5, search_limit=100, target_size=5
+            ),
+        )
+        alphas = [_make_event(f"alpha {i}", timestamp=_ts(i)) for i in range(7)]
+        betas = [_make_event(f"beta {i}", timestamp=_ts(10 + i)) for i in range(2)]
+
+        await memory.encode_events([*alphas, *betas])
+
+        assert await _stored_minutes(collection) == [
+            0,
+            1,
+            4,
+            5,
+            6,
+            10,
+            11,
+        ]
+
+    @_async
+    async def test_cross_batch_displaces_stored_records_and_their_links(
+        self,
+        event_memory_with_eviction,
+        fake_vector_store_collection,
+        fake_segment_store_partition,
+    ):
+        await event_memory_with_eviction.encode_events(
+            [_make_event(f"a{i}", timestamp=_ts(i)) for i in range(5)]
+        )
+        assert await _stored_minutes(fake_vector_store_collection) == [0, 1, 2, 3, 4]
+        stored_before = set(fake_vector_store_collection.records)
+
+        # A second batch grows the cluster past target: stored records from the
+        # temporal middle are displaced, from the vector store and the links.
+        await event_memory_with_eviction.encode_events(
+            [_make_event(f"b{i}", timestamp=_ts(5 + i)) for i in range(5)]
+        )
+
+        assert await _stored_minutes(fake_vector_store_collection) == [0, 1, 7, 8, 9]
+        displaced = stored_before - set(fake_vector_store_collection.records)
+        assert displaced
+        assert not (displaced & _linked(fake_segment_store_partition))
+        assert _linked(fake_segment_store_partition) == set(
+            fake_vector_store_collection.records
+        )
+        # Segments are untouched: every event is still expandable.
+        assert len(fake_segment_store_partition.segments) == 10
+
+    @_async
+    async def test_skipped_derivatives_are_never_linked(
+        self, event_memory_with_eviction, fake_segment_store_partition
+    ):
+        events = [_make_event(f"msg {i}", timestamp=_ts(i)) for i in range(20)]
+        await event_memory_with_eviction.encode_events(events)
+
+        assert len(_linked(fake_segment_store_partition)) == 5
+        assert len(fake_segment_store_partition.segments) == 20

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_system_filters.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_system_filters.py
@@ -1,0 +1,118 @@
+"""Tests for the translation between typed system filters and filter trees."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from memmachine_server.common.filter.filter_parser import (
+    And,
+    Comparison,
+    In,
+    IsNull,
+    Not,
+    Or,
+)
+from memmachine_server.common.property_keys import reserved_property_key
+from memmachine_server.episodic_memory.event_memory.system_filters import (
+    BLOCK_KIND_KEY,
+    EVENT_SESSION_KEY,
+    EVENT_SOURCE_KEY,
+    EVENT_TIMESTAMP_KEY,
+    SystemFilters,
+    conjoin,
+    split_system,
+    system_predicates,
+)
+
+_T0 = datetime(2026, 1, 1, tzinfo=UTC)
+_T1 = datetime(2026, 1, 2, tzinfo=UTC)
+
+
+def _conjuncts(expr):
+    if isinstance(expr, And):
+        return [*_conjuncts(expr.left), *_conjuncts(expr.right)]
+    return [expr]
+
+
+def test_no_system_filter_is_no_tree():
+    assert system_predicates() is None
+
+
+def test_predicates_name_the_reserved_keys():
+    tree = system_predicates(
+        since=_T0,
+        until=_T1,
+        session_ids=["s1"],
+        source_ids=["alice", "bob"],
+        block_kinds=["text"],
+    )
+    assert _conjuncts(tree) == [
+        Comparison(field=EVENT_TIMESTAMP_KEY, op=">=", value=_T0),
+        Comparison(field=EVENT_TIMESTAMP_KEY, op="<", value=_T1),
+        In(field=EVENT_SESSION_KEY, values=["s1"]),
+        In(field=EVENT_SOURCE_KEY, values=["alice", "bob"]),
+        In(field=BLOCK_KIND_KEY, values=["text"]),
+    ]
+
+
+def test_empty_ids_admit_nothing_and_none_admits_everything():
+    assert system_predicates(session_ids=None) is None
+    assert system_predicates(session_ids=[]) == In(field=EVENT_SESSION_KEY, values=[])
+
+
+def test_split_recovers_the_typed_values_and_leaves_the_rest():
+    caller = Comparison(field="color", op="=", value="red")
+    tree = conjoin(
+        [
+            system_predicates(since=_T0, until=_T1, session_ids=["s1"]),
+            caller,
+            Comparison(field=EVENT_SOURCE_KEY, op="=", value="alice"),
+        ]
+    )
+
+    filters, rest = split_system(tree)
+
+    assert filters == SystemFilters(
+        since=_T0, until=_T1, session_ids=["s1"], source_ids=["alice"]
+    )
+    assert rest == caller
+
+
+def test_split_of_nothing_is_nothing():
+    assert split_system(None) == (SystemFilters(), None)
+
+
+def test_split_intersects_repeated_conjuncts():
+    tree = And(
+        left=In(field=EVENT_SESSION_KEY, values=["a", "b"]),
+        right=And(
+            left=In(field=EVENT_SESSION_KEY, values=["b", "c"]),
+            right=And(
+                left=Comparison(field=EVENT_TIMESTAMP_KEY, op=">=", value=_T0),
+                right=Comparison(field=EVENT_TIMESTAMP_KEY, op=">=", value=_T1),
+            ),
+        ),
+    )
+    filters, rest = split_system(tree)
+    assert filters.session_ids == ["b"]
+    assert filters.since == _T1
+    assert rest is None
+
+
+@pytest.mark.parametrize(
+    "tree",
+    [
+        Or(
+            left=Comparison(field=EVENT_SESSION_KEY, op="=", value="s1"),
+            right=Comparison(field="color", op="=", value="red"),
+        ),
+        Not(expr=Comparison(field=EVENT_SESSION_KEY, op="=", value="s1")),
+        IsNull(field=EVENT_SESSION_KEY),
+        Comparison(field=EVENT_SESSION_KEY, op="!=", value="s1"),
+        Comparison(field=EVENT_TIMESTAMP_KEY, op=">", value=_T0),
+        Comparison(field=reserved_property_key("other", "field"), op="=", value="x"),
+    ],
+)
+def test_split_rejects_a_reserved_key_no_typed_value_carries(tree):
+    with pytest.raises(ValueError, match=r"reserved key|system field|takes only"):
+        split_system(tree)

--- a/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_system_filters.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/event_memory/test_system_filters.py
@@ -4,13 +4,17 @@ from datetime import UTC, datetime
 
 import pytest
 
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
     And,
-    Comparison,
+    Equals,
     In,
-    IsNull,
+    IsMissing,
     Not,
+    NotEquals,
     Or,
+    Ordering,
+    conjoin,
+    conjuncts,
 )
 from memmachine_server.common.property_keys import reserved_property_key
 from memmachine_server.episodic_memory.event_memory.system_filters import (
@@ -19,19 +23,12 @@ from memmachine_server.episodic_memory.event_memory.system_filters import (
     EVENT_SOURCE_KEY,
     EVENT_TIMESTAMP_KEY,
     SystemFilters,
-    conjoin,
     split_system,
     system_predicates,
 )
 
 _T0 = datetime(2026, 1, 1, tzinfo=UTC)
 _T1 = datetime(2026, 1, 2, tzinfo=UTC)
-
-
-def _conjuncts(expr):
-    if isinstance(expr, And):
-        return [*_conjuncts(expr.left), *_conjuncts(expr.right)]
-    return [expr]
 
 
 def test_no_system_filter_is_no_tree():
@@ -46,27 +43,29 @@ def test_predicates_name_the_reserved_keys():
         source_ids=["alice", "bob"],
         block_kinds=["text"],
     )
-    assert _conjuncts(tree) == [
-        Comparison(field=EVENT_TIMESTAMP_KEY, op=">=", value=_T0),
-        Comparison(field=EVENT_TIMESTAMP_KEY, op="<", value=_T1),
-        In(field=EVENT_SESSION_KEY, values=["s1"]),
-        In(field=EVENT_SOURCE_KEY, values=["alice", "bob"]),
-        In(field=BLOCK_KIND_KEY, values=["text"]),
+    assert conjuncts(tree) == [
+        Ordering(field=EVENT_TIMESTAMP_KEY, op=">=", value=_T0),
+        Ordering(field=EVENT_TIMESTAMP_KEY, op="<", value=_T1),
+        In(field=EVENT_SESSION_KEY, values=("s1",)),
+        In(field=EVENT_SOURCE_KEY, values=("alice", "bob")),
+        In(field=BLOCK_KIND_KEY, values=("text",)),
     ]
 
 
-def test_empty_ids_admit_nothing_and_none_admits_everything():
+def test_none_admits_everything_and_an_empty_list_is_not_a_predicate():
     assert system_predicates(session_ids=None) is None
-    assert system_predicates(session_ids=[]) == In(field=EVENT_SESSION_KEY, values=[])
+    # Admitting nothing needs no query, so it is the caller's answer, not a tree.
+    with pytest.raises(ValueError, match="admits nothing"):
+        system_predicates(session_ids=[])
 
 
 def test_split_recovers_the_typed_values_and_leaves_the_rest():
-    caller = Comparison(field="color", op="=", value="red")
+    caller = Equals(field="color", value="red")
     tree = conjoin(
         [
             system_predicates(since=_T0, until=_T1, session_ids=["s1"]),
             caller,
-            Comparison(field=EVENT_SOURCE_KEY, op="=", value="alice"),
+            Equals(field=EVENT_SOURCE_KEY, value="alice"),
         ]
     )
 
@@ -84,14 +83,20 @@ def test_split_of_nothing_is_nothing():
 
 def test_split_intersects_repeated_conjuncts():
     tree = And(
-        left=In(field=EVENT_SESSION_KEY, values=["a", "b"]),
-        right=And(
-            left=In(field=EVENT_SESSION_KEY, values=["b", "c"]),
-            right=And(
-                left=Comparison(field=EVENT_TIMESTAMP_KEY, op=">=", value=_T0),
-                right=Comparison(field=EVENT_TIMESTAMP_KEY, op=">=", value=_T1),
+        (
+            In(field=EVENT_SESSION_KEY, values=("a", "b")),
+            And(
+                (
+                    In(field=EVENT_SESSION_KEY, values=("b", "c")),
+                    And(
+                        (
+                            Ordering(field=EVENT_TIMESTAMP_KEY, op=">=", value=_T0),
+                            Ordering(field=EVENT_TIMESTAMP_KEY, op=">=", value=_T1),
+                        )
+                    ),
+                )
             ),
-        ),
+        )
     )
     filters, rest = split_system(tree)
     assert filters.session_ids == ["b"]
@@ -103,14 +108,16 @@ def test_split_intersects_repeated_conjuncts():
     "tree",
     [
         Or(
-            left=Comparison(field=EVENT_SESSION_KEY, op="=", value="s1"),
-            right=Comparison(field="color", op="=", value="red"),
+            (
+                Equals(field=EVENT_SESSION_KEY, value="s1"),
+                Equals(field="color", value="red"),
+            )
         ),
-        Not(expr=Comparison(field=EVENT_SESSION_KEY, op="=", value="s1")),
-        IsNull(field=EVENT_SESSION_KEY),
-        Comparison(field=EVENT_SESSION_KEY, op="!=", value="s1"),
-        Comparison(field=EVENT_TIMESTAMP_KEY, op=">", value=_T0),
-        Comparison(field=reserved_property_key("other", "field"), op="=", value="x"),
+        Not(Equals(field=EVENT_SESSION_KEY, value="s1")),
+        IsMissing(field=EVENT_SESSION_KEY),
+        NotEquals(field=EVENT_SESSION_KEY, value="s1"),
+        Ordering(field=EVENT_TIMESTAMP_KEY, op=">", value=_T0),
+        Equals(field=reserved_property_key("other", "field"), value="x"),
     ],
 )
 def test_split_rejects_a_reserved_key_no_typed_value_carries(tree):

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_episode_to_event.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_episode_to_event.py
@@ -10,11 +10,7 @@ from memmachine_server.common.episode_store import (
     Episode,
     EpisodeType,
 )
-from memmachine_server.episodic_memory.event_memory.data_types import (
-    NullContext,
-    ProducerContext,
-    TextBlock,
-)
+from memmachine_server.episodic_memory.event_memory.data_types import TextBlock
 from memmachine_server.episodic_memory.long_term_memory.long_term_memory import (
     _EVENT_UUID_NAMESPACE,
     LongTermMemory,
@@ -58,29 +54,18 @@ def test_event_uuid_is_deterministic_uuid5_of_episode_uid():
     assert LongTermMemory._episode_to_event(episode).uuid == event.uuid
 
 
-def test_message_episode_uses_producer_context():
-    episode = _episode(producer_id="alice", episode_type=EpisodeType.MESSAGE)
-    event = LongTermMemory._episode_to_event(episode)
-    assert isinstance(event.context, ProducerContext)
-    assert event.context.producer == "alice"
+def test_source_id_is_the_producer_id_and_nothing_else_identifies_the_event():
+    """The producer id is the one identity an episode has: it is the source.
 
-
-def test_non_message_episode_uses_null_context():
-    # Use any non-MESSAGE EpisodeType. The enum is defined in
-    # memmachine_common.api; pick the first non-MESSAGE entry dynamically so
-    # this test doesn't break when the enum gains members.
-    non_message = next(
-        (t for t in EpisodeType if t is not EpisodeType.MESSAGE),
-        None,
-    )
-    if non_message is None:
-        # Only MESSAGE exists today; this branch will start exercising once
-        # additional Episode types are introduced. Skip rather than assert
-        # invariant we can't yet exercise.
-        pytest.skip("Only MESSAGE EpisodeType exists; nothing else to verify yet")
-    episode = _episode(episode_type=non_message)
+    An episode has no conversation identity, so the session stays the
+    ungrouped stream, and the server holds no readable name, so no context
+    part is added.
+    """
+    episode = _episode(producer_id="alice")
     event = LongTermMemory._episode_to_event(episode)
-    assert isinstance(event.context, NullContext)
+    assert event.source_id == "alice"
+    assert event.session_id is None
+    assert event.context == {}
 
 
 def test_event_has_single_text_block_with_episode_content():

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
@@ -17,6 +17,7 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import Any, override
 from unittest.mock import create_autospec
+from uuid import uuid4
 
 import pytest
 
@@ -32,6 +33,11 @@ from memmachine_server.common.filter.filter_parser import (
 from memmachine_server.common.vector_store import VectorStore
 from memmachine_server.common.vector_store.data_types import (
     VectorStoreCollectionConfig,
+)
+from memmachine_server.episodic_memory.event_memory.data_types import (
+    SearchHit,
+    Segment,
+    TextBlock,
 )
 from memmachine_server.episodic_memory.event_memory.deriver.text_deriver import (
     WholeTextDeriver,
@@ -725,8 +731,8 @@ async def test_expand_context_window_stays_within_the_episode_limit(
     async def recording_get_segment_contexts(seed_segment_uuids, **kwargs):
         windows.append(
             (
-                kwargs.get("max_backward_segments", 0),
-                kwargs.get("max_forward_segments", 0),
+                kwargs.get("before", 0),
+                kwargs.get("after", 0),
             )
         )
         return await get_segment_contexts(seed_segment_uuids, **kwargs)
@@ -786,21 +792,23 @@ def test_unify_first_window_keeps_the_score():
 
 
 def test_episode_uid_context_dedup_and_nucleus():
-    class _Seg:
-        def __init__(self, uuid, uid):
-            self.uuid = uuid
-            self.properties = {"_episode_uid": uid}
+    def _seg(uid: str) -> Segment:
+        return Segment(
+            uuid=uuid4(),
+            event_uuid=uuid4(),
+            index=0,
+            offset=0,
+            timestamp=datetime(2026, 1, 15, 12, 0, tzinfo=UTC),
+            block=TextBlock(text=uid),
+            properties={"_episode_uid": uid},
+        )
 
-    class _Ctx:
-        def __init__(self):
-            self.seed_segment_uuid = "s2"
-            self.segments = [
-                _Seg("s1", "e1"),
-                _Seg("s2", "e2"),
-                _Seg("s3", "e2"),
-                _Seg("s4", "e3"),
-            ]
+    hit = SearchHit(
+        score=1.0,
+        seed=1,
+        segments=[_seg("e1"), _seg("e2"), _seg("e2"), _seg("e3")],
+    )
 
-    nucleus, context = LongTermMemory._episode_uid_context(_Ctx())
+    nucleus, context = LongTermMemory._episode_uid_context(hit)
     assert nucleus == "e2"
     assert context == ["e1", "e2", "e3"]

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
@@ -32,9 +32,6 @@ from memmachine_server.common.filter import (
     Ordering,
 )
 from memmachine_server.common.vector_store import VectorStore
-from memmachine_server.common.vector_store.data_types import (
-    VectorStoreCollectionConfig,
-)
 from memmachine_server.episodic_memory.event_memory.data_types import (
     SearchHit,
     Segment,
@@ -56,8 +53,8 @@ from memmachine_server.episodic_memory.long_term_memory import (
     LongTermMemory,
 )
 from server_tests.memmachine_server.common.reranker.fake_embedder import FakeEmbedder
-from server_tests.memmachine_server.common.vector_store.in_memory_vector_store_collection import (
-    InMemoryVectorStoreCollection,
+from server_tests.memmachine_server.common.vector_store.in_memory_vector_store_partition import (
+    InMemoryVectorStorePartition,
 )
 from server_tests.memmachine_server.episodic_memory.event_memory.conftest import (
     InMemorySegmentStorePartition,
@@ -148,14 +145,14 @@ def fake_embedder() -> FakeEmbedder:
 
 @pytest.fixture
 def vector_store():
-    """Stand-in for the parent VectorStore: only delete_collection is invoked."""
+    """Stand-in for the parent VectorStore: only delete_partition is invoked."""
     return create_autospec(VectorStore, instance=True)
 
 
 @pytest.fixture
-def vector_store_collection(fake_embedder):
-    return InMemoryVectorStoreCollection(
-        VectorStoreCollectionConfig(vector_dimensions=fake_embedder.dimensions),
+def vector_store_partition(fake_embedder):
+    return InMemoryVectorStorePartition(
+        "sess1",
         {
             **EventMemory.expected_vector_store_collection_schema(),
             **EVENT_BACKEND_SYSTEM_FIELDS,
@@ -180,7 +177,7 @@ def segment_store_partition() -> InMemorySegmentStorePartition:
 def long_term_memory(
     fake_embedder,
     vector_store,
-    vector_store_collection,
+    vector_store_partition,
     segment_store,
     segment_store_partition,
     fake_episode_storage,
@@ -189,8 +186,7 @@ def long_term_memory(
         EventBackendParams(
             session_id="sess1",
             vector_store=vector_store,
-            vector_store_collection=vector_store_collection,
-            vector_store_collection_namespace="long_term_memory",
+            vector_store_partition=vector_store_partition,
             segment_store=segment_store,
             segment_store_partition=segment_store_partition,
             partition_key="sess1",
@@ -295,10 +291,7 @@ async def test_drop_session_partition_calls_parent_lifecycle_hooks(
     segment_store,
 ):
     await long_term_memory.drop_session_partition()
-    vector_store.delete_collection.assert_awaited_once_with(
-        namespace="long_term_memory",
-        name="sess1",
-    )
+    vector_store.delete_partition.assert_awaited_once_with("sess1")
     segment_store.delete_partition.assert_awaited_once_with("sess1")
     # Reclamation is the sweeper's; the delete path never purges.
     segment_store.purge_deleted_partitions.assert_not_awaited()
@@ -435,7 +428,7 @@ async def test_unknown_user_metadata_field_passes_when_no_schema(long_term_memor
 async def test_unknown_user_metadata_field_raises_when_schema_configured(
     fake_embedder,
     vector_store,
-    vector_store_collection,
+    vector_store_partition,
     segment_store,
     segment_store_partition,
     fake_episode_storage,
@@ -445,8 +438,7 @@ async def test_unknown_user_metadata_field_raises_when_schema_configured(
         EventBackendParams(
             session_id="sess1",
             vector_store=vector_store,
-            vector_store_collection=vector_store_collection,
-            vector_store_collection_namespace="long_term_memory",
+            vector_store_partition=vector_store_partition,
             segment_store=segment_store,
             segment_store_partition=segment_store_partition,
             partition_key="sess1",
@@ -486,8 +478,8 @@ def _make_ltm(episodes: list[Episode]) -> LongTermMemory:
     No reranker is configured, so scores come straight from the vector store.
     """
     fake_embedder = FakeEmbedder()
-    vector_store_collection = InMemoryVectorStoreCollection(
-        VectorStoreCollectionConfig(vector_dimensions=fake_embedder.dimensions),
+    vector_store_partition = InMemoryVectorStorePartition(
+        "sess1",
         {
             **EventMemory.expected_vector_store_collection_schema(),
             **EVENT_BACKEND_SYSTEM_FIELDS,
@@ -497,8 +489,7 @@ def _make_ltm(episodes: list[Episode]) -> LongTermMemory:
         EventBackendParams(
             session_id="sess1",
             vector_store=create_autospec(VectorStore, instance=True),
-            vector_store_collection=vector_store_collection,
-            vector_store_collection_namespace="long_term_memory",
+            vector_store_partition=vector_store_partition,
             segment_store=create_autospec(SegmentStore, instance=True),
             segment_store_partition=InMemorySegmentStorePartition(),
             partition_key="sess1",
@@ -627,19 +618,18 @@ def timeline_storage(timeline_episodes) -> FakeEpisodeStorage:
 @pytest.fixture
 def timeline_long_term_memory(
     vector_store,
-    vector_store_collection,
+    vector_store_partition,
     segment_store,
     segment_store_partition,
     timeline_storage,
 ) -> LongTermMemory:
     # `RankedEmbedder` shares FakeEmbedder's dimensions, so the shared
-    # `vector_store_collection` config still applies.
+    # `vector_store_partition` config still applies.
     return LongTermMemory(
         EventBackendParams(
             session_id="sess1",
             vector_store=vector_store,
-            vector_store_collection=vector_store_collection,
-            vector_store_collection_namespace="long_term_memory",
+            vector_store_partition=vector_store_partition,
             segment_store=segment_store,
             segment_store_partition=segment_store_partition,
             partition_key="sess1",

--- a/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/long_term_memory/test_event_backend_wiring.py
@@ -27,8 +27,9 @@ from memmachine_server.common.episode_store import (
     EpisodeIdT,
     EpisodeStorage,
 )
-from memmachine_server.common.filter.filter_parser import (
-    Comparison as FilterComparison,
+from memmachine_server.common.filter import (
+    Equals,
+    Ordering,
 )
 from memmachine_server.common.vector_store import VectorStore
 from memmachine_server.common.vector_store.data_types import (
@@ -153,14 +154,13 @@ def vector_store():
 
 @pytest.fixture
 def vector_store_collection(fake_embedder):
-    config = VectorStoreCollectionConfig(
-        vector_dimensions=fake_embedder.dimensions,
-        indexed_properties_schema={
+    return InMemoryVectorStoreCollection(
+        VectorStoreCollectionConfig(vector_dimensions=fake_embedder.dimensions),
+        {
             **EventMemory.expected_vector_store_collection_schema(),
             **EVENT_BACKEND_SYSTEM_FIELDS,
         },
     )
-    return InMemoryVectorStoreCollection(config)
 
 
 @pytest.fixture
@@ -352,7 +352,7 @@ async def test_user_metadata_filter_round_trips(
     scored = await long_term_memory.search_scored(
         "fruit",
         num_episodes_limit=10,
-        property_filter=FilterComparison(field="m.color", op="=", value="red"),
+        property_filter=Equals(field="m.color", value="red"),
     )
     uids = {ep.uid for _, ep in scored}
     assert uids == {"m-1"}
@@ -391,7 +391,7 @@ async def test_system_field_filter_round_trips(
     scored = await long_term_memory.search_scored(
         "msg",
         num_episodes_limit=10,
-        property_filter=FilterComparison(field="producer_id", op="=", value="alice"),
+        property_filter=Equals(field="producer_id", value="alice"),
     )
     uids = {ep.uid for _, ep in scored}
     assert uids == {"s-1"}
@@ -412,9 +412,7 @@ async def test_unknown_bare_filter_field_raises(long_term_memory):
         await long_term_memory.search_scored(
             "msg",
             num_episodes_limit=10,
-            property_filter=FilterComparison(
-                field="producre_id", op="=", value="alice"
-            ),
+            property_filter=Equals(field="producre_id", value="alice"),
         )
 
 
@@ -429,7 +427,7 @@ async def test_unknown_user_metadata_field_passes_when_no_schema(long_term_memor
     scored = await long_term_memory.search_scored(
         "msg",
         num_episodes_limit=10,
-        property_filter=FilterComparison(field="m.anything", op="=", value="x"),
+        property_filter=Equals(field="m.anything", value="x"),
     )
     assert scored == []
 
@@ -465,7 +463,7 @@ async def test_unknown_user_metadata_field_raises_when_schema_configured(
         await ltm.search_scored(
             "msg",
             num_episodes_limit=10,
-            property_filter=FilterComparison(field="m.coloor", op="=", value="red"),
+            property_filter=Equals(field="m.coloor", value="red"),
         )
 
 
@@ -476,10 +474,8 @@ async def test_timestamp_filter_field_is_accepted(long_term_memory, episodes):
     await long_term_memory.search_scored(
         "anything",
         num_episodes_limit=10,
-        property_filter=FilterComparison(
-            field="timestamp",
-            op=">=",
-            value=datetime(2000, 1, 1, tzinfo=UTC),
+        property_filter=Ordering(
+            field="timestamp", op=">=", value=datetime(2000, 1, 1, tzinfo=UTC)
         ),
     )
 
@@ -491,13 +487,11 @@ def _make_ltm(episodes: list[Episode]) -> LongTermMemory:
     """
     fake_embedder = FakeEmbedder()
     vector_store_collection = InMemoryVectorStoreCollection(
-        VectorStoreCollectionConfig(
-            vector_dimensions=fake_embedder.dimensions,
-            indexed_properties_schema={
-                **EventMemory.expected_vector_store_collection_schema(),
-                **EVENT_BACKEND_SYSTEM_FIELDS,
-            },
-        )
+        VectorStoreCollectionConfig(vector_dimensions=fake_embedder.dimensions),
+        {
+            **EventMemory.expected_vector_store_collection_schema(),
+            **EVENT_BACKEND_SYSTEM_FIELDS,
+        },
     )
     return LongTermMemory(
         EventBackendParams(

--- a/packages/server/server_tests/memmachine_server/episodic_memory/short_term_memory/test_short_term_memory.py
+++ b/packages/server/server_tests/memmachine_server/episodic_memory/short_term_memory/test_short_term_memory.py
@@ -15,7 +15,9 @@ from memmachine_server.common.configuration.episodic_config import (
 )
 from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.episode_store import ContentType, Episode
-from memmachine_server.common.filter.filter_parser import parse_filter
+from memmachine_server.common.filter.filter_parser import (
+    parse_filter,
+)
 from memmachine_server.common.language_model import LanguageModel
 from memmachine_server.common.session_manager.session_data_manager import (
     SessionDataManager,
@@ -654,7 +656,7 @@ class TestSessionMemoryPublicAPI:
         assert len(episodes) == 1
         assert episodes == [ep1]
 
-        # IsNull filter: ep1 has no category
+        # IsMissing filter: ep1 has no category
         filter_str = "m.category IS NULL"
         filters = parse_filter(filter_str)
         episodes, _ = await memory.get_short_term_memory_context(

--- a/packages/server/server_tests/memmachine_server/main/test_memachine.py
+++ b/packages/server/server_tests/memmachine_server/main/test_memachine.py
@@ -7,7 +7,9 @@ import pytest
 
 from memmachine_server import MemMachine
 from memmachine_server.common.episode_store import EpisodeEntry
-from memmachine_server.common.filter.filter_parser import parse_filter
+from memmachine_server.common.filter.filter_parser import (
+    parse_filter,
+)
 from memmachine_server.common.session_manager.session_data_manager import (
     SessionDataManager,
 )

--- a/packages/server/server_tests/memmachine_server/main/test_memmachine_mock.py
+++ b/packages/server/server_tests/memmachine_server/main/test_memmachine_mock.py
@@ -27,8 +27,10 @@ from memmachine_server.common.episode_store import (
     EpisodeResponse,
 )
 from memmachine_server.common.errors import SessionNotFoundError
-from memmachine_server.common.filter.filter_parser import And as FilterAnd
-from memmachine_server.common.filter.filter_parser import Comparison as FilterComparison
+from memmachine_server.common.filter import (
+    And,
+    Equals,
+)
 from memmachine_server.common.session_manager.session_data_manager import (
     SessionDataManager,
 )
@@ -735,11 +737,7 @@ async def test_count_episodes_filters_by_session_only(
 
     assert result == 7
     episode_storage.get_episode_messages_count.assert_awaited_once_with(
-        filter_expr=FilterComparison(
-            field="session_key",
-            op="=",
-            value=session.session_key,
-        )
+        filter_expr=Equals(field="session_key", value=session.session_key)
     )
 
 
@@ -749,7 +747,7 @@ async def test_count_episodes_combines_search_filter(
 ):
     memmachine = MemMachine(minimal_conf, patched_resource_manager)
     session = DummySessionData("session-with-filter")
-    custom_filter = FilterComparison(field="topic", op="=", value="alpha")
+    custom_filter = Equals(field="topic", value="alpha")
     parsed_specs: list[str] = []
 
     def _fake_parse(spec: str | None):
@@ -772,13 +770,8 @@ async def test_count_episodes_combines_search_filter(
     await_args = episode_storage.get_episode_messages_count.await_args
     assert await_args is not None
     combined_filter = await_args.kwargs["filter_expr"]
-    assert combined_filter == FilterAnd(
-        left=FilterComparison(
-            field="session_key",
-            op="=",
-            value=session.session_key,
-        ),
-        right=custom_filter,
+    assert combined_filter == And(
+        (Equals(field="session_key", value=session.session_key), custom_filter)
     )
 
 

--- a/packages/server/server_tests/memmachine_server/semantic_memory/mock_semantic_memory_objects.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/mock_semantic_memory_objects.py
@@ -8,7 +8,9 @@ from pydantic import InstanceOf
 
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.episode_store import EpisodeIdT
-from memmachine_server.common.filter.filter_parser import FilterExpr
+from memmachine_server.common.filter import (
+    FilterExpr,
+)
 from memmachine_server.semantic_memory.semantic_model import (
     FeatureIdT,
     Resources,

--- a/packages/server/server_tests/memmachine_server/semantic_memory/storage/in_memory_semantic_storage.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/storage/in_memory_semantic_storage.py
@@ -12,28 +12,20 @@ from pydantic import InstanceOf
 
 from memmachine_server.common.episode_store import EpisodeIdT
 from memmachine_server.common.errors import InvalidArgumentError
+from memmachine_server.common.filter import (
+    And,
+    Equals,
+    FilterExpr,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
+)
 from memmachine_server.common.filter.filter_parser import (
     USER_METADATA_STORAGE_PREFIX,
-    FilterExpr,
     normalize_filter_field,
-)
-from memmachine_server.common.filter.filter_parser import (
-    And as FilterAnd,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Comparison as FilterComparison,
-)
-from memmachine_server.common.filter.filter_parser import (
-    In as FilterIn,
-)
-from memmachine_server.common.filter.filter_parser import (
-    IsNull as FilterIsNull,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Not as FilterNot,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Or as FilterOr,
 )
 from memmachine_server.semantic_memory.semantic_model import (
     FeatureIdT,
@@ -664,48 +656,35 @@ class InMemorySemanticStorage(SemanticStorage):
         entry: _FeatureEntry,
         expr: FilterExpr,
     ) -> bool:
-        if isinstance(expr, FilterIsNull):
-            value, _ = self._resolve_entry_field(entry, expr.field)
-            return value is None
-        if isinstance(expr, FilterIn):
-            value, _ = self._resolve_entry_field(entry, expr.field)
-            return value in expr.values
-        if isinstance(expr, FilterComparison):
-            return self._evaluate_comparison(entry, expr)
-        if isinstance(expr, FilterAnd):
-            return self._evaluate_filter_expr(
-                entry, expr.left
-            ) and self._evaluate_filter_expr(entry, expr.right)
-        if isinstance(expr, FilterOr):
-            return self._evaluate_filter_expr(
-                entry, expr.left
-            ) or self._evaluate_filter_expr(entry, expr.right)
-        if isinstance(expr, FilterNot):
-            return not self._evaluate_filter_expr(entry, expr.expr)
-        raise TypeError(f"Unsupported filter expression type: {type(expr)!r}")
+        match expr:
+            case IsMissing(field):
+                value, _ = self._resolve_entry_field(entry, field)
+                return value is None
+            case In(field, values):
+                value, _ = self._resolve_entry_field(entry, field)
+                return value in values
+            case Equals(field, expected):
+                value, _ = self._resolve_entry_field(entry, field)
+                return value == expected
+            case NotEquals(field, expected):
+                value, _ = self._resolve_entry_field(entry, field)
+                return value is not None and value != expected
+            case Ordering(field, op, expected):
+                value, _ = self._resolve_entry_field(entry, field)
+                return value is not None and self._COMPARE_OPS[op](value, expected)
+            case And(operands):
+                return all(self._evaluate_filter_expr(entry, o) for o in operands)
+            case Or(operands):
+                return any(self._evaluate_filter_expr(entry, o) for o in operands)
+            case Not(operand):
+                return not self._evaluate_filter_expr(entry, operand)
 
     _COMPARE_OPS: ClassVar[dict[str, Callable[[Any, Any], bool]]] = {
-        "=": lambda lhs, rhs: lhs == rhs,
-        "!=": lambda lhs, rhs: lhs != rhs,
         ">": lambda lhs, rhs: lhs > rhs,
         "<": lambda lhs, rhs: lhs < rhs,
         ">=": lambda lhs, rhs: lhs >= rhs,
         "<=": lambda lhs, rhs: lhs <= rhs,
     }
-
-    def _evaluate_comparison(
-        self,
-        entry: _FeatureEntry,
-        comparison: FilterComparison,
-    ) -> bool:
-        value, _ = self._resolve_entry_field(entry, comparison.field)
-        expected: Any = comparison.value
-        if comparison.op != "=" and value is None:
-            return False
-        op_fn = self._COMPARE_OPS.get(comparison.op)
-        if op_fn is None:
-            raise ValueError(f"Unsupported operator: {comparison.op}")
-        return op_fn(value, expected)
 
     def _resolve_entry_field(
         self,

--- a/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_semantic_storage.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_semantic_storage.py
@@ -13,7 +13,12 @@ from memmachine_server.common.episode_store import (
     EpisodeStorage,
 )
 from memmachine_server.common.errors import InvalidArgumentError
-from memmachine_server.common.filter.filter_parser import FilterExpr, parse_filter
+from memmachine_server.common.filter import (
+    FilterExpr,
+)
+from memmachine_server.common.filter.filter_parser import (
+    parse_filter,
+)
 from memmachine_server.semantic_memory.semantic_model import FeatureIdT, SemanticFeature
 from memmachine_server.semantic_memory.storage.neo4j_semantic_storage import (
     Neo4jSemanticStorage,
@@ -213,36 +218,6 @@ async def test_multiple_features(
     assert len(test_user_profile) == 2
     for i in range(len(test_user_profile)):
         assert test_user_profile[i].value == expected_test_user_profile[i]["value"]
-
-
-@pytest.mark.asyncio
-async def test_feature_value_comparison_filters(semantic_storage: SemanticStorage):
-    feature_ids: list[FeatureIdT] = [
-        await semantic_storage.add_feature(
-            set_id="cmp-user",
-            category_name="default",
-            feature="rank",
-            value=str(idx),
-            tag="numeric",
-            embedding=np.array([float(idx)], dtype=float),
-        )
-        for idx in range(1, 4)
-    ]
-
-    try:
-        greater_than_one = await _collect_feature_set(
-            semantic_storage,
-            filter_expr=_expr("value > '1'"),
-        )
-        assert {f.value for f in greater_than_one} == {"2", "3"}
-
-        up_to_two = await _collect_feature_set(
-            semantic_storage,
-            filter_expr=_expr("value <= '2'"),
-        )
-        assert {f.value for f in up_to_two} == {"1", "2"}
-    finally:
-        await semantic_storage.delete_features(feature_ids)
 
 
 @pytest.mark.asyncio
@@ -1535,30 +1510,6 @@ async def test_filter_not_equal(semantic_storage: SemanticStorage):
         results = await _collect_feature_set(
             semantic_storage,
             filter_expr=_expr("value != '1'"),
-        )
-        assert {f.value for f in results} == {"2", "3"}
-    finally:
-        await semantic_storage.delete_features(feature_ids)
-
-
-@pytest.mark.asyncio
-async def test_filter_greater_equal(semantic_storage: SemanticStorage):
-    feature_ids: list[FeatureIdT] = [
-        await semantic_storage.add_feature(
-            set_id="ge-user",
-            category_name="default",
-            feature="rank",
-            value=str(idx),
-            tag="numeric",
-            embedding=np.array([float(idx)], dtype=float),
-        )
-        for idx in range(1, 4)
-    ]
-
-    try:
-        results = await _collect_feature_set(
-            semantic_storage,
-            filter_expr=_expr("value >= '2'"),
         )
         assert {f.value for f in results} == {"2", "3"}
     finally:

--- a/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_vector_store_semantic_storage.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_vector_store_semantic_storage.py
@@ -6,7 +6,9 @@ from uuid import UUID
 import numpy as np
 import pytest
 
-from memmachine_server.common.filter.filter_parser import parse_filter
+from memmachine_server.common.filter.filter_parser import (
+    parse_filter,
+)
 from memmachine_server.common.vector_store import VectorStoreCollectionConfig
 from memmachine_server.semantic_memory.storage.storage_base import SemanticStorage
 from memmachine_server.semantic_memory.storage.vector_store_semantic_storage import (
@@ -21,15 +23,8 @@ from server_tests.memmachine_server.common.vector_store.in_memory_vector_store_c
 @pytest.fixture
 def vector_collection() -> InMemoryVectorStoreCollection:
     return InMemoryVectorStoreCollection(
-        VectorStoreCollectionConfig(
-            vector_dimensions=2,
-            indexed_properties_schema={
-                "set_id": str,
-                "category": str,
-                "tag": str,
-                "feature_name": str,
-            },
-        )
+        VectorStoreCollectionConfig(vector_dimensions=2),
+        {"set_id": str, "category": str, "tag": str, "feature_name": str},
     )
 
 

--- a/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_vector_store_semantic_storage.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/storage/test_vector_store_semantic_storage.py
@@ -9,21 +9,20 @@ import pytest
 from memmachine_server.common.filter.filter_parser import (
     parse_filter,
 )
-from memmachine_server.common.vector_store import VectorStoreCollectionConfig
 from memmachine_server.semantic_memory.storage.storage_base import SemanticStorage
 from memmachine_server.semantic_memory.storage.vector_store_semantic_storage import (
     VectorSemanticFeature,
     VectorStoreSemanticStorage,
 )
-from server_tests.memmachine_server.common.vector_store.in_memory_vector_store_collection import (
-    InMemoryVectorStoreCollection,
+from server_tests.memmachine_server.common.vector_store.in_memory_vector_store_partition import (
+    InMemoryVectorStorePartition,
 )
 
 
 @pytest.fixture
-def vector_collection() -> InMemoryVectorStoreCollection:
-    return InMemoryVectorStoreCollection(
-        VectorStoreCollectionConfig(vector_dimensions=2),
+def vector_collection() -> InMemoryVectorStorePartition:
+    return InMemoryVectorStorePartition(
+        "semantic_memory",
         {"set_id": str, "category": str, "tag": str, "feature_name": str},
     )
 
@@ -39,7 +38,7 @@ async def _vector_uuid(storage: VectorStoreSemanticStorage, feature_id) -> UUID:
 @pytest.mark.asyncio
 async def test_older_than_compares_instants_not_wall_clocks(
     sqlalchemy_sqlite_engine,
-    vector_collection: InMemoryVectorStoreCollection,
+    vector_collection: InMemoryVectorStorePartition,
 ):
     """A non-UTC-offset bound names an instant on SQLite, not a wall clock.
 
@@ -65,7 +64,7 @@ async def test_older_than_compares_instants_not_wall_clocks(
 @pytest.mark.asyncio
 async def test_add_update_delete_feature_keeps_vector_collection_in_sync(
     sqlalchemy_sqlite_engine,
-    vector_collection: InMemoryVectorStoreCollection,
+    vector_collection: InMemoryVectorStorePartition,
 ):
     storage = VectorStoreSemanticStorage(sqlalchemy_sqlite_engine, vector_collection)
     await storage.startup()
@@ -109,7 +108,7 @@ async def test_add_update_delete_feature_keeps_vector_collection_in_sync(
 @pytest.mark.asyncio
 async def test_each_feature_owns_a_distinct_vector_record(
     sqlalchemy_sqlite_engine,
-    vector_collection: InMemoryVectorStoreCollection,
+    vector_collection: InMemoryVectorStorePartition,
 ):
     """`vector_uuid` is minted per feature, so no two features can collide."""
     storage = VectorStoreSemanticStorage(sqlalchemy_sqlite_engine, vector_collection)
@@ -145,7 +144,7 @@ async def test_each_feature_owns_a_distinct_vector_record(
 @pytest.mark.asyncio
 async def test_vector_records_carry_no_properties(
     sqlalchemy_sqlite_engine,
-    vector_collection: InMemoryVectorStoreCollection,
+    vector_collection: InMemoryVectorStorePartition,
 ):
     """The feature row is the authority; the vector record holds only a vector."""
     storage = VectorStoreSemanticStorage(sqlalchemy_sqlite_engine, vector_collection)
@@ -177,7 +176,7 @@ async def test_vector_records_carry_no_properties(
 @pytest.mark.asyncio
 async def test_delete_feature_set_removes_the_vector_records(
     sqlalchemy_sqlite_engine,
-    vector_collection: InMemoryVectorStoreCollection,
+    vector_collection: InMemoryVectorStorePartition,
 ):
     """The uuids must be read before the rows go, or the vectors are orphaned."""
     storage = VectorStoreSemanticStorage(sqlalchemy_sqlite_engine, vector_collection)
@@ -216,7 +215,7 @@ async def test_delete_feature_set_removes_the_vector_records(
 @pytest.mark.asyncio
 async def test_delete_all_removes_the_vector_records(
     sqlalchemy_sqlite_engine,
-    vector_collection: InMemoryVectorStoreCollection,
+    vector_collection: InMemoryVectorStorePartition,
 ):
     storage = VectorStoreSemanticStorage(sqlalchemy_sqlite_engine, vector_collection)
     await storage.startup()
@@ -242,7 +241,7 @@ async def test_delete_all_removes_the_vector_records(
 @pytest.mark.asyncio
 async def test_vector_search_returns_relational_features_in_similarity_order(
     sqlalchemy_sqlite_engine,
-    vector_collection: InMemoryVectorStoreCollection,
+    vector_collection: InMemoryVectorStorePartition,
 ):
     storage = VectorStoreSemanticStorage(sqlalchemy_sqlite_engine, vector_collection)
     await storage.startup()

--- a/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_ingestion.py
@@ -13,7 +13,9 @@ from memmachine_server.common.episode_store import (
     EpisodeIdT,
     EpisodeStorage,
 )
-from memmachine_server.common.filter.filter_parser import parse_filter
+from memmachine_server.common.filter.filter_parser import (
+    parse_filter,
+)
 from memmachine_server.semantic_memory.semantic_ingestion import IngestionService
 from memmachine_server.semantic_memory.semantic_llm import (
     LLMReducedFeature,

--- a/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_memory.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_memory.py
@@ -4,7 +4,9 @@ import pytest
 
 from memmachine_server.common.episode_store import EpisodeStorage
 from memmachine_server.common.errors import InvalidSetIdConfigurationError
-from memmachine_server.common.filter.filter_parser import parse_filter
+from memmachine_server.common.filter.filter_parser import (
+    parse_filter,
+)
 from memmachine_server.semantic_memory.semantic_memory import SemanticService
 from memmachine_server.semantic_memory.storage.storage_base import SemanticStorage
 from server_tests.memmachine_server.semantic_memory.semantic_test_utils import (

--- a/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_memory_background.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_memory_background.py
@@ -6,7 +6,9 @@ import numpy as np
 import pytest
 
 from memmachine_server.common.episode_store import EpisodeStorage
-from memmachine_server.common.filter.filter_parser import parse_filter
+from memmachine_server.common.filter.filter_parser import (
+    parse_filter,
+)
 from memmachine_server.semantic_memory.config_store.config_store import (
     SemanticConfigStorage,
 )

--- a/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_session_manager.py
+++ b/packages/server/server_tests/memmachine_server/semantic_memory/test_semantic_session_manager.py
@@ -9,7 +9,9 @@ import pytest_asyncio
 
 from memmachine_server.common.episode_store import Episode, EpisodeEntry, EpisodeStorage
 from memmachine_server.common.errors import InvalidSetIdConfigurationError
-from memmachine_server.common.filter.filter_parser import parse_filter
+from memmachine_server.common.filter.filter_parser import (
+    parse_filter,
+)
 from memmachine_server.semantic_memory.config_store.config_store import (
     SemanticConfigStorage,
 )

--- a/packages/server/src/memmachine_server/common/configuration/database_conf.py
+++ b/packages/server/src/memmachine_server/common/configuration/database_conf.py
@@ -266,6 +266,54 @@ class QdrantConf(MetricsFactoryIdMixin, YamlSerializableMixin, ApiKeyMixin):
             "is set to match so all replicas confirm writes."
         ),
     )
+    request_timeout: float = Field(
+        ...,
+        description=(
+            "Seconds a request to Qdrant may take before the client gives up. "
+            "Required: every remote write is bounded by it."
+        ),
+    )
+    indexed_properties: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "The property keys every collection of this store indexes and filters "
+            "on, each with its type name (str, int, float, bool, datetime). The "
+            "system keys of the service using the store are added to these. A "
+            "record or a filter naming any other key is rejected."
+        ),
+    )
+    # The following mirror qdrant_client.models config objects as plain mappings
+    # (their natural serialized form) so qdrant-client stays an optional
+    # dependency here. They are validated against the real qdrant models when
+    # passed to QdrantVectorStoreParams. All apply only to native (data)
+    # collections, never the internal registry collections.
+    hnsw_config: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "HNSW index tuning for native (data) collections, mirroring "
+            "qdrant_client.models.HnswConfigDiff (e.g. ef_construct, payload_m). "
+            "'m' must be 0 or omitted because native collections are "
+            "multi-tenant and rely on per-tenant payload indexing."
+        ),
+    )
+    optimizers_config: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Optimizer tuning for native (data) collections, mirroring "
+            "qdrant_client.models.OptimizersConfigDiff "
+            "(e.g. indexing_threshold, default_segment_number)."
+        ),
+    )
+    quantization_config: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Quantization for native (data) collections, mirroring "
+            "qdrant_client.models.QuantizationConfig. Provide a single-key map "
+            "selecting the method, e.g. "
+            "{'turbo': {'always_ram': true, 'bits': 'bits2'}} for TurboQuant, "
+            "or a 'scalar' / 'product' / 'binary' map."
+        ),
+    )
 
 
 class MilvusConf(YamlSerializableMixin, WithValueFromEnv):
@@ -294,6 +342,22 @@ class MilvusConf(YamlSerializableMixin, WithValueFromEnv):
         description=(
             "Milvus consistency level for newly created collections. "
             "Supported values: Strong, Session, Bounded, Eventually."
+        ),
+    )
+    request_timeout: float = Field(
+        ...,
+        description=(
+            "Seconds a request to Milvus may take before the client gives up. "
+            "Required: every remote write is bounded by it."
+        ),
+    )
+    indexed_properties: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "The property keys every collection of this store indexes and filters "
+            "on, each with its type name (str, int, float, bool, datetime). The "
+            "system keys of the service using the store are added to these. A "
+            "record or a filter naming any other key is rejected."
         ),
     )
 
@@ -366,6 +430,15 @@ class SQLiteVectorStoreConf(YamlSerializableMixin):
             "to `index_directory`. Only relevant when `index_directory` is set."
         ),
     )
+    indexed_properties: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "The property keys every collection of this store indexes and filters "
+            "on, each with its type name (str, int, float, bool, datetime). The "
+            "system keys of the service using the store are added to these. A "
+            "record or a filter naming any other key is rejected."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_path(self) -> Self:
@@ -380,6 +453,15 @@ class SQLiteVecVectorStoreConf(YamlSerializableMixin):
     path: str = Field(
         ...,
         description="SQLite database file path (used as sqlite+aiosqlite:///<path>)",
+    )
+    indexed_properties: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "The property keys every collection of this store indexes and filters "
+            "on, each with its type name (str, int, float, bool, datetime). The "
+            "system keys of the service using the store are added to these. A "
+            "record or a filter naming any other key is rejected."
+        ),
     )
 
     @model_validator(mode="after")

--- a/packages/server/src/memmachine_server/common/configuration/episodic_config.py
+++ b/packages/server/src/memmachine_server/common/configuration/episodic_config.py
@@ -232,7 +232,10 @@ class EventLongTermMemoryConf(BaseModel):
         default_factory=dict,
         description=(
             "User-defined filterable properties and their type names "
-            '(e.g. {"my_field": "str"}). Type names: bool, int, float, str, datetime.'
+            '(e.g. {"my_field": "str"}). Type names: bool, int, float, str, datetime. '
+            "Names the caller keys a filter may use; which of them the vector "
+            "store indexes is declared on the store (`indexed_properties`), and "
+            "the rest are filtered through the segment store."
         ),
     )
     segmenter: SegmenterConf = Field(

--- a/packages/server/src/memmachine_server/common/data_types.py
+++ b/packages/server/src/memmachine_server/common/data_types.py
@@ -18,6 +18,9 @@ PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE: Final[dict[str, type[PropertyValue]]] = {
     v: k for k, v in PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME.items()
 }
 
+PropertyType = type[PropertyValue]
+"""The type of a property value: one of the scalar set."""
+
 FilterValue = bool | int | float | str | datetime | list[int] | list[str]
 """Type for filter expression values (includes list types for IN clauses)."""
 

--- a/packages/server/src/memmachine_server/common/episode_store/count_caching_episode_storage.py
+++ b/packages/server/src/memmachine_server/common/episode_store/count_caching_episode_storage.py
@@ -14,7 +14,7 @@ from memmachine_server.common.episode_store.episode_model import (
     EpisodeIdT,
 )
 from memmachine_server.common.episode_store.episode_storage import EpisodeStorage
-from memmachine_server.common.filter.filter_parser import Comparison, FilterExpr
+from memmachine_server.common.filter import Equals, FilterExpr
 
 
 @dataclass(frozen=True)
@@ -24,9 +24,7 @@ class _CacheEntry:
 
 def _session_key_from_filter(filter_expr: FilterExpr | None) -> str | None:
     """Return the session_key if the filter is exactly a session equality."""
-    if not isinstance(filter_expr, Comparison):
-        return None
-    if filter_expr.op != "=":
+    if not isinstance(filter_expr, Equals):
         return None
     if filter_expr.field not in {"session_key", "session"}:
         return None

--- a/packages/server/src/memmachine_server/common/episode_store/episode_sqlalchemy_store.py
+++ b/packages/server/src/memmachine_server/common/episode_store/episode_sqlalchemy_store.py
@@ -47,8 +47,8 @@ from memmachine_server.common.errors import (
     InvalidArgumentError,
     ResourceNotFoundError,
 )
+from memmachine_server.common.filter import FilterExpr
 from memmachine_server.common.filter.filter_parser import (
-    FilterExpr,
     demangle_user_metadata_key,
     normalize_filter_field,
 )

--- a/packages/server/src/memmachine_server/common/episode_store/episode_storage.py
+++ b/packages/server/src/memmachine_server/common/episode_store/episode_storage.py
@@ -10,7 +10,7 @@ from memmachine_server.common.episode_store.episode_model import (
     EpisodeEntry,
     EpisodeIdT,
 )
-from memmachine_server.common.filter.filter_parser import FilterExpr
+from memmachine_server.common.filter import FilterExpr
 
 
 class EpisodeStorage(ABC):

--- a/packages/server/src/memmachine_server/common/filter/__init__.py
+++ b/packages/server/src/memmachine_server/common/filter/__init__.py
@@ -1,1 +1,43 @@
-"""Utilities for parsing and handling filter expressions."""
+"""Filter expression trees and their compilation."""
+
+from .filter_expression import (
+    And,
+    Equals,
+    FilterExpr,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
+    OrderingOp,
+    conjoin,
+    conjuncts,
+    filter_fields,
+    filter_nodes,
+    map_filter_fields,
+    split_declared,
+)
+from .sql_filter_util import FieldEncoding, FieldResolver, compile_sql_filter
+
+__all__ = [
+    "And",
+    "Equals",
+    "FieldEncoding",
+    "FieldResolver",
+    "FilterExpr",
+    "In",
+    "IsMissing",
+    "Not",
+    "NotEquals",
+    "Or",
+    "Ordering",
+    "OrderingOp",
+    "compile_sql_filter",
+    "conjoin",
+    "conjuncts",
+    "filter_fields",
+    "filter_nodes",
+    "map_filter_fields",
+    "split_declared",
+]

--- a/packages/server/src/memmachine_server/common/filter/filter_expression.py
+++ b/packages/server/src/memmachine_server/common/filter/filter_expression.py
@@ -1,0 +1,257 @@
+"""
+Filter expression trees.
+
+A filter expression is built from the nodes below and compiled by each store
+into its own query language. `FilterExpr` is a closed union, so a compiler
+written as a `match` with no default arm is checked for exhaustiveness:
+adding a node here fails type checking in every store rather than raising on
+whichever query first reaches the new node.
+
+A predicate matches a record only when the field holds a value of the
+compared type. A record that does not carry the field, or carries it with a
+different type, is not a match -- which is what `NotEquals` and
+`Not(Equals(...))` distinguish: the former keeps only records that hold a
+comparable, differing value, the latter also keeps records that hold no
+comparable value at all.
+
+A datetime value denotes an instant, and a naive one means UTC. A node
+normalizes its datetime to a UTC-aware instant at construction, so every
+compiler receives instants and only chooses a representation.
+"""
+
+from collections.abc import Callable, Collection, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+from memmachine_server.common.data_types import OrderedValue, PropertyValue
+from memmachine_server.common.utils import ensure_tz_aware
+
+type FilterExpr = Equals | NotEquals | Ordering | In | IsMissing | And | Or | Not
+"""Any node of a filter expression tree."""
+
+OrderingOp = Literal[">", "<", ">=", "<="]
+
+
+def _utc_instant(value: datetime) -> datetime:
+    return ensure_tz_aware(value).astimezone(UTC)
+
+
+@dataclass(frozen=True)
+class Equals:
+    """Field holds a value equal to `value`."""
+
+    field: str
+    value: PropertyValue
+
+    def __post_init__(self) -> None:
+        """Normalize a datetime value to a UTC-aware instant."""
+        if isinstance(self.value, datetime):
+            object.__setattr__(self, "value", _utc_instant(self.value))
+
+
+@dataclass(frozen=True)
+class NotEquals:
+    """Field holds a comparable value that differs from `value`."""
+
+    field: str
+    value: PropertyValue
+
+    def __post_init__(self) -> None:
+        """Normalize a datetime value to a UTC-aware instant."""
+        if isinstance(self.value, datetime):
+            object.__setattr__(self, "value", _utc_instant(self.value))
+
+
+@dataclass(frozen=True)
+class Ordering:
+    """
+    Field holds a value ordered against `value`.
+
+    Only values with a total order are comparable, so `bool` and `str` are not
+    accepted: ordering booleans is meaningless, and ordering strings is a
+    lexicographic comparison whose result depends on how a store happens to
+    encode the value. Equality on those types is expressed with `Equals`.
+    """
+
+    field: str
+    op: OrderingOp
+    value: OrderedValue
+
+    def __post_init__(self) -> None:
+        """Reject a boolean, which `int` admits at runtime, and normalize a datetime."""
+        if isinstance(self.value, bool):
+            raise TypeError(f"Ordering({self.field!r}) value must not be a bool")
+        if isinstance(self.value, datetime):
+            object.__setattr__(self, "value", _utc_instant(self.value))
+
+
+@dataclass(frozen=True)
+class In:
+    """
+    Field holds a value among `values`.
+
+    Values are homogeneous because a store indexes and compares a property by
+    its type; a mixed list has no single type to compare against. Booleans are
+    excluded rather than treated as integers. At least one value is required:
+    a caller with nothing to admit has no query to make.
+    """
+
+    field: str
+    values: tuple[int, ...] | tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        """Reject value lists a store cannot compare as a single type."""
+        if not self.values:
+            raise ValueError(f"In({self.field!r}) requires at least one value")
+        if any(isinstance(value, bool) for value in self.values):
+            raise TypeError(f"In({self.field!r}) values must be int or str, not bool")
+        if len({type(value) for value in self.values}) > 1:
+            raise TypeError(
+                f"In({self.field!r}) values must all be int or all be str, got "
+                f"{sorted({type(value).__name__ for value in self.values})}"
+            )
+
+
+@dataclass(frozen=True)
+class IsMissing:
+    """
+    Field holds no comparable value.
+
+    True for a record that does not carry the field at all. Property values
+    are never null, so absence is the only way a field can hold nothing.
+    """
+
+    field: str
+
+
+@dataclass(frozen=True)
+class And:
+    """
+    All operands match.
+
+    At least one operand is required: an empty conjunction would oblige every
+    store to render an identity element, and callers already spell "no filter"
+    as `None`.
+    """
+
+    operands: tuple[FilterExpr, ...]
+
+    def __post_init__(self) -> None:
+        """Reject an empty conjunction."""
+        if not self.operands:
+            raise ValueError("And requires at least one operand")
+
+
+@dataclass(frozen=True)
+class Or:
+    """
+    At least one operand matches.
+
+    At least one operand is required, for the reason given on `And`.
+    """
+
+    operands: tuple[FilterExpr, ...]
+
+    def __post_init__(self) -> None:
+        """Reject an empty disjunction."""
+        if not self.operands:
+            raise ValueError("Or requires at least one operand")
+
+
+@dataclass(frozen=True)
+class Not:
+    """The operand does not match."""
+
+    operand: FilterExpr
+
+
+def map_filter_fields(
+    expr: FilterExpr,
+    transform: Callable[[str], str],
+) -> FilterExpr:
+    """Apply a field name transformation to every field in a filter tree."""
+    match expr:
+        case Equals(field, value):
+            return Equals(transform(field), value)
+        case NotEquals(field, value):
+            return NotEquals(transform(field), value)
+        case Ordering(field, op, value):
+            return Ordering(transform(field), op, value)
+        case In(field, values):
+            return In(transform(field), values)
+        case IsMissing(field):
+            return IsMissing(transform(field))
+        case And(operands):
+            return And(tuple(map_filter_fields(o, transform) for o in operands))
+        case Or(operands):
+            return Or(tuple(map_filter_fields(o, transform) for o in operands))
+        case Not(operand):
+            return Not(map_filter_fields(operand, transform))
+
+
+def filter_fields(expr: FilterExpr) -> frozenset[str]:
+    """Every field name a filter tree addresses."""
+    match expr:
+        case (
+            Equals(field)
+            | NotEquals(field)
+            | Ordering(field)
+            | In(field)
+            | IsMissing(field)
+        ):
+            return frozenset((field,))
+        case Not(operand):
+            return filter_fields(operand)
+        case And(operands) | Or(operands):
+            return frozenset(field for o in operands for field in filter_fields(o))
+
+
+def filter_nodes(expr: FilterExpr) -> frozenset[type]:
+    """The node classes a filter tree is built from."""
+    match expr:
+        case Not(operand):
+            return frozenset((Not,)) | filter_nodes(operand)
+        case And(operands) | Or(operands):
+            return frozenset((type(expr),)).union(*(filter_nodes(o) for o in operands))
+        case Equals() | NotEquals() | Ordering() | In() | IsMissing():
+            return frozenset((type(expr),))
+
+
+def conjoin(clauses: Iterable[FilterExpr | None]) -> FilterExpr | None:
+    """The conjunction of the given clauses; None when there are none."""
+    operands = tuple(clause for clause in clauses if clause is not None)
+    if not operands:
+        return None
+    if len(operands) == 1:
+        return operands[0]
+    return And(operands)
+
+
+def conjuncts(expr: FilterExpr | None) -> list[FilterExpr]:
+    """The top-level conjuncts of a tree, with nested conjunctions flattened."""
+    if expr is None:
+        return []
+    if isinstance(expr, And):
+        return [conjunct for o in expr.operands for conjunct in conjuncts(o)]
+    return [expr]
+
+
+def split_declared(
+    expr: FilterExpr | None, declared: Collection[str]
+) -> tuple[FilterExpr | None, FilterExpr | None]:
+    """
+    Split a tree into the conjuncts naming declared fields only, and the rest.
+
+    A conjunct is declared when every field it names is in `declared`; a
+    disjunction or negation that mixes declared and undeclared fields is
+    undeclared as a whole, since no part of it can be evaluated alone.
+    """
+    declared_part: list[FilterExpr] = []
+    undeclared_part: list[FilterExpr] = []
+    for conjunct in conjuncts(expr):
+        if filter_fields(conjunct) <= frozenset(declared):
+            declared_part.append(conjunct)
+        else:
+            undeclared_part.append(conjunct)
+    return conjoin(declared_part), conjoin(undeclared_part)

--- a/packages/server/src/memmachine_server/common/filter/filter_parser.py
+++ b/packages/server/src/memmachine_server/common/filter/filter_parser.py
@@ -1,109 +1,33 @@
-"""Module for parsing filter strings into dictionaries."""
+"""
+The server's textual filter language, parsed into filter expression trees.
+
+The HTTP API still speaks this language, so the parser stays as the server's
+translation into the tree in `filter_expression`; the tree is what every
+store compiles, and nothing below the API boundary parses text.
+"""
 
 import re
-from collections.abc import Callable
-from dataclasses import dataclass
-from datetime import UTC, datetime
-from typing import Literal, NamedTuple, Protocol, cast, runtime_checkable
+from datetime import datetime
+from typing import NamedTuple, cast
 
-from memmachine_server.common.data_types import PropertyValue
-from memmachine_server.common.utils import ensure_tz_aware
+from memmachine_server.common.data_types import OrderedValue, PropertyValue
+
+from .filter_expression import (
+    And,
+    Equals,
+    FilterExpr,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
+    OrderingOp,
+)
 
 
 class FilterParseError(ValueError):
     """Raised when the textual filter specification is invalid."""
-
-
-@runtime_checkable
-class FilterExpr(Protocol):
-    """Marker protocol for filter expression nodes.
-
-    A value-carrying node normalizes datetime values to UTC-aware
-    instants at construction (naive means UTC); compilers rely on this
-    and bind instants without re-normalizing.
-    """
-
-
-ComparisonOp = Literal["=", "!=", ">", "<", ">=", "<="]
-
-
-@dataclass(frozen=True)
-class Comparison(FilterExpr):
-    """Scalar comparison of a field against a value."""
-
-    field: str
-    op: ComparisonOp
-    value: PropertyValue
-
-    def __post_init__(self) -> None:
-        """Normalize a datetime value to a UTC-aware instant.
-
-        The filter language defines datetime semantics: a value denotes
-        an instant, and a naive value means UTC. Normalizing at node
-        construction hands every consumer -- parsed and programmatically
-        built trees alike -- UTC-aware instants; compilers only choose a
-        representation.
-        """
-        if isinstance(self.value, datetime):
-            object.__setattr__(
-                self, "value", ensure_tz_aware(self.value).astimezone(UTC)
-            )
-
-
-@dataclass(frozen=True)
-class In(FilterExpr):
-    """Membership test of a field against a list of values."""
-
-    field: str
-    values: list[int] | list[str]
-
-    def __post_init__(self) -> None:
-        """Defensively normalize datetime members to UTC-aware instants.
-
-        The declared value types exclude datetimes, but runtime lists
-        are unchecked.
-        """
-        if any(isinstance(value, datetime) for value in self.values):
-            object.__setattr__(
-                self,
-                "values",
-                [
-                    ensure_tz_aware(value).astimezone(UTC)
-                    if isinstance(value, datetime)
-                    else value
-                    for value in self.values
-                ],
-            )
-
-
-@dataclass(frozen=True)
-class IsNull(FilterExpr):
-    """Nullity check on a field (field IS NULL)."""
-
-    field: str
-
-
-@dataclass(frozen=True)
-class And(FilterExpr):
-    """Logical conjunction of two filter expressions."""
-
-    left: FilterExpr
-    right: FilterExpr
-
-
-@dataclass(frozen=True)
-class Or(FilterExpr):
-    """Logical disjunction of two filter expressions."""
-
-    left: FilterExpr
-    right: FilterExpr
-
-
-@dataclass(frozen=True)
-class Not(FilterExpr):
-    """Logical negation of a filter expression."""
-
-    expr: FilterExpr
 
 
 class Token(NamedTuple):
@@ -162,9 +86,7 @@ def _tokenize(s: str) -> list[Token]:
     return tokens
 
 
-_SCALAR_OPS: dict[str, ComparisonOp] = {
-    "EQ": "=",
-    "NE": "!=",
+_ORDERING_OPS: dict[str, OrderingOp] = {
     "GE": ">=",
     "LE": "<=",
     "GT": ">",
@@ -218,10 +140,14 @@ class _Parser:
 
             self.pos += 1
             rhs = self._parse_expression(prec + 1)
+            # A chain of one operator is one n-ary node, so the tree's shape
+            # does not depend on how the text happened to group it.
             if tok.type == "AND":
-                expr = And(left=expr, right=rhs)
+                left = expr.operands if isinstance(expr, And) else (expr,)
+                expr = And((*left, rhs))
             else:
-                expr = Or(left=expr, right=rhs)
+                left = expr.operands if isinstance(expr, Or) else (expr,)
+                expr = Or((*left, rhs))
 
         return expr
 
@@ -231,7 +157,7 @@ class _Parser:
             self._expect("RPAREN")
             return expr
         if self._accept("NOT"):
-            return Not(expr=self._parse_primary())
+            return Not(self._parse_primary())
         return self._parse_predicate()
 
     def _parse_predicate(self) -> FilterExpr:
@@ -242,17 +168,20 @@ class _Parser:
         field_tok = self._expect("IDENT")
         field = field_tok.value
 
-        op_tok = self._accept("EQ", "NE", "GE", "LE", "GT", "LT")
+        if self._accept("EQ"):
+            return Equals(field, self._parse_value())
+        if self._accept("NE"):
+            return NotEquals(field, self._parse_value())
+        op_tok = self._accept("GE", "LE", "GT", "LT")
         if op_tok:
-            value = self._parse_value()
-            return Comparison(field=field, op=_SCALAR_OPS[op_tok.type], value=value)
+            return Ordering(field, _ORDERING_OPS[op_tok.type], self._parse_ordered())
 
         # IN / NOT IN
         negate = self._accept("NOT") is not None
         if self._accept("IN"):
             values = self._parse_value_list()
-            expr: FilterExpr = In(field=field, values=values)
-            return Not(expr=expr) if negate else expr
+            expr: FilterExpr = In(field, values)
+            return Not(expr) if negate else expr
         if negate:
             raise FilterParseError(f"Expected IN after NOT for field {field}")
 
@@ -264,8 +193,8 @@ class _Parser:
                 raise FilterParseError(
                     "Expected NULL after IS/IS NOT",
                 )
-            expr = IsNull(field=field)
-            return Not(expr=expr) if negate else expr
+            expr = IsMissing(field)
+            return Not(expr) if negate else expr
 
         raise FilterParseError(
             f"Expected operator after field {field}: "
@@ -273,16 +202,16 @@ class _Parser:
             "membership (IN, NOT IN), or nullity (IS NULL, IS NOT NULL)"
         )
 
-    def _parse_value_list(self) -> list[int] | list[str]:
+    def _parse_value_list(self) -> tuple[int, ...] | tuple[str, ...]:
         self._expect("LPAREN")
         raw: list[int | str] = [self._parse_in_value()]
         while self._accept("COMMA"):
             raw.append(self._parse_in_value())
         self._expect("RPAREN")
         if all(isinstance(v, int) for v in raw):
-            return cast(list[int], raw)
+            return tuple(cast(list[int], raw))
         if all(isinstance(v, str) for v in raw):
-            return cast(list[str], raw)
+            return tuple(cast(list[str], raw))
         raise FilterParseError(
             "Mixed types in IN list: all values must be int or all str"
         )
@@ -293,6 +222,16 @@ class _Parser:
         if isinstance(value, bool) or not isinstance(value, int | str):
             raise FilterParseError(
                 f"IN lists only support int and str values, got {type(value).__name__}"
+            )
+        return value
+
+    def _parse_ordered(self) -> OrderedValue:
+        """Parse the value of an ordering comparison: a number or a date."""
+        value = self._parse_value()
+        if isinstance(value, bool) or not isinstance(value, int | float | datetime):
+            raise FilterParseError(
+                "Ordering comparisons (>, <, >=, <=) take a number or a date(), "
+                f"got {type(value).__name__}"
             )
         return value
 
@@ -371,32 +310,6 @@ def is_user_metadata_key(candidate_key: str) -> bool:
     return candidate_key.startswith(USER_METADATA_STORAGE_PREFIX)
 
 
-def map_filter_fields(
-    expr: FilterExpr,
-    transform: Callable[[str], str],
-) -> FilterExpr:
-    """Apply a field name transformation to all fields in a FilterExpr tree."""
-    if isinstance(expr, Comparison):
-        return Comparison(field=transform(expr.field), op=expr.op, value=expr.value)
-    if isinstance(expr, In):
-        return In(field=transform(expr.field), values=expr.values)
-    if isinstance(expr, IsNull):
-        return IsNull(field=transform(expr.field))
-    if isinstance(expr, And):
-        return And(
-            left=map_filter_fields(expr.left, transform),
-            right=map_filter_fields(expr.right, transform),
-        )
-    if isinstance(expr, Or):
-        return Or(
-            left=map_filter_fields(expr.left, transform),
-            right=map_filter_fields(expr.right, transform),
-        )
-    if isinstance(expr, Not):
-        return Not(expr=map_filter_fields(expr.expr, transform))
-    raise TypeError(f"Unsupported filter expression type: {type(expr)!r}")
-
-
 def parse_filter(spec: str | None) -> FilterExpr | None:
     """Parse the given textual filter specification."""
     if spec is None:
@@ -415,28 +328,23 @@ def to_property_filter(
     if expr is None:
         return None
 
-    comparisons = _flatten_conjunction(expr)
-    if not comparisons:
+    equalities = _flatten_conjunction(expr)
+    if not equalities:
         return None
 
-    property_filter: dict[str, PropertyValue | None] = {}
-    for comp in comparisons:
-        if comp.op != "=":
-            raise TypeError(
-                f"Legacy property filters only support '=' comparisons, not {comp.op}",
-            )
-        property_filter[comp.field] = comp.value
-    return property_filter
+    return {equality.field: equality.value for equality in equalities}
 
 
-def _flatten_conjunction(expr: FilterExpr) -> list[Comparison]:
-    if isinstance(expr, Comparison):
+def _flatten_conjunction(expr: FilterExpr) -> list[Equals]:
+    if isinstance(expr, Equals):
         return [expr]
     if isinstance(expr, And):
-        flattened: list[Comparison] = []
-        flattened.extend(_flatten_conjunction(expr.left))
-        flattened.extend(_flatten_conjunction(expr.right))
-        return flattened
+        return [
+            equality
+            for operand in expr.operands
+            for equality in _flatten_conjunction(operand)
+        ]
     raise TypeError(
-        "Legacy property filters only support AND expressions made of simple comparisons",
+        "Legacy property filters only support AND expressions made of simple "
+        "equality comparisons",
     )

--- a/packages/server/src/memmachine_server/common/filter/sql_filter_util.py
+++ b/packages/server/src/memmachine_server/common/filter/sql_filter_util.py
@@ -11,26 +11,32 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Literal
 
-from sqlalchemy import ColumnElement, and_, false, or_
+from sqlalchemy import ColumnElement, and_, or_
 
 from memmachine_server.common.data_types import (
     PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME,
     PropertyValue,
-)
-from memmachine_server.common.filter.filter_parser import (
-    And,
-    Comparison,
-    FilterExpr,
-    In,
-    IsNull,
-    Not,
-    Or,
 )
 from memmachine_server.common.properties_json import (
     PROPERTY_TYPE_KEY,
     PROPERTY_VALUE_KEY,
 )
 from memmachine_server.common.utils import ensure_tz_aware
+
+from .filter_expression import (
+    And,
+    Equals,
+    FilterExpr,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
+    OrderingOp,
+)
+
+type _LeafExpr = Equals | NotEquals | Ordering | In | IsMissing
 
 FieldEncoding = Literal["column", "json", "properties_json"]
 
@@ -45,9 +51,9 @@ Raises `ValueError` for unrecognised fields.
 """
 
 
-_COMPARISON_OPS: dict[str, Callable[[ColumnElement, object], ColumnElement[bool]]] = {
-    "=": lambda col, val: col == val,
-    "!=": lambda col, val: col != val,
+ORDERING_OPS: dict[
+    OrderingOp, Callable[[ColumnElement, object], ColumnElement[bool]]
+] = {
     ">": lambda col, val: col > val,
     "<": lambda col, val: col < val,
     ">=": lambda col, val: col >= val,
@@ -55,24 +61,21 @@ _COMPARISON_OPS: dict[str, Callable[[ColumnElement, object], ColumnElement[bool]
 }
 
 
-def _get_op(op: str) -> Callable[[ColumnElement, object], ColumnElement[bool]]:
-    op_fn = _COMPARISON_OPS.get(op)
-    if op_fn is None:
-        raise ValueError(f"Unsupported operator: {op!r}")
-    return op_fn
-
-
 def _compile_column_leaf(
-    expr: IsNull | In | Comparison,
+    expr: _LeafExpr,
     column: ColumnElement,
 ) -> ColumnElement[bool]:
-    if isinstance(expr, IsNull):
-        return column.is_(None)
-    if isinstance(expr, In):
-        if not expr.values:
-            return false()
-        return column.in_(expr.values)
-    return _get_op(expr.op)(column, expr.value)
+    match expr:
+        case IsMissing():
+            return column.is_(None)
+        case In(values=values):
+            return column.in_(values)
+        case Equals(value=value):
+            return column == value
+        case NotEquals(value=value):
+            return column != value
+        case Ordering(op=op, value=value):
+            return ORDERING_OPS[op](column, value)
 
 
 def _cast_json_value(
@@ -100,22 +103,24 @@ def _check_json_value(value: PropertyValue) -> bool | int | float | str:
 
 
 def _compile_json_leaf(
-    expr: IsNull | In | Comparison,
+    expr: _LeafExpr,
     column: ColumnElement,
 ) -> ColumnElement[bool]:
-    if isinstance(expr, IsNull):
-        # .as_string() emits ->> instead of JSON_QUOTE(JSON_EXTRACT(...)),
-        # which preserves SQL NULL for missing keys on SQLite.
-        return column.as_string().is_(None)
-    if isinstance(expr, In):
-        if not expr.values:
-            return false()
-        return _cast_json_value(column, _check_json_value(expr.values[0])).in_(
-            expr.values
-        )
-    return _get_op(expr.op)(
-        _cast_json_value(column, _check_json_value(expr.value)), expr.value
-    )
+    match expr:
+        case IsMissing():
+            # .as_string() emits ->> instead of JSON_QUOTE(JSON_EXTRACT(...)),
+            # which preserves SQL NULL for missing keys on SQLite.
+            return column.as_string().is_(None)
+        case In(values=values):
+            return _cast_json_value(column, values[0]).in_(values)
+        case Equals(value=value):
+            return _cast_json_value(column, _check_json_value(value)) == value
+        case NotEquals(value=value):
+            return _cast_json_value(column, _check_json_value(value)) != value
+        case Ordering(op=op, value=value):
+            return ORDERING_OPS[op](
+                _cast_json_value(column, _check_json_value(value)), value
+            )
 
 
 def _cast_properties_json_value(
@@ -134,43 +139,45 @@ def _cast_properties_json_value(
             value_path.as_string(),
             ensure_tz_aware(value).astimezone(UTC).isoformat(),
         )
-    if isinstance(value, str):
-        return value_path.as_string(), value
-    raise TypeError(f"Unsupported property value type: {type(value)!r}")
+    return value_path.as_string(), value
+
+
+def _properties_json_type_check(
+    column: ColumnElement,
+    property_type: type[PropertyValue],
+) -> ColumnElement[bool]:
+    """Restrict a typed-JSON field to values stored with the given type."""
+    type_name = PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[property_type]
+    return column[PROPERTY_TYPE_KEY].as_string() == type_name
 
 
 def _compile_properties_json_leaf(
-    expr: IsNull | In | Comparison,
+    expr: _LeafExpr,
     column: ColumnElement,
 ) -> ColumnElement[bool]:
-    if isinstance(expr, IsNull):
-        return column.as_string().is_(None)
-
-    if isinstance(expr, In):
-        if not expr.values:
-            return false()
-        first_value = expr.values[0]
-        type_name = PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[type(first_value)]
-        value_path = column[PROPERTY_VALUE_KEY]
-        type_check = column[PROPERTY_TYPE_KEY].as_string() == type_name
-        # One cast-and-normalize rule for both leaf shapes: every member
-        # is cast and normalized the way a Comparison value would be, and
-        # the column takes the first member's cast.
-        casts = [
-            _cast_properties_json_value(value_path, value) for value in expr.values
-        ]
-        casted_column = casts[0][0]
-        normalized_values = [normalized for _, normalized in casts]
-        return and_(type_check, casted_column.in_(normalized_values))
-
-    # Comparison
-    type_name = PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[type(expr.value)]
-    value_path = column[PROPERTY_VALUE_KEY]
-    type_check = column[PROPERTY_TYPE_KEY].as_string() == type_name
-    casted_column, normalized_value = _cast_properties_json_value(
-        value_path, expr.value
-    )
-    return and_(type_check, _get_op(expr.op)(casted_column, normalized_value))
+    match expr:
+        case IsMissing():
+            return column.as_string().is_(None)
+        case In(values=values):
+            # Values are homogeneous, so the first one names the type for all.
+            type_check = _properties_json_type_check(column, type(values[0]))
+            value_path = column[PROPERTY_VALUE_KEY]
+            if isinstance(values[0], int):
+                return and_(type_check, value_path.as_integer().in_(values))
+            return and_(type_check, value_path.as_string().in_(values))
+        case Equals(value=value) | NotEquals(value=value) | Ordering(value=value):
+            type_check = _properties_json_type_check(column, type(value))
+            casted_column, normalized_value = _cast_properties_json_value(
+                column[PROPERTY_VALUE_KEY], value
+            )
+            match expr:
+                case Equals():
+                    comparison = casted_column == normalized_value
+                case NotEquals():
+                    comparison = casted_column != normalized_value
+                case Ordering(op=op):
+                    comparison = ORDERING_OPS[op](casted_column, normalized_value)
+            return and_(type_check, comparison)
 
 
 def compile_sql_filter(
@@ -183,34 +190,23 @@ def compile_sql_filter(
     The `resolve_field` callback maps each field name to a
     `(column, FieldEncoding)` pair and raises `ValueError` for unknown fields.
 
-    Datetime values arrive already normalized -- `Comparison`/`In` nodes
-    convert them to UTC-aware instants at construction -- so
-    column-encoded leaves bind them as-is, and the JSON-text encodings
-    only choose a representation.
+    Datetime values arrive already normalized -- a node converts them to
+    UTC-aware instants at construction -- so column-encoded leaves bind them
+    as-is, and the JSON-text encodings only choose a representation.
     """
-    if isinstance(expr, Comparison | In | IsNull):
-        column, kind = resolve_field(expr.field)
-        if kind == "column":
-            return _compile_column_leaf(expr, column)
-        if kind == "json":
-            return _compile_json_leaf(expr, column)
-        if kind == "properties_json":
-            return _compile_properties_json_leaf(expr, column)
-        raise ValueError(f"Unknown field kind: {kind!r}")
-
-    if isinstance(expr, And):
-        return and_(
-            compile_sql_filter(expr.left, resolve_field),
-            compile_sql_filter(expr.right, resolve_field),
-        )
-
-    if isinstance(expr, Or):
-        return or_(
-            compile_sql_filter(expr.left, resolve_field),
-            compile_sql_filter(expr.right, resolve_field),
-        )
-
-    if isinstance(expr, Not):
-        return ~compile_sql_filter(expr.expr, resolve_field)
-
-    raise TypeError(f"Unsupported filter expression type: {type(expr)!r}")
+    match expr:
+        case Equals() | NotEquals() | Ordering() | In() | IsMissing():
+            column, kind = resolve_field(expr.field)
+            match kind:
+                case "column":
+                    return _compile_column_leaf(expr, column)
+                case "json":
+                    return _compile_json_leaf(expr, column)
+                case "properties_json":
+                    return _compile_properties_json_leaf(expr, column)
+        case And(operands):
+            return and_(*(compile_sql_filter(o, resolve_field) for o in operands))
+        case Or(operands):
+            return or_(*(compile_sql_filter(o, resolve_field) for o in operands))
+        case Not(operand):
+            return ~compile_sql_filter(operand, resolve_field)

--- a/packages/server/src/memmachine_server/common/property_keys.py
+++ b/packages/server/src/memmachine_server/common/property_keys.py
@@ -1,0 +1,73 @@
+"""
+Ownership of the MemMachine property key namespace.
+
+Property keys are shared between callers and MemMachine itself: a caller names
+its own metadata, and each memory system needs somewhere to put the fields it
+maintains. Keys beginning with `RESERVED_PROPERTY_KEY_PREFIX` belong to
+MemMachine; everything else belongs to the caller.
+
+The prefix is the distribution name, so its uniqueness is enforced by the
+package registry rather than assumed, and memory systems subdivide within it --
+`memmachine_event_timestamp`, `memmachine_<system>_<field>` -- rather than each
+reserving a further prefix from the caller.
+
+Build reserved keys with `reserved_property_key` rather than by concatenation:
+the alphabet and length available to a key are set by the vector store's naming
+contract, and the budget is easy to overrun once a prefix and a system name are
+spent.
+"""
+
+from typing import Final
+
+from memmachine_server.common.vector_store.utils import validate_identifier
+
+RESERVED_PROPERTY_KEY_PREFIX: Final[str] = "memmachine_"
+
+
+def is_reserved_property_key(key: str) -> bool:
+    """Return whether `key` belongs to MemMachine rather than to the caller."""
+    return key.startswith(RESERVED_PROPERTY_KEY_PREFIX)
+
+
+def reserved_property_key(system: str, field: str) -> str:
+    """
+    Build the reserved property key naming `field` of `system`.
+
+    Raises ValueError if the result does not satisfy the vector store's naming
+    contract, which is how a prefix plus a system name overrunning the length
+    budget is caught at import time rather than at first write.
+    """
+    key = f"{RESERVED_PROPERTY_KEY_PREFIX}{system}_{field}"
+    if not validate_identifier(key):
+        raise ValueError(
+            f"Reserved property key {key!r} ({len(key.encode())} bytes) does not "
+            f"satisfy the vector store naming contract: [a-z0-9_], at most 32 bytes."
+        )
+    return key
+
+
+def validate_caller_property_key(key: str) -> None:
+    """
+    Raise ValueError unless `key` is a legal caller-supplied property key.
+
+    A caller key must satisfy the vector store's naming contract -- `[a-z0-9_]`,
+    at most 32 bytes -- and must not fall in MemMachine's reserved namespace.
+    Keys are stored and filtered exactly as given: MemMachine never rewrites,
+    prefixes, or encodes them, so the key a caller writes is the key it filters
+    on, and an illegal key is rejected rather than repaired.
+
+    Properties are the only filterable surface, and they are stored in the
+    clear. An event's context and block go through the payload codec and are
+    never filterable, so choosing which data is safe to expose as a property is
+    the application's decision: to filter on provenance, project it into a
+    property rather than expecting `context` to be reachable.
+    """
+    if is_reserved_property_key(key):
+        raise ValueError(
+            f"Property key {key!r} is reserved: keys beginning with "
+            f"{RESERVED_PROPERTY_KEY_PREFIX!r} belong to MemMachine."
+        )
+    if not validate_identifier(key):
+        raise ValueError(
+            f"Property key {key!r} must match [a-z0-9_] and be at most 32 bytes."
+        )

--- a/packages/server/src/memmachine_server/common/resource_manager/__init__.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/__init__.py
@@ -1,10 +1,12 @@
 """Protocols for accessing shared MemMachine resources."""
 
+from collections.abc import Mapping
 from typing import Protocol, runtime_checkable
 
 from neo4j import AsyncDriver
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from memmachine_server.common.data_types import PropertyType
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.episode_store import EpisodeStorage
 from memmachine_server.common.language_model import LanguageModel
@@ -44,8 +46,10 @@ class CommonResourceManager(Protocol):
         """Return the vector graph store by name."""
         raise NotImplementedError
 
-    async def get_vector_store(self, name: str) -> VectorStore:
-        """Return the vector store by name."""
+    async def get_vector_store(
+        self, name: str, *, indexed_properties: Mapping[str, PropertyType]
+    ) -> VectorStore:
+        """Return the vector store by name, built for the service declaring these keys."""
         raise NotImplementedError
 
     async def get_segment_store(self, name: str) -> SegmentStore:

--- a/packages/server/src/memmachine_server/common/resource_manager/__init__.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/__init__.py
@@ -47,9 +47,14 @@ class CommonResourceManager(Protocol):
         raise NotImplementedError
 
     async def get_vector_store(
-        self, name: str, *, indexed_properties: Mapping[str, PropertyType]
+        self,
+        backend: str,
+        *,
+        collection: str,
+        vector_dimensions: int,
+        indexed_properties: Mapping[str, PropertyType],
     ) -> VectorStore:
-        """Return the vector store by name, built for the service declaring these keys."""
+        """Return the store for one collection on a configured backend."""
         raise NotImplementedError
 
     async def get_segment_store(self, name: str) -> SegmentStore:

--- a/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
@@ -3,10 +3,11 @@
 import asyncio
 import logging
 from asyncio import Lock
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, Self
 
 from neo4j import AsyncDriver, AsyncGraphDatabase
+from pydantic import TypeAdapter, ValidationError
 from sqlalchemy import event, text
 from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
@@ -14,10 +15,17 @@ from sqlalchemy.pool import ConnectionPoolEntry
 
 from memmachine_server.common.configuration.database_conf import (
     DatabasesConf,
+    MilvusConf,
     Neo4jConf,
+    QdrantConf,
     SqlAlchemyConf,
     SQLiteVectorStoreConf,
     SQLiteVectorStoreEngine,
+    SQLiteVecVectorStoreConf,
+)
+from memmachine_server.common.data_types import (
+    PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME,
+    PropertyType,
 )
 from memmachine_server.common.errors import (
     MilvusConfigurationError,
@@ -31,7 +39,7 @@ from memmachine_server.common.vector_graph_store.neo4j_vector_graph_store import
     Neo4jVectorGraphStore,
     Neo4jVectorGraphStoreParams,
 )
-from memmachine_server.common.vector_store import VectorStore
+from memmachine_server.common.vector_store import IndexedProperties, VectorStore
 from memmachine_server.common.vector_store.vector_search_engine import (
     VectorSearchEngine,
 )
@@ -45,6 +53,8 @@ if TYPE_CHECKING:
     from qdrant_client import AsyncQdrantClient
 
 logger = logging.getLogger(__name__)
+
+_INDEXED_PROPERTIES = TypeAdapter(IndexedProperties)
 
 
 def enable_sqlite_foreign_keys(engine: AsyncEngine) -> None:
@@ -147,23 +157,9 @@ class DatabaseManager:
             self.async_get_milvus_client(name, validate=validate)
             for name in self.conf.milvus_confs
         ]
-        sqlite_vs_tasks = [
-            self.async_get_sqlite_vector_store(name)
-            for name in self.conf.sqlite_vector_store_confs
-        ]
-        sqlite_vec_vs_tasks = [
-            self.async_get_sqlite_vec_vector_store(name)
-            for name in self.conf.sqlite_vec_vector_store_confs
-        ]
         # Lazy build will occur in get_* calls, but build_all can trigger them
         tasks = (
-            neo4j_tasks
-            + relation_db_tasks
-            + nebula_tasks
-            + qdrant_tasks
-            + milvus_tasks
-            + sqlite_vs_tasks
-            + sqlite_vec_vs_tasks
+            neo4j_tasks + relation_db_tasks + nebula_tasks + qdrant_tasks + milvus_tasks
         )
         await asyncio.gather(*tasks)
 
@@ -576,6 +572,98 @@ class DatabaseManager:
         for name, client in self.nebula_clients.items():
             await self.validate_nebula_client(name, client)
 
+    # --- Vector stores ---
+
+    async def get_vector_store(
+        self, name: str, *, indexed_properties: Mapping[str, PropertyType]
+    ) -> VectorStore:
+        """Return a vector store by name, built for the service declaring these keys.
+
+        The schema a store is built with is its configured user keys plus the
+        system keys of the one service that uses it, merged here on first
+        use. Services do not share a vector store: a later request whose keys
+        the store does not declare raises `VectorStoreConfigurationError`.
+        """
+        if name not in self._vector_store_locks:
+            async with self._lock:
+                self._vector_store_locks.setdefault(name, Lock())
+
+        async with self._vector_store_locks[name]:
+            store = self.vector_stores.get(name)
+            if store is None:
+                store = await self._build_vector_store(name, indexed_properties)
+                self.vector_stores[name] = store
+                return store
+            for key, property_type in indexed_properties.items():
+                if store.indexed_properties.get(key) is not property_type:
+                    raise VectorStoreConfigurationError(
+                        f"VectorStore '{name}' was built for another service and does "
+                        f"not declare {key!r} as "
+                        f"{PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[property_type]}; "
+                        "services do not share a vector store, so give each its own."
+                    )
+            return store
+
+    async def _build_vector_store(
+        self, name: str, system_properties: Mapping[str, PropertyType]
+    ) -> VectorStore:
+        if name in self.conf.qdrant_confs:
+            conf = self.conf.qdrant_confs[name]
+            return await self._build_qdrant_store(
+                name, conf, self._declared_properties(name, conf, system_properties)
+            )
+        if name in self.conf.milvus_confs:
+            conf = self.conf.milvus_confs[name]
+            return await self._build_milvus_store(
+                name, conf, self._declared_properties(name, conf, system_properties)
+            )
+        if name in self.conf.sqlite_vector_store_confs:
+            conf = self.conf.sqlite_vector_store_confs[name]
+            return await self._build_sqlite_vector_store(
+                name, conf, self._declared_properties(name, conf, system_properties)
+            )
+        if name in self.conf.sqlite_vec_vector_store_confs:
+            conf = self.conf.sqlite_vec_vector_store_confs[name]
+            return await self._build_sqlite_vec_vector_store(
+                name, conf, self._declared_properties(name, conf, system_properties)
+            )
+        raise ValueError(f"VectorStore '{name}' not found")
+
+    @staticmethod
+    def _declared_properties(
+        name: str,
+        conf: QdrantConf
+        | MilvusConf
+        | SQLiteVectorStoreConf
+        | SQLiteVecVectorStoreConf,
+        system_properties: Mapping[str, PropertyType],
+    ) -> dict[str, PropertyType]:
+        """The configured user keys plus the service's system keys, typed."""
+        try:
+            declared = _INDEXED_PROPERTIES.validate_python(conf.indexed_properties)
+        except ValidationError as e:
+            raise VectorStoreConfigurationError(
+                f"VectorStore '{name}' has invalid indexed_properties: {e}"
+            ) from e
+        for key, property_type in system_properties.items():
+            configured = declared.get(key)
+            if configured is not None and configured is not property_type:
+                raise VectorStoreConfigurationError(
+                    f"VectorStore '{name}' configures {key!r} as "
+                    f"{PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[configured]}, but the "
+                    f"service writes it as "
+                    f"{PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[property_type]}."
+                )
+            declared[key] = property_type
+        return declared
+
+    @staticmethod
+    async def _shutdown_vector_store(name: str, vector_store: VectorStore) -> None:
+        try:
+            await vector_store.shutdown()
+        except Exception as ex:
+            logger.warning("Error shutting down VectorStore '%s': %s", name, ex)
+
     # --- Qdrant ---
 
     @staticmethod
@@ -611,6 +699,7 @@ class DatabaseManager:
                 "grpc_port": conf.grpc_port,
                 "prefer_grpc": conf.prefer_grpc,
                 "https": conf.https,
+                "timeout": conf.request_timeout,
             }
             if conf.api_key.get_secret_value():
                 client_kwargs["api_key"] = conf.api_key.get_secret_value()
@@ -620,28 +709,45 @@ class DatabaseManager:
             if validate:
                 await self.validate_qdrant_client(name, client)
 
-            from memmachine_server.common.vector_store.qdrant_vector_store import (
-                QdrantVectorStore,
-                QdrantVectorStoreParams,
-            )
-
-            params = QdrantVectorStoreParams(
-                client=client,
-                is_distributed=conf.is_distributed,
-                registry_replication_factor=conf.registry_replication_factor,
-                metrics_factory=conf.get_metrics_factory(),
-            )
-            try:
-                store = QdrantVectorStore(params)
-                await store.startup()
-            except Exception:
-                await client.close()
-                raise
-
             self.qdrant_clients[name] = client
-            self.vector_stores[name] = store
-
             return client
+
+    async def _build_qdrant_store(
+        self,
+        name: str,
+        conf: QdrantConf,
+        indexed_properties: Mapping[str, PropertyType],
+    ) -> VectorStore:
+        client = await self.async_get_qdrant_client(name, validate=True)
+
+        from memmachine_server.common.vector_store.qdrant_vector_store import (
+            QdrantVectorStore,
+            QdrantVectorStoreParams,
+        )
+
+        # QdrantConf carries the native index and quantization settings as
+        # plain mappings, so qdrant-client stays optional for config parsing;
+        # the params model validates them against qdrant's own models.
+        try:
+            params = QdrantVectorStoreParams.model_validate(
+                {
+                    "client": client,
+                    "is_distributed": conf.is_distributed,
+                    "registry_replication_factor": conf.registry_replication_factor,
+                    "indexed_properties": indexed_properties,
+                    "hnsw_config": conf.hnsw_config,
+                    "optimizers_config": conf.optimizers_config,
+                    "quantization_config": conf.quantization_config,
+                    "metrics_factory": conf.get_metrics_factory(),
+                }
+            )
+        except ValidationError as e:
+            raise QdrantConfigurationError(
+                f"Qdrant config '{name}' is invalid: {e}"
+            ) from e
+        store = QdrantVectorStore(params)
+        await store.startup()
+        return store
 
     @staticmethod
     async def validate_qdrant_client(name: str, client: "AsyncQdrantClient") -> None:
@@ -688,7 +794,10 @@ class DatabaseManager:
 
             from pymilvus import MilvusClient
 
-            client_kwargs: dict[str, Any] = {"uri": conf.uri}
+            client_kwargs: dict[str, Any] = {
+                "uri": conf.uri,
+                "timeout": conf.request_timeout,
+            }
             token = conf.token.get_secret_value()
             if token:
                 client_kwargs["token"] = token
@@ -700,26 +809,30 @@ class DatabaseManager:
             if validate:
                 await self.validate_milvus_client(name, client)
 
-            from memmachine_server.common.vector_store.milvus_vector_store import (
-                MilvusVectorStore,
-                MilvusVectorStoreParams,
-            )
-
-            params = MilvusVectorStoreParams(
-                client=client,
-                consistency_level=conf.consistency_level,
-            )
-            try:
-                store = MilvusVectorStore(params)
-                await store.startup()
-            except Exception:
-                await asyncio.to_thread(client.close)
-                raise
-
             self.milvus_clients[name] = client
-            self.vector_stores[name] = store
-
             return client
+
+    async def _build_milvus_store(
+        self,
+        name: str,
+        conf: MilvusConf,
+        indexed_properties: Mapping[str, PropertyType],
+    ) -> VectorStore:
+        client = await self.async_get_milvus_client(name, validate=True)
+
+        from memmachine_server.common.vector_store.milvus_vector_store import (
+            MilvusVectorStore,
+            MilvusVectorStoreParams,
+        )
+
+        params = MilvusVectorStoreParams(
+            client=client,
+            consistency_level=conf.consistency_level,
+            indexed_properties=indexed_properties,
+        )
+        store = MilvusVectorStore(params)
+        await store.startup()
+        return store
 
     @staticmethod
     async def validate_milvus_client(name: str, client: "MilvusClient") -> None:
@@ -740,13 +853,6 @@ class DatabaseManager:
             await self.validate_milvus_client(name, client)
 
     # --- SQLite-backed VectorStores ---
-
-    @staticmethod
-    async def _shutdown_vector_store(name: str, vector_store: VectorStore) -> None:
-        try:
-            await vector_store.shutdown()
-        except Exception as ex:
-            logger.warning("Error shutting down VectorStore '%s': %s", name, ex)
 
     @staticmethod
     def _make_sqlite_search_engine_factory(
@@ -777,96 +883,66 @@ class DatabaseManager:
 
                 return hnswlib_factory
 
-    async def async_get_sqlite_vector_store(self, name: str) -> VectorStore:
-        """Return a SQLiteVectorStore, creating it if necessary (lazy)."""
-        if name not in self._vector_store_locks:
-            async with self._lock:
-                self._vector_store_locks.setdefault(name, Lock())
+    async def _build_sqlite_vector_store(
+        self,
+        name: str,
+        conf: SQLiteVectorStoreConf,
+        indexed_properties: Mapping[str, PropertyType],
+    ) -> VectorStore:
+        from memmachine_server.common.vector_store.sqlite_vector_store import (
+            SQLiteVectorStore,
+            SQLiteVectorStoreParams,
+        )
 
-        async with self._vector_store_locks[name]:
-            if name in self.vector_stores:
-                return self.vector_stores[name]
+        engine = create_async_engine(f"sqlite+aiosqlite:///{conf.path}")
+        self.vector_store_sql_engines[name] = engine
 
-            conf = self.conf.sqlite_vector_store_confs.get(name)
-            if not conf:
-                raise ValueError(f"SQLiteVectorStore config '{name}' not found.")
-
-            from memmachine_server.common.vector_store.sqlite_vector_store import (
-                SQLiteVectorStore,
-                SQLiteVectorStoreParams,
-            )
-
-            engine = create_async_engine(f"sqlite+aiosqlite:///{conf.path}")
-            self.vector_store_sql_engines[name] = engine
-
-            try:
-                store = SQLiteVectorStore(
-                    SQLiteVectorStoreParams(
-                        sqlalchemy_engine=engine,
-                        vector_search_engine_factory=self._make_sqlite_search_engine_factory(
-                            conf
-                        ),
-                        index_directory=conf.index_directory,
-                        save_threshold=conf.save_threshold,
-                    )
+        try:
+            store = SQLiteVectorStore(
+                SQLiteVectorStoreParams(
+                    sqlalchemy_engine=engine,
+                    vector_search_engine_factory=self._make_sqlite_search_engine_factory(
+                        conf
+                    ),
+                    index_directory=conf.index_directory,
+                    save_threshold=conf.save_threshold,
+                    indexed_properties=indexed_properties,
                 )
-                await store.startup()
-            except Exception as e:
-                await engine.dispose()
-                self.vector_store_sql_engines.pop(name, None)
-                raise VectorStoreConfigurationError(
-                    f"SQLiteVectorStore '{name}' failed to start: {e}",
-                ) from e
-
-            self.vector_stores[name] = store
-            return store
-
-    async def async_get_sqlite_vec_vector_store(self, name: str) -> VectorStore:
-        """Return a SQLiteVecVectorStore, creating it if necessary (lazy)."""
-        if name not in self._vector_store_locks:
-            async with self._lock:
-                self._vector_store_locks.setdefault(name, Lock())
-
-        async with self._vector_store_locks[name]:
-            if name in self.vector_stores:
-                return self.vector_stores[name]
-
-            conf = self.conf.sqlite_vec_vector_store_confs.get(name)
-            if not conf:
-                raise ValueError(f"SQLiteVecVectorStore config '{name}' not found.")
-
-            from memmachine_server.common.vector_store.sqlite_vec_vector_store import (
-                SQLiteVecVectorStore,
-                SQLiteVecVectorStoreParams,
             )
+            await store.startup()
+        except Exception as e:
+            await engine.dispose()
+            self.vector_store_sql_engines.pop(name, None)
+            raise VectorStoreConfigurationError(
+                f"SQLiteVectorStore '{name}' failed to start: {e}",
+            ) from e
+        return store
 
-            engine = create_async_engine(f"sqlite+aiosqlite:///{conf.path}")
-            self.vector_store_sql_engines[name] = engine
+    async def _build_sqlite_vec_vector_store(
+        self,
+        name: str,
+        conf: SQLiteVecVectorStoreConf,
+        indexed_properties: Mapping[str, PropertyType],
+    ) -> VectorStore:
+        from memmachine_server.common.vector_store.sqlite_vec_vector_store import (
+            SQLiteVecVectorStore,
+            SQLiteVecVectorStoreParams,
+        )
 
-            try:
-                store = SQLiteVecVectorStore(SQLiteVecVectorStoreParams(engine=engine))
-                await store.startup()
-            except Exception as e:
-                await engine.dispose()
-                self.vector_store_sql_engines.pop(name, None)
-                raise VectorStoreConfigurationError(
-                    f"SQLiteVecVectorStore '{name}' failed to start: {e}",
-                ) from e
+        engine = create_async_engine(f"sqlite+aiosqlite:///{conf.path}")
+        self.vector_store_sql_engines[name] = engine
 
-            self.vector_stores[name] = store
-            return store
-
-    async def get_vector_store(self, name: str) -> VectorStore:
-        """Return a vector store by name, auto-detecting the backend."""
-        if name in self.conf.qdrant_confs:
-            await self.async_get_qdrant_client(name, validate=True)
-            return self.vector_stores[name]
-        if name in self.conf.milvus_confs:
-            await self.async_get_milvus_client(name, validate=True)
-            return self.vector_stores[name]
-        if name in self.conf.sqlite_vector_store_confs:
-            return await self.async_get_sqlite_vector_store(name)
-        if name in self.conf.sqlite_vec_vector_store_confs:
-            return await self.async_get_sqlite_vec_vector_store(name)
-
-        raise ValueError(f"VectorStore '{name}' not found")
+        try:
+            store = SQLiteVecVectorStore(
+                SQLiteVecVectorStoreParams(
+                    engine=engine, indexed_properties=indexed_properties
+                )
+            )
+            await store.startup()
+        except Exception as e:
+            await engine.dispose()
+            self.vector_store_sql_engines.pop(name, None)
+            raise VectorStoreConfigurationError(
+                f"SQLiteVecVectorStore '{name}' failed to start: {e}",
+            ) from e
+        return store

--- a/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/database_manager.py
@@ -113,7 +113,8 @@ class DatabaseManager:
         """Initialize with database configuration."""
         self.conf = conf
         self.graph_stores: dict[str, VectorGraphStore] = {}
-        self.vector_stores: dict[str, VectorStore] = {}
+        # One store per (backend, collection): a store is one collection.
+        self.vector_stores: dict[tuple[str, str], VectorStore] = {}
         self.sql_engines: dict[str, AsyncEngine] = {}
         self.neo4j_drivers: dict[str, AsyncDriver] = {}
         # String annotation "NebulaAsyncClient" (forward reference) because the type
@@ -133,7 +134,7 @@ class DatabaseManager:
         self._nebula_locks: dict[str, Lock] = {}
         self._qdrant_locks: dict[str, Lock] = {}
         self._milvus_locks: dict[str, Lock] = {}
-        self._vector_store_locks: dict[str, Lock] = {}
+        self._vector_store_locks: dict[tuple[str, str], Lock] = {}
 
     async def build_all(self, validate: bool = False) -> Self:
         """Optionally eagerly initialize all backends."""
@@ -190,8 +191,10 @@ class DatabaseManager:
                 tasks.append(self._close_qdrant_client(name, client))
             for name, client in self.milvus_clients.items():
                 tasks.append(self._close_milvus_client(name, client))
-            for name, vector_store in self.vector_stores.items():
-                tasks.append(self._shutdown_vector_store(name, vector_store))
+            for (backend, collection), vector_store in self.vector_stores.items():
+                tasks.append(
+                    self._shutdown_vector_store(f"{backend}/{collection}", vector_store)
+                )
             await asyncio.gather(*tasks)
             self.graph_stores.clear()
             self.vector_stores.clear()
@@ -575,59 +578,120 @@ class DatabaseManager:
     # --- Vector stores ---
 
     async def get_vector_store(
-        self, name: str, *, indexed_properties: Mapping[str, PropertyType]
+        self,
+        backend: str,
+        *,
+        collection: str,
+        vector_dimensions: int,
+        indexed_properties: Mapping[str, PropertyType],
     ) -> VectorStore:
-        """Return a vector store by name, built for the service declaring these keys.
+        """Return the store for one collection on a configured backend, building it on first use.
 
-        The schema a store is built with is its configured user keys plus the
-        system keys of the one service that uses it, merged here on first
-        use. Services do not share a vector store: a later request whose keys
-        the store does not declare raises `VectorStoreConfigurationError`.
+        A store is one collection: one native collection with one
+        dimensionality and one declared schema, the backend's configured user
+        keys plus the system keys of the service building it, merged here.
+        The collection name keeps stores on one backend apart; asking for the
+        same collection again with other dimensions or keys is a
+        configuration error.
         """
-        if name not in self._vector_store_locks:
+        key = (backend, collection)
+        if key not in self._vector_store_locks:
             async with self._lock:
-                self._vector_store_locks.setdefault(name, Lock())
+                self._vector_store_locks.setdefault(key, Lock())
 
-        async with self._vector_store_locks[name]:
-            store = self.vector_stores.get(name)
+        async with self._vector_store_locks[key]:
+            store = self.vector_stores.get(key)
             if store is None:
-                store = await self._build_vector_store(name, indexed_properties)
-                self.vector_stores[name] = store
+                store = await self._build_vector_store(
+                    backend, collection, vector_dimensions, indexed_properties
+                )
+                self.vector_stores[key] = store
                 return store
-            for key, property_type in indexed_properties.items():
-                if store.indexed_properties.get(key) is not property_type:
-                    raise VectorStoreConfigurationError(
-                        f"VectorStore '{name}' was built for another service and does "
-                        f"not declare {key!r} as "
-                        f"{PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[property_type]}; "
-                        "services do not share a vector store, so give each its own."
-                    )
+            declared = self._declared_properties(
+                backend, self._vector_store_conf(backend), indexed_properties
+            )
+            if (
+                store.vector_dimensions != vector_dimensions
+                or dict(store.indexed_properties) != declared
+            ):
+                raise VectorStoreConfigurationError(
+                    f"VectorStore '{backend}' collection {collection!r} was built "
+                    f"with {store.vector_dimensions} dimensions and keys "
+                    f"{sorted(store.indexed_properties)}, but is asked for "
+                    f"{vector_dimensions} dimensions and keys {sorted(declared)}; "
+                    "one collection is one store, so give the other service its "
+                    "own collection."
+                )
             return store
 
+    def _vector_store_conf(
+        self, backend: str
+    ) -> QdrantConf | MilvusConf | SQLiteVectorStoreConf | SQLiteVecVectorStoreConf:
+        for confs in (
+            self.conf.qdrant_confs,
+            self.conf.milvus_confs,
+            self.conf.sqlite_vector_store_confs,
+            self.conf.sqlite_vec_vector_store_confs,
+        ):
+            if backend in confs:
+                return confs[backend]
+        raise ValueError(f"VectorStore '{backend}' not found")
+
     async def _build_vector_store(
-        self, name: str, system_properties: Mapping[str, PropertyType]
+        self,
+        backend: str,
+        collection: str,
+        vector_dimensions: int,
+        system_properties: Mapping[str, PropertyType],
     ) -> VectorStore:
-        if name in self.conf.qdrant_confs:
-            conf = self.conf.qdrant_confs[name]
-            return await self._build_qdrant_store(
-                name, conf, self._declared_properties(name, conf, system_properties)
-            )
-        if name in self.conf.milvus_confs:
-            conf = self.conf.milvus_confs[name]
-            return await self._build_milvus_store(
-                name, conf, self._declared_properties(name, conf, system_properties)
-            )
-        if name in self.conf.sqlite_vector_store_confs:
-            conf = self.conf.sqlite_vector_store_confs[name]
-            return await self._build_sqlite_vector_store(
-                name, conf, self._declared_properties(name, conf, system_properties)
-            )
-        if name in self.conf.sqlite_vec_vector_store_confs:
-            conf = self.conf.sqlite_vec_vector_store_confs[name]
-            return await self._build_sqlite_vec_vector_store(
-                name, conf, self._declared_properties(name, conf, system_properties)
-            )
-        raise ValueError(f"VectorStore '{name}' not found")
+        conf = self._vector_store_conf(backend)
+        declared = self._declared_properties(backend, conf, system_properties)
+        match conf:
+            case QdrantConf():
+                store = await self._build_qdrant_store(
+                    backend, conf, collection, vector_dimensions, declared
+                )
+            case MilvusConf():
+                store = await self._build_milvus_store(
+                    backend, conf, collection, vector_dimensions, declared
+                )
+            case SQLiteVectorStoreConf():
+                store = await self._build_sqlite_vector_store(
+                    backend, conf, collection, vector_dimensions, declared
+                )
+            case SQLiteVecVectorStoreConf():
+                store = await self._build_sqlite_vec_vector_store(
+                    backend, conf, collection, vector_dimensions, declared
+                )
+        try:
+            # Provisioning is the schema command's once it exists; until then
+            # the composition root provisions the collection it builds.
+            await store.provision()
+            await store.startup()
+        except Exception as e:
+            await self._release_unused_vector_store_sql_engine(backend)
+            raise VectorStoreConfigurationError(
+                f"VectorStore '{backend}' collection {collection!r} failed to start: {e}",
+            ) from e
+        return store
+
+    def _vector_store_sql_engine(self, backend: str, path: str) -> AsyncEngine:
+        """The engine behind a SQLite-backed vector store backend, shared by its collections."""
+        engine = self.vector_store_sql_engines.get(backend)
+        if engine is None:
+            engine = create_async_engine(f"sqlite+aiosqlite:///{path}")
+            self.vector_store_sql_engines[backend] = engine
+        return engine
+
+    async def _release_unused_vector_store_sql_engine(self, backend: str) -> None:
+        """Dispose a SQLite backend's engine if no built store uses it."""
+        engine = self.vector_store_sql_engines.get(backend)
+        if engine is None:
+            return
+        if any(built_backend == backend for built_backend, _ in self.vector_stores):
+            return
+        await engine.dispose()
+        self.vector_store_sql_engines.pop(backend, None)
 
     @staticmethod
     def _declared_properties(
@@ -714,11 +778,13 @@ class DatabaseManager:
 
     async def _build_qdrant_store(
         self,
-        name: str,
+        backend: str,
         conf: QdrantConf,
+        collection: str,
+        vector_dimensions: int,
         indexed_properties: Mapping[str, PropertyType],
     ) -> VectorStore:
-        client = await self.async_get_qdrant_client(name, validate=True)
+        client = await self.async_get_qdrant_client(backend, validate=True)
 
         from memmachine_server.common.vector_store.qdrant_vector_store import (
             QdrantVectorStore,
@@ -732,6 +798,8 @@ class DatabaseManager:
             params = QdrantVectorStoreParams.model_validate(
                 {
                     "client": client,
+                    "collection": collection,
+                    "vector_dimensions": vector_dimensions,
                     "is_distributed": conf.is_distributed,
                     "registry_replication_factor": conf.registry_replication_factor,
                     "indexed_properties": indexed_properties,
@@ -743,11 +811,9 @@ class DatabaseManager:
             )
         except ValidationError as e:
             raise QdrantConfigurationError(
-                f"Qdrant config '{name}' is invalid: {e}"
+                f"Qdrant config '{backend}' is invalid: {e}"
             ) from e
-        store = QdrantVectorStore(params)
-        await store.startup()
-        return store
+        return QdrantVectorStore(params)
 
     @staticmethod
     async def validate_qdrant_client(name: str, client: "AsyncQdrantClient") -> None:
@@ -814,25 +880,28 @@ class DatabaseManager:
 
     async def _build_milvus_store(
         self,
-        name: str,
+        backend: str,
         conf: MilvusConf,
+        collection: str,
+        vector_dimensions: int,
         indexed_properties: Mapping[str, PropertyType],
     ) -> VectorStore:
-        client = await self.async_get_milvus_client(name, validate=True)
+        client = await self.async_get_milvus_client(backend, validate=True)
 
         from memmachine_server.common.vector_store.milvus_vector_store import (
             MilvusVectorStore,
             MilvusVectorStoreParams,
         )
 
-        params = MilvusVectorStoreParams(
-            client=client,
-            consistency_level=conf.consistency_level,
-            indexed_properties=indexed_properties,
+        return MilvusVectorStore(
+            MilvusVectorStoreParams(
+                client=client,
+                collection=collection,
+                vector_dimensions=vector_dimensions,
+                consistency_level=conf.consistency_level,
+                indexed_properties=indexed_properties,
+            )
         )
-        store = MilvusVectorStore(params)
-        await store.startup()
-        return store
 
     @staticmethod
     async def validate_milvus_client(name: str, client: "MilvusClient") -> None:
@@ -885,8 +954,10 @@ class DatabaseManager:
 
     async def _build_sqlite_vector_store(
         self,
-        name: str,
+        backend: str,
         conf: SQLiteVectorStoreConf,
+        collection: str,
+        vector_dimensions: int,
         indexed_properties: Mapping[str, PropertyType],
     ) -> VectorStore:
         from memmachine_server.common.vector_store.sqlite_vector_store import (
@@ -894,34 +965,26 @@ class DatabaseManager:
             SQLiteVectorStoreParams,
         )
 
-        engine = create_async_engine(f"sqlite+aiosqlite:///{conf.path}")
-        self.vector_store_sql_engines[name] = engine
-
-        try:
-            store = SQLiteVectorStore(
-                SQLiteVectorStoreParams(
-                    sqlalchemy_engine=engine,
-                    vector_search_engine_factory=self._make_sqlite_search_engine_factory(
-                        conf
-                    ),
-                    index_directory=conf.index_directory,
-                    save_threshold=conf.save_threshold,
-                    indexed_properties=indexed_properties,
-                )
+        return SQLiteVectorStore(
+            SQLiteVectorStoreParams(
+                sqlalchemy_engine=self._vector_store_sql_engine(backend, conf.path),
+                collection=collection,
+                vector_dimensions=vector_dimensions,
+                indexed_properties=indexed_properties,
+                vector_search_engine_factory=self._make_sqlite_search_engine_factory(
+                    conf
+                ),
+                index_directory=conf.index_directory,
+                save_threshold=conf.save_threshold,
             )
-            await store.startup()
-        except Exception as e:
-            await engine.dispose()
-            self.vector_store_sql_engines.pop(name, None)
-            raise VectorStoreConfigurationError(
-                f"SQLiteVectorStore '{name}' failed to start: {e}",
-            ) from e
-        return store
+        )
 
     async def _build_sqlite_vec_vector_store(
         self,
-        name: str,
+        backend: str,
         conf: SQLiteVecVectorStoreConf,
+        collection: str,
+        vector_dimensions: int,
         indexed_properties: Mapping[str, PropertyType],
     ) -> VectorStore:
         from memmachine_server.common.vector_store.sqlite_vec_vector_store import (
@@ -929,20 +992,11 @@ class DatabaseManager:
             SQLiteVecVectorStoreParams,
         )
 
-        engine = create_async_engine(f"sqlite+aiosqlite:///{conf.path}")
-        self.vector_store_sql_engines[name] = engine
-
-        try:
-            store = SQLiteVecVectorStore(
-                SQLiteVecVectorStoreParams(
-                    engine=engine, indexed_properties=indexed_properties
-                )
+        return SQLiteVecVectorStore(
+            SQLiteVecVectorStoreParams(
+                engine=self._vector_store_sql_engine(backend, conf.path),
+                collection=collection,
+                vector_dimensions=vector_dimensions,
+                indexed_properties=indexed_properties,
             )
-            await store.startup()
-        except Exception as e:
-            await engine.dispose()
-            self.vector_store_sql_engines.pop(name, None)
-            raise VectorStoreConfigurationError(
-                f"SQLiteVecVectorStore '{name}' failed to start: {e}",
-            ) from e
-        return store
+        )

--- a/packages/server/src/memmachine_server/common/resource_manager/resource_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/resource_manager.py
@@ -3,12 +3,14 @@
 import asyncio
 import logging
 from asyncio import Lock
+from collections.abc import Mapping
 
 from neo4j import AsyncDriver
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from memmachine_server.common.configuration import Configuration
 from memmachine_server.common.configuration.mixin_confs import MetricsFactoryIdMixin
+from memmachine_server.common.data_types import PropertyType
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.episode_store import (
     CountCachingEpisodeStorage,
@@ -183,9 +185,13 @@ class ResourceManagerImpl:
         """Return a vector graph store by name."""
         return await self._database_manager.get_vector_graph_store(name)
 
-    async def get_vector_store(self, name: str) -> VectorStore:
-        """Return a vector store by name."""
-        return await self._database_manager.get_vector_store(name)
+    async def get_vector_store(
+        self, name: str, *, indexed_properties: Mapping[str, PropertyType]
+    ) -> VectorStore:
+        """Return a vector store by name, built for the service declaring these keys."""
+        return await self._database_manager.get_vector_store(
+            name, indexed_properties=indexed_properties
+        )
 
     async def get_segment_store(self, name: str) -> SegmentStore:
         """Return a segment store by name, constructing it on first access."""

--- a/packages/server/src/memmachine_server/common/resource_manager/resource_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/resource_manager.py
@@ -186,11 +186,19 @@ class ResourceManagerImpl:
         return await self._database_manager.get_vector_graph_store(name)
 
     async def get_vector_store(
-        self, name: str, *, indexed_properties: Mapping[str, PropertyType]
+        self,
+        backend: str,
+        *,
+        collection: str,
+        vector_dimensions: int,
+        indexed_properties: Mapping[str, PropertyType],
     ) -> VectorStore:
-        """Return a vector store by name, built for the service declaring these keys."""
+        """Return the store for one collection on a configured backend."""
         return await self._database_manager.get_vector_store(
-            name, indexed_properties=indexed_properties
+            backend,
+            collection=collection,
+            vector_dimensions=vector_dimensions,
+            indexed_properties=indexed_properties,
         )
 
     async def get_segment_store(self, name: str) -> SegmentStore:

--- a/packages/server/src/memmachine_server/common/resource_manager/semantic_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/semantic_manager.py
@@ -10,6 +10,7 @@ from memmachine_server.common.configuration import (
     SemanticMemoryConf,
     SemanticMemoryStorageBackend,
 )
+from memmachine_server.common.data_types import PropertyType
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.episode_store import EpisodeStorage
 from memmachine_server.common.errors import ResourceNotReadyError
@@ -49,6 +50,22 @@ from memmachine_server.semantic_memory.storage.vector_store_semantic_storage imp
 
 _VECTOR_STORE_NAMESPACE = "semantic_memory"
 _VECTOR_STORE_COLLECTION_NAME = "semantic_memory"
+
+# The keys semantic storage writes into every vector record; the vector
+# store is built with these plus its configured user keys.
+_SEMANTIC_INDEXED_PROPERTIES: dict[str, PropertyType] = {
+    "feature_id": str,
+    "set_id": str,
+    "set": str,
+    "semantic_category_id": str,
+    "category_name": str,
+    "category": str,
+    "tag_id": str,
+    "tag": str,
+    "feature": str,
+    "feature_name": str,
+    "value": str,
+}
 
 
 class SemanticResourceManager:
@@ -142,7 +159,9 @@ class SemanticResourceManager:
             feature_store_name,
             validate=True,
         )
-        vector_store = await self._resource_manager.get_vector_store(vector_store_name)
+        vector_store = await self._resource_manager.get_vector_store(
+            vector_store_name, indexed_properties=_SEMANTIC_INDEXED_PROPERTIES
+        )
         vector_dimensions = self._conf.vector_dimensions
         if vector_dimensions is None:
             vector_dimensions = (await self._get_default_embedder()).dimensions
@@ -150,22 +169,7 @@ class SemanticResourceManager:
         collection = await vector_store.open_or_create_collection(
             namespace=_VECTOR_STORE_NAMESPACE,
             name=_VECTOR_STORE_COLLECTION_NAME,
-            config=VectorStoreCollectionConfig(
-                vector_dimensions=vector_dimensions,
-                indexed_properties_schema={
-                    "feature_id": str,
-                    "set_id": str,
-                    "set": str,
-                    "semantic_category_id": str,
-                    "category_name": str,
-                    "category": str,
-                    "tag_id": str,
-                    "tag": str,
-                    "feature": str,
-                    "feature_name": str,
-                    "value": str,
-                },
-            ),
+            config=VectorStoreCollectionConfig(vector_dimensions=vector_dimensions),
         )
         storage = VectorStoreSemanticStorage(sql_engine, collection)
         await storage.startup()

--- a/packages/server/src/memmachine_server/common/resource_manager/semantic_manager.py
+++ b/packages/server/src/memmachine_server/common/resource_manager/semantic_manager.py
@@ -16,7 +16,10 @@ from memmachine_server.common.episode_store import EpisodeStorage
 from memmachine_server.common.errors import ResourceNotReadyError
 from memmachine_server.common.language_model import LanguageModel
 from memmachine_server.common.resource_manager import CommonResourceManager
-from memmachine_server.common.vector_store import VectorStoreCollectionConfig
+from memmachine_server.common.vector_store import (
+    get_or_create_partition,
+    validate_collection_name,
+)
 from memmachine_server.semantic_memory.config_store.caching_semantic_config_storage import (
     CachingSemanticConfigStorage,
 )
@@ -48,8 +51,22 @@ from memmachine_server.semantic_memory.storage.vector_store_semantic_storage imp
     VectorStoreSemanticStorage,
 )
 
-_VECTOR_STORE_NAMESPACE = "semantic_memory"
-_VECTOR_STORE_COLLECTION_NAME = "semantic_memory"
+_VECTOR_STORE_PURPOSE = "semantic_memory"
+_VECTOR_STORE_PARTITION_KEY = "semantic_memory"
+
+
+def _semantic_collection(embedder_id: str) -> str:
+    """The collection semantic memory keeps for one embedder."""
+    collection = f"{_VECTOR_STORE_PURPOSE}__{embedder_id}"
+    try:
+        validate_collection_name(collection)
+    except ValueError as error:
+        raise ValueError(
+            f"Embedder id {embedder_id!r} cannot name a vector store collection: "
+            f"{error} Rename the embedder in the configuration."
+        ) from error
+    return collection
+
 
 # The keys semantic storage writes into every vector record; the vector
 # store is built with these plus its configured user keys.
@@ -159,19 +176,19 @@ class SemanticResourceManager:
             feature_store_name,
             validate=True,
         )
-        vector_store = await self._resource_manager.get_vector_store(
-            vector_store_name, indexed_properties=_SEMANTIC_INDEXED_PROPERTIES
-        )
         vector_dimensions = self._conf.vector_dimensions
         if vector_dimensions is None:
             vector_dimensions = (await self._get_default_embedder()).dimensions
-
-        collection = await vector_store.open_or_create_collection(
-            namespace=_VECTOR_STORE_NAMESPACE,
-            name=_VECTOR_STORE_COLLECTION_NAME,
-            config=VectorStoreCollectionConfig(vector_dimensions=vector_dimensions),
+        vector_store = await self._resource_manager.get_vector_store(
+            vector_store_name,
+            collection=_semantic_collection(self._get_default_embedder_name()),
+            vector_dimensions=vector_dimensions,
+            indexed_properties=_SEMANTIC_INDEXED_PROPERTIES,
         )
-        storage = VectorStoreSemanticStorage(sql_engine, collection)
+        partition = await get_or_create_partition(
+            vector_store, _VECTOR_STORE_PARTITION_KEY
+        )
+        storage = VectorStoreSemanticStorage(sql_engine, partition)
         await storage.startup()
         return storage
 

--- a/packages/server/src/memmachine_server/common/vector_graph_store/nebula_graph_vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/nebula_graph_vector_graph_store.py
@@ -23,14 +23,16 @@ from typing import TYPE_CHECKING, Any
 from nebulagraph_python.py_data_types import NVector
 
 from memmachine_server.common.data_types import OrderedValue
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
     And,
-    Comparison,
+    Equals,
     FilterExpr,
     In,
-    IsNull,
+    IsMissing,
     Not,
+    NotEquals,
     Or,
+    Ordering,
 )
 
 from .data_types import (
@@ -1396,67 +1398,28 @@ class NebulaGraphVectorGraphStore(VectorGraphStore):
         if filter_expr is None:
             return ""
 
+        def prop_ref(field: str) -> str:
+            return f"{node_alias}.{self._sanitize_name(mangle_property_name(field))}"
+
         def render(expr: FilterExpr) -> str:
-            if isinstance(expr, Comparison):
-                prop_name = mangle_property_name(expr.field)
-                sanitized_prop = self._sanitize_name(prop_name)
-                prop_ref = f"{node_alias}.{sanitized_prop}"
-
-                if expr.op in ("=", "=="):
-                    value_str = self._format_value(expr.value)
-                    return f"{prop_ref} = {value_str}"
-                if expr.op == "!=":
-                    value_str = self._format_value(expr.value)
-                    return f"{prop_ref} <> {value_str}"
-                if expr.op == ">":
-                    value_str = self._format_value(expr.value)
-                    return f"{prop_ref} > {value_str}"
-                if expr.op == ">=":
-                    value_str = self._format_value(expr.value)
-                    return f"{prop_ref} >= {value_str}"
-                if expr.op == "<":
-                    value_str = self._format_value(expr.value)
-                    return f"{prop_ref} < {value_str}"
-                if expr.op == "<=":
-                    value_str = self._format_value(expr.value)
-                    return f"{prop_ref} <= {value_str}"
-                if expr.op == "in":
-                    if not isinstance(expr.value, list):
-                        raise ValueError("'in' operator requires list value")
-                    value_strs = [self._format_value(v) for v in expr.value]
-                    values_list = ", ".join(value_strs)
-                    return f"{prop_ref} IN [{values_list}]"
-                raise ValueError(f"Unsupported operator: {expr.op}")
-
-            if isinstance(expr, In):
-                prop_name = mangle_property_name(expr.field)
-                sanitized_prop = self._sanitize_name(prop_name)
-                prop_ref = f"{node_alias}.{sanitized_prop}"
-                value_strs = [self._format_value(v) for v in expr.values]
-                values_list = ", ".join(value_strs)
-                return f"{prop_ref} IN [{values_list}]"
-
-            if isinstance(expr, IsNull):
-                prop_name = mangle_property_name(expr.field)
-                sanitized_prop = self._sanitize_name(prop_name)
-                prop_ref = f"{node_alias}.{sanitized_prop}"
-                return f"{prop_ref} IS NULL"
-
-            if isinstance(expr, Not):
-                inner_clause = render(expr.expr)
-                return f"NOT ({inner_clause})"
-
-            if isinstance(expr, And):
-                left_clause = render(expr.left)
-                right_clause = render(expr.right)
-                return f"({left_clause}) AND ({right_clause})"
-
-            if isinstance(expr, Or):
-                left_clause = render(expr.left)
-                right_clause = render(expr.right)
-                return f"({left_clause}) OR ({right_clause})"
-
-            raise ValueError(f"Unsupported filter expression type: {type(expr)}")
+            match expr:
+                case Equals(field, value):
+                    return f"{prop_ref(field)} = {self._format_value(value)}"
+                case NotEquals(field, value):
+                    return f"{prop_ref(field)} <> {self._format_value(value)}"
+                case Ordering(field, op, value):
+                    return f"{prop_ref(field)} {op} {self._format_value(value)}"
+                case In(field, values):
+                    values_list = ", ".join(self._format_value(v) for v in values)
+                    return f"{prop_ref(field)} IN [{values_list}]"
+                case IsMissing(field):
+                    return f"{prop_ref(field)} IS NULL"
+                case Not(operand):
+                    return f"NOT ({render(operand)})"
+                case And(operands):
+                    return " AND ".join(f"({render(o)})" for o in operands)
+                case Or(operands):
+                    return " OR ".join(f"({render(o)})" for o in operands)
 
         where_clause = render(filter_expr)
         return where_clause

--- a/packages/server/src/memmachine_server/common/vector_graph_store/neo4j_vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/neo4j_vector_graph_store.py
@@ -21,26 +21,16 @@ from memmachine_server.common.data_types import (
     FilterValue,
     OrderedValue,
 )
-from memmachine_server.common.filter.filter_parser import (
-    And as FilterAnd,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Comparison as FilterComparison,
-)
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
+    And,
+    Equals,
     FilterExpr,
-)
-from memmachine_server.common.filter.filter_parser import (
-    In as FilterIn,
-)
-from memmachine_server.common.filter.filter_parser import (
-    IsNull as FilterIsNull,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Not as FilterNot,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Or as FilterOr,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
 )
 from memmachine_server.common.metrics_factory import MetricsFactory, OperationTracker
 from memmachine_server.common.neo4j_utils import (
@@ -1225,6 +1215,16 @@ class Neo4jVectorGraphStore(VectorGraphStore):
         return query_filter_string, query_filter_params
 
     @staticmethod
+    def _comparison_operator(expr: Equals | NotEquals | Ordering) -> str:
+        match expr:
+            case Equals():
+                return "="
+            case NotEquals():
+                return "!="
+            case Ordering(op=op):
+                return op
+
+    @staticmethod
     def _render_filter_expr(
         entity_query_alias: str,
         query_value_parameter: str,
@@ -1233,56 +1233,47 @@ class Neo4jVectorGraphStore(VectorGraphStore):
         _render = Neo4jVectorGraphStore._render_filter_expr
         _sanitize = Neo4jVectorGraphStore._sanitize_name
 
-        if isinstance(expr, FilterIsNull):
-            field_ref = (
-                f"{entity_query_alias}.{_sanitize(mangle_property_name(expr.field))}"
-            )
-            return f"{field_ref} IS NULL", {}
+        def field_ref(field: str) -> str:
+            return f"{entity_query_alias}.{_sanitize(mangle_property_name(field))}"
 
-        if isinstance(expr, FilterIn):
-            field_ref = (
-                f"{entity_query_alias}.{_sanitize(mangle_property_name(expr.field))}"
-            )
-            param_name = _sanitize(f"filter_expr_param_{uuid4()}")
-            condition = f"{field_ref} IN ${query_value_parameter}.{param_name}"
-            params: dict[str, FilterValue] = {param_name: expr.values}
-            return condition, params
-
-        if isinstance(expr, FilterComparison):
-            field_ref = (
-                f"{entity_query_alias}.{_sanitize(mangle_property_name(expr.field))}"
-            )
-            param_name = _sanitize(f"filter_expr_param_{uuid4()}")
-            condition = render_comparison(
-                left=field_ref,
-                op=expr.op,
-                right=f"${query_value_parameter}.{param_name}",
-                value=expr.value,
-            )
-            params = {
-                param_name: cast(FilterValue, sanitize_value_for_neo4j(expr.value))
-            }
-            return condition, params
-
-        if isinstance(expr, FilterAnd):
-            left_cond, left_params = _render(
-                entity_query_alias, query_value_parameter, expr.left
-            )
-            right_cond, right_params = _render(
-                entity_query_alias, query_value_parameter, expr.right
-            )
-            return f"({left_cond}) AND ({right_cond})", left_params | right_params
-        if isinstance(expr, FilterOr):
-            left_cond, left_params = _render(
-                entity_query_alias, query_value_parameter, expr.left
-            )
-            right_cond, right_params = _render(
-                entity_query_alias, query_value_parameter, expr.right
-            )
-            return f"({left_cond}) OR ({right_cond})", left_params | right_params
-        if isinstance(expr, FilterNot):
-            inner_cond, inner_params = _render(
-                entity_query_alias, query_value_parameter, expr.expr
-            )
-            return f"NOT ({inner_cond})", inner_params
-        raise TypeError(f"Unsupported filter expression type: {type(expr)!r}")
+        match expr:
+            case IsMissing(field):
+                return f"{field_ref(field)} IS NULL", {}
+            case In(field, values):
+                param_name = _sanitize(f"filter_expr_param_{uuid4()}")
+                condition = (
+                    f"{field_ref(field)} IN ${query_value_parameter}.{param_name}"
+                )
+                return condition, {param_name: cast(FilterValue, list(values))}
+            case (
+                Equals(field, value)
+                | NotEquals(field, value)
+                | Ordering(field, _, value)
+            ):
+                param_name = _sanitize(f"filter_expr_param_{uuid4()}")
+                condition = render_comparison(
+                    left=field_ref(field),
+                    op=Neo4jVectorGraphStore._comparison_operator(expr),
+                    right=f"${query_value_parameter}.{param_name}",
+                    value=value,
+                )
+                return condition, {
+                    param_name: cast(FilterValue, sanitize_value_for_neo4j(value))
+                }
+            case And(operands) | Or(operands):
+                joiner = " AND " if isinstance(expr, And) else " OR "
+                rendered = [
+                    _render(entity_query_alias, query_value_parameter, operand)
+                    for operand in operands
+                ]
+                params: dict[str, FilterValue] = {}
+                for _, operand_params in rendered:
+                    params |= operand_params
+                return joiner.join(
+                    f"({condition})" for condition, _ in rendered
+                ), params
+            case Not(operand):
+                inner_cond, inner_params = _render(
+                    entity_query_alias, query_value_parameter, operand
+                )
+                return f"NOT ({inner_cond})", inner_params

--- a/packages/server/src/memmachine_server/common/vector_graph_store/vector_graph_store.py
+++ b/packages/server/src/memmachine_server/common/vector_graph_store/vector_graph_store.py
@@ -9,9 +9,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 
 from memmachine_server.common.data_types import OrderedValue
-from memmachine_server.common.filter.filter_parser import (
-    FilterExpr,
-)
+from memmachine_server.common.filter import FilterExpr
 
 from .data_types import Edge, Node
 

--- a/packages/server/src/memmachine_server/common/vector_store/__init__.py
+++ b/packages/server/src/memmachine_server/common/vector_store/__init__.py
@@ -1,8 +1,13 @@
 """Public exports for vector store."""
 
 from .data_types import (
+    IndexedProperties,
+    IndexedPropertiesMismatchError,
+    PropertyTypeMismatchError,
     QueryResult,
     Record,
+    UndeclaredPropertyKeyError,
+    UnsupportedFilterError,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
     VectorStoreCollectionConfigMismatchError,
@@ -10,8 +15,13 @@ from .data_types import (
 from .vector_store import VectorStore, VectorStoreCollection
 
 __all__ = [
+    "IndexedProperties",
+    "IndexedPropertiesMismatchError",
+    "PropertyTypeMismatchError",
     "QueryResult",
     "Record",
+    "UndeclaredPropertyKeyError",
+    "UnsupportedFilterError",
     "VectorStore",
     "VectorStoreCollection",
     "VectorStoreCollectionAlreadyExistsError",

--- a/packages/server/src/memmachine_server/common/vector_store/__init__.py
+++ b/packages/server/src/memmachine_server/common/vector_store/__init__.py
@@ -2,29 +2,30 @@
 
 from .data_types import (
     IndexedProperties,
-    IndexedPropertiesMismatchError,
+    PartitionSchema,
     PropertyTypeMismatchError,
     QueryResult,
     Record,
     UndeclaredPropertyKeyError,
     UnsupportedFilterError,
-    VectorStoreCollectionAlreadyExistsError,
-    VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
+    VectorStorePartitionAlreadyExistsError,
+    VectorStorePartitionSchemaMismatchError,
+    validate_collection_name,
 )
-from .vector_store import VectorStore, VectorStoreCollection
+from .vector_store import VectorStore, VectorStorePartition, get_or_create_partition
 
 __all__ = [
     "IndexedProperties",
-    "IndexedPropertiesMismatchError",
+    "PartitionSchema",
     "PropertyTypeMismatchError",
     "QueryResult",
     "Record",
     "UndeclaredPropertyKeyError",
     "UnsupportedFilterError",
     "VectorStore",
-    "VectorStoreCollection",
-    "VectorStoreCollectionAlreadyExistsError",
-    "VectorStoreCollectionConfig",
-    "VectorStoreCollectionConfigMismatchError",
+    "VectorStorePartition",
+    "VectorStorePartitionAlreadyExistsError",
+    "VectorStorePartitionSchemaMismatchError",
+    "get_or_create_partition",
+    "validate_collection_name",
 ]

--- a/packages/server/src/memmachine_server/common/vector_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_store/data_types.py
@@ -1,17 +1,76 @@
 """Data types for vector store."""
 
-from collections.abc import Mapping
+from collections.abc import Collection, Iterable, Mapping
+from typing import Annotated
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    field_validator,
+)
 
 from memmachine_server.common.data_types import (
     PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE,
     PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME,
+    PropertyType,
     PropertyValue,
 )
 
 from .utils import validate_identifier
+
+
+def _coerce_property_types(value: object) -> object:
+    # Deployment configuration names a type ("str", "datetime"); code passes
+    # the type itself. Both are accepted, and the names are resolved here.
+    if not isinstance(value, Mapping):
+        return value
+    resolved: dict[str, object] = {}
+    for key, property_type in value.items():
+        if isinstance(property_type, str):
+            if property_type not in PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE:
+                raise ValueError(
+                    f"Unknown property type name {property_type!r} for key {key!r}; "
+                    f"expected one of {sorted(PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE)}"
+                )
+            resolved[key] = PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE[property_type]
+        else:
+            resolved[key] = property_type
+    return resolved
+
+
+def _validate_property_keys(value: dict[str, PropertyType]) -> dict[str, PropertyType]:
+    for key in value:
+        if not validate_identifier(key):
+            raise ValueError(
+                f"Property key {key!r} must match [a-z0-9_]+ and be at most 32 bytes"
+            )
+    return value
+
+
+IndexedProperties = Annotated[
+    dict[str, PropertyType],
+    BeforeValidator(_coerce_property_types),
+    AfterValidator(_validate_property_keys),
+]
+"""
+The one schema a store declares for every collection it holds: each key a
+store indexes and filters on, with the type its values hold. Declared once,
+from deployment configuration merged with the system keys of the consumer the
+store is built for; a record or a filter naming any other key is rejected.
+"""
+
+
+def indexed_property_names(
+    indexed_properties: Mapping[str, PropertyType],
+) -> dict[str, str]:
+    """The JSON form of a declared schema: each type by its name."""
+    return {
+        key: PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[property_type]
+        for key, property_type in sorted(indexed_properties.items())
+    }
 
 
 class VectorStoreCollectionConfig(BaseModel):
@@ -21,54 +80,9 @@ class VectorStoreCollectionConfig(BaseModel):
     Attributes:
         vector_dimensions (int):
             Dimensionality of vectors stored in the collection.
-        indexed_properties_schema (dict[str, type[PropertyValue]]):
-            Schema suggesting which properties should be indexed for filtering.
     """
 
     vector_dimensions: int
-    indexed_properties_schema: dict[str, type[PropertyValue]] = Field(
-        default_factory=dict
-    )
-
-    @field_validator("indexed_properties_schema", mode="after")
-    @classmethod
-    def _validate_property_keys(
-        cls, v: dict[str, type[PropertyValue]]
-    ) -> dict[str, type[PropertyValue]]:
-        for key in v:
-            if not validate_identifier(key):
-                raise ValueError(
-                    f"Property key {key!r} must match [a-z0-9_]+ and be at most 32 bytes"
-                )
-        return v
-
-    @field_validator("indexed_properties_schema", mode="before")
-    @classmethod
-    def _coerce_indexed_properties_schema(cls, v: object) -> object:
-        if v is None:
-            return {}
-        if isinstance(v, Mapping):
-            result = {}
-            for key, value in v.items():
-                if isinstance(value, str):
-                    if value not in PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE:
-                        raise ValueError(
-                            f"Unknown property type name {value!r} for key {key!r}."
-                        )
-                    result[key] = PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE[value]
-                else:
-                    result[key] = value
-            return result
-
-        return v
-
-    @field_serializer("indexed_properties_schema")
-    def _serialize_indexed_properties_schema(
-        self, v: dict[str, type[PropertyValue]]
-    ) -> dict[str, str]:
-        return {
-            k: PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[val] for k, val in sorted(v.items())
-        }
 
 
 class VectorStoreCollectionAlreadyExistsError(Exception):
@@ -103,6 +117,74 @@ class VectorStoreCollectionConfigMismatchError(Exception):
         )
 
 
+class IndexedPropertiesMismatchError(Exception):
+    """
+    Raised when a collection's stored schema differs from the store's declaration.
+
+    A store built with one `indexed_properties` schema holds columns and
+    indexes for exactly those keys; a collection created under another
+    schema cannot be served without a migration, which nothing here performs.
+    """
+
+    def __init__(
+        self,
+        namespace: str,
+        name: str,
+        stored: Mapping[str, str],
+        declared: Mapping[str, str],
+    ) -> None:
+        """Initialize with the collection and the two schemas, as type names."""
+        self.namespace = namespace
+        self.name = name
+        self.stored = dict(stored)
+        self.declared = dict(declared)
+        super().__init__(
+            f"Collection ({namespace!r}, {name!r}) was created with indexed "
+            f"properties {self.stored}, but the store declares {self.declared}."
+        )
+
+
+class UndeclaredPropertyKeyError(ValueError):
+    """Raised when a record or a filter names a key the store has not declared."""
+
+    def __init__(self, keys: Iterable[str], declared: Collection[str]) -> None:
+        """Initialize with the offending keys and the declared ones."""
+        self.keys = sorted(set(keys))
+        self.declared = sorted(declared)
+        super().__init__(
+            f"Property keys {self.keys} are not declared by the vector store; "
+            f"declared keys: {self.declared}."
+        )
+
+
+class PropertyTypeMismatchError(ValueError):
+    """Raised when a record's value is not of its key's declared type."""
+
+    def __init__(self, key: str, declared: PropertyType, value: PropertyValue) -> None:
+        """Initialize with the key, its declared type and the offending value."""
+        self.key = key
+        self.declared = declared
+        self.value = value
+        super().__init__(
+            f"Property {key!r} is declared as "
+            f"{PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[declared]}, "
+            f"got {type(value).__name__} {value!r}."
+        )
+
+
+class UnsupportedFilterError(ValueError):
+    """Raised when a filter uses a node the store cannot evaluate during a search."""
+
+    def __init__(self, nodes: Iterable[type], supported: Collection[type]) -> None:
+        """Initialize with the offending node classes and the supported ones."""
+        self.nodes = sorted({node.__name__ for node in nodes})
+        self.supported = sorted(node.__name__ for node in supported)
+        super().__init__(
+            f"Filter nodes {self.nodes} are not evaluated by this vector store; "
+            f"supported nodes: {self.supported}."
+        )
+
+
 class Record(BaseModel):
     """
     A record to write to a vector store collection.
@@ -117,7 +199,7 @@ class Record(BaseModel):
         vector (list[float]):
             Vector for similarity search.
         properties (dict[str, PropertyValue]):
-            Property key-value pairs.
+            Property key-value pairs, each key one the store declares.
             Stored for property filtering; never returned
             (default: `{}`).
     """

--- a/packages/server/src/memmachine_server/common/vector_store/data_types.py
+++ b/packages/server/src/memmachine_server/common/vector_store/data_types.py
@@ -1,5 +1,6 @@
 """Data types for vector store."""
 
+import re
 from collections.abc import Collection, Iterable, Mapping
 from typing import Annotated
 from uuid import UUID
@@ -73,74 +74,76 @@ def indexed_property_names(
     }
 
 
-class VectorStoreCollectionConfig(BaseModel):
-    """
-    Configuration for a logical collection in a vector store.
+COLLECTION_NAME_MAX_BYTES = 64
+"""Bound on a collection name, in bytes; a store's one native name."""
 
-    Attributes:
-        vector_dimensions (int):
-            Dimensionality of vectors stored in the collection.
-    """
-
-    vector_dimensions: int
+_COLLECTION_NAME_RE = re.compile(r"^[a-z0-9_]+$")
 
 
-class VectorStoreCollectionAlreadyExistsError(Exception):
-    """Raised when creating a collection that already exists."""
-
-    def __init__(self, namespace: str, name: str) -> None:
-        """Initialize with the namespace and name of the existing collection."""
-        self.namespace = namespace
-        self.name = name
-        super().__init__(f"Collection ({namespace!r}, {name!r}) already exists.")
-
-
-class VectorStoreCollectionConfigMismatchError(Exception):
-    """Raised when opening a collection with a different configuration than it was created with."""
-
-    def __init__(
-        self,
-        namespace: str,
-        name: str,
-        existing_config: VectorStoreCollectionConfig,
-        requested_config: VectorStoreCollectionConfig,
-    ) -> None:
-        """Initialize with the namespace, name, and configurations."""
-        self.namespace = namespace
-        self.name = name
-        self.existing_config = existing_config
-        self.requested_config = requested_config
-        super().__init__(
-            f"Collection ({namespace!r}, {name!r}) already exists with a different configuration. "
-            f"Existing config: {existing_config.model_dump_json()}, "
-            f"requested config: {requested_config.model_dump_json()}."
+def validate_collection_name(name: str) -> None:
+    """Raise ValueError unless `name` can name a native collection on every backend."""
+    if (
+        not _COLLECTION_NAME_RE.match(name)
+        or len(name.encode()) > COLLECTION_NAME_MAX_BYTES
+    ):
+        raise ValueError(
+            f"Collection name {name!r} must match [a-z0-9_]+ and be at most "
+            f"{COLLECTION_NAME_MAX_BYTES} bytes."
         )
 
 
-class IndexedPropertiesMismatchError(Exception):
+class PartitionSchema(BaseModel):
     """
-    Raised when a collection's stored schema differs from the store's declaration.
+    What a partition was created under: its store's dimensions and schema.
 
-    A store built with one `indexed_properties` schema holds columns and
-    indexes for exactly those keys; a collection created under another
-    schema cannot be served without a migration, which nothing here performs.
+    Recorded beside the partition so a store built with other dimensions or
+    another declared schema fails loudly instead of reading columns or
+    vectors that are not there.
+    """
+
+    vector_dimensions: int
+    indexed_properties: dict[str, str]
+    """The declared schema, each type by its name."""
+
+
+class VectorStorePartitionAlreadyExistsError(Exception):
+    """Raised when creating a partition that already exists."""
+
+    def __init__(self, collection: str, partition_key: str) -> None:
+        """Initialize with the collection and the key of the existing partition."""
+        self.collection = collection
+        self.partition_key = partition_key
+        super().__init__(
+            f"Partition {partition_key!r} of collection {collection!r} already exists."
+        )
+
+
+class VectorStorePartitionSchemaMismatchError(Exception):
+    """
+    Raised when a partition's recorded schema differs from its store's.
+
+    A store built with one dimensionality and one `indexed_properties`
+    schema holds columns and indexes for exactly those; a partition created
+    under others cannot be served without a migration, which nothing here
+    performs.
     """
 
     def __init__(
         self,
-        namespace: str,
-        name: str,
-        stored: Mapping[str, str],
-        declared: Mapping[str, str],
+        collection: str,
+        partition_key: str,
+        stored: PartitionSchema,
+        declared: PartitionSchema,
     ) -> None:
-        """Initialize with the collection and the two schemas, as type names."""
-        self.namespace = namespace
-        self.name = name
-        self.stored = dict(stored)
-        self.declared = dict(declared)
+        """Initialize with the partition and the two schemas."""
+        self.collection = collection
+        self.partition_key = partition_key
+        self.stored = stored
+        self.declared = declared
         super().__init__(
-            f"Collection ({namespace!r}, {name!r}) was created with indexed "
-            f"properties {self.stored}, but the store declares {self.declared}."
+            f"Partition {partition_key!r} of collection {collection!r} was created "
+            f"under {stored.model_dump()}, but the store declares "
+            f"{declared.model_dump()}."
         )
 
 

--- a/packages/server/src/memmachine_server/common/vector_store/declared_properties.py
+++ b/packages/server/src/memmachine_server/common/vector_store/declared_properties.py
@@ -1,0 +1,53 @@
+"""Enforcement of a store's declared schema at the write and query boundaries."""
+
+from collections.abc import Iterable, Mapping
+
+from memmachine_server.common.data_types import PropertyType, PropertyValue
+from memmachine_server.common.filter import FilterExpr, filter_fields, filter_nodes
+
+from .data_types import (
+    PropertyTypeMismatchError,
+    UndeclaredPropertyKeyError,
+    UnsupportedFilterError,
+)
+
+
+def require_declared_properties(
+    properties: Mapping[str, PropertyValue],
+    indexed_properties: Mapping[str, PropertyType],
+) -> None:
+    """
+    Raise unless every property is declared and holds a value of its type.
+
+    Called before anything is sent, so an undeclared key never reaches a
+    backend, and a declared key never holds a value its column or index
+    would have to coerce.
+    """
+    undeclared = properties.keys() - indexed_properties.keys()
+    if undeclared:
+        raise UndeclaredPropertyKeyError(undeclared, indexed_properties.keys())
+    for key, value in properties.items():
+        # `bool` is an `int` at runtime and is its own property type here.
+        if type(value) is not indexed_properties[key]:
+            raise PropertyTypeMismatchError(key, indexed_properties[key], value)
+
+
+def require_supported_filter(
+    property_filter: FilterExpr,
+    indexed_properties: Mapping[str, PropertyType],
+    supported_filter_nodes: Iterable[type],
+) -> None:
+    """
+    Raise unless a filter names declared keys only and uses supported nodes.
+
+    An undeclared key never exists in the store, so a filter naming one has
+    nothing to scan for; a node outside `supported_filter_nodes` is one the
+    backend cannot evaluate during its search.
+    """
+    undeclared = filter_fields(property_filter) - indexed_properties.keys()
+    if undeclared:
+        raise UndeclaredPropertyKeyError(undeclared, indexed_properties.keys())
+    supported = frozenset(supported_filter_nodes)
+    unsupported = filter_nodes(property_filter) - supported
+    if unsupported:
+        raise UnsupportedFilterError(unsupported, supported)

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -14,35 +14,24 @@ from pydantic import BaseModel, Field, InstanceOf
 from pymilvus import DataType, MilvusClient
 from pymilvus.exceptions import MilvusException
 
-from memmachine_server.common.data_types import PropertyValue
-from memmachine_server.common.filter.filter_parser import (
-    And as FilterAnd,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Comparison as FilterComparison,
-)
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.data_types import PropertyType, PropertyValue
+from memmachine_server.common.filter import (
+    And,
+    Equals,
     FilterExpr,
-)
-from memmachine_server.common.filter.filter_parser import (
-    In as FilterIn,
-)
-from memmachine_server.common.filter.filter_parser import (
-    IsNull as FilterIsNull,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Not as FilterNot,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Or as FilterOr,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
+    OrderingOp,
 )
 from memmachine_server.common.metrics_factory import MetricsFactory, OperationTracker
-from memmachine_server.common.properties_json import (
-    encode_properties,
-)
 from memmachine_server.common.utils import compute_cosine_similarity, ensure_tz_aware
 
 from .data_types import (
+    IndexedProperties,
     QueryMatch,
     QueryResult,
     Record,
@@ -50,21 +39,27 @@ from .data_types import (
     VectorStoreCollectionConfig,
     VectorStoreCollectionConfigMismatchError,
 )
-from .utils import validate_filter, validate_identifier
+from .declared_properties import require_declared_properties, require_supported_filter
+from .utils import validate_identifier
 from .vector_store import VectorStore, VectorStoreCollection
 
 _ID_FIELD = "id"
 _RECORD_UUID_FIELD = "record_uuid"
 _PARTITION_KEY_FIELD = "partition_key"
 _VECTOR_FIELD = "vector"
-_PROPERTIES_FIELD = "properties"
 _PROPERTY_FILTER_PREFIX = "_p_"
+
+_INVERSE_ORDERING: dict[OrderingOp, OrderingOp] = {
+    ">": "<=",
+    ">=": "<",
+    "<": ">=",
+    "<=": ">",
+}
 
 _MAX_UUID_LENGTH = 36
 _MAX_PRIMARY_ID_LENGTH = 128
 _MAX_PARTITION_KEY_LENGTH = 32
 _REGISTRY_VECTOR_DIMENSION = 2
-_FALSE_EXPR = f'{_ID_FIELD} == "__memmachine_no_match__"'
 
 
 def _expr_string(value: str) -> str:
@@ -98,41 +93,73 @@ def _normalize_property_filter_value(value: PropertyValue) -> PropertyValue:
 class MilvusVectorStoreCollection(VectorStoreCollection):
     """A logical collection backed by Milvus."""
 
-    _RANGE_OPERATORS: ClassVar[set[str]] = {">", ">=", "<", "<="}
+    _SUPPORTED_FILTER_NODES: ClassVar[frozenset[type]] = frozenset(
+        {Equals, NotEquals, Ordering, In, IsMissing, And, Or, Not}
+    )
 
     @staticmethod
     def _build_milvus_filter(expr: FilterExpr) -> str:
         """Convert a FilterExpr tree into a Milvus filter expression."""
-        if isinstance(expr, FilterComparison):
-            return MilvusVectorStoreCollection._build_milvus_comparison(expr)
-        if isinstance(expr, FilterIn):
-            if not expr.values:
-                return _FALSE_EXPR
-            values = ", ".join(_literal(value) for value in expr.values)
-            return f"{_property_field(expr.field)} in [{values}]"
-        if isinstance(expr, FilterIsNull):
-            return f"{_property_field(expr.field)} is null"
-        if isinstance(expr, FilterNot):
-            return (
-                f"not ({MilvusVectorStoreCollection._build_milvus_filter(expr.expr)})"
-            )
-        if isinstance(expr, FilterAnd):
-            left = MilvusVectorStoreCollection._build_milvus_filter(expr.left)
-            right = MilvusVectorStoreCollection._build_milvus_filter(expr.right)
-            return f"({left}) && ({right})"
-        if isinstance(expr, FilterOr):
-            left = MilvusVectorStoreCollection._build_milvus_filter(expr.left)
-            right = MilvusVectorStoreCollection._build_milvus_filter(expr.right)
-            return f"({left}) || ({right})"
-        message = f"Unsupported filter expression type: {type(expr)}"
-        raise TypeError(message)
+        build = MilvusVectorStoreCollection._build_milvus_filter
+        match expr:
+            case Equals(field, value):
+                return f"{_property_field(field)} == {_literal(value)}"
+            case NotEquals(field, value):
+                return f"{_property_field(field)} != {_literal(value)}"
+            case Ordering(field, op, value):
+                return f"{_property_field(field)} {op} {_literal(value)}"
+            case In(field, values):
+                literals = ", ".join(_literal(value) for value in values)
+                return f"{_property_field(field)} in [{literals}]"
+            case IsMissing(field):
+                return f"{_property_field(field)} is null"
+            case Not(operand):
+                return MilvusVectorStoreCollection._negated(operand)
+            case And(operands):
+                return " && ".join(f"({build(o)})" for o in operands)
+            case Or(operands):
+                return " || ".join(f"({build(o)})" for o in operands)
 
     @staticmethod
-    def _build_milvus_comparison(comparison: FilterComparison) -> str:
-        """Convert a Comparison into a Milvus filter expression."""
-        field = _property_field(comparison.field)
-        operator = "==" if comparison.op == "=" else comparison.op
-        return f"{field} {operator} {_literal(comparison.value)}"
+    def _negated(expr: FilterExpr) -> str:
+        """The complement of a tree as a Milvus expression, pushed to the leaves.
+
+        Milvus's own `not` does not admit entities lacking the field, so a
+        negated predicate is rendered as the inverse predicate or the field's
+        absence, which is the complement the filter language defines.
+        """
+        build = MilvusVectorStoreCollection._build_milvus_filter
+        negated = MilvusVectorStoreCollection._negated
+        match expr:
+            case Equals(field, value):
+                return (
+                    f"({_property_field(field)} != {_literal(value)}) || "
+                    f"({_property_field(field)} is null)"
+                )
+            case NotEquals(field, value):
+                return (
+                    f"({_property_field(field)} == {_literal(value)}) || "
+                    f"({_property_field(field)} is null)"
+                )
+            case Ordering(field, op, value):
+                return (
+                    f"({_property_field(field)} {_INVERSE_ORDERING[op]} {_literal(value)}) || "
+                    f"({_property_field(field)} is null)"
+                )
+            case In(field, values):
+                literals = ", ".join(_literal(value) for value in values)
+                return (
+                    f"({_property_field(field)} not in [{literals}]) || "
+                    f"({_property_field(field)} is null)"
+                )
+            case IsMissing(field):
+                return f"{_property_field(field)} is not null"
+            case Not(operand):
+                return build(operand)
+            case And(operands):
+                return " || ".join(f"({negated(o)})" for o in operands)
+            case Or(operands):
+                return " && ".join(f"({negated(o)})" for o in operands)
 
     @staticmethod
     def _primary_id(partition_key: str, record_uuid: UUID) -> str:
@@ -146,6 +173,7 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         collection_name: str,
         partition_key: str,
         config: VectorStoreCollectionConfig,
+        indexed_properties: Mapping[str, PropertyType],
         tracker: OperationTracker,
     ) -> None:
         """Initialize with a Milvus client and collection name."""
@@ -153,6 +181,7 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         self._collection_name = collection_name
         self._partition_key = partition_key
         self._config = config
+        self._indexed_properties = dict(indexed_properties)
         self._tracker = tracker
 
     @property
@@ -161,20 +190,28 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         """The configuration for this collection."""
         return self._config
 
+    @property
+    @override
+    def indexed_properties(self) -> Mapping[str, PropertyType]:
+        return self._indexed_properties
+
+    @property
+    @override
+    def supported_filter_nodes(self) -> frozenset[type]:
+        return MilvusVectorStoreCollection._SUPPORTED_FILTER_NODES
+
     def _build_entity(self, record: Record) -> dict[str, Any]:
         """Build a Milvus entity from a vector store record."""
-        properties = record.properties if record.properties is not None else {}
         entity: dict[str, Any] = {
             _ID_FIELD: self._primary_id(self._partition_key, record.uuid),
             _RECORD_UUID_FIELD: str(record.uuid),
             _PARTITION_KEY_FIELD: self._partition_key,
             _VECTOR_FIELD: record.vector,
-            _PROPERTIES_FIELD: encode_properties(properties),
         }
         # Explicit nulls clear stale dynamic fields during native Milvus upserts.
-        for key in self._config.indexed_properties_schema:
+        for key in self._indexed_properties:
             entity[_property_field(key)] = None
-        for key, value in properties.items():
+        for key, value in record.properties.items():
             entity[_property_field(key)] = _normalize_property_filter_value(value)
         return entity
 
@@ -210,6 +247,8 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
             if not records:
                 return
 
+            for record in records:
+                require_declared_properties(record.properties, self._indexed_properties)
             entities = [self._build_entity(record) for record in records]
 
             def _upsert() -> None:
@@ -239,8 +278,11 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
 
             filter_expr = self._partition_filter()
             if property_filter is not None:
-                if not validate_filter(property_filter):
-                    raise ValueError("Filter contains an invalid property key")
+                require_supported_filter(
+                    property_filter,
+                    self._indexed_properties,
+                    MilvusVectorStoreCollection._SUPPORTED_FILTER_NODES,
+                )
                 property_expr = self._build_milvus_filter(property_filter)
                 filter_expr = f"({filter_expr}) && ({property_expr})"
 
@@ -314,6 +356,10 @@ class MilvusVectorStoreParams(BaseModel):
     Attributes:
         client (MilvusClient): Milvus client instance.
         consistency_level (str): Collection consistency level for newly created collections.
+        indexed_properties (IndexedProperties):
+            The declared schema every collection of this store carries: each
+            key is a dynamic field a search filters on, and a record or a
+            filter naming any other key is rejected.
         metrics_factory (MetricsFactory | None): Metrics factory for collecting usage metrics.
     """
 
@@ -324,6 +370,10 @@ class MilvusVectorStoreParams(BaseModel):
     consistency_level: str = Field(
         default="Session",
         description="Milvus consistency level for newly created collections",
+    )
+    indexed_properties: IndexedProperties = Field(
+        ...,
+        description="The declared schema every collection of this store carries",
     )
     metrics_factory: InstanceOf[MetricsFactory] | None = Field(
         None,
@@ -338,7 +388,6 @@ class MilvusVectorStore(VectorStore):
 
     _REGISTRY_SUFFIX: ClassVar[str] = "__registry"
     _REGISTRY_VECTOR_DIMENSIONS: ClassVar[str] = "vector_dimensions"
-    _REGISTRY_INDEXED_PROPERTIES_SCHEMA: ClassVar[str] = "indexed_properties_schema"
     _REGISTRY_CONFIG: ClassVar[str] = "config"
 
     _name_locks: ClassVar[
@@ -378,6 +427,7 @@ class MilvusVectorStore(VectorStore):
         super().__init__()
         self._client = params.client
         self._consistency_level = params.consistency_level
+        self._indexed_properties = params.indexed_properties
         self._tracker = OperationTracker(
             params.metrics_factory,
             prefix="vector_store_milvus",
@@ -385,6 +435,11 @@ class MilvusVectorStore(VectorStore):
         self._client_name_locks = MilvusVectorStore._name_locks.setdefault(
             self._client, defaultdict(asyncio.Lock)
         )
+
+    @property
+    @override
+    def indexed_properties(self) -> Mapping[str, PropertyType]:
+        return self._indexed_properties
 
     @override
     async def startup(self) -> None:
@@ -497,9 +552,6 @@ class MilvusVectorStore(VectorStore):
         """Parse a VectorStoreCollectionConfig from a registry entry."""
         return VectorStoreCollectionConfig(
             vector_dimensions=entry[MilvusVectorStore._REGISTRY_VECTOR_DIMENSIONS],
-            indexed_properties_schema=entry[
-                MilvusVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA
-            ],
         )
 
     def _build_collection_handle(
@@ -513,6 +565,7 @@ class MilvusVectorStore(VectorStore):
             ),
             partition_key=name,
             config=config,
+            indexed_properties=self._indexed_properties,
             tracker=self._tracker,
         )
 
@@ -553,10 +606,6 @@ class MilvusVectorStore(VectorStore):
                 datatype=DataType.FLOAT_VECTOR,
                 dim=config.vector_dimensions,
             )
-            schema.add_field(
-                field_name=_PROPERTIES_FIELD,
-                datatype=DataType.JSON,
-            )
 
             index_params = self._client.prepare_index_params()
             index_params.add_index(
@@ -592,9 +641,6 @@ class MilvusVectorStore(VectorStore):
                     _VECTOR_FIELD: [0.0] * _REGISTRY_VECTOR_DIMENSION,
                     self._REGISTRY_CONFIG: {
                         self._REGISTRY_VECTOR_DIMENSIONS: config.vector_dimensions,
-                        self._REGISTRY_INDEXED_PROPERTIES_SCHEMA: config.model_dump(
-                            mode="json"
-                        )["indexed_properties_schema"],
                     },
                 }
             ],

--- a/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/milvus_vector_store.py
@@ -1,7 +1,6 @@
 """Milvus-based vector store implementation."""
 
 import asyncio
-import hashlib
 import json
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
@@ -10,7 +9,7 @@ from typing import Any, ClassVar, cast, override
 from uuid import UUID
 from weakref import WeakKeyDictionary
 
-from pydantic import BaseModel, Field, InstanceOf
+from pydantic import BaseModel, Field, InstanceOf, field_validator
 from pymilvus import DataType, MilvusClient
 from pymilvus.exceptions import MilvusException
 
@@ -32,16 +31,18 @@ from memmachine_server.common.utils import compute_cosine_similarity, ensure_tz_
 
 from .data_types import (
     IndexedProperties,
+    PartitionSchema,
     QueryMatch,
     QueryResult,
     Record,
-    VectorStoreCollectionAlreadyExistsError,
-    VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
+    VectorStorePartitionAlreadyExistsError,
+    VectorStorePartitionSchemaMismatchError,
+    indexed_property_names,
+    validate_collection_name,
 )
 from .declared_properties import require_declared_properties, require_supported_filter
 from .utils import validate_identifier
-from .vector_store import VectorStore, VectorStoreCollection
+from .vector_store import VectorStore, VectorStorePartition
 
 _ID_FIELD = "id"
 _RECORD_UUID_FIELD = "record_uuid"
@@ -90,8 +91,8 @@ def _normalize_property_filter_value(value: PropertyValue) -> PropertyValue:
     return value
 
 
-class MilvusVectorStoreCollection(VectorStoreCollection):
-    """A logical collection backed by Milvus."""
+class MilvusVectorStorePartition(VectorStorePartition):
+    """A partition backed by Milvus: one partition-key value inside the store's collection."""
 
     _SUPPORTED_FILTER_NODES: ClassVar[frozenset[type]] = frozenset(
         {Equals, NotEquals, Ordering, In, IsMissing, And, Or, Not}
@@ -100,7 +101,7 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
     @staticmethod
     def _build_milvus_filter(expr: FilterExpr) -> str:
         """Convert a FilterExpr tree into a Milvus filter expression."""
-        build = MilvusVectorStoreCollection._build_milvus_filter
+        build = MilvusVectorStorePartition._build_milvus_filter
         match expr:
             case Equals(field, value):
                 return f"{_property_field(field)} == {_literal(value)}"
@@ -114,7 +115,7 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
             case IsMissing(field):
                 return f"{_property_field(field)} is null"
             case Not(operand):
-                return MilvusVectorStoreCollection._negated(operand)
+                return MilvusVectorStorePartition._negated(operand)
             case And(operands):
                 return " && ".join(f"({build(o)})" for o in operands)
             case Or(operands):
@@ -128,8 +129,8 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         negated predicate is rendered as the inverse predicate or the field's
         absence, which is the complement the filter language defines.
         """
-        build = MilvusVectorStoreCollection._build_milvus_filter
-        negated = MilvusVectorStoreCollection._negated
+        build = MilvusVectorStorePartition._build_milvus_filter
+        negated = MilvusVectorStorePartition._negated
         match expr:
             case Equals(field, value):
                 return (
@@ -172,23 +173,20 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
         client: MilvusClient,
         collection_name: str,
         partition_key: str,
-        config: VectorStoreCollectionConfig,
         indexed_properties: Mapping[str, PropertyType],
         tracker: OperationTracker,
     ) -> None:
-        """Initialize with a Milvus client and collection name."""
+        """Initialize with a Milvus client and the collection and partition it is bound to."""
         self._client = client
         self._collection_name = collection_name
         self._partition_key = partition_key
-        self._config = config
         self._indexed_properties = dict(indexed_properties)
         self._tracker = tracker
 
     @property
     @override
-    def config(self) -> VectorStoreCollectionConfig:
-        """The configuration for this collection."""
-        return self._config
+    def partition_key(self) -> str:
+        return self._partition_key
 
     @property
     @override
@@ -198,7 +196,7 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
     @property
     @override
     def supported_filter_nodes(self) -> frozenset[type]:
-        return MilvusVectorStoreCollection._SUPPORTED_FILTER_NODES
+        return MilvusVectorStorePartition._SUPPORTED_FILTER_NODES
 
     def _build_entity(self, record: Record) -> dict[str, Any]:
         """Build a Milvus entity from a vector store record."""
@@ -281,7 +279,7 @@ class MilvusVectorStoreCollection(VectorStoreCollection):
                 require_supported_filter(
                     property_filter,
                     self._indexed_properties,
-                    MilvusVectorStoreCollection._SUPPORTED_FILTER_NODES,
+                    MilvusVectorStorePartition._SUPPORTED_FILTER_NODES,
                 )
                 property_expr = self._build_milvus_filter(property_filter)
                 filter_expr = f"({filter_expr}) && ({property_expr})"
@@ -355,9 +353,14 @@ class MilvusVectorStoreParams(BaseModel):
 
     Attributes:
         client (MilvusClient): Milvus client instance.
-        consistency_level (str): Collection consistency level for newly created collections.
+        collection (str):
+            The collection this store is; the native Milvus collection's
+            name, so stores of different collections may share the client.
+        vector_dimensions (int):
+            Dimensionality of every vector in the store.
+        consistency_level (str): Consistency level for the collections this store creates.
         indexed_properties (IndexedProperties):
-            The declared schema every collection of this store carries: each
+            The declared schema every partition of this store carries: each
             key is a dynamic field a search filters on, and a record or a
             filter naming any other key is rejected.
         metrics_factory (MetricsFactory | None): Metrics factory for collecting usage metrics.
@@ -367,30 +370,48 @@ class MilvusVectorStoreParams(BaseModel):
         ...,
         description="Milvus client instance",
     )
+    collection: str = Field(
+        ...,
+        description="The collection this store is; the native Milvus collection's name",
+    )
+    vector_dimensions: int = Field(
+        ..., gt=0, description="Dimensionality of every vector in the store"
+    )
     consistency_level: str = Field(
         default="Session",
-        description="Milvus consistency level for newly created collections",
+        description="Milvus consistency level for the collections this store creates",
     )
     indexed_properties: IndexedProperties = Field(
         ...,
-        description="The declared schema every collection of this store carries",
+        description="The declared schema every partition of this store carries",
     )
     metrics_factory: InstanceOf[MetricsFactory] | None = Field(
         None,
         description="An instance of MetricsFactory for collecting usage metrics",
     )
 
+    @field_validator("collection")
+    @classmethod
+    def _validate_collection(cls, collection: str) -> str:
+        validate_collection_name(collection)
+        return collection
+
 
 class MilvusVectorStore(VectorStore):
-    """Asynchronous Milvus-based implementation of VectorStore."""
+    """Asynchronous Milvus-based implementation of VectorStore.
+
+    The store is one native Milvus collection, named at construction, in
+    which every partition is a partition-key value. A registry collection
+    beside it records which partitions exist and what they were created
+    under.
+    """
 
     _MILVUS_METRIC_TYPE: ClassVar[str] = "COSINE"
 
     _REGISTRY_SUFFIX: ClassVar[str] = "__registry"
-    _REGISTRY_VECTOR_DIMENSIONS: ClassVar[str] = "vector_dimensions"
-    _REGISTRY_CONFIG: ClassVar[str] = "config"
+    _REGISTRY_SCHEMA: ClassVar[str] = "schema"
 
-    _name_locks: ClassVar[
+    _partition_locks: ClassVar[
         WeakKeyDictionary[
             MilvusClient,
             defaultdict[tuple[str, str], asyncio.Lock],
@@ -409,37 +430,52 @@ class MilvusVectorStore(VectorStore):
         message = str(error).lower()
         return "not found" in message or "can't find" in message
 
-    @staticmethod
-    def _registry_collection_name(namespace: str) -> str:
-        """Return the registry collection name for a namespace."""
-        return f"memmachine_{namespace}{MilvusVectorStore._REGISTRY_SUFFIX}"
-
-    @staticmethod
-    def _build_native_collection_name(
-        namespace: str, config: VectorStoreCollectionConfig
-    ) -> str:
-        """Build a deterministic native collection name from namespace and config."""
-        digest = hashlib.sha256(config.model_dump_json().encode()).hexdigest()
-        return f"memmachine_{namespace}__{digest}"
-
     def __init__(self, params: MilvusVectorStoreParams) -> None:
         """Initialize the vector store with the provided parameters."""
         super().__init__()
         self._client = params.client
+        self._collection = params.collection
+        self._vector_dimensions = params.vector_dimensions
         self._consistency_level = params.consistency_level
         self._indexed_properties = params.indexed_properties
         self._tracker = OperationTracker(
             params.metrics_factory,
             prefix="vector_store_milvus",
         )
-        self._client_name_locks = MilvusVectorStore._name_locks.setdefault(
+        self._client_partition_locks = MilvusVectorStore._partition_locks.setdefault(
             self._client, defaultdict(asyncio.Lock)
         )
 
     @property
     @override
+    def collection(self) -> str:
+        return self._collection
+
+    @property
+    @override
+    def vector_dimensions(self) -> int:
+        return self._vector_dimensions
+
+    @property
+    @override
     def indexed_properties(self) -> Mapping[str, PropertyType]:
         return self._indexed_properties
+
+    @property
+    def _registry_collection_name(self) -> str:
+        return f"{self._collection}{MilvusVectorStore._REGISTRY_SUFFIX}"
+
+    def _declared_schema(self) -> PartitionSchema:
+        return PartitionSchema(
+            vector_dimensions=self._vector_dimensions,
+            indexed_properties=indexed_property_names(self._indexed_properties),
+        )
+
+    @override
+    async def provision(self) -> None:
+        async with self._tracker("provision"):
+            await self._ensure_registry_collection()
+            await self._ensure_native_collection()
 
     @override
     async def startup(self) -> None:
@@ -449,11 +485,9 @@ class MilvusVectorStore(VectorStore):
     async def shutdown(self) -> None:
         """No-op; client lifecycle is managed externally."""
 
-    async def _ensure_namespace_registry_collection(self, namespace: str) -> None:
-        """Idempotently create the registry collection for a namespace."""
-        registry_collection_name = MilvusVectorStore._registry_collection_name(
-            namespace
-        )
+    async def _ensure_registry_collection(self) -> None:
+        """Idempotently create the registry collection."""
+        registry_collection_name = self._registry_collection_name
         if await asyncio.to_thread(
             self._client.has_collection, registry_collection_name
         ):
@@ -476,7 +510,7 @@ class MilvusVectorStore(VectorStore):
                 dim=_REGISTRY_VECTOR_DIMENSION,
             )
             schema.add_field(
-                field_name=self._REGISTRY_CONFIG,
+                field_name=self._REGISTRY_SCHEMA,
                 datatype=DataType.JSON,
             )
 
@@ -500,83 +534,9 @@ class MilvusVectorStore(VectorStore):
             if not MilvusVectorStore._is_already_exists_error(exc):
                 raise
 
-    async def _get_registry_entry(
-        self, namespace: str, name: str
-    ) -> dict[str, Any] | None:
-        """Retrieve the registry entry for a logical collection name."""
-        registry_collection_name = MilvusVectorStore._registry_collection_name(
-            namespace
-        )
-        if not await asyncio.to_thread(
-            self._client.has_collection, registry_collection_name
-        ):
-            return None
-
-        filter_expr = f"{_ID_FIELD} == {_expr_string(name)}"
-        try:
-            result = await asyncio.to_thread(
-                self._client.get,
-                collection_name=registry_collection_name,
-                ids=[name],
-                output_fields=[_ID_FIELD, self._REGISTRY_CONFIG],
-            )
-        except MilvusException as exc:
-            if MilvusVectorStore._is_not_found_error(exc):
-                return None
-            raise
-
-        entries = list(result)
-        if not entries:
-            return None
-        entry = entries[0]
-        entry_id = entry.get(_ID_FIELD)
-        if entry_id is not None and entry_id != name:
-            return None
-        config = cast(dict[str, Any], entry.get(self._REGISTRY_CONFIG))
-        if config is None:
-            # Older clients may not include the primary key in get() output unless queried.
-            rows = await asyncio.to_thread(
-                self._client.query,
-                collection_name=registry_collection_name,
-                filter=filter_expr,
-                output_fields=[_ID_FIELD, self._REGISTRY_CONFIG],
-            )
-            rows = list(rows)
-            if not rows:
-                return None
-            config = cast(dict[str, Any], rows[0][self._REGISTRY_CONFIG])
-        return config
-
-    @staticmethod
-    def _parse_entry(entry: Mapping[str, Any]) -> VectorStoreCollectionConfig:
-        """Parse a VectorStoreCollectionConfig from a registry entry."""
-        return VectorStoreCollectionConfig(
-            vector_dimensions=entry[MilvusVectorStore._REGISTRY_VECTOR_DIMENSIONS],
-        )
-
-    def _build_collection_handle(
-        self, namespace: str, name: str, config: VectorStoreCollectionConfig
-    ) -> MilvusVectorStoreCollection:
-        """Build a MilvusVectorStoreCollection handle."""
-        return MilvusVectorStoreCollection(
-            client=self._client,
-            collection_name=MilvusVectorStore._build_native_collection_name(
-                namespace, config
-            ),
-            partition_key=name,
-            config=config,
-            indexed_properties=self._indexed_properties,
-            tracker=self._tracker,
-        )
-
-    async def _create_native_collection(
-        self, namespace: str, config: VectorStoreCollectionConfig
-    ) -> None:
+    async def _ensure_native_collection(self) -> None:
         """Idempotently create the native Milvus collection."""
-        native_collection_name = MilvusVectorStore._build_native_collection_name(
-            namespace, config
-        )
-        if await asyncio.to_thread(self._client.has_collection, native_collection_name):
+        if await asyncio.to_thread(self._client.has_collection, self._collection):
             return
 
         def _create_collection() -> None:
@@ -604,7 +564,7 @@ class MilvusVectorStore(VectorStore):
             schema.add_field(
                 field_name=_VECTOR_FIELD,
                 datatype=DataType.FLOAT_VECTOR,
-                dim=config.vector_dimensions,
+                dim=self._vector_dimensions,
             )
 
             index_params = self._client.prepare_index_params()
@@ -615,7 +575,7 @@ class MilvusVectorStore(VectorStore):
             )
 
             self._client.create_collection(
-                collection_name=native_collection_name,
+                collection_name=self._collection,
                 schema=schema,
                 index_params=index_params,
                 consistency_level=self._consistency_level,
@@ -627,143 +587,130 @@ class MilvusVectorStore(VectorStore):
             if not MilvusVectorStore._is_already_exists_error(exc):
                 raise
 
-    async def _register_collection(
-        self, namespace: str, name: str, config: VectorStoreCollectionConfig
-    ) -> None:
-        """Write the logical collection entry to the registry."""
-        registry_name = MilvusVectorStore._registry_collection_name(namespace)
+    async def _stored_schema(self, partition_key: str) -> PartitionSchema | None:
+        """The schema the partition was created under; raises if it is not this store's."""
+        registry_collection_name = self._registry_collection_name
+        if not await asyncio.to_thread(
+            self._client.has_collection, registry_collection_name
+        ):
+            return None
+
+        try:
+            result = await asyncio.to_thread(
+                self._client.get,
+                collection_name=registry_collection_name,
+                ids=[partition_key],
+                output_fields=[_ID_FIELD, self._REGISTRY_SCHEMA],
+            )
+        except MilvusException as exc:
+            if MilvusVectorStore._is_not_found_error(exc):
+                return None
+            raise
+
+        entries = list(result)
+        if not entries:
+            return None
+        entry = entries[0]
+        entry_id = entry.get(_ID_FIELD)
+        if entry_id is not None and entry_id != partition_key:
+            return None
+        stored = cast(dict[str, Any] | None, entry.get(self._REGISTRY_SCHEMA))
+        if stored is None:
+            # Older clients may not include the primary key in get() output unless queried.
+            rows = await asyncio.to_thread(
+                self._client.query,
+                collection_name=registry_collection_name,
+                filter=f"{_ID_FIELD} == {_expr_string(partition_key)}",
+                output_fields=[_ID_FIELD, self._REGISTRY_SCHEMA],
+            )
+            rows = list(rows)
+            if not rows:
+                return None
+            stored = cast(dict[str, Any], rows[0][self._REGISTRY_SCHEMA])
+
+        stored_schema = PartitionSchema.model_validate(stored)
+        declared_schema = self._declared_schema()
+        if stored_schema != declared_schema:
+            raise VectorStorePartitionSchemaMismatchError(
+                self._collection, partition_key, stored_schema, declared_schema
+            )
+        return stored_schema
+
+    def _partition_handle(self, partition_key: str) -> MilvusVectorStorePartition:
+        return MilvusVectorStorePartition(
+            client=self._client,
+            collection_name=self._collection,
+            partition_key=partition_key,
+            indexed_properties=self._indexed_properties,
+            tracker=self._tracker,
+        )
+
+    async def _register_partition(self, partition_key: str) -> None:
+        """Write the partition's entry to the registry."""
         await asyncio.to_thread(
             self._client.insert,
-            collection_name=registry_name,
+            collection_name=self._registry_collection_name,
             data=[
                 {
-                    _ID_FIELD: name,
+                    _ID_FIELD: partition_key,
                     _VECTOR_FIELD: [0.0] * _REGISTRY_VECTOR_DIMENSION,
-                    self._REGISTRY_CONFIG: {
-                        self._REGISTRY_VECTOR_DIMENSIONS: config.vector_dimensions,
-                    },
+                    self._REGISTRY_SCHEMA: self._declared_schema().model_dump(
+                        mode="json"
+                    ),
                 }
             ],
         )
 
+    @staticmethod
+    def _require_partition_key(partition_key: str) -> None:
+        if not validate_identifier(partition_key):
+            raise ValueError(
+                f"Partition key {partition_key!r} must match [a-z0-9_]+ and be at "
+                "most 32 bytes"
+            )
+
     @override
-    async def create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> None:
-        """Create a logical collection in the Milvus vector store."""
-        if not validate_identifier(namespace):
-            raise ValueError(
-                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        if not validate_identifier(name):
-            raise ValueError(
-                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
+    async def create_partition(self, partition_key: str) -> None:
+        """Create a partition in the store's collection."""
+        MilvusVectorStore._require_partition_key(partition_key)
         async with (
-            self._client_name_locks[(namespace, name)],
-            self._tracker("create_collection"),
+            self._client_partition_locks[(self._collection, partition_key)],
+            self._tracker("create_partition"),
         ):
-            await self._ensure_namespace_registry_collection(namespace)
-            if await self._get_registry_entry(namespace, name) is not None:
-                raise VectorStoreCollectionAlreadyExistsError(namespace, name)
-            await self._create_native_collection(namespace, config)
-            await self._register_collection(namespace, name, config)
+            if await self._stored_schema(partition_key) is not None:
+                raise VectorStorePartitionAlreadyExistsError(
+                    self._collection, partition_key
+                )
+            await self._register_partition(partition_key)
 
     @override
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> MilvusVectorStoreCollection:
-        """Open the collection if it exists, or create and return it."""
-        if not validate_identifier(namespace):
-            raise ValueError(
-                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        if not validate_identifier(name):
-            raise ValueError(
-                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        async with (
-            self._client_name_locks[(namespace, name)],
-            self._tracker("open_or_create_collection"),
-        ):
-            entry = await self._get_registry_entry(namespace, name)
-            if entry is not None:
-                existing_config = MilvusVectorStore._parse_entry(entry)
-                if existing_config != config:
-                    raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
-                    )
-                return self._build_collection_handle(namespace, name, existing_config)
-
-            await self._ensure_namespace_registry_collection(namespace)
-            await self._create_native_collection(namespace, config)
-            await self._register_collection(namespace, name, config)
-            return self._build_collection_handle(namespace, name, config)
-
-    @override
-    async def open_collection(
-        self, *, namespace: str, name: str
-    ) -> MilvusVectorStoreCollection | None:
-        """Get a collection handle from the vector store."""
-        if not validate_identifier(namespace):
-            raise ValueError(
-                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        if not validate_identifier(name):
-            raise ValueError(
-                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        entry = await self._get_registry_entry(namespace, name)
-        if entry is None:
+    async def get_partition(
+        self, partition_key: str
+    ) -> MilvusVectorStorePartition | None:
+        """Get a handle bound to an existing partition."""
+        MilvusVectorStore._require_partition_key(partition_key)
+        if await self._stored_schema(partition_key) is None:
             return None
-        return self._build_collection_handle(
-            namespace, name, MilvusVectorStore._parse_entry(entry)
-        )
+        return self._partition_handle(partition_key)
 
     @override
-    async def close_collection(self, *, collection: VectorStoreCollection) -> None:
-        """No-op; Milvus collection handles require no explicit close."""
-
-    @override
-    async def delete_collection(self, *, namespace: str, name: str) -> None:
-        """Delete a logical collection from the Milvus vector store."""
-        if not validate_identifier(namespace):
-            raise ValueError(
-                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        if not validate_identifier(name):
-            raise ValueError(
-                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
+    async def delete_partition(self, partition_key: str) -> None:
+        """Delete a partition and its records from the store's collection."""
+        MilvusVectorStore._require_partition_key(partition_key)
         async with (
-            self._client_name_locks[(namespace, name)],
-            self._tracker("delete_collection"),
+            self._client_partition_locks[(self._collection, partition_key)],
+            self._tracker("delete_partition"),
         ):
-            entry = await self._get_registry_entry(namespace, name)
-            if entry is None:
+            if await self._stored_schema(partition_key) is None:
                 return
 
-            config = MilvusVectorStore._parse_entry(entry)
-            native_collection_name = MilvusVectorStore._build_native_collection_name(
-                namespace, config
-            )
-            registry_name = MilvusVectorStore._registry_collection_name(namespace)
-
             await asyncio.to_thread(
                 self._client.delete,
-                collection_name=native_collection_name,
-                filter=f"{_PARTITION_KEY_FIELD} == {_expr_string(name)}",
+                collection_name=self._collection,
+                filter=f"{_PARTITION_KEY_FIELD} == {_expr_string(partition_key)}",
             )
             await asyncio.to_thread(
                 self._client.delete,
-                collection_name=registry_name,
-                ids=[name],
+                collection_name=self._registry_collection_name,
+                ids=[partition_key],
             )

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -5,45 +5,38 @@ import hashlib
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime
-from typing import Any, ClassVar, cast, override
+from typing import Any, ClassVar, Self, cast, override
 from uuid import UUID, uuid5
 from weakref import WeakKeyDictionary
 
 import grpc
 import grpc.aio
-from pydantic import BaseModel, Field, InstanceOf
+from pydantic import BaseModel, Field, InstanceOf, model_validator
 from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.http.exceptions import ResponseHandlingException, UnexpectedResponse
 
 from memmachine_server.common.data_types import (
     OrderedValue,
+    PropertyType,
     PropertyValue,
 )
-from memmachine_server.common.filter.filter_parser import (
-    And as FilterAnd,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Comparison as FilterComparison,
-)
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
+    And,
+    Equals,
     FilterExpr,
-)
-from memmachine_server.common.filter.filter_parser import (
-    In as FilterIn,
-)
-from memmachine_server.common.filter.filter_parser import (
-    IsNull as FilterIsNull,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Not as FilterNot,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Or as FilterOr,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
+    OrderingOp,
 )
 from memmachine_server.common.metrics_factory import MetricsFactory, OperationTracker
 from memmachine_server.common.utils import ensure_tz_aware
 
 from .data_types import (
+    IndexedProperties,
     QueryMatch,
     QueryResult,
     Record,
@@ -51,7 +44,8 @@ from .data_types import (
     VectorStoreCollectionConfig,
     VectorStoreCollectionConfigMismatchError,
 )
-from .utils import validate_filter, validate_identifier
+from .declared_properties import require_declared_properties, require_supported_filter
+from .utils import validate_identifier
 from .vector_store import VectorStore, VectorStoreCollection
 
 # Point payload keys (stored on every Qdrant point).
@@ -76,156 +70,93 @@ def _partition_filter(partition_key: str) -> models.Filter:
 class QdrantVectorStoreCollection(VectorStoreCollection):
     """A collection backed by Qdrant."""
 
-    _RANGE_OPERATORS: ClassVar[dict[str, str]] = {
+    _RANGE_OPERATORS: ClassVar[dict[OrderingOp, str]] = {
         ">": "gt",
         ">=": "gte",
         "<": "lt",
         "<=": "lte",
     }
 
+    _SUPPORTED_FILTER_NODES: ClassVar[frozenset[type]] = frozenset(
+        {Equals, NotEquals, Ordering, In, IsMissing, And, Or, Not}
+    )
+
     @staticmethod
     def _build_qdrant_filter(expr: FilterExpr) -> models.Filter:
         """Convert a FilterExpr tree into a Qdrant Filter."""
-        if isinstance(expr, FilterComparison):
-            return QdrantVectorStoreCollection._build_qdrant_comparison(expr)
-        if isinstance(expr, FilterIn):
-            return QdrantVectorStoreCollection._in_filter(expr.field, expr.values)
-        if isinstance(expr, FilterIsNull):
-            return QdrantVectorStoreCollection._null_filter(expr.field, negate=False)
-        if isinstance(expr, FilterNot):
-            return models.Filter(
-                must_not=[QdrantVectorStoreCollection._build_qdrant_filter(expr.expr)]
-            )
-        if isinstance(expr, FilterAnd):
-            left = QdrantVectorStoreCollection._build_qdrant_filter(expr.left)
-            right = QdrantVectorStoreCollection._build_qdrant_filter(expr.right)
-            return models.Filter(must=[left, right])
-        if isinstance(expr, FilterOr):
-            left = QdrantVectorStoreCollection._build_qdrant_filter(expr.left)
-            right = QdrantVectorStoreCollection._build_qdrant_filter(expr.right)
-            return models.Filter(should=[left, right])
-        message = f"Unsupported filter expression type: {type(expr)}"
-        raise TypeError(message)
-
-    @staticmethod
-    def _build_qdrant_comparison(comparison: FilterComparison) -> models.Filter:
-        """Convert a Comparison into a Qdrant Filter."""
-        field = comparison.field
-        operator = comparison.op
-        value = comparison.value
-
-        if operator in ("=", "!="):
-            negate = operator == "!="
-            if isinstance(value, float):
-                return QdrantVectorStoreCollection._float_eq_filter(
-                    field, value, negate=negate
+        build = QdrantVectorStoreCollection._build_qdrant_filter
+        eq_condition = QdrantVectorStoreCollection._eq_condition
+        missing_condition = QdrantVectorStoreCollection._missing_condition
+        match expr:
+            case Equals(field, value):
+                return models.Filter(must=[eq_condition(field, value)])
+            case NotEquals(field, value):
+                # `must_not` of the match alone would also admit points
+                # lacking the field; a differing value is one the point holds.
+                return models.Filter(
+                    must_not=[eq_condition(field, value), missing_condition(field)]
                 )
-            if isinstance(value, datetime):
-                return QdrantVectorStoreCollection._datetime_eq_filter(
-                    field, value, negate=negate
+            case Ordering(field, op, value):
+                return models.Filter(
+                    must=[
+                        QdrantVectorStoreCollection._range_condition(
+                            field,
+                            value,
+                            QdrantVectorStoreCollection._RANGE_OPERATORS[op],
+                        )
+                    ]
                 )
-            return QdrantVectorStoreCollection._match_filter(
-                field, value, negate=negate
-            )
-        if operator in QdrantVectorStoreCollection._RANGE_OPERATORS:
-            if not isinstance(value, OrderedValue):
-                message = (
-                    f"Range filter on '{field}' requires a numeric or datetime value, "
-                    f"got {type(value).__name__}"
+            case In(field, values):
+                return models.Filter(
+                    must=[
+                        models.FieldCondition(
+                            key=field, match=models.MatchAny(any=list(values))
+                        )
+                    ]
                 )
-                raise TypeError(message)
-            return QdrantVectorStoreCollection._range_filter(
-                field, value, QdrantVectorStoreCollection._RANGE_OPERATORS[operator]
+            case IsMissing(field):
+                return models.Filter(must=[missing_condition(field)])
+            case Not(operand):
+                return models.Filter(must_not=[build(operand)])
+            case And(operands):
+                return models.Filter(must=[build(o) for o in operands])
+            case Or(operands):
+                return models.Filter(should=[build(o) for o in operands])
+
+    @staticmethod
+    def _eq_condition(field: str, value: PropertyValue) -> models.FieldCondition:
+        """Match a field against a value, by the only condition Qdrant offers for its type."""
+        if isinstance(value, float):
+            # MatchValue does not accept floats.
+            return models.FieldCondition(
+                key=field, range=models.Range(gte=value, lte=value)
             )
-
-        message = f"Unsupported filter operator: {operator}"
-        raise ValueError(message)
-
-    @staticmethod
-    def _match_filter(
-        field: str,
-        value: bool | int | str,
-        *,
-        negate: bool,
-    ) -> models.Filter:
-        condition = models.FieldCondition(
-            key=field,
-            match=models.MatchValue(value=value),
-        )
-        if negate:
-            return models.Filter(must_not=[condition])
-        return models.Filter(must=[condition])
+        if isinstance(value, datetime):
+            instant = ensure_tz_aware(value)
+            return models.FieldCondition(
+                key=field, range=models.DatetimeRange(gte=instant, lte=instant)
+            )
+        return models.FieldCondition(key=field, match=models.MatchValue(value=value))
 
     @staticmethod
-    def _float_eq_filter(field: str, value: float, *, negate: bool) -> models.Filter:
-        """Use a range filter for float equality since MatchValue doesn't accept floats."""
-        condition = models.FieldCondition(
-            key=field,
-            range=models.Range(gte=value, lte=value),
-        )
-        if negate:
-            return models.Filter(must_not=[condition])
-        return models.Filter(must=[condition])
-
-    @staticmethod
-    def _datetime_eq_filter(
-        field: str, value: datetime, *, negate: bool
-    ) -> models.Filter:
-        """Use a DatetimeRange filter for datetime equality since MatchValue doesn't accept datetimes."""
-        value = ensure_tz_aware(value)
-        condition = models.FieldCondition(
-            key=field,
-            range=models.DatetimeRange(gte=value, lte=value),
-        )
-        if negate:
-            return models.Filter(must_not=[condition])
-        return models.Filter(must=[condition])
-
-    @staticmethod
-    def _in_filter(field: str, value: list[int] | list[str]) -> models.Filter:
-        return models.Filter(
-            must=[
-                models.FieldCondition(
-                    key=field,
-                    match=models.MatchAny(any=value),
-                ),
-            ],
-        )
-
-    @staticmethod
-    def _range_filter(
+    def _range_condition(
         field: str,
         value: OrderedValue,
         range_parameter: str,
-    ) -> models.Filter:
+    ) -> models.FieldCondition:
         if isinstance(value, datetime):
-            value = ensure_tz_aware(value)
-            return models.Filter(
-                must=[
-                    models.FieldCondition(
-                        key=field,
-                        range=models.DatetimeRange(**{range_parameter: value}),
-                    ),
-                ],
+            return models.FieldCondition(
+                key=field,
+                range=models.DatetimeRange(**{range_parameter: ensure_tz_aware(value)}),
             )
-
-        return models.Filter(
-            must=[
-                models.FieldCondition(
-                    key=field,
-                    range=models.Range(**{range_parameter: value}),
-                ),
-            ],
+        return models.FieldCondition(
+            key=field, range=models.Range(**{range_parameter: value})
         )
 
     @staticmethod
-    def _null_filter(field: str, *, negate: bool) -> models.Filter:
-        condition = models.IsEmptyCondition(
-            is_empty=models.PayloadField(key=field),
-        )
-        if negate:
-            return models.Filter(must_not=[condition])
-        return models.Filter(must=[condition])
+    def _missing_condition(field: str) -> models.IsEmptyCondition:
+        """Points that do not carry the field."""
+        return models.IsEmptyCondition(is_empty=models.PayloadField(key=field))
 
     def __init__(
         self,
@@ -234,6 +165,7 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
         collection_name: str,
         partition_key: str,
         config: VectorStoreCollectionConfig,
+        indexed_properties: Mapping[str, PropertyType],
         tracker: OperationTracker,
         shard_key: str | None = None,
     ) -> None:
@@ -243,6 +175,7 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
         self._collection_name = collection_name
         self._partition_key = partition_key
         self._config = config
+        self._indexed_properties = dict(indexed_properties)
         self._shard_key = shard_key
 
     @property
@@ -251,44 +184,29 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
         """The configuration for this collection."""
         return self._config
 
+    @property
+    @override
+    def indexed_properties(self) -> Mapping[str, PropertyType]:
+        return self._indexed_properties
+
+    @property
+    @override
+    def supported_filter_nodes(self) -> frozenset[type]:
+        return QdrantVectorStoreCollection._SUPPORTED_FILTER_NODES
+
     def _build_payload(
         self,
-        properties: dict[str, PropertyValue] | None,
+        properties: Mapping[str, PropertyValue],
     ) -> dict[str, PropertyValue]:
         """Build Qdrant-compatible payload from record properties."""
         payload: dict[str, PropertyValue] = {
             _PAYLOAD_PARTITION_KEY: self._partition_key,
         }
-        if properties:
-            for key, value in properties.items():
-                if value is None:
-                    continue
-                if isinstance(value, datetime):
-                    payload[key] = ensure_tz_aware(value)
-                else:
-                    payload[key] = value
+        for key, value in properties.items():
+            payload[key] = (
+                ensure_tz_aware(value) if isinstance(value, datetime) else value
+            )
         return payload
-
-    def _parse_payload(
-        self,
-        payload: dict[str, Any] | None,
-    ) -> dict[str, PropertyValue] | None:
-        """Parse record properties from Qdrant payload."""
-        if payload is None:
-            return None
-
-        indexed_properties_schema = self._config.indexed_properties_schema
-        result: dict[str, PropertyValue] = {}
-        for key, value in payload.items():
-            if key == _PAYLOAD_PARTITION_KEY or value is None:
-                continue
-            if indexed_properties_schema.get(key) is datetime and isinstance(
-                value, str
-            ):
-                result[key] = datetime.fromisoformat(value)
-            else:
-                result[key] = cast(PropertyValue, value)
-        return result
 
     @override
     async def upsert(
@@ -300,12 +218,12 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
         async with self._tracker("upsert"):
             points: list[models.PointStruct] = []
             for record in records:
-                properties = record.properties
+                require_declared_properties(record.properties, self._indexed_properties)
                 points.append(
                     models.PointStruct(
                         id=record.uuid,
                         vector=record.vector,
-                        payload=self._build_payload(properties),
+                        payload=self._build_payload(record.properties),
                     )
                 )
             if points:
@@ -343,9 +261,12 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
                 return []
 
             partition_key_filter = _partition_filter(self._partition_key)
-            if property_filter:
-                if not validate_filter(property_filter):
-                    raise ValueError("Filter contains an invalid property key")
+            if property_filter is not None:
+                require_supported_filter(
+                    property_filter,
+                    self._indexed_properties,
+                    QdrantVectorStoreCollection._SUPPORTED_FILTER_NODES,
+                )
                 property_qdrant_filter = (
                     QdrantVectorStoreCollection._build_qdrant_filter(property_filter)
                 )
@@ -430,11 +351,30 @@ class QdrantVectorStoreParams(BaseModel):
         registry_replication_factor (int):
             Replication factor for registry collections. Write consistency factor is
             set to match so all replicas confirm writes before returning, guaranteeing
-            read-your-writes from any available replica.
+            read-your-writes from any available replica
+            (default: 1).
+        indexed_properties (IndexedProperties):
+            The declared schema every collection of this store carries: each
+            key gets a payload index of its declared type, and a record or a
+            filter naming any other key is rejected.
+        hnsw_config (HnswConfigDiff | None):
+            Optional HNSW index tuning applied to native collections.
+            `m` must be 0 or unset: native collections are multi-tenant
+            and disable the global graph in favor of per-tenant payload indexing,
+            so tune `payload_m` rather than `m`.
+            Does not apply to registry collections
+            (default: None).
+        optimizers_config (OptimizersConfigDiff | None):
+            Optional optimizer tuning applied to native collections.
+            Does not apply to registry collections
+            (default: None).
+        quantization_config (QuantizationConfig | None):
+            Optional quantization applied to native collections.
+            Does not apply to registry collections
+            (default: None).
         metrics_factory (MetricsFactory | None):
             An instance of MetricsFactory for collecting usage metrics
             (default: None).
-
     """
 
     client: InstanceOf[AsyncQdrantClient] = Field(
@@ -459,10 +399,48 @@ class QdrantVectorStoreParams(BaseModel):
             "read-your-writes from any available replica"
         ),
     )
+    indexed_properties: IndexedProperties = Field(
+        ...,
+        description="The declared schema every collection of this store carries",
+    )
+    hnsw_config: models.HnswConfigDiff | None = Field(
+        None,
+        description=(
+            "Optional HNSW index tuning applied to native collections. "
+            "`m` must be 0 or unset: native collections are multi-tenant "
+            "and disable the global graph in favor of per-tenant payload indexing, "
+            "so tune `payload_m` rather than `m`. "
+            "Does not apply to registry collections"
+        ),
+    )
+    optimizers_config: models.OptimizersConfigDiff | None = Field(
+        None,
+        description=(
+            "Optional optimizer tuning applied to native collections. "
+            "Does not apply to registry collections"
+        ),
+    )
+    quantization_config: models.QuantizationConfig | None = Field(
+        None,
+        description=(
+            "Optional quantization applied to native collections. "
+            "Does not apply to registry collections"
+        ),
+    )
     metrics_factory: InstanceOf[MetricsFactory] | None = Field(
         None,
         description="An instance of MetricsFactory for collecting usage metrics",
     )
+
+    @model_validator(mode="after")
+    def _validate_hnsw_m(self) -> Self:
+        if self.hnsw_config is not None and self.hnsw_config.m not in (None, 0):
+            raise ValueError(
+                "hnsw_config.m must be 0 or unset: native collections are "
+                "multi-tenant and disable the global graph in favor of per-tenant "
+                "payload indexing, so tune payload_m rather than m"
+            )
+        return self
 
 
 class QdrantVectorStore(VectorStore):
@@ -484,7 +462,9 @@ class QdrantVectorStore(VectorStore):
     _REGISTRY_SUFFIX: ClassVar[str] = "__registry"
     _REGISTRY_NAME: ClassVar[str] = "name"
     _REGISTRY_VECTOR_DIMENSIONS: ClassVar[str] = "vector_dimensions"
-    _REGISTRY_INDEXED_PROPERTIES_SCHEMA: ClassVar[str] = "indexed_properties_schema"
+
+    # The per-tenant graph size when no override is configured.
+    _DEFAULT_NATIVE_PAYLOAD_M: ClassVar[int] = 16
 
     # Fixed UUID namespace for deterministic registry point IDs.
     _REGISTRY_UUID_NAMESPACE: ClassVar[UUID] = UUID(
@@ -546,8 +526,10 @@ class QdrantVectorStore(VectorStore):
         self._is_distributed = params.is_distributed
 
         self._registry_replication_factor = params.registry_replication_factor
-
-        self._hnsw_m = 16
+        self._indexed_properties = params.indexed_properties
+        self._hnsw_config = params.hnsw_config
+        self._optimizers_config = params.optimizers_config
+        self._quantization_config = params.quantization_config
 
         self._tracker = OperationTracker(
             params.metrics_factory,
@@ -558,6 +540,11 @@ class QdrantVectorStore(VectorStore):
             self._client, defaultdict(asyncio.Lock)
         )
 
+    @property
+    @override
+    def indexed_properties(self) -> Mapping[str, PropertyType]:
+        return self._indexed_properties
+
     @override
     async def startup(self) -> None:
         """No-op; client lifecycle is managed externally."""
@@ -565,6 +552,22 @@ class QdrantVectorStore(VectorStore):
     @override
     async def shutdown(self) -> None:
         """No-op; client lifecycle is managed externally."""
+
+    def _native_hnsw_config(self) -> models.HnswConfigDiff:
+        """The HNSW config of a native collection: the overrides, with `m` pinned at 0.
+
+        A native collection is multi-tenant, so the global graph is disabled
+        and each tenant gets its own graph of `payload_m` links.
+        """
+        overrides = self._hnsw_config or models.HnswConfigDiff()
+        return overrides.model_copy(
+            update={
+                "m": 0,
+                "payload_m": overrides.payload_m
+                if overrides.payload_m is not None
+                else QdrantVectorStore._DEFAULT_NATIVE_PAYLOAD_M,
+            }
+        )
 
     async def _ensure_namespace_registry_collection(self, namespace: str) -> None:
         """Idempotently create the registry collection for a namespace."""
@@ -626,9 +629,6 @@ class QdrantVectorStore(VectorStore):
         """Parse a VectorStoreCollectionConfig from a registry entry."""
         return VectorStoreCollectionConfig(
             vector_dimensions=entry[QdrantVectorStore._REGISTRY_VECTOR_DIMENSIONS],
-            indexed_properties_schema=entry[
-                QdrantVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA
-            ],
         )
 
     def _build_collection_handle(
@@ -642,6 +642,7 @@ class QdrantVectorStore(VectorStore):
             ),
             partition_key=name,
             config=config,
+            indexed_properties=self._indexed_properties,
             tracker=self._tracker,
             shard_key=name if self._is_distributed else None,
         )
@@ -666,10 +667,9 @@ class QdrantVectorStore(VectorStore):
                 vectors_config=models.VectorParams(
                     size=config.vector_dimensions, distance=distance
                 ),
-                hnsw_config=models.HnswConfigDiff(
-                    m=0,
-                    payload_m=self._hnsw_m,
-                ),
+                hnsw_config=self._native_hnsw_config(),
+                optimizers_config=self._optimizers_config,
+                quantization_config=self._quantization_config,
                 sharding_method=(
                     models.ShardingMethod.CUSTOM if self._is_distributed else None
                 ),
@@ -687,7 +687,7 @@ class QdrantVectorStore(VectorStore):
                 ),
             )
         ]
-        for prop_name, prop_type in config.indexed_properties_schema.items():
+        for prop_name, prop_type in self._indexed_properties.items():
             index_type = QdrantVectorStore._PROPERTY_TYPE_TO_INDEX_TYPE.get(prop_type)
             if index_type is not None:
                 indexes.append((prop_name, index_type))
@@ -730,9 +730,6 @@ class QdrantVectorStore(VectorStore):
                     payload={
                         QdrantVectorStore._REGISTRY_NAME: name,
                         QdrantVectorStore._REGISTRY_VECTOR_DIMENSIONS: config.vector_dimensions,
-                        QdrantVectorStore._REGISTRY_INDEXED_PROPERTIES_SCHEMA: config.model_dump(
-                            mode="json"
-                        )["indexed_properties_schema"],
                     },
                 ),
             ],

--- a/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/qdrant_vector_store.py
@@ -1,7 +1,6 @@
 """Qdrant-based vector store implementation."""
 
 import asyncio
-import hashlib
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime
@@ -11,7 +10,7 @@ from weakref import WeakKeyDictionary
 
 import grpc
 import grpc.aio
-from pydantic import BaseModel, Field, InstanceOf, model_validator
+from pydantic import BaseModel, Field, InstanceOf, field_validator, model_validator
 from qdrant_client import AsyncQdrantClient, models
 from qdrant_client.http.exceptions import ResponseHandlingException, UnexpectedResponse
 
@@ -37,16 +36,18 @@ from memmachine_server.common.utils import ensure_tz_aware
 
 from .data_types import (
     IndexedProperties,
+    PartitionSchema,
     QueryMatch,
     QueryResult,
     Record,
-    VectorStoreCollectionAlreadyExistsError,
-    VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
+    VectorStorePartitionAlreadyExistsError,
+    VectorStorePartitionSchemaMismatchError,
+    indexed_property_names,
+    validate_collection_name,
 )
 from .declared_properties import require_declared_properties, require_supported_filter
 from .utils import validate_identifier
-from .vector_store import VectorStore, VectorStoreCollection
+from .vector_store import VectorStore, VectorStorePartition
 
 # Point payload keys (stored on every Qdrant point).
 # System keys use _SYSTEM_KEY_PREFIX, which contains a hyphen. Hyphens are valid in
@@ -67,8 +68,8 @@ def _partition_filter(partition_key: str) -> models.Filter:
     )
 
 
-class QdrantVectorStoreCollection(VectorStoreCollection):
-    """A collection backed by Qdrant."""
+class QdrantVectorStorePartition(VectorStorePartition):
+    """A partition backed by Qdrant: one payload value inside the store's collection."""
 
     _RANGE_OPERATORS: ClassVar[dict[OrderingOp, str]] = {
         ">": "gt",
@@ -84,9 +85,9 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
     @staticmethod
     def _build_qdrant_filter(expr: FilterExpr) -> models.Filter:
         """Convert a FilterExpr tree into a Qdrant Filter."""
-        build = QdrantVectorStoreCollection._build_qdrant_filter
-        eq_condition = QdrantVectorStoreCollection._eq_condition
-        missing_condition = QdrantVectorStoreCollection._missing_condition
+        build = QdrantVectorStorePartition._build_qdrant_filter
+        eq_condition = QdrantVectorStorePartition._eq_condition
+        missing_condition = QdrantVectorStorePartition._missing_condition
         match expr:
             case Equals(field, value):
                 return models.Filter(must=[eq_condition(field, value)])
@@ -99,10 +100,10 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
             case Ordering(field, op, value):
                 return models.Filter(
                     must=[
-                        QdrantVectorStoreCollection._range_condition(
+                        QdrantVectorStorePartition._range_condition(
                             field,
                             value,
-                            QdrantVectorStoreCollection._RANGE_OPERATORS[op],
+                            QdrantVectorStorePartition._RANGE_OPERATORS[op],
                         )
                     ]
                 )
@@ -164,25 +165,22 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
         client: AsyncQdrantClient,
         collection_name: str,
         partition_key: str,
-        config: VectorStoreCollectionConfig,
         indexed_properties: Mapping[str, PropertyType],
         tracker: OperationTracker,
         shard_key: str | None = None,
     ) -> None:
-        """Initialize with a Qdrant client and collection name."""
+        """Initialize with a Qdrant client and the collection and partition it is bound to."""
         self._client = client
         self._tracker = tracker
         self._collection_name = collection_name
         self._partition_key = partition_key
-        self._config = config
         self._indexed_properties = dict(indexed_properties)
         self._shard_key = shard_key
 
     @property
     @override
-    def config(self) -> VectorStoreCollectionConfig:
-        """The configuration for this collection."""
-        return self._config
+    def partition_key(self) -> str:
+        return self._partition_key
 
     @property
     @override
@@ -192,7 +190,7 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
     @property
     @override
     def supported_filter_nodes(self) -> frozenset[type]:
-        return QdrantVectorStoreCollection._SUPPORTED_FILTER_NODES
+        return QdrantVectorStorePartition._SUPPORTED_FILTER_NODES
 
     def _build_payload(
         self,
@@ -265,10 +263,10 @@ class QdrantVectorStoreCollection(VectorStoreCollection):
                 require_supported_filter(
                     property_filter,
                     self._indexed_properties,
-                    QdrantVectorStoreCollection._SUPPORTED_FILTER_NODES,
+                    QdrantVectorStorePartition._SUPPORTED_FILTER_NODES,
                 )
                 property_qdrant_filter = (
-                    QdrantVectorStoreCollection._build_qdrant_filter(property_filter)
+                    QdrantVectorStorePartition._build_qdrant_filter(property_filter)
                 )
                 qdrant_filter = models.Filter(
                     must=[partition_key_filter, property_qdrant_filter]
@@ -342,11 +340,16 @@ class QdrantVectorStoreParams(BaseModel):
     Attributes:
         client (AsyncQdrantClient):
             Async Qdrant client instance.
+        collection (str):
+            The collection this store is; the native Qdrant collection's
+            name, so stores of different collections may share the client.
+        vector_dimensions (int):
+            Dimensionality of every vector in the store.
         is_distributed (bool):
             Whether the Qdrant cluster is running in distributed mode.
-            If True, native collections use custom sharding
-            so each logical collection maps to a dedicated shard key.
-            This enables logical collection deletion via shard drop
+            If True, the native collection uses custom sharding
+            so each partition maps to a dedicated shard key.
+            This enables partition deletion via shard drop
             instead of filter-based deletion.
         registry_replication_factor (int):
             Replication factor for registry collections. Write consistency factor is
@@ -354,7 +357,7 @@ class QdrantVectorStoreParams(BaseModel):
             read-your-writes from any available replica
             (default: 1).
         indexed_properties (IndexedProperties):
-            The declared schema every collection of this store carries: each
+            The declared schema every partition of this store carries: each
             key gets a payload index of its declared type, and a record or a
             filter naming any other key is rejected.
         hnsw_config (HnswConfigDiff | None):
@@ -381,13 +384,20 @@ class QdrantVectorStoreParams(BaseModel):
         ...,
         description="Async Qdrant client instance",
     )
+    collection: str = Field(
+        ...,
+        description="The collection this store is; the native Qdrant collection's name",
+    )
+    vector_dimensions: int = Field(
+        ..., gt=0, description="Dimensionality of every vector in the store"
+    )
     is_distributed: bool = Field(
         False,
         description=(
             "Whether the Qdrant cluster is running in distributed mode. "
-            "If True, native collections use custom sharding "
-            "so each logical collection maps to a dedicated shard key. "
-            "This enables logical collection deletion via shard drop "
+            "If True, the native collection uses custom sharding "
+            "so each partition maps to a dedicated shard key. "
+            "This enables partition deletion via shard drop "
             "instead of filter-based deletion"
         ),
     )
@@ -401,7 +411,7 @@ class QdrantVectorStoreParams(BaseModel):
     )
     indexed_properties: IndexedProperties = Field(
         ...,
-        description="The declared schema every collection of this store carries",
+        description="The declared schema every partition of this store carries",
     )
     hnsw_config: models.HnswConfigDiff | None = Field(
         None,
@@ -432,6 +442,12 @@ class QdrantVectorStoreParams(BaseModel):
         description="An instance of MetricsFactory for collecting usage metrics",
     )
 
+    @field_validator("collection")
+    @classmethod
+    def _validate_collection(cls, collection: str) -> str:
+        validate_collection_name(collection)
+        return collection
+
     @model_validator(mode="after")
     def _validate_hnsw_m(self) -> Self:
         if self.hnsw_config is not None and self.hnsw_config.m not in (None, 0):
@@ -444,7 +460,13 @@ class QdrantVectorStoreParams(BaseModel):
 
 
 class QdrantVectorStore(VectorStore):
-    """Asynchronous Qdrant-based implementation of VectorStore."""
+    """Asynchronous Qdrant-based implementation of VectorStore.
+
+    The store is one native Qdrant collection, named at construction, in
+    which every partition is a payload value (and, in distributed mode, a
+    shard key). A registry collection beside it records which partitions
+    exist and what they were created under.
+    """
 
     _QDRANT_DISTANCE: ClassVar[models.Distance] = models.Distance.COSINE
 
@@ -458,10 +480,10 @@ class QdrantVectorStore(VectorStore):
         datetime: models.PayloadSchemaType.DATETIME,
     }
 
-    # Registry collection keys (stored on registry points, one per logical collection)
+    # Registry collection keys (stored on registry points, one per partition)
     _REGISTRY_SUFFIX: ClassVar[str] = "__registry"
-    _REGISTRY_NAME: ClassVar[str] = "name"
-    _REGISTRY_VECTOR_DIMENSIONS: ClassVar[str] = "vector_dimensions"
+    _REGISTRY_PARTITION_KEY: ClassVar[str] = "partition_key"
+    _REGISTRY_SCHEMA: ClassVar[str] = "schema"
 
     # The per-tenant graph size when no override is configured.
     _DEFAULT_NATIVE_PAYLOAD_M: ClassVar[int] = 16
@@ -472,7 +494,7 @@ class QdrantVectorStore(VectorStore):
     )
 
     # Keyed by client so locks are garbage-collected when the client is.
-    _name_locks: ClassVar[
+    _partition_locks: ClassVar[
         WeakKeyDictionary[
             AsyncQdrantClient,
             defaultdict[tuple[str, str], asyncio.Lock],
@@ -502,27 +524,16 @@ class QdrantVectorStore(VectorStore):
         return False
 
     @staticmethod
-    def _registry_collection_name(namespace: str) -> str:
-        """Return the registry collection name for a namespace."""
-        return f"{namespace}{QdrantVectorStore._REGISTRY_SUFFIX}"
-
-    @staticmethod
-    def _registry_point_uuid(name: str) -> UUID:
-        """Return a deterministic UUID for a logical collection name."""
-        return uuid5(QdrantVectorStore._REGISTRY_UUID_NAMESPACE, name)
-
-    @staticmethod
-    def _build_native_collection_name(
-        namespace: str, config: VectorStoreCollectionConfig
-    ) -> str:
-        """Build a deterministic native collection name from namespace and config."""
-        digest = hashlib.sha256(config.model_dump_json().encode()).hexdigest()
-        return f"{namespace}__{digest}"
+    def _registry_point_uuid(partition_key: str) -> UUID:
+        """Return a deterministic UUID for a partition key."""
+        return uuid5(QdrantVectorStore._REGISTRY_UUID_NAMESPACE, partition_key)
 
     def __init__(self, params: QdrantVectorStoreParams) -> None:
         """Initialize the vector store with the provided parameters."""
         super().__init__()
         self._client: AsyncQdrantClient = params.client
+        self._collection = params.collection
+        self._vector_dimensions = params.vector_dimensions
         self._is_distributed = params.is_distributed
 
         self._registry_replication_factor = params.registry_replication_factor
@@ -536,28 +547,40 @@ class QdrantVectorStore(VectorStore):
             prefix="vector_store_qdrant",
         )
 
-        self._client_name_locks = QdrantVectorStore._name_locks.setdefault(
+        self._client_partition_locks = QdrantVectorStore._partition_locks.setdefault(
             self._client, defaultdict(asyncio.Lock)
         )
+
+    @property
+    @override
+    def collection(self) -> str:
+        return self._collection
+
+    @property
+    @override
+    def vector_dimensions(self) -> int:
+        return self._vector_dimensions
 
     @property
     @override
     def indexed_properties(self) -> Mapping[str, PropertyType]:
         return self._indexed_properties
 
-    @override
-    async def startup(self) -> None:
-        """No-op; client lifecycle is managed externally."""
+    @property
+    def _registry_collection_name(self) -> str:
+        return f"{self._collection}{QdrantVectorStore._REGISTRY_SUFFIX}"
 
-    @override
-    async def shutdown(self) -> None:
-        """No-op; client lifecycle is managed externally."""
+    def _declared_schema(self) -> PartitionSchema:
+        return PartitionSchema(
+            vector_dimensions=self._vector_dimensions,
+            indexed_properties=indexed_property_names(self._indexed_properties),
+        )
 
     def _native_hnsw_config(self) -> models.HnswConfigDiff:
-        """The HNSW config of a native collection: the overrides, with `m` pinned at 0.
+        """The HNSW config of the native collection: the overrides, with `m` pinned at 0.
 
-        A native collection is multi-tenant, so the global graph is disabled
-        and each tenant gets its own graph of `payload_m` links.
+        The collection is multi-tenant, so the global graph is disabled and
+        each partition gets its own graph of `payload_m` links.
         """
         overrides = self._hnsw_config or models.HnswConfigDiff()
         return overrides.model_copy(
@@ -569,14 +592,25 @@ class QdrantVectorStore(VectorStore):
             }
         )
 
-    async def _ensure_namespace_registry_collection(self, namespace: str) -> None:
-        """Idempotently create the registry collection for a namespace."""
-        registry_collection_name = QdrantVectorStore._registry_collection_name(
-            namespace
-        )
+    @override
+    async def provision(self) -> None:
+        async with self._tracker("provision"):
+            await self._ensure_registry_collection()
+            await self._ensure_native_collection()
+
+    @override
+    async def startup(self) -> None:
+        """No-op; client lifecycle is managed externally."""
+
+    @override
+    async def shutdown(self) -> None:
+        """No-op; client lifecycle is managed externally."""
+
+    async def _ensure_registry_collection(self) -> None:
+        """Idempotently create the registry collection."""
         try:
             await self._client.create_collection(
-                collection_name=registry_collection_name,
+                collection_name=self._registry_collection_name,
                 vectors_config=models.VectorParams(
                     size=1,
                     distance=models.Distance.COSINE,
@@ -591,81 +625,19 @@ class QdrantVectorStore(VectorStore):
             if not QdrantVectorStore._is_already_exists_error(e):
                 raise
 
-    async def _get_registry_entry(
-        self, namespace: str, name: str
-    ) -> dict[str, Any] | None:
-        """
-        Retrieve the registry entry for a logical collection name.
-
-        Verifies the stored name matches
-        to guard against SHA-1 collisions in the uuid5 point ID.
-        """
-        registry_collection_name = QdrantVectorStore._registry_collection_name(
-            namespace
-        )
-        point_uuid = QdrantVectorStore._registry_point_uuid(name)
-        try:
-            points = await self._client.retrieve(
-                collection_name=registry_collection_name,
-                ids=[point_uuid],
-                with_payload=True,
-            )
-        except (UnexpectedResponse, grpc.aio.AioRpcError, ValueError) as e:
-            if QdrantVectorStore._is_not_found_error(e):
-                return None
-            raise
-
-        if not points:
-            return None
-
-        payload = cast(dict[str, Any], points[0].payload)
-        if payload.get(QdrantVectorStore._REGISTRY_NAME) != name:
-            return None
-
-        return payload
-
-    @staticmethod
-    def _parse_entry(entry: Mapping[str, Any]) -> VectorStoreCollectionConfig:
-        """Parse a VectorStoreCollectionConfig from a registry entry."""
-        return VectorStoreCollectionConfig(
-            vector_dimensions=entry[QdrantVectorStore._REGISTRY_VECTOR_DIMENSIONS],
-        )
-
-    def _build_collection_handle(
-        self, namespace: str, name: str, config: VectorStoreCollectionConfig
-    ) -> QdrantVectorStoreCollection:
-        """Build a QdrantVectorStoreCollection handle."""
-        return QdrantVectorStoreCollection(
-            client=self._client,
-            collection_name=QdrantVectorStore._build_native_collection_name(
-                namespace, config
-            ),
-            partition_key=name,
-            config=config,
-            indexed_properties=self._indexed_properties,
-            tracker=self._tracker,
-            shard_key=name if self._is_distributed else None,
-        )
-
-    async def _create_native_collection(
-        self, namespace: str, config: VectorStoreCollectionConfig
-    ) -> None:
+    async def _ensure_native_collection(self) -> None:
         """Idempotently create the native Qdrant collection and payload indexes."""
-        native_collection_name = QdrantVectorStore._build_native_collection_name(
-            namespace, config
-        )
-        distance = QdrantVectorStore._QDRANT_DISTANCE
         # The collection and its indexes are created under separate guards. Sharing
         # one meant a collection that already existed - a second worker, or a retry
         # after a crash between the two calls - raised on create_collection, took
         # the already-exists path, and left the collection with no payload indexes
-        # at all. The lock above is keyed on the client object, so it serialises
-        # callers within a process and not across uvicorn workers.
+        # at all.
         try:
             await self._client.create_collection(
-                collection_name=native_collection_name,
+                collection_name=self._collection,
                 vectors_config=models.VectorParams(
-                    size=config.vector_dimensions, distance=distance
+                    size=self._vector_dimensions,
+                    distance=QdrantVectorStore._QDRANT_DISTANCE,
                 ),
                 hnsw_config=self._native_hnsw_config(),
                 optimizers_config=self._optimizers_config,
@@ -695,7 +667,7 @@ class QdrantVectorStore(VectorStore):
         for field_name, field_schema in indexes:
             try:
                 await self._client.create_payload_index(
-                    collection_name=native_collection_name,
+                    collection_name=self._collection,
                     field_name=field_name,
                     field_schema=field_schema,
                 )
@@ -703,182 +675,147 @@ class QdrantVectorStore(VectorStore):
                 if not QdrantVectorStore._is_already_exists_error(e):
                     raise
 
-    async def _ensure_shard_key(
-        self, native_collection_name: str, shard_key: str
-    ) -> None:
-        """Idempotently create a shard key on a native collection."""
+    async def _stored_schema(self, partition_key: str) -> PartitionSchema | None:
+        """
+        The schema the partition was created under; raises if it is not this store's.
+
+        Verifies the stored key matches to guard against collisions in the
+        uuid5 point ID.
+        """
+        point_uuid = QdrantVectorStore._registry_point_uuid(partition_key)
         try:
-            await self._client.create_shard_key(
-                native_collection_name, shard_key=shard_key
+            points = await self._client.retrieve(
+                collection_name=self._registry_collection_name,
+                ids=[point_uuid],
+                with_payload=True,
             )
+        except (UnexpectedResponse, grpc.aio.AioRpcError, ValueError) as e:
+            if QdrantVectorStore._is_not_found_error(e):
+                return None
+            raise
+
+        if not points:
+            return None
+
+        payload = cast(dict[str, Any], points[0].payload)
+        if payload.get(QdrantVectorStore._REGISTRY_PARTITION_KEY) != partition_key:
+            return None
+
+        stored_schema = PartitionSchema.model_validate(
+            payload[QdrantVectorStore._REGISTRY_SCHEMA]
+        )
+        declared_schema = self._declared_schema()
+        if stored_schema != declared_schema:
+            raise VectorStorePartitionSchemaMismatchError(
+                self._collection, partition_key, stored_schema, declared_schema
+            )
+        return stored_schema
+
+    def _partition_handle(self, partition_key: str) -> QdrantVectorStorePartition:
+        return QdrantVectorStorePartition(
+            client=self._client,
+            collection_name=self._collection,
+            partition_key=partition_key,
+            indexed_properties=self._indexed_properties,
+            tracker=self._tracker,
+            shard_key=partition_key if self._is_distributed else None,
+        )
+
+    async def _ensure_shard_key(self, shard_key: str) -> None:
+        """Idempotently create a shard key on the native collection."""
+        try:
+            await self._client.create_shard_key(self._collection, shard_key=shard_key)
         except (UnexpectedResponse, grpc.aio.AioRpcError) as e:
             if "already exists" not in str(e).lower():
                 raise
 
-    async def _register_collection(
-        self, namespace: str, name: str, config: VectorStoreCollectionConfig
-    ) -> None:
-        """Write the logical collection entry to the registry."""
-        registry_name = QdrantVectorStore._registry_collection_name(namespace)
-        point_uuid = QdrantVectorStore._registry_point_uuid(name)
+    async def _register_partition(self, partition_key: str) -> None:
+        """Write the partition's entry to the registry."""
         await self._client.upsert(
-            collection_name=registry_name,
+            collection_name=self._registry_collection_name,
             points=[
                 models.PointStruct(
-                    id=point_uuid,
+                    id=QdrantVectorStore._registry_point_uuid(partition_key),
                     vector=[0.0],
                     payload={
-                        QdrantVectorStore._REGISTRY_NAME: name,
-                        QdrantVectorStore._REGISTRY_VECTOR_DIMENSIONS: config.vector_dimensions,
+                        QdrantVectorStore._REGISTRY_PARTITION_KEY: partition_key,
+                        QdrantVectorStore._REGISTRY_SCHEMA: self._declared_schema().model_dump(
+                            mode="json"
+                        ),
                     },
                 ),
             ],
             wait=True,
         )
 
+    @staticmethod
+    def _require_partition_key(partition_key: str) -> None:
+        if not validate_identifier(partition_key):
+            raise ValueError(
+                f"Partition key {partition_key!r} must match [a-z0-9_]+ and be at "
+                "most 32 bytes"
+            )
+
     @override
-    async def create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> None:
-        """Create a logical collection in the Qdrant vector store."""
-        if not validate_identifier(namespace):
-            raise ValueError(
-                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        if not validate_identifier(name):
-            raise ValueError(
-                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
+    async def create_partition(self, partition_key: str) -> None:
+        """Create a partition in the store's collection."""
+        QdrantVectorStore._require_partition_key(partition_key)
+        # The lock is keyed on the client object, so it serialises callers
+        # within a process and not across uvicorn workers.
         async with (
-            self._client_name_locks[(namespace, name)],
-            self._tracker("create_collection"),
+            self._client_partition_locks[(self._collection, partition_key)],
+            self._tracker("create_partition"),
         ):
-            await self._ensure_namespace_registry_collection(namespace)
-            if await self._get_registry_entry(namespace, name) is not None:
-                raise VectorStoreCollectionAlreadyExistsError(namespace, name)
-            await self._create_native_collection(namespace, config)
-            if self._is_distributed:
-                native_collection_name = (
-                    QdrantVectorStore._build_native_collection_name(namespace, config)
+            if await self._stored_schema(partition_key) is not None:
+                raise VectorStorePartitionAlreadyExistsError(
+                    self._collection, partition_key
                 )
-                await self._ensure_shard_key(native_collection_name, name)
-            await self._register_collection(namespace, name, config)
+            if self._is_distributed:
+                await self._ensure_shard_key(partition_key)
+            await self._register_partition(partition_key)
 
     @override
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> QdrantVectorStoreCollection:
-        """Open the collection if it exists, or create and return it."""
-        if not validate_identifier(namespace):
-            raise ValueError(
-                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        if not validate_identifier(name):
-            raise ValueError(
-                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        async with (
-            self._client_name_locks[(namespace, name)],
-            self._tracker("open_or_create_collection"),
-        ):
-            entry = await self._get_registry_entry(namespace, name)
-            if entry is not None:
-                existing_config = QdrantVectorStore._parse_entry(entry)
-                if existing_config != config:
-                    raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
-                    )
-                return self._build_collection_handle(namespace, name, existing_config)
-
-            await self._ensure_namespace_registry_collection(namespace)
-            await self._create_native_collection(namespace, config)
-            if self._is_distributed:
-                native_collection_name = (
-                    QdrantVectorStore._build_native_collection_name(namespace, config)
-                )
-                await self._ensure_shard_key(native_collection_name, name)
-            await self._register_collection(namespace, name, config)
-            return self._build_collection_handle(namespace, name, config)
-
-    @override
-    async def open_collection(
-        self, *, namespace: str, name: str
-    ) -> QdrantVectorStoreCollection | None:
-        """Get a collection handle from the vector store."""
-        if not validate_identifier(namespace):
-            raise ValueError(
-                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        if not validate_identifier(name):
-            raise ValueError(
-                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        entry = await self._get_registry_entry(namespace, name)
-        if entry is None:
+    async def get_partition(
+        self, partition_key: str
+    ) -> QdrantVectorStorePartition | None:
+        """Get a handle bound to an existing partition."""
+        QdrantVectorStore._require_partition_key(partition_key)
+        if await self._stored_schema(partition_key) is None:
             return None
-        return self._build_collection_handle(
-            namespace, name, QdrantVectorStore._parse_entry(entry)
-        )
+        return self._partition_handle(partition_key)
 
     @override
-    async def close_collection(self, *, collection: VectorStoreCollection) -> None:
-        """No-op; Qdrant collection handles require no explicit close."""
-
-    @override
-    async def delete_collection(self, *, namespace: str, name: str) -> None:
-        """Delete a logical collection from the Qdrant vector store."""
-        if not validate_identifier(namespace):
-            raise ValueError(
-                f"Namespace {namespace!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
-        if not validate_identifier(name):
-            raise ValueError(
-                f"Name {name!r} must match [a-z0-9_]+ and be at most 32 bytes"
-            )
+    async def delete_partition(self, partition_key: str) -> None:
+        """Delete a partition and its records from the store's collection."""
+        QdrantVectorStore._require_partition_key(partition_key)
         async with (
-            self._client_name_locks[(namespace, name)],
-            self._tracker("delete_collection"),
+            self._client_partition_locks[(self._collection, partition_key)],
+            self._tracker("delete_partition"),
         ):
-            entry = await self._get_registry_entry(namespace, name)
-            if entry is None:
+            if await self._stored_schema(partition_key) is None:
                 return
-
-            config = QdrantVectorStore._parse_entry(entry)
-            native_collection_name = QdrantVectorStore._build_native_collection_name(
-                namespace, config
-            )
 
             # Delete partition data, then registry entry.
             if self._is_distributed:
                 try:
                     await self._client.delete_shard_key(
-                        native_collection_name, shard_key=name
+                        self._collection, shard_key=partition_key
                     )
                 except (UnexpectedResponse, grpc.aio.AioRpcError) as e:
                     if "does not exist" not in str(e).lower():
                         raise
             else:
                 await self._client.delete(
-                    collection_name=native_collection_name,
+                    collection_name=self._collection,
                     points_selector=models.FilterSelector(
-                        filter=_partition_filter(name),
+                        filter=_partition_filter(partition_key),
                     ),
                 )
 
-            registry_name = QdrantVectorStore._registry_collection_name(namespace)
-            point_uuid = QdrantVectorStore._registry_point_uuid(name)
             await self._client.delete(
-                collection_name=registry_name,
+                collection_name=self._registry_collection_name,
                 points_selector=models.PointIdsList(
-                    points=[point_uuid],
+                    points=[QdrantVectorStore._registry_point_uuid(partition_key)],
                 ),
                 wait=True,
             )

--- a/packages/server/src/memmachine_server/common/vector_store/sql_columns.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sql_columns.py
@@ -1,0 +1,164 @@
+"""
+Declared properties as typed SQL columns, for the SQLite-backed stores.
+
+A store's declared schema gives its records table one typed column per key,
+each indexed, so a filter is an indexed comparison rather than a scan over
+serialized properties. Column names are prefixed so a declared key can never
+collide with the table's own columns.
+
+SQLite has no datetime type, so a datetime property is stored as an integer
+of microseconds since the epoch, the precision the SQL stores keep, and a
+bound compares as the same integer.
+"""
+
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    Float,
+    Index,
+    Table,
+    Text,
+    and_,
+    false,
+    func,
+    or_,
+)
+from sqlalchemy.sql.elements import ColumnElement
+
+from memmachine_server.common.data_types import PropertyType, PropertyValue
+from memmachine_server.common.filter import (
+    And,
+    Equals,
+    FilterExpr,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
+)
+from memmachine_server.common.filter.sql_filter_util import ORDERING_OPS
+from memmachine_server.common.utils import ensure_tz_aware
+
+PROPERTY_COLUMN_PREFIX = "p_"
+
+_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+_MICROSECOND = timedelta(microseconds=1)
+
+
+def property_column_name(key: str) -> str:
+    """The column holding a declared property."""
+    return f"{PROPERTY_COLUMN_PREFIX}{key}"
+
+
+def epoch_microseconds(value: datetime) -> int:
+    """A datetime as microseconds since the epoch, exactly."""
+    return (ensure_tz_aware(value) - _EPOCH) // _MICROSECOND
+
+
+def property_columns(indexed_properties: Mapping[str, PropertyType]) -> list[Column]:
+    """One nullable column per declared key, typed by the key's declared type."""
+    columns: list[Column] = []
+    for key, property_type in indexed_properties.items():
+        if property_type is bool:
+            column_type = Boolean()
+        elif property_type is int or property_type is datetime:
+            column_type = BigInteger()
+        elif property_type is float:
+            column_type = Float()
+        else:
+            column_type = Text()
+        columns.append(Column(property_column_name(key), column_type, nullable=True))
+    return columns
+
+
+def property_indexes(
+    table: Table, indexed_properties: Mapping[str, PropertyType]
+) -> list[Index]:
+    """One index per declared key, named after the table and the column."""
+    return [
+        Index(
+            f"{table.name}__{property_column_name(key)}",
+            table.c[property_column_name(key)],
+        )
+        for key in indexed_properties
+    ]
+
+
+def property_column_values(
+    properties: Mapping[str, PropertyValue],
+    indexed_properties: Mapping[str, PropertyType],
+) -> dict[str, PropertyValue | None]:
+    """The column values of a record's properties; an absent key is NULL."""
+    values: dict[str, PropertyValue | None] = {
+        property_column_name(key): None for key in indexed_properties
+    }
+    for key, value in properties.items():
+        values[property_column_name(key)] = (
+            epoch_microseconds(value) if isinstance(value, datetime) else value
+        )
+    return values
+
+
+def compile_property_filter(
+    expr: FilterExpr,
+    table: Table,
+    indexed_properties: Mapping[str, PropertyType],
+) -> ColumnElement[bool]:
+    """
+    Compile a filter over the declared columns of a records table.
+
+    A predicate matches only a value of the compared type, so a leaf whose
+    value is not of its key's declared type matches nothing rather than
+    whatever the database's affinity would coerce. `Not` is the complement
+    of a match: a row holding no value, whose comparison is NULL, is kept.
+    """
+    match expr:
+        case Equals() | NotEquals() | Ordering() | In() | IsMissing():
+            return _compile_leaf(expr, table, indexed_properties)
+        case And(operands):
+            return and_(
+                *(
+                    compile_property_filter(o, table, indexed_properties)
+                    for o in operands
+                )
+            )
+        case Or(operands):
+            return or_(
+                *(
+                    compile_property_filter(o, table, indexed_properties)
+                    for o in operands
+                )
+            )
+        case Not(operand):
+            inner = compile_property_filter(operand, table, indexed_properties)
+            return ~func.coalesce(inner, false())
+
+
+def _compile_leaf(
+    expr: Equals | NotEquals | Ordering | In | IsMissing,
+    table: Table,
+    indexed_properties: Mapping[str, PropertyType],
+) -> ColumnElement[bool]:
+    column = table.c[property_column_name(expr.field)]
+    declared = indexed_properties[expr.field]
+    match expr:
+        case IsMissing():
+            return column.is_(None)
+        case In(values=values):
+            return column.in_(values) if type(values[0]) is declared else false()
+        case Equals(value=value) | NotEquals(value=value) | Ordering(value=value):
+            if type(value) is not declared:
+                return false()
+            bound = epoch_microseconds(value) if isinstance(value, datetime) else value
+            match expr:
+                case Equals():
+                    return column == bound
+                case NotEquals():
+                    return column != bound
+                case Ordering(op=op):
+                    return ORDERING_OPS[op](column, bound)

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -4,6 +4,12 @@ Vector store backed by SQLite + sqlite-vec.
 Each logical collection gets its own records table and vec0 virtual table.
 Partition keys are avoided in favor of per-collection tables,
 since sqlite-vec ANN indexes may not support them.
+
+The records table carries one typed, indexed column per declared property,
+and a filtered query hands the KNN an allowlist of the rows the filter
+admits, so the filter is evaluated during the search: vec0 ranks only the
+allowed rows, and a filtered search returns fewer only when the filter
+admits fewer.
 """
 
 from collections.abc import Iterable, Mapping, Sequence
@@ -18,36 +24,60 @@ from sqlalchemy import (
     Column,
     Integer,
     MetaData,
+    Select,
     String,
     Table,
     Uuid,
+    column,
     delete,
     event,
     select,
     text,
 )
+from sqlalchemy import table as sql_table
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase, MappedColumn, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
+from sqlalchemy.sql.elements import ColumnElement
 
-from memmachine_server.common.filter.filter_parser import FilterExpr
-from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
-from memmachine_server.common.properties_json import (
-    encode_properties,
+from memmachine_server.common.data_types import PropertyType
+from memmachine_server.common.filter import (
+    And,
+    Equals,
+    FilterExpr,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
 )
 
 from .data_types import (
+    IndexedProperties,
+    IndexedPropertiesMismatchError,
     QueryMatch,
     QueryResult,
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
     VectorStoreCollectionConfigMismatchError,
+    indexed_property_names,
 )
-from .utils import validate_filter, validate_identifier
+from .declared_properties import require_declared_properties, require_supported_filter
+from .sql_columns import (
+    compile_property_filter,
+    property_column_name,
+    property_column_values,
+    property_columns,
+    property_indexes,
+)
+from .utils import validate_identifier
 from .vector_store import VectorStore, VectorStoreCollection
+
+_INDEXED_PROPERTIES_KEY = "indexed_properties"
 
 
 class BaseSQLiteVecVectorStore(DeclarativeBase):
@@ -59,6 +89,9 @@ class _CollectionRow(BaseSQLiteVecVectorStore):
 
     namespace: MappedColumn[str] = mapped_column(String(255), primary_key=True)
     name: MappedColumn[str] = mapped_column(String(255), primary_key=True)
+    # The collection config plus the declared schema it was created under,
+    # so a store built with another schema fails loudly instead of reading
+    # columns that are not there.
     config_json: MappedColumn[dict[str, JsonValue]] = mapped_column(
         JSON, nullable=False
     )
@@ -67,17 +100,23 @@ class _CollectionRow(BaseSQLiteVecVectorStore):
 class SQLiteVecVectorStoreCollection(VectorStoreCollection):
     """A logical collection backed by SQLite + sqlite-vec."""
 
+    _SUPPORTED_FILTER_NODES: ClassVar[frozenset[type]] = frozenset(
+        {Equals, NotEquals, Ordering, In, IsMissing, And, Or, Not}
+    )
+
     def __init__(
         self,
         *,
         create_session: async_sessionmaker[AsyncSession],
         config: VectorStoreCollectionConfig,
+        indexed_properties: Mapping[str, PropertyType],
         records_table: Table,
         vector_table_name: str,
     ) -> None:
         """Initialize with session factory and table references."""
         self._create_session = create_session
         self._config = config
+        self._indexed_properties = dict(indexed_properties)
         self._records_table = records_table
         self._vector_table_name = vector_table_name
 
@@ -85,6 +124,16 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
     @override
     def config(self) -> VectorStoreCollectionConfig:
         return self._config
+
+    @property
+    @override
+    def indexed_properties(self) -> Mapping[str, PropertyType]:
+        return self._indexed_properties
+
+    @property
+    @override
+    def supported_filter_nodes(self) -> frozenset[type]:
+        return SQLiteVecVectorStoreCollection._SUPPORTED_FILTER_NODES
 
     @staticmethod
     def _serialize_vector(vector: Sequence[float]) -> bytes:
@@ -100,27 +149,33 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         records = list(records)
         if not records:
             return
+        for record in records:
+            require_declared_properties(record.properties, self._indexed_properties)
+
+        property_column_names = [
+            property_column_name(key) for key in self._indexed_properties
+        ]
+        insert_records = sqlite_insert(self._records_table)
+        upsert_records = insert_records.on_conflict_do_update(
+            index_elements=[self._records_table.c.uuid],
+            # With no declared column the update is a no-op that still
+            # returns the existing row, which `RETURNING` needs.
+            set_={
+                name: insert_records.excluded[name]
+                for name in (property_column_names or ["uuid"])
+            },
+        ).returning(self._records_table.c.uuid, self._records_table.c.rowid)
 
         async with self._create_session() as session, session.begin():
-            upsert_records = (
-                sqlite_insert(self._records_table)
-                .on_conflict_do_update(
-                    index_elements=[self._records_table.c.uuid],
-                    set_={
-                        "properties": sqlite_insert(
-                            self._records_table
-                        ).excluded.properties,
-                    },
-                )
-                .returning(self._records_table.c.uuid, self._records_table.c.rowid)
-            )
             rows = (
                 await session.execute(
                     upsert_records,
                     [
                         {
                             "uuid": record.uuid,
-                            "properties": encode_properties(record.properties),
+                            **property_column_values(
+                                record.properties, self._indexed_properties
+                            ),
                         }
                         for record in records
                     ],
@@ -128,15 +183,13 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
             ).all()
             uuid_to_rowid: dict[UUID, int] = {row.uuid: row.rowid for row in rows}
 
-            vector_params = []
-            for record in records:
-                assert record.vector is not None  # Validated above.
-                vector_params.append(
-                    {
-                        "rowid": uuid_to_rowid[record.uuid],
-                        "vector": self._serialize_vector(record.vector),
-                    }
-                )
+            vector_params = [
+                {
+                    "rowid": uuid_to_rowid[record.uuid],
+                    "vector": self._serialize_vector(record.vector),
+                }
+                for record in records
+            ]
             await session.execute(
                 text(f"DELETE FROM [{self._vector_table_name}] WHERE rowid = :rowid"),
                 vector_params,
@@ -168,24 +221,27 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         if limit <= 0:
             return [QueryResult(matches=[]) for _ in query_vectors]
 
-        if property_filter is not None and not validate_filter(property_filter):
-            raise ValueError("Filter contains invalid field names")
+        filter_expression: ColumnElement[bool] | None = None
+        if property_filter is not None:
+            require_supported_filter(
+                property_filter,
+                self._indexed_properties,
+                SQLiteVecVectorStoreCollection._SUPPORTED_FILTER_NODES,
+            )
+            filter_expression = compile_property_filter(
+                property_filter, self._records_table, self._indexed_properties
+            )
 
         k = min(limit, self._MAX_K)
 
         results: list[QueryResult] = []
         async with self._create_session() as session:
             for query_vector in query_vectors:
-                query_blob = self._serialize_vector(query_vector)
-
                 knn_rows = (
                     await session.execute(
-                        text(
-                            f"SELECT rowid, distance FROM [{self._vector_table_name}] "
-                            f"WHERE vector MATCH :query AND k = :k "
-                            f"ORDER BY distance"
-                        ),
-                        {"query": query_blob, "k": k},
+                        self._knn_statement(
+                            self._serialize_vector(query_vector), k, filter_expression
+                        )
                     )
                 ).all()
 
@@ -196,46 +252,61 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
                     session=session,
                     rowid_to_distance=rowid_to_distance,
                     min_cosine_similarity=min_cosine_similarity,
-                    property_filter=property_filter,
                 )
                 results.append(QueryResult(matches=matches))
 
         return results
+
+    def _knn_statement(
+        self,
+        query_blob: bytes,
+        k: int,
+        filter_expression: ColumnElement[bool] | None,
+    ) -> Select:
+        """The KNN over the vec0 table, restricted to the rows a filter admits.
+
+        vec0 takes a `rowid IN (...)` constraint into the search itself, so
+        the `k` nearest are the nearest among the admitted rows.
+        """
+        statement = (
+            select(column("rowid"), column("distance"))
+            .select_from(sql_table(self._vector_table_name))
+            .where(
+                text("vector MATCH :query AND k = :k").bindparams(query=query_blob, k=k)
+            )
+        )
+        if filter_expression is not None:
+            statement = statement.where(
+                column("rowid").in_(
+                    select(self._records_table.c.rowid).where(filter_expression)
+                )
+            )
+        return statement.order_by(column("distance"))
 
     async def _build_matches(
         self,
         session: AsyncSession,
         rowid_to_distance: Mapping[int, float],
         min_cosine_similarity: float | None,
-        property_filter: FilterExpr | None,
     ) -> list[QueryMatch]:
-        matched_rowids = list(rowid_to_distance.keys())
+        if not rowid_to_distance:
+            return []
 
-        fetch_records = select(
-            self._records_table.c.uuid, self._records_table.c.rowid
-        ).where(
-            self._records_table.c.rowid.in_(matched_rowids),
-        )
-        if property_filter is not None:
-            fetch_records = fetch_records.where(
-                compile_sql_filter(
-                    property_filter,
-                    lambda field: (
-                        self._records_table.c.properties[field],
-                        "properties_json",
-                    ),
+        matched_rows = (
+            await session.execute(
+                select(self._records_table.c.uuid, self._records_table.c.rowid).where(
+                    self._records_table.c.rowid.in_(list(rowid_to_distance)),
                 )
             )
-
-        matched_rows = (await session.execute(fetch_records)).all()
+        ).all()
 
         matches: list[QueryMatch] = []
         for row in matched_rows:
-            distance = rowid_to_distance.get(row.rowid)
-            if distance is None:
-                continue
-
-            cosine_similarity = self._distance_to_cosine_similarity(distance)
+            cosine_similarity = (
+                SQLiteVecVectorStoreCollection._distance_to_cosine_similarity(
+                    rowid_to_distance[row.rowid]
+                )
+            )
             if (
                 min_cosine_similarity is not None
                 and cosine_similarity < min_cosine_similarity
@@ -294,11 +365,19 @@ class SQLiteVecVectorStoreParams(BaseModel):
 
     Attributes:
         engine (AsyncEngine): Async SQLAlchemy engine (sqlite+aiosqlite).
+        indexed_properties (IndexedProperties):
+            The declared schema every collection of this store carries: each
+            key is a typed, indexed column of the collection's records table,
+            and a record or a filter naming any other key is rejected.
     """
 
     engine: InstanceOf[AsyncEngine] = Field(
         ...,
         description="Async SQLAlchemy engine (sqlite+aiosqlite)",
+    )
+    indexed_properties: IndexedProperties = Field(
+        ...,
+        description="The declared schema every collection of this store carries",
     )
 
     @field_validator("engine")
@@ -329,6 +408,7 @@ class SQLiteVecVectorStore(VectorStore):
     def __init__(self, params: SQLiteVecVectorStoreParams) -> None:
         """Initialize the vector store with the provided parameters."""
         self._engine = params.engine
+        self._indexed_properties = params.indexed_properties
         self._create_session = async_sessionmaker(self._engine, expire_on_commit=False)
         self._sa_metadata = MetaData()
 
@@ -345,6 +425,11 @@ class SQLiteVecVectorStore(VectorStore):
                 await aio_connection.enable_load_extension(False)
 
             dbapi_connection.run_async(_load_extension)
+
+    @property
+    @override
+    def indexed_properties(self) -> Mapping[str, PropertyType]:
+        return self._indexed_properties
 
     @override
     async def startup(self) -> None:
@@ -371,13 +456,7 @@ class SQLiteVecVectorStore(VectorStore):
                 raise VectorStoreCollectionAlreadyExistsError(namespace, name)
 
             await self._ensure_collection_tables(session, namespace, name, config)
-            session.add(
-                _CollectionRow(
-                    namespace=namespace,
-                    name=name,
-                    config_json=config.model_dump(mode="json"),
-                )
-            )
+            session.add(self._collection_row(namespace, name, config))
 
     @override
     async def open_or_create_collection(
@@ -400,30 +479,16 @@ class SQLiteVecVectorStore(VectorStore):
                 records_table, vector_table_name = await self._ensure_collection_tables(
                     session, namespace, name, existing_config
                 )
-                return SQLiteVecVectorStoreCollection(
-                    create_session=self._create_session,
-                    config=existing_config,
-                    records_table=records_table,
-                    vector_table_name=vector_table_name,
+                return self._collection_handle(
+                    existing_config, records_table, vector_table_name
                 )
 
             records_table, vector_table_name = await self._ensure_collection_tables(
                 session, namespace, name, config
             )
-            session.add(
-                _CollectionRow(
-                    namespace=namespace,
-                    name=name,
-                    config_json=config.model_dump(mode="json"),
-                )
-            )
+            session.add(self._collection_row(namespace, name, config))
 
-        return SQLiteVecVectorStoreCollection(
-            create_session=self._create_session,
-            config=config,
-            records_table=records_table,
-            vector_table_name=vector_table_name,
-        )
+        return self._collection_handle(config, records_table, vector_table_name)
 
     @override
     async def open_collection(
@@ -437,13 +502,10 @@ class SQLiteVecVectorStore(VectorStore):
         if existing is None:
             return None
 
-        records_table = self._records_table(namespace, name)
-        vector_table_name = self._vector_table_name(namespace, name)
-        return SQLiteVecVectorStoreCollection(
-            create_session=self._create_session,
-            config=existing,
-            records_table=records_table,
-            vector_table_name=vector_table_name,
+        return self._collection_handle(
+            existing,
+            self._records_table(namespace, name),
+            self._vector_table_name(namespace, name),
         )
 
     @override
@@ -456,7 +518,14 @@ class SQLiteVecVectorStore(VectorStore):
             raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
 
         async with self._create_session() as session, session.begin():
-            existing = await self._get_stored_config(session, namespace, name)
+            existing = (
+                await session.execute(
+                    select(_CollectionRow.config_json).where(
+                        _CollectionRow.namespace == namespace,
+                        _CollectionRow.name == name,
+                    )
+                )
+            ).scalar_one_or_none()
             if existing is None:
                 return
 
@@ -491,10 +560,39 @@ class SQLiteVecVectorStore(VectorStore):
     def _vector_table_name(namespace: str, name: str) -> str:
         return f"{SQLiteVecVectorStore._collection_prefix(namespace, name)}_vc"
 
+    def _collection_row(
+        self, namespace: str, name: str, config: VectorStoreCollectionConfig
+    ) -> _CollectionRow:
+        return _CollectionRow(
+            namespace=namespace,
+            name=name,
+            config_json={
+                **config.model_dump(mode="json"),
+                _INDEXED_PROPERTIES_KEY: indexed_property_names(
+                    self._indexed_properties
+                ),
+            },
+        )
+
+    def _collection_handle(
+        self,
+        config: VectorStoreCollectionConfig,
+        records_table: Table,
+        vector_table_name: str,
+    ) -> SQLiteVecVectorStoreCollection:
+        return SQLiteVecVectorStoreCollection(
+            create_session=self._create_session,
+            config=config,
+            indexed_properties=self._indexed_properties,
+            records_table=records_table,
+            vector_table_name=vector_table_name,
+        )
+
     async def _get_stored_config(
         self, session: AsyncSession, namespace: str, name: str
     ) -> VectorStoreCollectionConfig | None:
-        stored_config = (
+        """The collection's config; raises if it was created under another schema."""
+        stored = (
             await session.execute(
                 select(_CollectionRow.config_json).where(
                     _CollectionRow.namespace == namespace,
@@ -502,19 +600,37 @@ class SQLiteVecVectorStore(VectorStore):
                 )
             )
         ).scalar_one_or_none()
-        if stored_config is None:
+        if stored is None:
             return None
-        return VectorStoreCollectionConfig.model_validate(stored_config)
+        stored_properties = stored.get(_INDEXED_PROPERTIES_KEY)
+        declared_properties = indexed_property_names(self._indexed_properties)
+        if stored_properties != declared_properties:
+            raise IndexedPropertiesMismatchError(
+                namespace,
+                name,
+                stored_properties if isinstance(stored_properties, dict) else {},
+                declared_properties,
+            )
+        return VectorStoreCollectionConfig.model_validate(
+            {
+                key: value
+                for key, value in stored.items()
+                if key != _INDEXED_PROPERTIES_KEY
+            }
+        )
 
     def _records_table(self, namespace: str, name: str) -> Table:
-        return Table(
+        records_table = Table(
             self._records_table_name(namespace, name),
             self._sa_metadata,
             Column("rowid", Integer, primary_key=True, autoincrement=True),
             Column("uuid", Uuid, nullable=False, unique=True),
-            Column("properties", JSON, nullable=False, default=dict),
+            *property_columns(self._indexed_properties),
             extend_existing=True,
         )
+        if not records_table.indexes:
+            property_indexes(records_table, self._indexed_properties)
+        return records_table
 
     async def _ensure_collection_tables(
         self,
@@ -540,21 +656,5 @@ class SQLiteVecVectorStore(VectorStore):
                 f")"
             )
         )
-
-        properties_column = Column("properties", JSON)
-        for field_name in config.indexed_properties_schema:
-            value_expr = properties_column[field_name]["v"].as_string()
-            compiled_expr = value_expr.compile(
-                dialect=session.bind.dialect,
-                compile_kwargs={"literal_binds": True},
-            )
-            index_name = f"{records_table.name}__{field_name}_v"
-            await session.execute(
-                text(
-                    f"CREATE INDEX IF NOT EXISTS [{index_name}] "
-                    f"ON [{records_table.name}]"
-                    f"({compiled_expr})"
-                )
-            )
 
         return records_table, vector_table_name

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vec_vector_store.py
@@ -1,9 +1,9 @@
 """
 Vector store backed by SQLite + sqlite-vec.
 
-Each logical collection gets its own records table and vec0 virtual table.
-Partition keys are avoided in favor of per-collection tables,
-since sqlite-vec ANN indexes may not support them.
+The store is one collection. Each partition gets its own records table and
+vec0 virtual table, named by the collection and the partition key, so
+stores of different collections may share one engine.
 
 The records table carries one typed, indexed column per declared property,
 and a filtered query hands the KNN an allowlist of the rows the filter
@@ -56,15 +56,16 @@ from memmachine_server.common.filter import (
 )
 
 from .data_types import (
+    COLLECTION_NAME_MAX_BYTES,
     IndexedProperties,
-    IndexedPropertiesMismatchError,
+    PartitionSchema,
     QueryMatch,
     QueryResult,
     Record,
-    VectorStoreCollectionAlreadyExistsError,
-    VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
+    VectorStorePartitionAlreadyExistsError,
+    VectorStorePartitionSchemaMismatchError,
     indexed_property_names,
+    validate_collection_name,
 )
 from .declared_properties import require_declared_properties, require_supported_filter
 from .sql_columns import (
@@ -75,30 +76,32 @@ from .sql_columns import (
     property_indexes,
 )
 from .utils import validate_identifier
-from .vector_store import VectorStore, VectorStoreCollection
-
-_INDEXED_PROPERTIES_KEY = "indexed_properties"
+from .vector_store import VectorStore, VectorStorePartition
 
 
 class BaseSQLiteVecVectorStore(DeclarativeBase):
     """Base class for SQLiteVecVectorStore ORM models."""
 
 
-class _CollectionRow(BaseSQLiteVecVectorStore):
-    __tablename__ = "vector_store_sqlite_vec_cl"
+class _PartitionRow(BaseSQLiteVecVectorStore):
+    """The registry: one row per partition, keyed by its collection and key."""
 
-    namespace: MappedColumn[str] = mapped_column(String(255), primary_key=True)
-    name: MappedColumn[str] = mapped_column(String(255), primary_key=True)
-    # The collection config plus the declared schema it was created under,
-    # so a store built with another schema fails loudly instead of reading
-    # columns that are not there.
-    config_json: MappedColumn[dict[str, JsonValue]] = mapped_column(
+    __tablename__ = "vector_store_sqlite_vec_pt"
+
+    collection: MappedColumn[str] = mapped_column(
+        String(COLLECTION_NAME_MAX_BYTES), primary_key=True
+    )
+    partition_key: MappedColumn[str] = mapped_column(String(255), primary_key=True)
+    # The dimensions and declared schema the partition was created under, so
+    # a store built with others fails loudly instead of reading columns and
+    # vectors that are not there.
+    schema_json: MappedColumn[dict[str, JsonValue]] = mapped_column(
         JSON, nullable=False
     )
 
 
-class SQLiteVecVectorStoreCollection(VectorStoreCollection):
-    """A logical collection backed by SQLite + sqlite-vec."""
+class SQLiteVecVectorStorePartition(VectorStorePartition):
+    """A partition backed by SQLite + sqlite-vec."""
 
     _SUPPORTED_FILTER_NODES: ClassVar[frozenset[type]] = frozenset(
         {Equals, NotEquals, Ordering, In, IsMissing, And, Or, Not}
@@ -108,22 +111,22 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         self,
         *,
         create_session: async_sessionmaker[AsyncSession],
-        config: VectorStoreCollectionConfig,
+        partition_key: str,
         indexed_properties: Mapping[str, PropertyType],
         records_table: Table,
         vector_table_name: str,
     ) -> None:
         """Initialize with session factory and table references."""
         self._create_session = create_session
-        self._config = config
+        self._partition_key = partition_key
         self._indexed_properties = dict(indexed_properties)
         self._records_table = records_table
         self._vector_table_name = vector_table_name
 
     @property
     @override
-    def config(self) -> VectorStoreCollectionConfig:
-        return self._config
+    def partition_key(self) -> str:
+        return self._partition_key
 
     @property
     @override
@@ -133,7 +136,7 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
     @property
     @override
     def supported_filter_nodes(self) -> frozenset[type]:
-        return SQLiteVecVectorStoreCollection._SUPPORTED_FILTER_NODES
+        return SQLiteVecVectorStorePartition._SUPPORTED_FILTER_NODES
 
     @staticmethod
     def _serialize_vector(vector: Sequence[float]) -> bytes:
@@ -226,7 +229,7 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
             require_supported_filter(
                 property_filter,
                 self._indexed_properties,
-                SQLiteVecVectorStoreCollection._SUPPORTED_FILTER_NODES,
+                SQLiteVecVectorStorePartition._SUPPORTED_FILTER_NODES,
             )
             filter_expression = compile_property_filter(
                 property_filter, self._records_table, self._indexed_properties
@@ -303,7 +306,7 @@ class SQLiteVecVectorStoreCollection(VectorStoreCollection):
         matches: list[QueryMatch] = []
         for row in matched_rows:
             cosine_similarity = (
-                SQLiteVecVectorStoreCollection._distance_to_cosine_similarity(
+                SQLiteVecVectorStorePartition._distance_to_cosine_similarity(
                     rowid_to_distance[row.rowid]
                 )
             )
@@ -365,9 +368,14 @@ class SQLiteVecVectorStoreParams(BaseModel):
 
     Attributes:
         engine (AsyncEngine): Async SQLAlchemy engine (sqlite+aiosqlite).
+        collection (str):
+            The collection this store is; names its tables, so stores of
+            different collections may share the engine.
+        vector_dimensions (int):
+            Dimensionality of every vector in the store.
         indexed_properties (IndexedProperties):
-            The declared schema every collection of this store carries: each
-            key is a typed, indexed column of the collection's records table,
+            The declared schema every partition of this store carries: each
+            key is a typed, indexed column of the partition's records table,
             and a record or a filter naming any other key is rejected.
     """
 
@@ -375,10 +383,20 @@ class SQLiteVecVectorStoreParams(BaseModel):
         ...,
         description="Async SQLAlchemy engine (sqlite+aiosqlite)",
     )
+    collection: str = Field(..., description="The collection this store is")
+    vector_dimensions: int = Field(
+        ..., gt=0, description="Dimensionality of every vector in the store"
+    )
     indexed_properties: IndexedProperties = Field(
         ...,
-        description="The declared schema every collection of this store carries",
+        description="The declared schema every partition of this store carries",
     )
+
+    @field_validator("collection")
+    @classmethod
+    def _validate_collection(cls, collection: str) -> str:
+        validate_collection_name(collection)
+        return collection
 
     @field_validator("engine")
     @classmethod
@@ -400,7 +418,7 @@ class SQLiteVecVectorStore(VectorStore):
     """
     Vector store backed by SQLite + sqlite-vec.
 
-    Each logical collection gets its own records table and vec0 virtual table.
+    Each partition gets its own records table and vec0 virtual table.
     """
 
     _SQLITE_VEC_DISTANCE_METRIC: ClassVar[str] = "cosine"
@@ -408,6 +426,8 @@ class SQLiteVecVectorStore(VectorStore):
     def __init__(self, params: SQLiteVecVectorStoreParams) -> None:
         """Initialize the vector store with the provided parameters."""
         self._engine = params.engine
+        self._collection = params.collection
+        self._vector_dimensions = params.vector_dimensions
         self._indexed_properties = params.indexed_properties
         self._create_session = async_sessionmaker(self._engine, expire_on_commit=False)
         self._sa_metadata = MetaData()
@@ -428,117 +448,96 @@ class SQLiteVecVectorStore(VectorStore):
 
     @property
     @override
+    def collection(self) -> str:
+        return self._collection
+
+    @property
+    @override
+    def vector_dimensions(self) -> int:
+        return self._vector_dimensions
+
+    @property
+    @override
     def indexed_properties(self) -> Mapping[str, PropertyType]:
         return self._indexed_properties
 
     @override
-    async def startup(self) -> None:
+    async def provision(self) -> None:
         async with self._engine.begin() as connection:
             await connection.run_sync(BaseSQLiteVecVectorStore.metadata.create_all)
+
+    @override
+    async def startup(self) -> None:
+        pass
 
     @override
     async def shutdown(self) -> None:
         pass
 
     @override
-    async def create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> None:
-        if not validate_identifier(namespace) or not validate_identifier(name):
-            raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
+    async def create_partition(self, partition_key: str) -> None:
+        if not validate_identifier(partition_key):
+            raise ValueError(f"Invalid partition key {partition_key!r}")
         async with self._create_session() as session, session.begin():
-            existing_config = await self._get_stored_config(session, namespace, name)
-            if existing_config is not None:
-                raise VectorStoreCollectionAlreadyExistsError(namespace, name)
-
-            await self._ensure_collection_tables(session, namespace, name, config)
-            session.add(self._collection_row(namespace, name, config))
-
-    @override
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> VectorStoreCollection:
-        if not validate_identifier(namespace) or not validate_identifier(name):
-            raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
-        async with self._create_session() as session, session.begin():
-            existing_config = await self._get_stored_config(session, namespace, name)
-            if existing_config is not None:
-                if existing_config != config:
-                    raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
-                    )
-
-                records_table, vector_table_name = await self._ensure_collection_tables(
-                    session, namespace, name, existing_config
-                )
-                return self._collection_handle(
-                    existing_config, records_table, vector_table_name
+            if await self._stored_schema(session, partition_key) is not None:
+                raise VectorStorePartitionAlreadyExistsError(
+                    self._collection, partition_key
                 )
 
-            records_table, vector_table_name = await self._ensure_collection_tables(
-                session, namespace, name, config
+            await self._ensure_partition_tables(session, partition_key)
+            session.add(
+                _PartitionRow(
+                    collection=self._collection,
+                    partition_key=partition_key,
+                    schema_json=self._declared_schema().model_dump(mode="json"),
+                )
             )
-            session.add(self._collection_row(namespace, name, config))
-
-        return self._collection_handle(config, records_table, vector_table_name)
 
     @override
-    async def open_collection(
-        self, *, namespace: str, name: str
-    ) -> VectorStoreCollection | None:
-        if not validate_identifier(namespace) or not validate_identifier(name):
-            raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
+    async def get_partition(self, partition_key: str) -> VectorStorePartition | None:
+        if not validate_identifier(partition_key):
+            raise ValueError(f"Invalid partition key {partition_key!r}")
 
         async with self._create_session() as session:
-            existing = await self._get_stored_config(session, namespace, name)
-        if existing is None:
+            schema = await self._stored_schema(session, partition_key)
+        if schema is None:
             return None
 
-        return self._collection_handle(
-            existing,
-            self._records_table(namespace, name),
-            self._vector_table_name(namespace, name),
+        return SQLiteVecVectorStorePartition(
+            create_session=self._create_session,
+            partition_key=partition_key,
+            indexed_properties=self._indexed_properties,
+            records_table=self._records_table(partition_key),
+            vector_table_name=self._vector_table_name(partition_key),
         )
 
     @override
-    async def close_collection(self, *, collection: VectorStoreCollection) -> None:
-        pass  # No resources to release.
-
-    @override
-    async def delete_collection(self, *, namespace: str, name: str) -> None:
-        if not validate_identifier(namespace) or not validate_identifier(name):
-            raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
+    async def delete_partition(self, partition_key: str) -> None:
+        if not validate_identifier(partition_key):
+            raise ValueError(f"Invalid partition key {partition_key!r}")
 
         async with self._create_session() as session, session.begin():
-            existing = (
+            exists = (
                 await session.execute(
-                    select(_CollectionRow.config_json).where(
-                        _CollectionRow.namespace == namespace,
-                        _CollectionRow.name == name,
+                    select(_PartitionRow.partition_key).where(
+                        _PartitionRow.collection == self._collection,
+                        _PartitionRow.partition_key == partition_key,
                     )
                 )
             ).scalar_one_or_none()
-            if existing is None:
+            if exists is None:
                 return
 
-            records_table = self._records_table(namespace, name)
-            vector_table_name = self._vector_table_name(namespace, name)
+            records_table = self._records_table(partition_key)
+            vector_table_name = self._vector_table_name(partition_key)
 
             await session.execute(text(f"DROP TABLE IF EXISTS [{vector_table_name}]"))
             await session.execute(text(f"DROP TABLE IF EXISTS [{records_table.name}]"))
 
             await session.execute(
-                delete(_CollectionRow).where(
-                    _CollectionRow.namespace == namespace,
-                    _CollectionRow.name == name,
+                delete(_PartitionRow).where(
+                    _PartitionRow.collection == self._collection,
+                    _PartitionRow.partition_key == partition_key,
                 )
             )
 
@@ -546,82 +545,50 @@ class SQLiteVecVectorStore(VectorStore):
 
     # Helpers.
 
-    @staticmethod
-    def _collection_prefix(namespace: str, name: str) -> str:
+    def _partition_prefix(self, partition_key: str) -> str:
+        collection = self._collection
         return (
-            f"vector_store_sqlite_vec_{len(namespace)}_{namespace}_{len(name)}_{name}"
+            f"vector_store_sqlite_vec_{len(collection)}_{collection}"
+            f"_{len(partition_key)}_{partition_key}"
         )
 
-    @staticmethod
-    def _records_table_name(namespace: str, name: str) -> str:
-        return f"{SQLiteVecVectorStore._collection_prefix(namespace, name)}_rc"
+    def _records_table_name(self, partition_key: str) -> str:
+        return f"{self._partition_prefix(partition_key)}_rc"
 
-    @staticmethod
-    def _vector_table_name(namespace: str, name: str) -> str:
-        return f"{SQLiteVecVectorStore._collection_prefix(namespace, name)}_vc"
+    def _vector_table_name(self, partition_key: str) -> str:
+        return f"{self._partition_prefix(partition_key)}_vc"
 
-    def _collection_row(
-        self, namespace: str, name: str, config: VectorStoreCollectionConfig
-    ) -> _CollectionRow:
-        return _CollectionRow(
-            namespace=namespace,
-            name=name,
-            config_json={
-                **config.model_dump(mode="json"),
-                _INDEXED_PROPERTIES_KEY: indexed_property_names(
-                    self._indexed_properties
-                ),
-            },
+    def _declared_schema(self) -> PartitionSchema:
+        return PartitionSchema(
+            vector_dimensions=self._vector_dimensions,
+            indexed_properties=indexed_property_names(self._indexed_properties),
         )
 
-    def _collection_handle(
-        self,
-        config: VectorStoreCollectionConfig,
-        records_table: Table,
-        vector_table_name: str,
-    ) -> SQLiteVecVectorStoreCollection:
-        return SQLiteVecVectorStoreCollection(
-            create_session=self._create_session,
-            config=config,
-            indexed_properties=self._indexed_properties,
-            records_table=records_table,
-            vector_table_name=vector_table_name,
-        )
-
-    async def _get_stored_config(
-        self, session: AsyncSession, namespace: str, name: str
-    ) -> VectorStoreCollectionConfig | None:
-        """The collection's config; raises if it was created under another schema."""
+    async def _stored_schema(
+        self, session: AsyncSession, partition_key: str
+    ) -> PartitionSchema | None:
+        """The schema the partition was created under; raises if it is not this store's."""
         stored = (
             await session.execute(
-                select(_CollectionRow.config_json).where(
-                    _CollectionRow.namespace == namespace,
-                    _CollectionRow.name == name,
+                select(_PartitionRow.schema_json).where(
+                    _PartitionRow.collection == self._collection,
+                    _PartitionRow.partition_key == partition_key,
                 )
             )
         ).scalar_one_or_none()
         if stored is None:
             return None
-        stored_properties = stored.get(_INDEXED_PROPERTIES_KEY)
-        declared_properties = indexed_property_names(self._indexed_properties)
-        if stored_properties != declared_properties:
-            raise IndexedPropertiesMismatchError(
-                namespace,
-                name,
-                stored_properties if isinstance(stored_properties, dict) else {},
-                declared_properties,
+        stored_schema = PartitionSchema.model_validate(stored)
+        declared_schema = self._declared_schema()
+        if stored_schema != declared_schema:
+            raise VectorStorePartitionSchemaMismatchError(
+                self._collection, partition_key, stored_schema, declared_schema
             )
-        return VectorStoreCollectionConfig.model_validate(
-            {
-                key: value
-                for key, value in stored.items()
-                if key != _INDEXED_PROPERTIES_KEY
-            }
-        )
+        return stored_schema
 
-    def _records_table(self, namespace: str, name: str) -> Table:
+    def _records_table(self, partition_key: str) -> Table:
         records_table = Table(
-            self._records_table_name(namespace, name),
+            self._records_table_name(partition_key),
             self._sa_metadata,
             Column("rowid", Integer, primary_key=True, autoincrement=True),
             Column("uuid", Uuid, nullable=False, unique=True),
@@ -632,15 +599,13 @@ class SQLiteVecVectorStore(VectorStore):
             property_indexes(records_table, self._indexed_properties)
         return records_table
 
-    async def _ensure_collection_tables(
+    async def _ensure_partition_tables(
         self,
         session: AsyncSession,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
+        partition_key: str,
     ) -> tuple[Table, str]:
-        records_table = self._records_table(namespace, name)
-        vector_table_name = self._vector_table_name(namespace, name)
+        records_table = self._records_table(partition_key)
+        vector_table_name = self._vector_table_name(partition_key)
 
         connection = await session.connection()
         await connection.run_sync(
@@ -651,7 +616,7 @@ class SQLiteVecVectorStore(VectorStore):
         await session.execute(
             text(
                 f"CREATE VIRTUAL TABLE IF NOT EXISTS [{vector_table_name}] USING vec0("
-                f"vector float[{config.vector_dimensions}] "
+                f"vector float[{self._vector_dimensions}] "
                 f"distance_metric={SQLiteVecVectorStore._SQLITE_VEC_DISTANCE_METRIC}"
                 f")"
             )

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -27,7 +27,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from pathlib import Path
-from typing import override
+from typing import ClassVar, override
 from uuid import UUID
 
 import numpy as np
@@ -58,25 +58,45 @@ from sqlalchemy.orm import DeclarativeBase, MappedColumn, Session, mapped_column
 from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 from sqlalchemy.sql.elements import ColumnElement
 
-from memmachine_server.common.filter.filter_parser import FilterExpr
-from memmachine_server.common.filter.sql_filter_util import compile_sql_filter
-from memmachine_server.common.properties_json import (
-    encode_properties,
+from memmachine_server.common.data_types import PropertyType
+from memmachine_server.common.filter import (
+    And,
+    Equals,
+    FilterExpr,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
 )
 
 from .data_types import (
+    IndexedProperties,
+    IndexedPropertiesMismatchError,
     QueryMatch,
     QueryResult,
     Record,
     VectorStoreCollectionAlreadyExistsError,
     VectorStoreCollectionConfig,
     VectorStoreCollectionConfigMismatchError,
+    indexed_property_names,
 )
-from .utils import validate_filter, validate_identifier
+from .declared_properties import require_declared_properties, require_supported_filter
+from .sql_columns import (
+    compile_property_filter,
+    property_column_name,
+    property_column_values,
+    property_columns,
+    property_indexes,
+)
+from .utils import validate_identifier
 from .vector_search_engine import VectorSearchEngine
 from .vector_store import VectorStore, VectorStoreCollection
 
 logger = logging.getLogger(__name__)
+
+_INDEXED_PROPERTIES_KEY = "indexed_properties"
 
 
 class IndexLoadError(RuntimeError):
@@ -102,6 +122,9 @@ class _CollectionRow(BaseSQLiteVectorStore):
 
     namespace: MappedColumn[str] = mapped_column(String(255), primary_key=True)
     name: MappedColumn[str] = mapped_column(String(255), primary_key=True)
+    # The collection config plus the declared schema it was created under,
+    # so a store built with another schema fails loudly instead of reading
+    # columns that are not there.
     config_json: MappedColumn[dict[str, JsonValue]] = mapped_column(
         JSON, nullable=False
     )
@@ -247,6 +270,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         namespace: str,
         name: str,
         config: VectorStoreCollectionConfig,
+        indexed_properties: Mapping[str, PropertyType],
         index_path: str | None,
         save_threshold: int,
     ) -> None:
@@ -260,14 +284,29 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         self._name = name
 
         self._config = config
+        self._indexed_properties = dict(indexed_properties)
 
         self._index_path = index_path
         self._save_threshold = save_threshold
+
+    _SUPPORTED_FILTER_NODES: ClassVar[frozenset[type]] = frozenset(
+        {Equals, NotEquals, Ordering, In, IsMissing, And, Or, Not}
+    )
 
     @property
     @override
     def config(self) -> VectorStoreCollectionConfig:
         return self._config
+
+    @property
+    @override
+    def indexed_properties(self) -> Mapping[str, PropertyType]:
+        return self._indexed_properties
+
+    @property
+    @override
+    def supported_filter_nodes(self) -> frozenset[type]:
+        return SQLiteVectorStoreCollection._SUPPORTED_FILTER_NODES
 
     async def _maybe_save_index(self) -> None:
         """Save the index to disk if applied pending operations exceed the threshold."""
@@ -299,27 +338,33 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         records = list(records)
         if not records:
             return
+        for record in records:
+            require_declared_properties(record.properties, self._indexed_properties)
+
+        property_column_names = [
+            property_column_name(key) for key in self._indexed_properties
+        ]
+        insert_records = sqlite_insert(self._records_table)
+        upsert_records = insert_records.on_conflict_do_update(
+            index_elements=[self._records_table.c.uuid],
+            # With no declared column the update is a no-op that still
+            # returns the existing row, which `RETURNING` needs.
+            set_={
+                name: insert_records.excluded[name]
+                for name in (property_column_names or ["uuid"])
+            },
+        ).returning(self._records_table.c.uuid, self._records_table.c.row_id)
 
         async with self._create_session() as session, session.begin():
-            upsert_records = (
-                sqlite_insert(self._records_table)
-                .on_conflict_do_update(
-                    index_elements=[self._records_table.c.uuid],
-                    set_={
-                        "properties": sqlite_insert(
-                            self._records_table
-                        ).excluded.properties,
-                    },
-                )
-                .returning(self._records_table.c.uuid, self._records_table.c.row_id)
-            )
             rows = (
                 await session.execute(
                     upsert_records,
                     [
                         {
                             "uuid": record.uuid,
-                            "properties": encode_properties(record.properties),
+                            **property_column_values(
+                                record.properties, self._indexed_properties
+                            ),
                         }
                         for record in records
                     ],
@@ -402,8 +447,12 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         if limit <= 0:
             return [QueryResult(matches=[]) for _ in query_vectors]
 
-        if property_filter is not None and not validate_filter(property_filter):
-            raise ValueError("Filter contains invalid field names")
+        if property_filter is not None:
+            require_supported_filter(
+                property_filter,
+                self._indexed_properties,
+                SQLiteVectorStoreCollection._SUPPORTED_FILTER_NODES,
+            )
 
         key_filter = self._build_key_filter(property_filter)
 
@@ -435,12 +484,8 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         return SQLiteVectorStoreCollection._KeyFilter(
             sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
             records_table=self._records_table,
-            filter_expression=compile_sql_filter(
-                property_filter,
-                lambda field: (
-                    self._records_table.c.properties[field],
-                    "properties_json",
-                ),
+            filter_expression=compile_property_filter(
+                property_filter, self._records_table, self._indexed_properties
             ),
         )
 
@@ -566,6 +611,10 @@ class SQLiteVectorStoreParams(BaseModel):
             Number of engine operations before auto-saving the index to disk.
             Only applies when index_directory is set
             (default: 1000).
+        indexed_properties (IndexedProperties):
+            The declared schema every collection of this store carries: each
+            key is a typed, indexed column of the collection's records table,
+            and a record or a filter naming any other key is rejected.
     """
 
     sqlalchemy_engine: InstanceOf[AsyncEngine] = Field(
@@ -590,6 +639,10 @@ class SQLiteVectorStoreParams(BaseModel):
             "Number of engine operations before auto-saving the index to disk. "
             "Only applies when index_directory is set"
         ),
+    )
+    indexed_properties: IndexedProperties = Field(
+        ...,
+        description="The declared schema every collection of this store carries",
     )
 
     @field_validator("sqlalchemy_engine")
@@ -624,6 +677,7 @@ class SQLiteVectorStore(VectorStore):
             Path(params.index_directory) if params.index_directory else None
         )
         self._save_threshold = params.save_threshold
+        self._indexed_properties = params.indexed_properties
 
         self._create_session = async_sessionmaker(
             self._sqlalchemy_engine, expire_on_commit=False
@@ -646,6 +700,11 @@ class SQLiteVectorStore(VectorStore):
             cursor.close()
 
         self._started = False
+
+    @property
+    @override
+    def indexed_properties(self) -> Mapping[str, PropertyType]:
+        return self._indexed_properties
 
     def _require_started(self) -> None:
         if not self._started:
@@ -767,13 +826,7 @@ class SQLiteVectorStore(VectorStore):
 
             self._clear_search_engine_state(namespace, name)
             await self._ensure_collection_resources(session, namespace, name, config)
-            session.add(
-                _CollectionRow(
-                    namespace=namespace,
-                    name=name,
-                    config_json=config.model_dump(mode="json"),
-                )
-            )
+            session.add(self._collection_row(namespace, name, config))
 
     @override
     async def open_or_create_collection(
@@ -807,6 +860,7 @@ class SQLiteVectorStore(VectorStore):
                     namespace=namespace,
                     name=name,
                     config=existing_config,
+                    indexed_properties=self._indexed_properties,
                     index_path=str(index_path) if index_path is not None else None,
                     save_threshold=self._save_threshold,
                 )
@@ -815,13 +869,7 @@ class SQLiteVectorStore(VectorStore):
             records_table, search_engine = await self._ensure_collection_resources(
                 session, namespace, name, config
             )
-            session.add(
-                _CollectionRow(
-                    namespace=namespace,
-                    name=name,
-                    config_json=config.model_dump(mode="json"),
-                )
-            )
+            session.add(self._collection_row(namespace, name, config))
 
         return SQLiteVectorStoreCollection(
             create_session=self._create_session,
@@ -831,6 +879,7 @@ class SQLiteVectorStore(VectorStore):
             namespace=namespace,
             name=name,
             config=config,
+            indexed_properties=self._indexed_properties,
             index_path=str(index_path) if index_path is not None else None,
             save_threshold=self._save_threshold,
         )
@@ -865,6 +914,7 @@ class SQLiteVectorStore(VectorStore):
             namespace=namespace,
             name=name,
             config=existing,
+            indexed_properties=self._indexed_properties,
             index_path=str(index_path) if index_path is not None else None,
             save_threshold=self._save_threshold,
         )
@@ -916,13 +966,30 @@ class SQLiteVectorStore(VectorStore):
 
     def _records_table(self, namespace: str, name: str) -> Table:
         """Get or create a SQLAlchemy Table for a per-collection records table."""
-        return Table(
+        records_table = Table(
             f"{self._collection_prefix(namespace, name)}_rc",
             self._sa_metadata,
             Column("row_id", Integer, primary_key=True, autoincrement=True),
             Column("uuid", Uuid, nullable=False, unique=True),
-            Column("properties", JSON, nullable=False, default=dict),
+            *property_columns(self._indexed_properties),
             extend_existing=True,
+        )
+        if not records_table.indexes:
+            property_indexes(records_table, self._indexed_properties)
+        return records_table
+
+    def _collection_row(
+        self, namespace: str, name: str, config: VectorStoreCollectionConfig
+    ) -> _CollectionRow:
+        return _CollectionRow(
+            namespace=namespace,
+            name=name,
+            config_json={
+                **config.model_dump(mode="json"),
+                _INDEXED_PROPERTIES_KEY: indexed_property_names(
+                    self._indexed_properties
+                ),
+            },
         )
 
     def _index_path(self, namespace: str, name: str) -> Path | None:
@@ -944,7 +1011,8 @@ class SQLiteVectorStore(VectorStore):
         namespace: str,
         name: str,
     ) -> VectorStoreCollectionConfig | None:
-        row = (
+        """The collection's config; raises if it was created under another schema."""
+        stored = (
             await session.execute(
                 select(_CollectionRow.config_json).where(
                     _CollectionRow.namespace == namespace,
@@ -952,9 +1020,24 @@ class SQLiteVectorStore(VectorStore):
                 )
             )
         ).scalar_one_or_none()
-        if row is None:
+        if stored is None:
             return None
-        return VectorStoreCollectionConfig.model_validate(row)
+        stored_properties = stored.get(_INDEXED_PROPERTIES_KEY)
+        declared_properties = indexed_property_names(self._indexed_properties)
+        if stored_properties != declared_properties:
+            raise IndexedPropertiesMismatchError(
+                namespace,
+                name,
+                stored_properties if isinstance(stored_properties, dict) else {},
+                declared_properties,
+            )
+        return VectorStoreCollectionConfig.model_validate(
+            {
+                key: value
+                for key, value in stored.items()
+                if key != _INDEXED_PROPERTIES_KEY
+            }
+        )
 
     async def _get_or_create_vector_search_engine(
         self,

--- a/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/sqlite_vector_store.py
@@ -1,8 +1,9 @@
 """
 Vector store backed by SQLite + pluggable vector search engine.
 
-Each logical collection gets its own records table and vector search engine.
-A pending operations table tracks search engine operations for crash recovery:
+The store is one collection. Each partition gets its own records table and
+vector search engine, and a pending operations table shared by the
+collection's partitions tracks search engine operations for crash recovery:
 on startup, unfinalized operations are replayed.
 
 What survives a crash
@@ -72,15 +73,16 @@ from memmachine_server.common.filter import (
 )
 
 from .data_types import (
+    COLLECTION_NAME_MAX_BYTES,
     IndexedProperties,
-    IndexedPropertiesMismatchError,
+    PartitionSchema,
     QueryMatch,
     QueryResult,
     Record,
-    VectorStoreCollectionAlreadyExistsError,
-    VectorStoreCollectionConfig,
-    VectorStoreCollectionConfigMismatchError,
+    VectorStorePartitionAlreadyExistsError,
+    VectorStorePartitionSchemaMismatchError,
     indexed_property_names,
+    validate_collection_name,
 )
 from .declared_properties import require_declared_properties, require_supported_filter
 from .sql_columns import (
@@ -92,23 +94,21 @@ from .sql_columns import (
 )
 from .utils import validate_identifier
 from .vector_search_engine import VectorSearchEngine
-from .vector_store import VectorStore, VectorStoreCollection
+from .vector_store import VectorStore, VectorStorePartition
 
 logger = logging.getLogger(__name__)
 
-_INDEXED_PROPERTIES_KEY = "indexed_properties"
-
 
 class IndexLoadError(RuntimeError):
-    """Raised when a collection's on-disk index file cannot be loaded."""
+    """Raised when a partition's on-disk index file cannot be loaded."""
 
-    def __init__(self, namespace: str, name: str, path: Path) -> None:
-        """Initialize with the collection namespace, name, and index file path."""
-        self.namespace = namespace
-        self.name = name
+    def __init__(self, collection: str, partition_key: str, path: Path) -> None:
+        """Initialize with the collection, the partition key, and the index file path."""
+        self.collection = collection
+        self.partition_key = partition_key
         self.path = path
         super().__init__(
-            f"Index for collection ({namespace!r}, {name!r}) "
+            f"Index for partition {partition_key!r} of collection {collection!r} "
             f"at {path} could not be loaded"
         )
 
@@ -117,15 +117,23 @@ class BaseSQLiteVectorStore(DeclarativeBase):
     """Base class for SQLiteVectorStore ORM models."""
 
 
-class _CollectionRow(BaseSQLiteVectorStore):
-    __tablename__ = "vector_store_sqlite_cl"
+class _PartitionRow(BaseSQLiteVectorStore):
+    """The registry: one row per partition, keyed by its collection and key.
 
-    namespace: MappedColumn[str] = mapped_column(String(255), primary_key=True)
-    name: MappedColumn[str] = mapped_column(String(255), primary_key=True)
-    # The collection config plus the declared schema it was created under,
-    # so a store built with another schema fails loudly instead of reading
-    # columns that are not there.
-    config_json: MappedColumn[dict[str, JsonValue]] = mapped_column(
+    Stores of different collections may share one engine, so the collection
+    is part of the key and every read names it.
+    """
+
+    __tablename__ = "vector_store_sqlite_pt"
+
+    collection: MappedColumn[str] = mapped_column(
+        String(COLLECTION_NAME_MAX_BYTES), primary_key=True
+    )
+    partition_key: MappedColumn[str] = mapped_column(String(255), primary_key=True)
+    # The dimensions and declared schema the partition was created under, so
+    # a store built with others fails loudly instead of reading columns and
+    # vectors that are not there.
+    schema_json: MappedColumn[dict[str, JsonValue]] = mapped_column(
         JSON, nullable=False
     )
     # Flips to True after the first successful index save.
@@ -138,10 +146,10 @@ class _CollectionRow(BaseSQLiteVectorStore):
 
 class _PendingOperationRow(BaseSQLiteVectorStore):
     """
-    Pending collection operations for crash recovery.
+    Pending partition operations for crash recovery.
 
-    One row per (namespace, name, record). New operations replace old ones.
-    Lifecycle:
+    One row per (collection, partition, record). New operations replace old
+    ones. Lifecycle:
     1. Inserted in the same SQLite transaction as the records table change.
     2. Marked `applied=True` after the search engine processes the operation.
     3. Applied operations are deleted after the search engine is saved to disk.
@@ -151,17 +159,19 @@ class _PendingOperationRow(BaseSQLiteVectorStore):
     __tablename__ = "vector_store_sqlite_pd_op"
     __table_args__ = (
         ForeignKeyConstraint(
-            ["namespace", "name"],
+            ["collection", "partition_key"],
             [
-                f"{_CollectionRow.__tablename__}.namespace",
-                f"{_CollectionRow.__tablename__}.name",
+                f"{_PartitionRow.__tablename__}.collection",
+                f"{_PartitionRow.__tablename__}.partition_key",
             ],
             ondelete="CASCADE",
         ),
     )
 
-    namespace: MappedColumn[str] = mapped_column(String(255), primary_key=True)
-    name: MappedColumn[str] = mapped_column(String(255), primary_key=True)
+    collection: MappedColumn[str] = mapped_column(
+        String(COLLECTION_NAME_MAX_BYTES), primary_key=True
+    )
+    partition_key: MappedColumn[str] = mapped_column(String(255), primary_key=True)
     record_row_id: MappedColumn[int] = mapped_column(Integer, primary_key=True)
     operation_type: MappedColumn[str] = mapped_column(
         String(8), nullable=False
@@ -170,15 +180,15 @@ class _PendingOperationRow(BaseSQLiteVectorStore):
     applied: MappedColumn[bool] = mapped_column(Boolean, nullable=False, default=False)
 
 
-async def _save_collection_index(
+async def _save_partition_index(
     *,
     create_session: async_sessionmaker[AsyncSession],
-    namespace: str,
-    name: str,
+    collection: str,
+    partition_key: str,
     search_engine: VectorSearchEngine,
     path: str,
 ) -> None:
-    """Publish a collection's index to disk and trim the operations it holds.
+    """Publish a partition's index to disk and trim the operations it holds.
 
     The order is the whole protocol. The pending log is the only other copy of
     these vectors -- the records table has no vector column -- so an applied row
@@ -194,24 +204,24 @@ async def _save_collection_index(
     async with create_session() as session, session.begin():
         await session.execute(
             delete(_PendingOperationRow).where(
-                _PendingOperationRow.namespace == namespace,
-                _PendingOperationRow.name == name,
+                _PendingOperationRow.collection == collection,
+                _PendingOperationRow.partition_key == partition_key,
                 _PendingOperationRow.applied.is_(True),
             )
         )
         await session.execute(
-            update(_CollectionRow)
+            update(_PartitionRow)
             .where(
-                _CollectionRow.namespace == namespace,
-                _CollectionRow.name == name,
-                _CollectionRow.index_saved.is_(False),
+                _PartitionRow.collection == collection,
+                _PartitionRow.partition_key == partition_key,
+                _PartitionRow.index_saved.is_(False),
             )
             .values(index_saved=True)
         )
 
 
-class SQLiteVectorStoreCollection(VectorStoreCollection):
-    """A logical collection backed by SQLite + a pluggable vector search engine."""
+class SQLiteVectorStorePartition(VectorStorePartition):
+    """A partition backed by SQLite + a pluggable vector search engine."""
 
     class _KeyFilter:
         """Per-candidate SQL filter using a sync SQLAlchemy session."""
@@ -267,23 +277,21 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         sync_sqlalchemy_engine: Engine,
         records_table: Table,
         search_engine: VectorSearchEngine,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
+        collection: str,
+        partition_key: str,
         indexed_properties: Mapping[str, PropertyType],
         index_path: str | None,
         save_threshold: int,
     ) -> None:
-        """Initialize a collection handle."""
+        """Initialize a partition handle."""
         self._create_session = create_session
         self._sync_sqlalchemy_engine = sync_sqlalchemy_engine
         self._records_table = records_table
         self._search_engine = search_engine
 
-        self._namespace = namespace
-        self._name = name
+        self._collection = collection
+        self._partition_key = partition_key
 
-        self._config = config
         self._indexed_properties = dict(indexed_properties)
 
         self._index_path = index_path
@@ -295,8 +303,8 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
     @property
     @override
-    def config(self) -> VectorStoreCollectionConfig:
-        return self._config
+    def partition_key(self) -> str:
+        return self._partition_key
 
     @property
     @override
@@ -306,7 +314,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
     @property
     @override
     def supported_filter_nodes(self) -> frozenset[type]:
-        return SQLiteVectorStoreCollection._SUPPORTED_FILTER_NODES
+        return SQLiteVectorStorePartition._SUPPORTED_FILTER_NODES
 
     async def _maybe_save_index(self) -> None:
         """Save the index to disk if applied pending operations exceed the threshold."""
@@ -317,18 +325,18 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
             count = (
                 await session.execute(
                     select(func.count()).where(
-                        _PendingOperationRow.namespace == self._namespace,
-                        _PendingOperationRow.name == self._name,
+                        _PendingOperationRow.collection == self._collection,
+                        _PendingOperationRow.partition_key == self._partition_key,
                         _PendingOperationRow.applied.is_(True),
                     )
                 )
             ).scalar_one()
 
         if count >= self._save_threshold:
-            await _save_collection_index(
+            await _save_partition_index(
                 create_session=self._create_session,
-                namespace=self._namespace,
-                name=self._name,
+                collection=self._collection,
+                partition_key=self._partition_key,
                 search_engine=self._search_engine,
                 path=self._index_path,
             )
@@ -374,8 +382,8 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
 
             pending_operation_values = [
                 {
-                    "namespace": self._namespace,
-                    "name": self._name,
+                    "collection": self._collection,
+                    "partition_key": self._partition_key,
                     "record_row_id": uuid_to_row_id[record.uuid],
                     "operation_type": "upsert",
                     "vector": np.array(record.vector, dtype=np.float32).tobytes(),
@@ -387,7 +395,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 upsert_pending_operation = sqlite_insert(_PendingOperationRow)
                 await session.execute(
                     upsert_pending_operation.on_conflict_do_update(
-                        index_elements=["namespace", "name", "record_row_id"],
+                        index_elements=["collection", "partition_key", "record_row_id"],
                         set_={
                             "operation_type": upsert_pending_operation.excluded.operation_type,
                             "vector": upsert_pending_operation.excluded.vector,
@@ -419,8 +427,8 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 await session.execute(
                     update(_PendingOperationRow)
                     .where(
-                        _PendingOperationRow.namespace == self._namespace,
-                        _PendingOperationRow.name == self._name,
+                        _PendingOperationRow.collection == self._collection,
+                        _PendingOperationRow.partition_key == self._partition_key,
                         _PendingOperationRow.record_row_id.in_(
                             list(engine_vectors.keys())
                         ),
@@ -451,7 +459,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
             require_supported_filter(
                 property_filter,
                 self._indexed_properties,
-                SQLiteVectorStoreCollection._SUPPORTED_FILTER_NODES,
+                SQLiteVectorStorePartition._SUPPORTED_FILTER_NODES,
             )
 
         key_filter = self._build_key_filter(property_filter)
@@ -481,7 +489,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
         if property_filter is None:
             return None
 
-        return SQLiteVectorStoreCollection._KeyFilter(
+        return SQLiteVectorStorePartition._KeyFilter(
             sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
             records_table=self._records_table,
             filter_expression=compile_property_filter(
@@ -551,7 +559,7 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
             upsert_pending_operation = sqlite_insert(_PendingOperationRow)
             await session.execute(
                 upsert_pending_operation.on_conflict_do_update(
-                    index_elements=["namespace", "name", "record_row_id"],
+                    index_elements=["collection", "partition_key", "record_row_id"],
                     set_={
                         "operation_type": upsert_pending_operation.excluded.operation_type,
                         "applied": upsert_pending_operation.excluded.applied,
@@ -559,8 +567,8 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
                 ),
                 [
                     {
-                        "namespace": self._namespace,
-                        "name": self._name,
+                        "collection": self._collection,
+                        "partition_key": self._partition_key,
                         "record_row_id": record_row_id,
                         "operation_type": "delete",
                         "applied": False,
@@ -580,8 +588,8 @@ class SQLiteVectorStoreCollection(VectorStoreCollection):
             await session.execute(
                 update(_PendingOperationRow)
                 .where(
-                    _PendingOperationRow.namespace == self._namespace,
-                    _PendingOperationRow.name == self._name,
+                    _PendingOperationRow.collection == self._collection,
+                    _PendingOperationRow.partition_key == self._partition_key,
                     _PendingOperationRow.record_row_id.in_(record_row_ids),
                     _PendingOperationRow.applied.is_(False),
                 )
@@ -600,9 +608,18 @@ class SQLiteVectorStoreParams(BaseModel):
     Attributes:
         sqlalchemy_engine (AsyncEngine):
             Async SQLAlchemy engine (sqlite+aiosqlite).
-        engine_factory (Callable[[int], VectorSearchEngine]):
+        collection (str):
+            The collection this store is; names its tables and index files,
+            so stores of different collections may share the engine.
+        vector_dimensions (int):
+            Dimensionality of every vector in the store.
+        indexed_properties (IndexedProperties):
+            The declared schema every partition of this store carries: each
+            key is a typed, indexed column of the partition's records table,
+            and a record or a filter naming any other key is rejected.
+        vector_search_engine_factory (Callable[[int], VectorSearchEngine]):
             Factory for creating :class:`VectorSearchEngine` instances.
-            Receives `(ndim, metric)` and returns a search engine.
+            Receives the number of dimensions and returns a search engine.
         index_directory (str | None):
             Directory for persisting index files.
             If None, indexes are in-memory only
@@ -611,20 +628,24 @@ class SQLiteVectorStoreParams(BaseModel):
             Number of engine operations before auto-saving the index to disk.
             Only applies when index_directory is set
             (default: 1000).
-        indexed_properties (IndexedProperties):
-            The declared schema every collection of this store carries: each
-            key is a typed, indexed column of the collection's records table,
-            and a record or a filter naming any other key is rejected.
     """
 
     sqlalchemy_engine: InstanceOf[AsyncEngine] = Field(
         ..., description="Async SQLAlchemy engine (sqlite+aiosqlite)"
     )
+    collection: str = Field(..., description="The collection this store is")
+    vector_dimensions: int = Field(
+        ..., gt=0, description="Dimensionality of every vector in the store"
+    )
+    indexed_properties: IndexedProperties = Field(
+        ...,
+        description="The declared schema every partition of this store carries",
+    )
     vector_search_engine_factory: VectorSearchEngineFactory = Field(
         ...,
         description=(
             "Factory for creating VectorSearchEngine instances. "
-            "Receives `(ndim, metric)` and returns a search engine"
+            "Receives the number of dimensions and returns a search engine"
         ),
     )
     index_directory: str | None = Field(
@@ -640,10 +661,12 @@ class SQLiteVectorStoreParams(BaseModel):
             "Only applies when index_directory is set"
         ),
     )
-    indexed_properties: IndexedProperties = Field(
-        ...,
-        description="The declared schema every collection of this store carries",
-    )
+
+    @field_validator("collection")
+    @classmethod
+    def _validate_collection(cls, collection: str) -> str:
+        validate_collection_name(collection)
+        return collection
 
     @field_validator("sqlalchemy_engine")
     @classmethod
@@ -665,24 +688,26 @@ class SQLiteVectorStore(VectorStore):
     """
     Vector store backed by SQLite + a pluggable vector search engine.
 
-    Each logical collection gets its own records table and engine instance.
+    Each partition gets its own records table and engine instance.
     """
 
     def __init__(self, params: SQLiteVectorStoreParams) -> None:
         """Initialize the vector store with the provided parameters."""
         self._sqlalchemy_engine = params.sqlalchemy_engine
+        self._collection = params.collection
+        self._vector_dimensions = params.vector_dimensions
+        self._indexed_properties = params.indexed_properties
         self._vector_search_engine_factory = params.vector_search_engine_factory
 
         self._index_directory = (
             Path(params.index_directory) if params.index_directory else None
         )
         self._save_threshold = params.save_threshold
-        self._indexed_properties = params.indexed_properties
 
         self._create_session = async_sessionmaker(
             self._sqlalchemy_engine, expire_on_commit=False
         )
-        self._search_engines: dict[tuple[str, str], VectorSearchEngine] = {}
+        self._search_engines: dict[str, VectorSearchEngine] = {}
         self._sa_metadata = MetaData()
 
         self._sync_sqlalchemy_engine = create_engine(
@@ -703,6 +728,16 @@ class SQLiteVectorStore(VectorStore):
 
     @property
     @override
+    def collection(self) -> str:
+        return self._collection
+
+    @property
+    @override
+    def vector_dimensions(self) -> int:
+        return self._vector_dimensions
+
+    @property
+    @override
     def indexed_properties(self) -> Mapping[str, PropertyType]:
         return self._indexed_properties
 
@@ -713,52 +748,58 @@ class SQLiteVectorStore(VectorStore):
             )
 
     @override
-    async def startup(self) -> None:
-        if self._started:
-            return
-
+    async def provision(self) -> None:
         if self._index_directory is not None:
             self._index_directory.mkdir(parents=True, exist_ok=True)
 
         async with self._sqlalchemy_engine.begin() as connection:
             await connection.run_sync(BaseSQLiteVectorStore.metadata.create_all)
 
+    @override
+    async def startup(self) -> None:
+        if self._started:
+            return
+
         await self._replay_pending_operations()
 
         self._started = True
 
     async def _replay_pending_operations(self) -> None:
-        """Replay any pending engine operations."""
+        """Replay any pending engine operations of this collection."""
         async with self._create_session() as session:
             pending_operations = (
-                (await session.execute(select(_PendingOperationRow))).scalars().all()
+                (
+                    await session.execute(
+                        select(_PendingOperationRow).where(
+                            _PendingOperationRow.collection == self._collection
+                        )
+                    )
+                )
+                .scalars()
+                .all()
             )
 
         if not pending_operations:
             return
 
-        operations_by_collection: dict[tuple[str, str], list[_PendingOperationRow]] = (
-            defaultdict(list)
+        operations_by_partition: dict[str, list[_PendingOperationRow]] = defaultdict(
+            list
         )
         for operation in pending_operations:
-            operations_by_collection[(operation.namespace, operation.name)].append(
-                operation
-            )
+            operations_by_partition[operation.partition_key].append(operation)
 
-        for (namespace, name), operations in operations_by_collection.items():
-            await self._replay_collection_operations(namespace, name, operations)
+        for partition_key, operations in operations_by_partition.items():
+            await self._replay_partition_operations(partition_key, operations)
 
-    async def _replay_collection_operations(
-        self, namespace: str, name: str, operations: Iterable[_PendingOperationRow]
+    async def _replay_partition_operations(
+        self, partition_key: str, operations: Iterable[_PendingOperationRow]
     ) -> None:
         async with self._create_session() as session:
-            config = await self._get_stored_config(session, namespace, name)
-        if config is None:
+            schema = await self._stored_schema(session, partition_key)
+        if schema is None:
             return
 
-        search_engine = await self._get_or_create_vector_search_engine(
-            namespace, name, config
-        )
+        search_engine = await self._get_or_create_vector_search_engine(partition_key)
 
         upserted_vectors: dict[int, list[float]] = {}
         deleted_row_ids: list[int] = []
@@ -783,8 +824,8 @@ class SQLiteVectorStore(VectorStore):
             await session.execute(
                 update(_PendingOperationRow)
                 .where(
-                    _PendingOperationRow.namespace == namespace,
-                    _PendingOperationRow.name == name,
+                    _PendingOperationRow.collection == self._collection,
+                    _PendingOperationRow.partition_key == partition_key,
                     _PendingOperationRow.record_row_id.in_(all_row_ids),
                 )
                 .values(applied=True)
@@ -794,13 +835,13 @@ class SQLiteVectorStore(VectorStore):
     async def shutdown(self) -> None:
         self._require_started()
         if self._index_directory is not None:
-            for (namespace, name), search_engine in self._search_engines.items():
-                path = self._index_path(namespace, name)
+            for partition_key, search_engine in self._search_engines.items():
+                path = self._index_path(partition_key)
                 assert path is not None
-                await _save_collection_index(
+                await _save_partition_index(
                     create_session=self._create_session,
-                    namespace=namespace,
-                    name=name,
+                    collection=self._collection,
+                    partition_key=partition_key,
                     search_engine=search_engine,
                     path=str(path),
                 )
@@ -808,133 +849,70 @@ class SQLiteVectorStore(VectorStore):
         self._started = False
 
     @override
-    async def create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> None:
+    async def create_partition(self, partition_key: str) -> None:
         self._require_started()
-        if not validate_identifier(namespace) or not validate_identifier(name):
-            raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
+        if not validate_identifier(partition_key):
+            raise ValueError(f"Invalid partition key {partition_key!r}")
 
         async with self._create_session() as session, session.begin():
-            existing_config = await self._get_stored_config(session, namespace, name)
-            if existing_config is not None:
-                raise VectorStoreCollectionAlreadyExistsError(namespace, name)
-
-            self._clear_search_engine_state(namespace, name)
-            await self._ensure_collection_resources(session, namespace, name, config)
-            session.add(self._collection_row(namespace, name, config))
-
-    @override
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> VectorStoreCollection:
-        self._require_started()
-        if not validate_identifier(namespace) or not validate_identifier(name):
-            raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
-
-        index_path = self._index_path(namespace, name)
-
-        async with self._create_session() as session, session.begin():
-            existing_config = await self._get_stored_config(session, namespace, name)
-            if existing_config is not None:
-                if existing_config != config:
-                    raise VectorStoreCollectionConfigMismatchError(
-                        namespace, name, existing_config, config
-                    )
-                records_table, search_engine = await self._ensure_collection_resources(
-                    session, namespace, name, existing_config
-                )
-                return SQLiteVectorStoreCollection(
-                    create_session=self._create_session,
-                    sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
-                    records_table=records_table,
-                    search_engine=search_engine,
-                    namespace=namespace,
-                    name=name,
-                    config=existing_config,
-                    indexed_properties=self._indexed_properties,
-                    index_path=str(index_path) if index_path is not None else None,
-                    save_threshold=self._save_threshold,
+            if await self._stored_schema(session, partition_key) is not None:
+                raise VectorStorePartitionAlreadyExistsError(
+                    self._collection, partition_key
                 )
 
-            self._clear_search_engine_state(namespace, name)
-            records_table, search_engine = await self._ensure_collection_resources(
-                session, namespace, name, config
+            self._clear_search_engine_state(partition_key)
+            await self._ensure_partition_resources(session, partition_key)
+            session.add(
+                _PartitionRow(
+                    collection=self._collection,
+                    partition_key=partition_key,
+                    schema_json=self._declared_schema().model_dump(mode="json"),
+                )
             )
-            session.add(self._collection_row(namespace, name, config))
-
-        return SQLiteVectorStoreCollection(
-            create_session=self._create_session,
-            sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
-            records_table=records_table,
-            search_engine=search_engine,
-            namespace=namespace,
-            name=name,
-            config=config,
-            indexed_properties=self._indexed_properties,
-            index_path=str(index_path) if index_path is not None else None,
-            save_threshold=self._save_threshold,
-        )
 
     @override
-    async def open_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-    ) -> VectorStoreCollection | None:
+    async def get_partition(self, partition_key: str) -> VectorStorePartition | None:
         self._require_started()
-        if not validate_identifier(namespace) or not validate_identifier(name):
-            raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
+        if not validate_identifier(partition_key):
+            raise ValueError(f"Invalid partition key {partition_key!r}")
 
         async with self._create_session() as session:
-            existing = await self._get_stored_config(session, namespace, name)
-        if existing is None:
+            schema = await self._stored_schema(session, partition_key)
+        if schema is None:
             return None
 
-        records_table = self._records_table(namespace, name)
-        search_engine = await self._get_or_create_vector_search_engine(
-            namespace, name, existing
-        )
-
-        index_path = self._index_path(namespace, name)
-        return SQLiteVectorStoreCollection(
+        index_path = self._index_path(partition_key)
+        return SQLiteVectorStorePartition(
             create_session=self._create_session,
             sync_sqlalchemy_engine=self._sync_sqlalchemy_engine,
-            records_table=records_table,
-            search_engine=search_engine,
-            namespace=namespace,
-            name=name,
-            config=existing,
+            records_table=self._records_table(partition_key),
+            search_engine=await self._get_or_create_vector_search_engine(partition_key),
+            collection=self._collection,
+            partition_key=partition_key,
             indexed_properties=self._indexed_properties,
             index_path=str(index_path) if index_path is not None else None,
             save_threshold=self._save_threshold,
         )
 
     @override
-    async def close_collection(self, *, collection: VectorStoreCollection) -> None:
+    async def delete_partition(self, partition_key: str) -> None:
         self._require_started()
-
-    @override
-    async def delete_collection(self, *, namespace: str, name: str) -> None:
-        self._require_started()
-        if not validate_identifier(namespace) or not validate_identifier(name):
-            raise ValueError(f"Invalid namespace {namespace!r} or name {name!r}")
+        if not validate_identifier(partition_key):
+            raise ValueError(f"Invalid partition key {partition_key!r}")
 
         async with self._create_session() as session:
-            existing = await self._get_stored_config(session, namespace, name)
-        if existing is None:
+            exists = (
+                await session.execute(
+                    select(_PartitionRow.partition_key).where(
+                        _PartitionRow.collection == self._collection,
+                        _PartitionRow.partition_key == partition_key,
+                    )
+                )
+            ).scalar_one_or_none()
+        if exists is None:
             return
 
-        records_table = self._records_table(namespace, name)
+        records_table = self._records_table(partition_key)
         async with self._create_session() as session, session.begin():
             connection = await session.connection()
             await connection.run_sync(
@@ -942,32 +920,35 @@ class SQLiteVectorStore(VectorStore):
             )
 
             await session.execute(
-                delete(_CollectionRow).where(
-                    _CollectionRow.namespace == namespace,
-                    _CollectionRow.name == name,
+                delete(_PartitionRow).where(
+                    _PartitionRow.collection == self._collection,
+                    _PartitionRow.partition_key == partition_key,
                 )
             )
 
         self._sa_metadata.remove(records_table)
 
         # If unlink fails, the orphan is harmless.
-        # _clear_search_engine_state will clean it up if a new collection with the same name is created.
-        index_path = self._index_path(namespace, name)
+        # _clear_search_engine_state will clean it up if a new partition with the same key is created.
+        index_path = self._index_path(partition_key)
         if index_path is not None and index_path.exists():
             index_path.unlink()
-        self._search_engines.pop((namespace, name), None)
+        self._search_engines.pop(partition_key, None)
 
     # Helpers.
 
-    @staticmethod
-    def _collection_prefix(namespace: str, name: str) -> str:
-        """Unique prefix for a logical collection's native resources."""
-        return f"vector_store_sqlite_{len(namespace)}_{namespace}_{len(name)}_{name}"
+    def _partition_prefix(self, partition_key: str) -> str:
+        """Unique prefix for a partition's native resources."""
+        collection = self._collection
+        return (
+            f"vector_store_sqlite_{len(collection)}_{collection}"
+            f"_{len(partition_key)}_{partition_key}"
+        )
 
-    def _records_table(self, namespace: str, name: str) -> Table:
-        """Get or create a SQLAlchemy Table for a per-collection records table."""
+    def _records_table(self, partition_key: str) -> Table:
+        """Get or create a SQLAlchemy Table for a per-partition records table."""
         records_table = Table(
-            f"{self._collection_prefix(namespace, name)}_rc",
+            f"{self._partition_prefix(partition_key)}_rc",
             self._sa_metadata,
             Column("row_id", Integer, primary_key=True, autoincrement=True),
             Column("uuid", Uuid, nullable=False, unique=True),
@@ -978,87 +959,65 @@ class SQLiteVectorStore(VectorStore):
             property_indexes(records_table, self._indexed_properties)
         return records_table
 
-    def _collection_row(
-        self, namespace: str, name: str, config: VectorStoreCollectionConfig
-    ) -> _CollectionRow:
-        return _CollectionRow(
-            namespace=namespace,
-            name=name,
-            config_json={
-                **config.model_dump(mode="json"),
-                _INDEXED_PROPERTIES_KEY: indexed_property_names(
-                    self._indexed_properties
-                ),
-            },
+    def _declared_schema(self) -> PartitionSchema:
+        return PartitionSchema(
+            vector_dimensions=self._vector_dimensions,
+            indexed_properties=indexed_property_names(self._indexed_properties),
         )
 
-    def _index_path(self, namespace: str, name: str) -> Path | None:
-        """Return the on-disk index path for a collection, or None if in-memory."""
+    def _index_path(self, partition_key: str) -> Path | None:
+        """Return the on-disk index path for a partition, or None if in-memory."""
         if self._index_directory is None:
             return None
-        return self._index_directory / f"{self._collection_prefix(namespace, name)}.idx"
+        return self._index_directory / f"{self._partition_prefix(partition_key)}.idx"
 
-    def _clear_search_engine_state(self, namespace: str, name: str) -> None:
-        """Remove any in-memory engine and on-disk index for a collection."""
-        self._search_engines.pop((namespace, name), None)
-        index_path = self._index_path(namespace, name)
+    def _clear_search_engine_state(self, partition_key: str) -> None:
+        """Remove any in-memory engine and on-disk index for a partition."""
+        self._search_engines.pop(partition_key, None)
+        index_path = self._index_path(partition_key)
         if index_path is not None and index_path.exists():
             index_path.unlink()
 
-    async def _get_stored_config(
+    async def _stored_schema(
         self,
         session: AsyncSession,
-        namespace: str,
-        name: str,
-    ) -> VectorStoreCollectionConfig | None:
-        """The collection's config; raises if it was created under another schema."""
+        partition_key: str,
+    ) -> PartitionSchema | None:
+        """The schema the partition was created under; raises if it is not this store's."""
         stored = (
             await session.execute(
-                select(_CollectionRow.config_json).where(
-                    _CollectionRow.namespace == namespace,
-                    _CollectionRow.name == name,
+                select(_PartitionRow.schema_json).where(
+                    _PartitionRow.collection == self._collection,
+                    _PartitionRow.partition_key == partition_key,
                 )
             )
         ).scalar_one_or_none()
         if stored is None:
             return None
-        stored_properties = stored.get(_INDEXED_PROPERTIES_KEY)
-        declared_properties = indexed_property_names(self._indexed_properties)
-        if stored_properties != declared_properties:
-            raise IndexedPropertiesMismatchError(
-                namespace,
-                name,
-                stored_properties if isinstance(stored_properties, dict) else {},
-                declared_properties,
+        stored_schema = PartitionSchema.model_validate(stored)
+        declared_schema = self._declared_schema()
+        if stored_schema != declared_schema:
+            raise VectorStorePartitionSchemaMismatchError(
+                self._collection, partition_key, stored_schema, declared_schema
             )
-        return VectorStoreCollectionConfig.model_validate(
-            {
-                key: value
-                for key, value in stored.items()
-                if key != _INDEXED_PROPERTIES_KEY
-            }
-        )
+        return stored_schema
 
     async def _get_or_create_vector_search_engine(
-        self,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
+        self, partition_key: str
     ) -> VectorSearchEngine:
-        cache_key = (namespace, name)
-        if cache_key in self._search_engines:
-            return self._search_engines[cache_key]
+        if partition_key in self._search_engines:
+            return self._search_engines[partition_key]
 
-        search_engine = self._vector_search_engine_factory(config.vector_dimensions)
+        search_engine = self._vector_search_engine_factory(self._vector_dimensions)
 
-        index_path = self._index_path(namespace, name)
+        index_path = self._index_path(partition_key)
         if index_path is not None:
             async with self._create_session() as session:
                 saved = (
                     await session.execute(
-                        select(_CollectionRow.index_saved).where(
-                            _CollectionRow.namespace == namespace,
-                            _CollectionRow.name == name,
+                        select(_PartitionRow.index_saved).where(
+                            _PartitionRow.collection == self._collection,
+                            _PartitionRow.partition_key == partition_key,
                         )
                     )
                 ).scalar_one_or_none()
@@ -1069,22 +1028,20 @@ class SQLiteVectorStore(VectorStore):
                 try:
                     await search_engine.load(str(index_path))
                 except Exception as e:
-                    raise IndexLoadError(namespace, name, index_path) from e
+                    raise IndexLoadError(
+                        self._collection, partition_key, index_path
+                    ) from e
 
-        self._search_engines[cache_key] = search_engine
+        self._search_engines[partition_key] = search_engine
         return search_engine
 
-    async def _ensure_collection_resources(
+    async def _ensure_partition_resources(
         self,
         session: AsyncSession,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
+        partition_key: str,
     ) -> tuple[Table, VectorSearchEngine]:
-        records_table = self._records_table(namespace, name)
-        search_engine = await self._get_or_create_vector_search_engine(
-            namespace, name, config
-        )
+        records_table = self._records_table(partition_key)
+        search_engine = await self._get_or_create_vector_search_engine(partition_key)
 
         connection = await session.connection()
         await connection.run_sync(

--- a/packages/server/src/memmachine_server/common/vector_store/utils.py
+++ b/packages/server/src/memmachine_server/common/vector_store/utils.py
@@ -2,28 +2,6 @@
 
 import re
 
-from memmachine_server.common.filter.filter_parser import (
-    And as FilterAnd,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Comparison as FilterComparison,
-)
-from memmachine_server.common.filter.filter_parser import (
-    FilterExpr,
-)
-from memmachine_server.common.filter.filter_parser import (
-    In as FilterIn,
-)
-from memmachine_server.common.filter.filter_parser import (
-    IsNull as FilterIsNull,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Not as FilterNot,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Or as FilterOr,
-)
-
 _IDENTIFIER_RE = re.compile(r"^[a-z0-9_]+$")
 _IDENTIFIER_MAX_BYTES = 32
 
@@ -34,14 +12,3 @@ def validate_identifier(value: str) -> bool:
         bool(_IDENTIFIER_RE.match(value))
         and len(value.encode()) <= _IDENTIFIER_MAX_BYTES
     )
-
-
-def validate_filter(expr: FilterExpr) -> bool:
-    """Return whether all field names in the filter tree are valid identifiers."""
-    if isinstance(expr, (FilterComparison, FilterIn, FilterIsNull)):
-        return validate_identifier(expr.field)
-    if isinstance(expr, FilterNot):
-        return validate_filter(expr.expr)
-    if isinstance(expr, (FilterAnd, FilterOr)):
-        return validate_filter(expr.left) and validate_filter(expr.right)
-    raise TypeError(f"Unsupported filter expression type: {type(expr)}")

--- a/packages/server/src/memmachine_server/common/vector_store/vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_store.py
@@ -5,12 +5,11 @@ Defines the interface for adding, querying, and deleting records.
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from uuid import UUID
 
-from memmachine_server.common.filter.filter_parser import (
-    FilterExpr,
-)
+from memmachine_server.common.data_types import PropertyType
+from memmachine_server.common.filter import FilterExpr
 
 from .data_types import (
     QueryResult,
@@ -26,17 +25,35 @@ class VectorStoreCollection(ABC):
     Identified by a (namespace, name) pair.
     All data operations are scoped to this logical collection.
 
-    Implementations must support storing and filtering on record properties
-    not declared in the configured indexed properties schema.
-
-    The schema exists to support indexing on fixed-type record properties.
-    Record properties not declared in the schema may have mixed-type values.
+    A collection stores the properties its store declares
+    (`indexed_properties`), typed and indexed for filtering during a
+    search, and no others: a record or a filter naming an undeclared key is
+    rejected, so an undeclared key never exists in the store, neither
+    stored write-only nor scanned for.
     """
 
     @property
     @abstractmethod
     def config(self) -> VectorStoreCollectionConfig:
         """The configuration for this collection."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def indexed_properties(self) -> Mapping[str, PropertyType]:
+        """The declared schema: every key this collection stores and filters on."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def supported_filter_nodes(self) -> frozenset[type]:
+        """
+        The filter node classes the backend evaluates during a search.
+
+        A `query` whose filter uses any other node raises
+        `UnsupportedFilterError`; a caller routes such a predicate to a store
+        that evaluates it afterward.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -54,9 +71,14 @@ class VectorStoreCollection(ABC):
         Args:
             records (Iterable[Record]):
                 Iterable of records to upsert.
-                Records containing properties
-                not in the indexed properties schema
-                are allowed.
+
+        Raises:
+            UndeclaredPropertyKeyError:
+                If a record carries a key the store has not declared;
+                raised before anything is sent.
+            PropertyTypeMismatchError:
+                If a record's value is not of its key's declared type;
+                raised before anything is sent.
         """
         raise NotImplementedError
 
@@ -83,19 +105,27 @@ class VectorStoreCollection(ABC):
                 The vectors to compare against.
             limit (int):
                 Maximum number of matching records to return per query vector.
+                A filtered search returns fewer when the filter admits fewer.
             min_cosine_similarity (float | None):
                 If provided, only return matches whose cosine similarity
                 is greater than or equal to this value
                 (default: None).
             property_filter (FilterExpr | None):
-                Filter expression tree.
-                If None or empty, no property filtering is applied
+                Filter expression tree over declared keys, evaluated during
+                the search.
+                If None, no property filtering is applied
                 (default: None).
 
         Returns:
             list[QueryResult]:
                 Results for each query vector,
                 ordered as in the input iterable.
+
+        Raises:
+            UndeclaredPropertyKeyError:
+                If the filter names a key the store has not declared.
+            UnsupportedFilterError:
+                If the filter uses a node outside `supported_filter_nodes`.
         """
         raise NotImplementedError
 
@@ -124,14 +154,25 @@ class VectorStore(ABC):
     The consumer is responsible for sharding names across processes.
 
     Different namespaces are fully independent (separate native collections).
-    Multiple logical collections with the same (namespace, vector dimensions, indexed properties schema)
+    Multiple logical collections with the same (namespace, vector dimensions)
     may share a native collection to reduce overhead.
+
+    A store declares one indexed-property schema for every collection it
+    holds, from deployment configuration merged with the system keys of the
+    consumer it is built for; the schema is fixed for the life of the
+    store's data, and changing it is a migration.
 
     Naming constraints:
         - Namespaces, names, and property keys must match `[a-z0-9_]+`
           (lowercase alphanumeric and underscores only).
         - Each identifier must be at most 32 bytes.
     """
+
+    @property
+    @abstractmethod
+    def indexed_properties(self) -> Mapping[str, PropertyType]:
+        """The declared schema every collection of this store carries."""
+        raise NotImplementedError
 
     @abstractmethod
     async def startup(self) -> None:
@@ -155,7 +196,7 @@ class VectorStore(ABC):
         Create a logical collection in the vector store and return a handle to it.
 
         A (namespace, name) pair uniquely identifies a collection.
-        The configuration (dimensions, schema) is fixed at creation time.
+        The configuration (dimensions) is fixed at creation time.
 
         Args:
             namespace (str):

--- a/packages/server/src/memmachine_server/common/vector_store/vector_store.py
+++ b/packages/server/src/memmachine_server/common/vector_store/vector_store.py
@@ -1,9 +1,13 @@
 """
 Abstract base class for a vector store.
 
-Defines the interface for adding, querying, and deleting records.
+A store is one collection: a body of records searched together, with one
+dimensionality and one declared schema, named at construction. Within it,
+a partition holds one tenant's records, and `VectorStorePartition` is the
+handle a data consumer holds for it.
 """
 
+import contextlib
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
 from uuid import UUID
@@ -11,21 +15,18 @@ from uuid import UUID
 from memmachine_server.common.data_types import PropertyType
 from memmachine_server.common.filter import FilterExpr
 
-from .data_types import (
-    QueryResult,
-    Record,
-    VectorStoreCollectionConfig,
-)
+from .data_types import QueryResult, Record, VectorStorePartitionAlreadyExistsError
 
 
-class VectorStoreCollection(ABC):
+class VectorStorePartition(ABC):
     """
-    A logical collection in a vector store.
+    One partition of a vector store, bound to its key.
 
-    Identified by a (namespace, name) pair.
-    All data operations are scoped to this logical collection.
+    All data operations are scoped to the partition. The handle owns
+    nothing: a caller builds one with `VectorStore.get_partition`, drops it,
+    and builds another at will.
 
-    A collection stores the properties its store declares
+    A partition stores the properties its store declares
     (`indexed_properties`), typed and indexed for filtering during a
     search, and no others: a record or a filter naming an undeclared key is
     rejected, so an undeclared key never exists in the store, neither
@@ -34,14 +35,14 @@ class VectorStoreCollection(ABC):
 
     @property
     @abstractmethod
-    def config(self) -> VectorStoreCollectionConfig:
-        """The configuration for this collection."""
+    def partition_key(self) -> str:
+        """The key this handle is bound to."""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def indexed_properties(self) -> Mapping[str, PropertyType]:
-        """The declared schema: every key this collection stores and filters on."""
+        """The declared schema: every key this partition stores and filters on."""
         raise NotImplementedError
 
     @property
@@ -63,7 +64,7 @@ class VectorStoreCollection(ABC):
         records: Iterable[Record],
     ) -> None:
         """
-        Upsert records in the collection.
+        Upsert records in the partition.
 
         Insert records with new UUIDs,
         and update records with existing UUIDs.
@@ -136,7 +137,7 @@ class VectorStoreCollection(ABC):
         record_uuids: Iterable[UUID],
     ) -> None:
         """
-        Delete records from the collection by their UUIDs.
+        Delete records from the partition by their UUIDs.
 
         Args:
             record_uuids (Iterable[UUID]):
@@ -145,33 +146,79 @@ class VectorStoreCollection(ABC):
         raise NotImplementedError
 
 
+async def get_or_create_partition(
+    store: "VectorStore", partition_key: str
+) -> VectorStorePartition:
+    """
+    The partition, created if it does not exist.
+
+    Losing a creation race to a concurrent creator is fine: the winner's
+    partition is the one returned.
+    """
+    partition = await store.get_partition(partition_key)
+    if partition is not None:
+        return partition
+    with contextlib.suppress(VectorStorePartitionAlreadyExistsError):
+        await store.create_partition(partition_key)
+    partition = await store.get_partition(partition_key)
+    if partition is None:
+        raise RuntimeError(
+            f"Partition {partition_key!r} of collection {store.collection!r} was "
+            "deleted between its creation and this lookup"
+        )
+    return partition
+
+
 class VectorStore(ABC):
     """
     Abstract base class for a vector store.
 
-    A given logical collection identified by a (namespace, name) pair
-    must be managed by at most one process at a time.
-    The consumer is responsible for sharding names across processes.
+    A store is one collection, named at construction with its vector
+    dimensions and its declared schema; the composition root builds one
+    store per collection it needs, and the name is what keeps two stores
+    over one engine or one client apart. Every partition of the store
+    shares the collection's dimensions and schema, and the schema is fixed
+    for the life of the store's data: changing it is a migration.
 
-    Different namespaces are fully independent (separate native collections).
-    Multiple logical collections with the same (namespace, vector dimensions)
-    may share a native collection to reduce overhead.
-
-    A store declares one indexed-property schema for every collection it
-    holds, from deployment configuration merged with the system keys of the
-    consumer it is built for; the schema is fixed for the life of the
-    store's data, and changing it is a migration.
+    A given partition must be managed by at most one process at a time.
+    The consumer is responsible for sharding partition keys across
+    processes.
 
     Naming constraints:
-        - Namespaces, names, and property keys must match `[a-z0-9_]+`
-          (lowercase alphanumeric and underscores only).
-        - Each identifier must be at most 32 bytes.
+        - Collection names must match `[a-z0-9_]+` and be at most 64 bytes.
+        - Partition keys and property keys must match `[a-z0-9_]+`
+          (lowercase alphanumeric and underscores only) and be at most
+          32 bytes.
     """
 
     @property
     @abstractmethod
+    def collection(self) -> str:
+        """The collection this store is."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def vector_dimensions(self) -> int:
+        """Dimensionality of every vector in the store."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
     def indexed_properties(self) -> Mapping[str, PropertyType]:
-        """The declared schema every collection of this store carries."""
+        """The declared schema every partition of this store carries."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def provision(self) -> None:
+        """
+        Create the collection's durable resources, idempotently.
+
+        The native collection and its payload indexes, or the tables and
+        indexes beside the data; whatever must exist before a partition can
+        be created. Run once per deployment change by whoever owns the
+        schema, before `startup`; never by a request.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -185,106 +232,49 @@ class VectorStore(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> None:
+    async def create_partition(self, partition_key: str) -> None:
         """
-        Create a logical collection in the vector store and return a handle to it.
-
-        A (namespace, name) pair uniquely identifies a collection.
-        The configuration (dimensions) is fixed at creation time.
+        Create a partition.
 
         Args:
-            namespace (str):
-                Groups related collections and guarantees storage
-                isolation at the native collection level.
-            name (str):
-                Name to identify the collection within a namespace.
-            config (VectorStoreCollectionConfig):
-                Configuration for the collection.
+            partition_key (str):
+                The key of the partition.
 
         Raises:
-            VectorStoreCollectionAlreadyExistsError: If a collection with the same
-                (namespace, name) already exists.
+            VectorStorePartitionAlreadyExistsError: If the partition already exists.
         """
         raise NotImplementedError
 
     @abstractmethod
-    async def open_or_create_collection(
-        self,
-        *,
-        namespace: str,
-        name: str,
-        config: VectorStoreCollectionConfig,
-    ) -> VectorStoreCollection:
+    async def get_partition(self, partition_key: str) -> VectorStorePartition | None:
         """
-        Open the collection if it exists, or create it if it does not.
+        Get a handle for an existing partition.
 
         Args:
-            namespace (str):
-                Groups related collections and guarantees storage
-                isolation at the native collection level.
-            name (str):
-                Name to identify the collection within a namespace.
-            config (VectorStoreCollectionConfig):
-                Configuration for the collection.
+            partition_key (str):
+                The key of the partition.
 
         Returns:
-            VectorStoreCollection:
-                A handle to the opened or created collection.
+            VectorStorePartition | None:
+                A handle bound to the partition, or None if the partition
+                does not exist.
 
         Raises:
-            VectorStoreCollectionConfigMismatchError: If a collection with the same
-                (namespace, name) already exists with a different configuration.
+            VectorStorePartitionSchemaMismatchError:
+                If the partition was created under other dimensions or
+                another declared schema than this store's.
         """
         raise NotImplementedError
 
     @abstractmethod
-    async def open_collection(
-        self, *, namespace: str, name: str
-    ) -> VectorStoreCollection | None:
+    async def delete_partition(self, partition_key: str) -> None:
         """
-        Get a handle to a logical collection in the vector store.
+        Delete a partition and all of its records.
+
+        Idempotent.
 
         Args:
-            namespace (str):
-                Namespace of the collection.
-            name (str):
-                Name of the collection within the namespace.
-
-        Returns:
-            VectorStoreCollection | None:
-                A handle to the opened collection, or None if it does not exist.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    async def close_collection(self, *, collection: VectorStoreCollection) -> None:
-        """
-        Close a collection handle.
-
-        Args:
-            collection (Collection):
-                The handle of the collection to close.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    async def delete_collection(self, *, namespace: str, name: str) -> None:
-        """
-        Delete a logical collection from the vector store.
-
-        This will delete all data in the collection.
-        It is idempotent.
-
-        Args:
-            namespace (str):
-                Namespace of the collection.
-            name (str):
-                Name of the collection within the namespace.
+            partition_key (str):
+                The key of the partition to delete.
         """
         raise NotImplementedError

--- a/packages/server/src/memmachine_server/episodic_memory/declarative_memory/declarative_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/declarative_memory/declarative_memory.py
@@ -12,10 +12,7 @@ from pydantic import BaseModel, Field, InstanceOf
 
 from memmachine_server.common.data_types import PropertyValue
 from memmachine_server.common.embedder.embedder import Embedder
-from memmachine_server.common.filter.filter_parser import (
-    FilterExpr,
-    map_filter_fields,
-)
+from memmachine_server.common.filter import FilterExpr, map_filter_fields
 from memmachine_server.common.reranker.reranker import Reranker
 from memmachine_server.common.utils import extract_sentences
 from memmachine_server.common.vector_graph_store import Edge, Node, VectorGraphStore

--- a/packages/server/src/memmachine_server/episodic_memory/episodic_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/episodic_memory.py
@@ -31,9 +31,7 @@ from memmachine_server.common.episode_store import (
     EpisodeResponse,
 )
 from memmachine_server.common.episode_store.episode_model import episodes_to_string
-from memmachine_server.common.filter.filter_parser import (
-    FilterExpr,
-)
+from memmachine_server.common.filter import FilterExpr
 from memmachine_server.common.metrics_factory import MetricsFactory
 from memmachine_server.episodic_memory.long_term_memory.long_term_memory import (
     LongTermMemory,

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/data_types.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/data_types.py
@@ -1,10 +1,15 @@
 """Data types for EventMemory."""
 
+import logging
+from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from datetime import datetime, tzinfo
 from typing import (
     Annotated,
+    ClassVar,
     Literal,
+    cast,
+    override,
 )
 from uuid import UUID
 
@@ -23,172 +28,12 @@ from memmachine_server.common.properties_json import (
     decode_properties,
     encode_properties,
 )
+from memmachine_server.common.vector_store.utils import validate_identifier
 
-# Block: leaf content type.
-#
-# Different Block types do not just represent different modalities;
-# they represent different content types,
-# each requiring distinct downstream processing logic.
-# Plain text, JSON, and HTML may all be processed differently
-# despite sharing the text modality.
+logger = logging.getLogger(__name__)
 
 
-class TextBlock(BaseModel):
-    """Plain text block."""
-
-    block_type: Literal["text"] = "text"
-    text: str
-
-
-Block = Annotated[
-    TextBlock,
-    Field(discriminator="block_type"),
-]
-
-
-class ProducerContext(BaseModel):
-    """The content is produced by a producer."""
-
-    context_type: Literal["producer"] = "producer"
-    producer: str
-
-
-class NullContext(BaseModel):
-    """No context is attached."""
-
-    context_type: Literal["null"] = "null"
-
-
-ContextUnion = ProducerContext | NullContext
-
-Context = Annotated[
-    ContextUnion,
-    Field(discriminator="context_type"),
-]
-
-_CONTEXT_ADAPTER = TypeAdapter(Context | None)
-_BLOCK_ADAPTER = TypeAdapter(Block)
-
-
-def encode_context(context: Context | None) -> dict[str, JsonValue] | None:
-    """Encode a context into JSON-compatible data."""
-    return _CONTEXT_ADAPTER.dump_python(context, mode="json")
-
-
-def decode_context(encoded: Mapping[str, JsonValue] | None) -> Context | None:
-    """Decode a context from JSON-compatible data."""
-    return _CONTEXT_ADAPTER.validate_python(encoded)
-
-
-def encode_block(block: Block) -> dict[str, JsonValue]:
-    """Encode a block into JSON-compatible data."""
-    return _BLOCK_ADAPTER.dump_python(block, mode="json")
-
-
-def decode_block(encoded: Mapping[str, JsonValue]) -> Block:
-    """Decode a block from JSON-compatible data."""
-    return _BLOCK_ADAPTER.validate_python(encoded)
-
-
-# Event, Segment, Derivative: core data models for EventMemory.
-
-
-class Event(BaseModel):
-    """An event."""
-
-    uuid: UUID
-    timestamp: datetime
-    context: Context = Field(default_factory=NullContext)
-    blocks: list[Block]
-    properties: dict[str, PropertyValue] = Field(default_factory=dict)
-
-    @field_validator("properties", mode="before")
-    @classmethod
-    def _deserialize_properties(cls, v: object) -> object:
-        if not isinstance(v, Mapping):
-            return v
-        try:
-            return decode_properties(v)
-        except (TypeError, ValueError):
-            return v
-
-    @field_serializer("properties")
-    def _serialize_properties(
-        self, v: dict[str, PropertyValue]
-    ) -> dict[str, dict[str, bool | int | float | str]]:
-        return encode_properties(v)
-
-    def __hash__(self) -> int:
-        """Hash an event by its UUID."""
-        return hash(self.uuid)
-
-
-class Segment(BaseModel):
-    """Snapshot of an event, representing a smaller unit of content."""
-
-    uuid: UUID
-    event_uuid: UUID
-    index: int
-    offset: int
-    timestamp: datetime
-    context: Context = Field(default_factory=NullContext)
-    block: Block
-    properties: dict[str, PropertyValue] = Field(default_factory=dict)
-
-    @field_validator("properties", mode="before")
-    @classmethod
-    def _deserialize_properties(cls, v: object) -> object:
-        if not isinstance(v, Mapping):
-            return v
-        try:
-            return decode_properties(v)
-        except (TypeError, ValueError):
-            # Not type-tagged data (e.g. plain PropertyValue from code).
-            return v
-
-    @field_serializer("properties")
-    def _serialize_properties(
-        self, v: dict[str, PropertyValue]
-    ) -> dict[str, dict[str, bool | int | float | str]]:
-        return encode_properties(v)
-
-    def __hash__(self) -> int:
-        """Hash a segment by its UUID."""
-        return hash(self.uuid)
-
-
-class Derivative(BaseModel):
-    """Information derived from a segment."""
-
-    uuid: UUID
-    segment_uuid: UUID
-    timestamp: datetime
-    context: Context = Field(default_factory=NullContext)
-    block: Block
-    properties: dict[str, PropertyValue] = Field(default_factory=dict)
-
-    @field_validator("properties", mode="before")
-    @classmethod
-    def _deserialize_properties(cls, v: object) -> object:
-        if not isinstance(v, Mapping):
-            return v
-        try:
-            return decode_properties(v)
-        except (TypeError, ValueError):
-            return v
-
-    @field_serializer("properties")
-    def _serialize_properties(
-        self, v: dict[str, PropertyValue]
-    ) -> dict[str, dict[str, bool | int | float | str]]:
-        return encode_properties(v)
-
-    def __hash__(self) -> int:
-        """Hash a derivative by its UUID."""
-        return hash(self.uuid)
-
-
-# FormatOptions: options for formatting query result.
+# FormatOptions: options for rendering timestamps and names into text.
 
 # CLDR datetime style. Ordered from compact to verbose.
 DateTimeStyle = Literal["short", "medium", "long", "full"]
@@ -203,18 +48,354 @@ class FormatOptions(BaseModel):
     timezone: InstanceOf[tzinfo] | None = None
 
 
-# QueryResult: the result of a memory query.
+# Block: leaf content type.
+#
+# Different Block kinds do not just represent different modalities;
+# they represent different content types,
+# each requiring distinct downstream processing logic.
+# Plain text, JSON, and HTML may all be processed differently
+# despite sharing the text modality.
 
 
-class ScoredSegmentContext(BaseModel):
-    """A segment context anchored on a seed segment, with a score."""
+class Block(BaseModel, ABC):
+    """One unit of an event's content.
+
+    `kind` is the discriminator every registered family uses: a subclass
+    narrows it to a `Literal` naming its kind. A kind name matches
+    `[a-z0-9_]` and is bounded like a property key.
+    """
+
+    kind: str
+
+    @abstractmethod
+    def render(self, options: FormatOptions) -> str | None:
+        """The reader's text for this block; None renders nothing."""
+        raise NotImplementedError
+
+
+class TextBlock(Block):
+    """Plain text block."""
+
+    kind: Literal["text"] = "text"
+    text: str
+
+    @override
+    def render(self, options: FormatOptions) -> str | None:
+        return self.text
+
+
+RegisteredBlock = Annotated[
+    TextBlock,
+    Field(discriminator="kind"),
+]
+"""The union of registered block kinds; closed over `TextBlock` until the
+kind table lands."""
+
+_BLOCK_ADAPTER = TypeAdapter(RegisteredBlock)
+
+
+def encode_block(block: Block) -> dict[str, JsonValue]:
+    """Encode a block into JSON-compatible data."""
+    return _BLOCK_ADAPTER.dump_python(block, mode="json")
+
+
+def decode_block(encoded: Mapping[str, JsonValue]) -> Block:
+    """Decode a block from JSON-compatible data."""
+    return _BLOCK_ADAPTER.validate_python(encoded)
+
+
+# Context: typed, non-filterable data attached to content, keyed by part kind.
+
+
+class ContextPart(BaseModel, ABC):
+    """One registered kind of context, keyed by `kind` in a `Context`.
+
+    A part carries data the processing steps and the renderer read
+    (`get_part`), never anything to filter on: identity is `Event.source_id`
+    and everything else filterable is a property.
+    """
+
+    kind: ClassVar[str]
+
+    @abstractmethod
+    def render(self, options: FormatOptions) -> str | None:
+        """This part's contribution to a rendered segment; None contributes nothing."""
+        raise NotImplementedError
+
+
+class Author(ContextPart):
+    """The readable name of the content's author, as it was at the event."""
+
+    kind: ClassVar[str] = "author"
+    name: str
+
+    @override
+    def render(self, options: FormatOptions) -> str | None:
+        return self.name
+
+
+class UnknownPart(ContextPart):
+    """A part of a kind the running process does not register.
+
+    Produced only by `decode_context`; keeps the kind name and the data so the
+    context round-trips unchanged, renders nothing and is read by no step.
+    """
+
+    kind_name: str
+    data: dict[str, JsonValue]
+
+    @override
+    def render(self, options: FormatOptions) -> str | None:
+        return None
+
+
+Context = Mapping[str, ContextPart]
+"""A mapping from part kind to the one part of that kind; no context is `{}`."""
+
+_CONTEXT_PART_KINDS: dict[str, type[ContextPart]] = {Author.kind: Author}
+"""The registered context part kinds. Built-ins register by import."""
+
+for _kind in _CONTEXT_PART_KINDS:
+    if not validate_identifier(_kind):
+        raise ValueError(
+            f"Context part kind {_kind!r} must match [a-z0-9_] and be at most 32 bytes."
+        )
+
+
+def part_kind(part: ContextPart) -> str:
+    """The kind name a part is keyed by."""
+    if isinstance(part, UnknownPart):
+        return part.kind_name
+    return type(part).kind
+
+
+def get_part[P: ContextPart](context: Context, part: type[P]) -> P | None:
+    """The part of a registered kind, or None when the context has none."""
+    found = context.get(part.kind)
+    if isinstance(found, part):
+        return found
+    return None
+
+
+def with_part(context: Context, part: ContextPart) -> Context:
+    """A context with `part` set under its kind, replacing any part of that kind."""
+    return {**context, part_kind(part): part}
+
+
+def without_part(context: Context, part: type[ContextPart]) -> Context:
+    """A context without the part of a registered kind."""
+    return {kind: found for kind, found in context.items() if kind != part.kind}
+
+
+def encode_context(context: Context) -> dict[str, JsonValue]:
+    """Encode a context into JSON-compatible data, as `{kind: fields}`."""
+    return {
+        kind: part.data
+        if isinstance(part, UnknownPart)
+        else part.model_dump(mode="json")
+        for kind, part in context.items()
+    }
+
+
+def decode_context(encoded: Mapping[str, JsonValue]) -> Context:
+    """Decode a context from JSON-compatible data.
+
+    A kind this process does not register decodes to an `UnknownPart`, so
+    nothing is dropped and the context encodes back unchanged.
+    """
+    context: dict[str, ContextPart] = {}
+    for kind, fields in encoded.items():
+        if not isinstance(fields, Mapping):
+            raise TypeError(
+                f"Context part {kind!r} must encode as an object, "
+                f"got {type(fields).__name__}"
+            )
+        part_type = _CONTEXT_PART_KINDS.get(kind)
+        if part_type is None:
+            logger.warning(
+                "Context part kind %r is not registered; keeping it as data", kind
+            )
+            context[kind] = UnknownPart(
+                kind_name=kind, data=cast(Mapping[str, JsonValue], fields)
+            )
+        else:
+            context[kind] = part_type.model_validate(fields)
+    return context
+
+
+def _deserialize_context(value: object) -> object:
+    # Encoded contexts (`{kind: fields}`) arrive from JSON; a mapping of
+    # parts is already decoded and passes through.
+    if isinstance(value, Mapping) and not all(
+        isinstance(part, ContextPart) for part in value.values()
+    ):
+        return decode_context(cast(Mapping[str, JsonValue], value))
+    return value
+
+
+def _deserialize_properties(value: object) -> object:
+    if not isinstance(value, Mapping):
+        return value
+    try:
+        return decode_properties(value)
+    except (TypeError, ValueError):
+        # Not type-tagged data (e.g. plain PropertyValue from code).
+        return value
+
+
+# Event, Segment, Derivative: core data models for EventMemory.
+
+
+class Event(BaseModel):
+    """An event."""
+
+    uuid: UUID
+    timestamp: datetime
+    session_id: str | None = None
+    source_id: str | None = None
+    context: Context = Field(default_factory=dict)
+    blocks: list[RegisteredBlock]
+    properties: dict[str, PropertyValue] = Field(default_factory=dict)
+
+    @field_validator("context", mode="before")
+    @classmethod
+    def _validate_context(cls, v: object) -> object:
+        return _deserialize_context(v)
+
+    @field_serializer("context")
+    def _serialize_context(self, v: Context) -> dict[str, JsonValue]:
+        return encode_context(v)
+
+    @field_validator("properties", mode="before")
+    @classmethod
+    def _validate_properties(cls, v: object) -> object:
+        return _deserialize_properties(v)
+
+    @field_serializer("properties")
+    def _serialize_properties(
+        self, v: dict[str, PropertyValue]
+    ) -> dict[str, dict[str, bool | int | float | str]]:
+        return encode_properties(v)
+
+    def __hash__(self) -> int:
+        """Hash an event by its UUID."""
+        return hash(self.uuid)
+
+
+class Segment(BaseModel):
+    """Snapshot of an event, representing a smaller unit of content.
+
+    `session_id`, `source_id`, `context`, `timestamp` and `properties` are
+    copied verbatim from the event by the segmenter; the segment store
+    depends on the copy.
+    """
+
+    uuid: UUID
+    event_uuid: UUID
+    index: int
+    offset: int
+    timestamp: datetime
+    session_id: str | None = None
+    source_id: str | None = None
+    context: Context = Field(default_factory=dict)
+    block: RegisteredBlock
+    properties: dict[str, PropertyValue] = Field(default_factory=dict)
+
+    @field_validator("context", mode="before")
+    @classmethod
+    def _validate_context(cls, v: object) -> object:
+        return _deserialize_context(v)
+
+    @field_serializer("context")
+    def _serialize_context(self, v: Context) -> dict[str, JsonValue]:
+        return encode_context(v)
+
+    @field_validator("properties", mode="before")
+    @classmethod
+    def _validate_properties(cls, v: object) -> object:
+        return _deserialize_properties(v)
+
+    @field_serializer("properties")
+    def _serialize_properties(
+        self, v: dict[str, PropertyValue]
+    ) -> dict[str, dict[str, bool | int | float | str]]:
+        return encode_properties(v)
+
+    def __hash__(self) -> int:
+        """Hash a segment by its UUID."""
+        return hash(self.uuid)
+
+
+class Derivative(BaseModel):
+    """Information derived from a segment.
+
+    `session_id`, `source_id`, `context`, `timestamp` and `properties` are
+    copied verbatim from the segment by the deriver.
+    """
+
+    uuid: UUID
+    segment_uuid: UUID
+    timestamp: datetime
+    session_id: str | None = None
+    source_id: str | None = None
+    context: Context = Field(default_factory=dict)
+    block: RegisteredBlock
+    properties: dict[str, PropertyValue] = Field(default_factory=dict)
+
+    @field_validator("context", mode="before")
+    @classmethod
+    def _validate_context(cls, v: object) -> object:
+        return _deserialize_context(v)
+
+    @field_serializer("context")
+    def _serialize_context(self, v: Context) -> dict[str, JsonValue]:
+        return encode_context(v)
+
+    @field_validator("properties", mode="before")
+    @classmethod
+    def _validate_properties(cls, v: object) -> object:
+        return _deserialize_properties(v)
+
+    @field_serializer("properties")
+    def _serialize_properties(
+        self, v: dict[str, PropertyValue]
+    ) -> dict[str, dict[str, bool | int | float | str]]:
+        return encode_properties(v)
+
+    def __hash__(self) -> int:
+        """Hash a derivative by its UUID."""
+        return hash(self.uuid)
+
+
+# Results and options.
+
+
+class SearchHit(BaseModel):
+    """One matched derivative with the context window around its segment."""
 
     score: float
-    seed_segment_uuid: UUID
+    """Cosine similarity of the matched derivative."""
+    seed: int
+    """Index in `segments` of the matched segment."""
     segments: list[Segment]
+    """The context window, in the store's order."""
 
 
-class QueryResult(BaseModel):
-    """Memory query result, ordered by reranker score."""
+class Neighborhood(BaseModel):
+    """The segments around an anchor, never the anchor itself."""
 
-    scored_segment_contexts: list[ScoredSegmentContext]
+    before: list[Segment]
+    """In order, ending just before the anchor."""
+    after: list[Segment]
+    """In order, starting just after the anchor."""
+
+
+class EvictionOptions(BaseModel):
+    """How EventMemory trims clusters of near-duplicate derivatives."""
+
+    similarity_threshold: float = Field(ge=-1.0, le=1.0)
+    """Cosine similarity at or above which two derivatives are one cluster."""
+    search_limit: int = Field(gt=0)
+    """Stored neighbors consulted per new derivative."""
+    target_size: int = Field(gt=0)
+    """A cluster larger than this is trimmed to it."""

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/data_types.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/data_types.py
@@ -390,6 +390,20 @@ class Neighborhood(BaseModel):
     """In order, starting just after the anchor."""
 
 
+class FilterOptions(BaseModel):
+    """How EventMemory applies the part of a filter the vector store does not evaluate."""
+
+    max_overfetch_factor: int = Field(default=64, ge=1)
+    """Cap on widening the vector search, as a multiple of `limit`.
+
+    A predicate on a key the vector store does not declare is applied
+    afterward by the segment store, and a seed it drops leaves the search
+    short; the search is widened until `limit` hits survive or the fetch
+    reaches `limit * max_overfetch_factor`, where it returns what survived.
+    A query with no undeclared part never widens.
+    """
+
+
 class EvictionOptions(BaseModel):
     """How EventMemory trims clusters of near-duplicate derivatives."""
 

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/deriver/text_deriver.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/deriver/text_deriver.py
@@ -7,13 +7,13 @@ from uuid import uuid4
 
 from memmachine_server.common.utils import extract_sentences
 from memmachine_server.episodic_memory.event_memory.data_types import (
+    Author,
     Context,
     Derivative,
     FormatOptions,
-    NullContext,
-    ProducerContext,
     Segment,
     TextBlock,
+    get_part,
 )
 from memmachine_server.episodic_memory.event_memory.deriver.deriver import Deriver
 from memmachine_server.episodic_memory.event_memory.formatting import (
@@ -23,15 +23,10 @@ from memmachine_server.episodic_memory.event_memory.formatting import (
 
 def _format_with_context(context: Context, text: str) -> str:
     """Format text within its context."""
-    match context:
-        case ProducerContext(producer=producer):
-            return f"{producer}: {text}"
-        case NullContext():
-            return text
-        case _:
-            raise NotImplementedError(
-                f"Unsupported context type: {type(context).__name__}"
-            )
+    author = get_part(context, Author)
+    if author is None:
+        return text
+    return f"{author.name}: {text}"
 
 
 def _format_for_embedding(
@@ -42,7 +37,7 @@ def _format_for_embedding(
     """Format a segment's text as an embedding anchor."""
     # Mirror the query result formatters: the message text is JSON-dumped
     # (ensure_ascii=False) so it is a single escaped token, while the
-    # producer prefix stays outside the quotes.
+    # author prefix stays outside the quotes.
     body = _format_with_context(segment.context, json.dumps(text, ensure_ascii=False))
     if format_options is None:
         format_options = FormatOptions(time_style=None)
@@ -60,6 +55,8 @@ def _build_text_derivatives(segment: Segment, texts: Iterable[str]) -> list[Deri
             uuid=uuid4(),
             segment_uuid=segment.uuid,
             timestamp=segment.timestamp,
+            session_id=segment.session_id,
+            source_id=segment.source_id,
             context=segment.context,
             block=TextBlock(text=text),
             properties=segment.properties,
@@ -86,7 +83,7 @@ class WholeTextDeriver(Deriver):
                 )
             case _:
                 raise NotImplementedError(
-                    f"Unsupported block type: {type(segment.block).__name__}"
+                    f"Unsupported block kind: {segment.block.kind!r}"
                 )
 
 
@@ -111,5 +108,5 @@ class SentenceTextDeriver(Deriver):
                 )
             case _:
                 raise NotImplementedError(
-                    f"Unsupported block type: {type(segment.block).__name__}"
+                    f"Unsupported block kind: {segment.block.kind!r}"
                 )

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
@@ -12,12 +12,20 @@ from uuid import UUID
 import numpy as np
 from pydantic import BaseModel, Field, InstanceOf
 
-from memmachine_server.common.data_types import PropertyValue
+from memmachine_server.common.data_types import (
+    PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME,
+    PropertyType,
+    PropertyValue,
+)
 from memmachine_server.common.embedder import Embedder
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
     FilterExpr,
-    demangle_user_metadata_key,
+    conjoin,
     map_filter_fields,
+    split_declared,
+)
+from memmachine_server.common.filter.filter_parser import (
+    demangle_user_metadata_key,
     normalize_filter_field,
 )
 from memmachine_server.common.metrics_factory import (
@@ -38,6 +46,7 @@ from .data_types import (
     Derivative,
     Event,
     EvictionOptions,
+    FilterOptions,
     FormatOptions,
     Neighborhood,
     SearchHit,
@@ -53,7 +62,6 @@ from .system_filters import (
     EVENT_SESSION_KEY,
     EVENT_SOURCE_KEY,
     EVENT_TIMESTAMP_KEY,
-    conjoin,
     system_predicates,
 )
 
@@ -68,6 +76,33 @@ mints, never content.
 
 # The context part kinds rendering prints, in the order they are printed.
 _RENDERED_PART_KINDS: tuple[type[ContextPart], ...] = (Author,)
+
+# Each widening step multiplies the vector fetch by this.
+_OVERFETCH_BASE = 4
+
+
+class InvalidCollectionSchemaError(ValueError):
+    """Raised when a vector store collection does not declare EventMemory's system keys."""
+
+    def __init__(
+        self,
+        missing: Mapping[str, PropertyType],
+        declared: Mapping[str, PropertyType],
+    ) -> None:
+        """Initialize with the keys the collection lacks and the ones it declares."""
+        self.missing = dict(missing)
+        self.declared = dict(declared)
+        super().__init__(
+            "The vector store collection does not declare the system keys EventMemory "
+            f"writes: missing {_schema_names(missing)}, declared {_schema_names(declared)}."
+        )
+
+
+def _schema_names(schema: Mapping[str, PropertyType]) -> dict[str, str]:
+    return {
+        key: PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[property_type]
+        for key, property_type in sorted(schema.items())
+    }
 
 
 class EventMemoryParams(BaseModel):
@@ -94,6 +129,9 @@ class EventMemoryParams(BaseModel):
             Trim clusters of near-duplicate derivatives at ingest. None
             keeps every derivative and issues no eviction query
             (default: None).
+        filter (FilterOptions):
+            How far a search widens to make up for seeds the segment store's
+            post-filter drops (default: `FilterOptions()`).
         metrics_factory (MetricsFactory | None):
             An instance of MetricsFactory for collecting usage metrics
             (default: None).
@@ -126,6 +164,10 @@ class EventMemoryParams(BaseModel):
     eviction: EvictionOptions | None = Field(
         None,
         description="Trim clusters of near-duplicate derivatives at ingest",
+    )
+    filter: FilterOptions = Field(
+        default_factory=FilterOptions,
+        description="How far a search widens over the segment store's post-filter",
     )
     metrics_factory: InstanceOf[MetricsFactory] | None = Field(
         None,
@@ -175,21 +217,24 @@ class EventMemory:
         self._embedder = params.embedder
         self._format_options = params.format_options
         self._eviction = params.eviction
+        self._filter = params.filter
 
         self._tracker = OperationTracker(
             params.metrics_factory,
             prefix="event_memory",
         )
 
-        declared_fields = frozenset(
-            params.vector_store_collection.config.indexed_properties_schema
-        )
-        missing_fields = EventMemory._RESERVED_PROPERTY_SCHEMA.keys() - declared_fields
-        if missing_fields:
-            raise ValueError(
-                f"Collection schema missing fields required by EventMemory: "
-                f"{', '.join(sorted(missing_fields))}"
-            )
+        # The store declares what it indexes; the system keys must be among
+        # them, with the types this memory writes.
+        declared = dict(params.vector_store_collection.indexed_properties)
+        missing = {
+            key: property_type
+            for key, property_type in EventMemory._RESERVED_PROPERTY_SCHEMA.items()
+            if declared.get(key) is not property_type
+        }
+        if missing:
+            raise InvalidCollectionSchemaError(missing, declared)
+        self._declared_properties = declared
 
         self._encode_events_phase_seconds: MetricsFactory.Histogram | None = None
         self._query_phase_seconds: MetricsFactory.Histogram | None = None
@@ -210,12 +255,20 @@ class EventMemory:
         Validate a batch of events before encoding.
 
         Raises ValueError if any event supplies a property key in the
-        reserved namespace or outside the naming contract, or a session
-        or source id longer than `ID_MAX_BYTES`.
+        reserved namespace or outside the naming contract, a value of another
+        type than the vector store declares for its key, or a session or
+        source id longer than `ID_MAX_BYTES`.
         """
         for event in events:
-            for key in event.properties:
+            for key, value in event.properties.items():
                 validate_caller_property_key(key)
+                declared = self._declared_properties.get(key)
+                if declared is not None and type(value) is not declared:
+                    raise ValueError(
+                        f"Event {event.uuid} property {key!r} is a "
+                        f"{type(value).__name__}; the vector store declares it as "
+                        f"{PROPERTY_TYPE_TO_PROPERTY_TYPE_NAME[declared]}."
+                    )
             for name, value in (
                 ("session_id", event.session_id),
                 ("source_id", event.source_id),
@@ -344,7 +397,7 @@ class EventMemory:
             )
         )
         derivative_records = [
-            EventMemory._build_derivative_record(
+            self._build_derivative_record(
                 derivative, embeddings_by_derivative[derivative.uuid]
             )
             for derivative in derivatives
@@ -406,16 +459,25 @@ class EventMemory:
             if segment_uuid in segments_by_uuid
         }
 
-    @staticmethod
     def _build_derivative_record(
+        self,
         derivative: Derivative,
         derivative_embedding: Sequence[float],
     ) -> Record:
-        """Build a vector record from a derivative and its embedding."""
+        """Build a vector record from a derivative and its embedding.
+
+        Only the caller properties the store declares go in: an undeclared
+        key never exists in the vector store, and the segment store holds
+        every property for the filtering the vector store does not do.
+        """
         # Caller properties first: a reserved key cannot reach here
         # (encode_events validates), and building in this order makes the
         # merge itself enforce that a system value always wins.
-        properties: dict[str, PropertyValue] = dict(derivative.properties)
+        properties: dict[str, PropertyValue] = {
+            key: value
+            for key, value in derivative.properties.items()
+            if key in self._declared_properties
+        }
         properties[EVENT_TIMESTAMP_KEY] = derivative.timestamp
         if derivative.session_id is not None:
             properties[EVENT_SESSION_KEY] = derivative.session_id
@@ -629,6 +691,12 @@ class EventMemory:
         session_ids = list(session_ids) if session_ids is not None else None
         source_ids = list(source_ids) if source_ids is not None else None
         block_kinds = list(block_kinds) if block_kinds is not None else None
+        # An empty id or kind list admits nothing, and needs no query to say so.
+        if any(
+            ids is not None and not ids
+            for ids in (session_ids, source_ids, block_kinds)
+        ):
+            return []
 
         query_embedding = (
             await self._embedder.search_embed(
@@ -637,7 +705,16 @@ class EventMemory:
         )[0]
         t_embedding = time.monotonic()
 
-        # Translate filter fields for vector store.
+        # One plan. The vector store gets the system predicates and the part
+        # of the caller's filter naming keys it declares, evaluated during
+        # the search; the rest is the segment store's, applied to the seeds
+        # afterward, and the search is widened to make up for what it drops.
+        declared_part, undeclared_part = split_declared(
+            map_filter_fields(property_filter, EventMemory._to_vector_record_property)
+            if property_filter is not None
+            else None,
+            self._declared_properties,
+        )
         collection_filter = conjoin(
             [
                 system_predicates(
@@ -647,23 +724,89 @@ class EventMemory:
                     source_ids=source_ids,
                     block_kinds=block_kinds,
                 ),
-                map_filter_fields(
-                    property_filter, EventMemory._to_vector_record_property
-                )
-                if property_filter is not None
-                else None,
+                declared_part,
             ]
         )
 
-        # Search derivative collection for matches.
-        [query_result] = await self._vector_store_collection.query(
-            query_vectors=[query_embedding],
-            limit=limit,
-            min_cosine_similarity=min_cosine_similarity,
-            property_filter=collection_filter,
-        )
-        t_vector_query = time.monotonic()
+        before = expand_context // 3
+        after = expand_context - before
 
+        max_fetch = limit * self._filter.max_overfetch_factor
+        fetch_limit = limit
+        vector_query_seconds = 0.0
+        segment_query_seconds = 0.0
+        while True:
+            t_vector_start = time.monotonic()
+            [query_result] = await self._vector_store_collection.query(
+                query_vectors=[query_embedding],
+                limit=fetch_limit,
+                min_cosine_similarity=min_cosine_similarity,
+                property_filter=collection_filter,
+            )
+            t_vector_query = time.monotonic()
+            vector_query_seconds += t_vector_query - t_vector_start
+
+            hits = await self._hits(
+                query_result,
+                before=before,
+                after=after,
+                since=since,
+                until=until,
+                source_ids=source_ids,
+                block_kinds=block_kinds,
+                property_filter=property_filter,
+            )
+            segment_query_seconds += time.monotonic() - t_vector_query
+
+            exhausted = len(query_result.matches) < fetch_limit
+            if (
+                undeclared_part is None
+                or len(hits) >= limit
+                or exhausted
+                or fetch_limit >= max_fetch
+            ):
+                break
+            fetch_limit = min(fetch_limit * _OVERFETCH_BASE, max_fetch)
+
+        phase_durations = {
+            "embedding": t_embedding - t_start,
+            "vector_query": vector_query_seconds,
+            "segment_query": segment_query_seconds,
+        }
+
+        logger.debug(
+            "query timing: %s total=%.3fs",
+            " ".join(
+                f"{phase}={duration:.3f}s"
+                for phase, duration in phase_durations.items()
+            ),
+            time.monotonic() - t_start,
+        )
+
+        if self._query_phase_seconds is not None:
+            for phase, duration in phase_durations.items():
+                self._query_phase_seconds.observe(duration, labels={"phase": phase})
+
+        return hits[:limit]
+
+    async def _hits(
+        self,
+        query_result: QueryResult,
+        *,
+        before: int,
+        after: int,
+        since: datetime.datetime | None,
+        until: datetime.datetime | None,
+        source_ids: list[str] | None,
+        block_kinds: list[str] | None,
+        property_filter: FilterExpr | None,
+    ) -> list[SearchHit]:
+        """The hits of one vector query: each seed's window, in similarity order.
+
+        The segment store applies the whole caller filter to the seed and its
+        window, so a neighbor satisfies what the seed satisfies; a seed the
+        store does not return is dropped.
+        """
         segment_by_derivative = (
             await self._segment_store_partition.get_segment_uuids_by_derivative_uuids(
                 match.record_uuid for match in query_result.matches
@@ -681,9 +824,6 @@ class EventMemory:
             if segment_uuid not in seed_cosine_similarities:
                 seed_cosine_similarities[segment_uuid] = match.cosine_similarity
 
-        before = expand_context // 3
-        after = expand_context - before
-
         segment_contexts_by_seed = (
             await self._segment_store_partition.get_segment_contexts(
                 seed_segment_uuids=seed_cosine_similarities.keys(),
@@ -696,9 +836,7 @@ class EventMemory:
                 property_filter=property_filter,
             )
         )
-        t_segment_query = time.monotonic()
 
-        # Seeds the store did not return are dropped; similarity order is kept.
         hits: list[SearchHit] = []
         for seed_uuid, score in seed_cosine_similarities.items():
             segments = segment_contexts_by_seed.get(seed_uuid)
@@ -710,26 +848,6 @@ class EventMemory:
                 if segment.uuid == seed_uuid
             )
             hits.append(SearchHit(score=score, seed=seed_index, segments=segments))
-
-        phase_durations = {
-            "embedding": t_embedding - t_start,
-            "vector_query": t_vector_query - t_embedding,
-            "segment_query": t_segment_query - t_vector_query,
-        }
-
-        logger.debug(
-            "query timing: %s total=%.3fs",
-            " ".join(
-                f"{phase}={duration:.3f}s"
-                for phase, duration in phase_durations.items()
-            ),
-            time.monotonic() - t_start,
-        )
-
-        if self._query_phase_seconds is not None:
-            for phase, duration in phase_durations.items():
-                self._query_phase_seconds.observe(duration, labels={"phase": phase})
-
         return hits
 
     async def expand(

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
@@ -37,7 +37,7 @@ from memmachine_server.common.reranker import Reranker
 from memmachine_server.common.vector_store import (
     QueryResult,
     Record,
-    VectorStoreCollection,
+    VectorStorePartition,
 )
 
 from .data_types import (
@@ -82,7 +82,7 @@ _OVERFETCH_BASE = 4
 
 
 class InvalidCollectionSchemaError(ValueError):
-    """Raised when a vector store collection does not declare EventMemory's system keys."""
+    """Raised when a vector store's collection does not declare EventMemory's system keys."""
 
     def __init__(
         self,
@@ -93,7 +93,7 @@ class InvalidCollectionSchemaError(ValueError):
         self.missing = dict(missing)
         self.declared = dict(declared)
         super().__init__(
-            "The vector store collection does not declare the system keys EventMemory "
+            "The vector store's collection does not declare the system keys EventMemory "
             f"writes: missing {_schema_names(missing)}, declared {_schema_names(declared)}."
         )
 
@@ -112,8 +112,8 @@ class EventMemoryParams(BaseModel):
     Attributes:
         segment_store_partition (SegmentStorePartition):
             Segment store partition.
-        vector_store_collection (VectorStoreCollection):
-            Vector store collection.
+        vector_store_partition (VectorStorePartition):
+            Vector store partition.
         segmenter (Segmenter):
             Segmenter that segments events into segments.
         deriver (Deriver):
@@ -141,9 +141,9 @@ class EventMemoryParams(BaseModel):
         ...,
         description="Segment store partition",
     )
-    vector_store_collection: InstanceOf[VectorStoreCollection] = Field(
+    vector_store_partition: InstanceOf[VectorStorePartition] = Field(
         ...,
-        description="Vector store collection",
+        description="Vector store partition",
     )
     segmenter: InstanceOf[Segmenter] = Field(
         ...,
@@ -211,7 +211,7 @@ class EventMemory:
 
         """
         self._segment_store_partition = params.segment_store_partition
-        self._vector_store_collection = params.vector_store_collection
+        self._vector_store_partition = params.vector_store_partition
         self._segmenter = params.segmenter
         self._deriver = params.deriver
         self._embedder = params.embedder
@@ -226,7 +226,7 @@ class EventMemory:
 
         # The store declares what it indexes; the system keys must be among
         # them, with the types this memory writes.
-        declared = dict(params.vector_store_collection.indexed_properties)
+        declared = dict(params.vector_store_partition.indexed_properties)
         missing = {
             key: property_type
             for key, property_type in EventMemory._RESERVED_PROPERTY_SCHEMA.items()
@@ -358,7 +358,7 @@ class EventMemory:
                 derivative_embeddings,
                 self._eviction.similarity_threshold,
             )
-            stored_neighbors = await self._vector_store_collection.query(
+            stored_neighbors = await self._vector_store_partition.query(
                 query_vectors=derivative_embeddings,
                 min_cosine_similarity=self._eviction.similarity_threshold,
                 limit=self._eviction.search_limit,
@@ -404,9 +404,9 @@ class EventMemory:
             if derivative.uuid not in skipped_uuids
         ]
         if derivative_records:
-            await self._vector_store_collection.upsert(records=derivative_records)
+            await self._vector_store_partition.upsert(records=derivative_records)
         if displaced_uuids:
-            await self._vector_store_collection.delete(record_uuids=displaced_uuids)
+            await self._vector_store_partition.delete(record_uuids=displaced_uuids)
             await self._segment_store_partition.delete_derivatives(displaced_uuids)
         t_vector_store = time.monotonic()
 
@@ -737,7 +737,7 @@ class EventMemory:
         segment_query_seconds = 0.0
         while True:
             t_vector_start = time.monotonic()
-            [query_result] = await self._vector_store_collection.query(
+            [query_result] = await self._vector_store_partition.query(
                 query_vectors=[query_embedding],
                 limit=fetch_limit,
                 min_cosine_similarity=min_cosine_similarity,
@@ -1074,7 +1074,7 @@ class EventMemory:
 
         # Delete from vector DB first, then segment store.
         if derivative_uuids:
-            await self._vector_store_collection.delete(record_uuids=derivative_uuids)
+            await self._vector_store_partition.delete(record_uuids=derivative_uuids)
 
         await self._segment_store_partition.delete_segments(
             segment_uuids=segment_uuids,

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/event_memory.py
@@ -5,10 +5,11 @@ import datetime
 import json
 import logging
 import time
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from typing import ClassVar, cast
 from uuid import UUID
 
+import numpy as np
 from pydantic import BaseModel, Field, InstanceOf
 
 from memmachine_server.common.data_types import PropertyValue
@@ -23,30 +24,50 @@ from memmachine_server.common.metrics_factory import (
     MetricsFactory,
     OperationTracker,
 )
+from memmachine_server.common.property_keys import validate_caller_property_key
 from memmachine_server.common.reranker import Reranker
 from memmachine_server.common.vector_store import (
+    QueryResult,
     Record,
     VectorStoreCollection,
 )
 
 from .data_types import (
-    Block,
+    Author,
+    ContextPart,
     Derivative,
     Event,
+    EvictionOptions,
     FormatOptions,
-    NullContext,
-    ProducerContext,
-    QueryResult,
-    ScoredSegmentContext,
+    Neighborhood,
+    SearchHit,
     Segment,
-    TextBlock,
+    get_part,
 )
 from .deriver import Deriver
 from .formatting import format_timestamp
 from .segment_store import SegmentStorePartition
 from .segmenter import Segmenter
+from .system_filters import (
+    BLOCK_KIND_KEY,
+    EVENT_SESSION_KEY,
+    EVENT_SOURCE_KEY,
+    EVENT_TIMESTAMP_KEY,
+    conjoin,
+    system_predicates,
+)
 
 logger = logging.getLogger(__name__)
+
+ID_MAX_BYTES = 255
+"""Bound on `Event.session_id` and `Event.source_id`, in bytes.
+
+The width the store's key columns use; an id is an identifier a caller
+mints, never content.
+"""
+
+# The context part kinds rendering prints, in the order they are printed.
+_RENDERED_PART_KINDS: tuple[type[ContextPart], ...] = (Author,)
 
 
 class EventMemoryParams(BaseModel):
@@ -64,9 +85,14 @@ class EventMemoryParams(BaseModel):
             Deriver that derives derivatives from segments.
         embedder (Embedder):
             Embedder instance for creating embeddings.
-        reranker (Reranker | None):
-            Reranker instance for scoring search results.
-            If None, embedding similarity scores are used instead
+        format_options (FormatOptions):
+            How the deriver formats a segment's timestamp and author into
+            the text it embeds. Fixed per memory because a memory's
+            derivatives must be formatted one way; a display format is a
+            call argument (default: a full date and no time).
+        eviction (EvictionOptions | None):
+            Trim clusters of near-duplicate derivatives at ingest. None
+            keeps every derivative and issues no eviction query
             (default: None).
         metrics_factory (MetricsFactory | None):
             An instance of MetricsFactory for collecting usage metrics
@@ -93,10 +119,13 @@ class EventMemoryParams(BaseModel):
         ...,
         description="Embedder instance for creating embeddings",
     )
-    reranker: InstanceOf[Reranker] | None = Field(
+    format_options: FormatOptions = Field(
+        default_factory=lambda: FormatOptions(time_style=None),
+        description="How the deriver formats the text it embeds",
+    )
+    eviction: EvictionOptions | None = Field(
         None,
-        description="Reranker instance for scoring search results. "
-        "If None, embedding similarity scores are used instead",
+        description="Trim clusters of near-duplicate derivatives at ingest",
     )
     metrics_factory: InstanceOf[MetricsFactory] | None = Field(
         None,
@@ -107,12 +136,18 @@ class EventMemoryParams(BaseModel):
 class EventMemory:
     """Event memory system."""
 
-    # System-defined metadata field names. Reserved.
-    _TIMESTAMP_FIELD_NAME = "_timestamp"
-
-    _BASE_EVENT_MEMORY_FIELD_NAMES: ClassVar[frozenset[str]] = frozenset(
-        {_TIMESTAMP_FIELD_NAME}
-    )
+    # Every system value written into a vector record, under the reserved
+    # keys `system_filters` owns, with the type the collection declares:
+    # the fields a search filters on at the vector stage, and nothing
+    # else. The derivative's segment and event are not among them: the
+    # segment store owns those mappings, and a copy here could only go
+    # stale.
+    _RESERVED_PROPERTY_SCHEMA: ClassVar[dict[str, type[PropertyValue]]] = {
+        EVENT_TIMESTAMP_KEY: cast(type[PropertyValue], datetime.datetime),
+        EVENT_SESSION_KEY: cast(type[PropertyValue], str),
+        EVENT_SOURCE_KEY: cast(type[PropertyValue], str),
+        BLOCK_KIND_KEY: cast(type[PropertyValue], str),
+    }
 
     @classmethod
     def expected_vector_store_collection_schema(cls) -> dict[str, type[PropertyValue]]:
@@ -122,9 +157,7 @@ class EventMemory:
         Callers should merge this with any user or external system-defined properties
         when creating the collection so that EventMemory's reserved fields are efficiently filterable.
         """
-        return {
-            cls._TIMESTAMP_FIELD_NAME: cast(type[PropertyValue], datetime.datetime),
-        }
+        return dict(cls._RESERVED_PROPERTY_SCHEMA)
 
     def __init__(self, params: EventMemoryParams) -> None:
         """
@@ -140,24 +173,22 @@ class EventMemory:
         self._segmenter = params.segmenter
         self._deriver = params.deriver
         self._embedder = params.embedder
-        self._reranker = params.reranker
+        self._format_options = params.format_options
+        self._eviction = params.eviction
 
         self._tracker = OperationTracker(
             params.metrics_factory,
             prefix="event_memory",
         )
 
-        self._schema_fields = frozenset(
+        declared_fields = frozenset(
             params.vector_store_collection.config.indexed_properties_schema
         )
-
-        missing_base_fields = (
-            EventMemory._BASE_EVENT_MEMORY_FIELD_NAMES - self._schema_fields
-        )
-        if missing_base_fields:
+        missing_fields = EventMemory._RESERVED_PROPERTY_SCHEMA.keys() - declared_fields
+        if missing_fields:
             raise ValueError(
                 f"Collection schema missing fields required by EventMemory: "
-                f"{', '.join(sorted(missing_base_fields))}"
+                f"{', '.join(sorted(missing_fields))}"
             )
 
         self._encode_events_phase_seconds: MetricsFactory.Histogram | None = None
@@ -178,60 +209,58 @@ class EventMemory:
         """
         Validate a batch of events before encoding.
 
-        Raises ValueError if any event supplies a reserved field name in its properties,
-        or if the collection schema is missing fields required by EventMemory.
+        Raises ValueError if any event supplies a property key in the
+        reserved namespace or outside the naming contract, or a session
+        or source id longer than `ID_MAX_BYTES`.
         """
-        events = list(events)
+        for event in events:
+            for key in event.properties:
+                validate_caller_property_key(key)
+            for name, value in (
+                ("session_id", event.session_id),
+                ("source_id", event.source_id),
+            ):
+                if value is not None and len(value.encode()) > ID_MAX_BYTES:
+                    raise ValueError(
+                        f"Event {event.uuid} {name} is {len(value.encode())} bytes; "
+                        f"the maximum is {ID_MAX_BYTES}."
+                    )
 
-        reserved_fields = {
-            field
-            for event in events
-            for field in event.properties
-            if field in EventMemory._BASE_EVENT_MEMORY_FIELD_NAMES
-        }
-        if reserved_fields:
-            raise ValueError(
-                f"Event properties must not contain reserved fields: "
-                f"{', '.join(sorted(reserved_fields))}"
-            )
-
-    async def encode_events(
-        self,
-        events: Iterable[Event],
-        *,
-        format_options: FormatOptions | None = None,
-    ) -> None:
+    async def encode_events(self, events: Iterable[Event]) -> None:
         """
         Encode events.
 
+        A batch is written whole: each event's earlier encoding is forgotten
+        first, so a repeated batch leaves one copy.
+
         Args:
             events (Iterable[Event]): The events to encode.
-            format_options (FormatOptions | None):
-                Options for formatting.
-                (default: None).
 
         Raises:
             ValueError:
-                If any event supplies a reserved field name in its properties,
-                or if the collection schema is missing fields required by any event's Context type.
+                If any event supplies a reserved or illegal property key, or
+                a session or source id over `ID_MAX_BYTES`.
         """
         async with self._tracker("encode_events"):
-            await self._encode_events(events, format_options=format_options)
+            await self._encode_events(events)
 
-    async def _encode_events(
-        self,
-        events: Iterable[Event],
-        *,
-        format_options: FormatOptions | None,
-    ) -> None:
+    async def _encode_events(self, events: Iterable[Event]) -> None:
         t_start = time.monotonic()
 
         events = list(events)
         self._validate_events(events)
+        if not events:
+            return
+
+        await self._forget_events({event.uuid for event in events})
+
+        # Temporal order within the batch, so that eviction among the
+        # batch's own derivatives is what serial ingestion would decide.
+        events = sorted(events, key=lambda event: (event.timestamp, event.uuid))
 
         segment_lists = await asyncio.gather(
             *(
-                self._segmenter.segment(event, format_options=format_options)
+                self._segmenter.segment(event, format_options=self._format_options)
                 for event in events
             )
         )
@@ -242,7 +271,7 @@ class EventMemory:
 
         derivative_lists = await asyncio.gather(
             *(
-                self._deriver.derive(segment, format_options=format_options)
+                self._deriver.derive(segment, format_options=self._format_options)
                 for segment in segments
             )
         )
@@ -259,42 +288,81 @@ class EventMemory:
 
         derivative_texts: list[str] = []
         for derivative in derivatives:
-            text = EventMemory._extract_text(derivative.block)
+            text = derivative.block.render(self._format_options)
             if text is None:
                 raise NotImplementedError(
-                    f"Unsupported block type: {type(derivative.block).__name__}"
+                    f"Cannot embed a derivative of block kind {derivative.block.kind!r}"
                 )
             derivative_texts.append(text)
 
         derivative_embeddings = await self._embedder.ingest_embed(derivative_texts)
         t_embedding = time.monotonic()
 
+        displaced_uuids: set[UUID] = set()
+        skipped_uuids: set[UUID] = set()
+        if self._eviction is not None and derivatives:
+            batch_predecessors = EventMemory._compute_batch_predecessors(
+                derivative_embeddings,
+                self._eviction.similarity_threshold,
+            )
+            stored_neighbors = await self._vector_store_collection.query(
+                query_vectors=derivative_embeddings,
+                min_cosine_similarity=self._eviction.similarity_threshold,
+                limit=self._eviction.search_limit,
+            )
+            stored_timestamps = await self._stored_derivative_timestamps(
+                match.record_uuid
+                for query_result in stored_neighbors
+                for match in query_result.matches
+            )
+            displaced_uuids, skipped_uuids = EventMemory._select_eviction_targets(
+                derivatives,
+                stored_neighbors,
+                batch_predecessors,
+                stored_timestamps,
+                self._eviction.target_size,
+            )
+        t_eviction = time.monotonic()
+
         await self._segment_store_partition.add_segments(
             {
-                segment: [derivative.uuid for derivative in segment_derivatives]
+                segment: [
+                    derivative.uuid
+                    for derivative in segment_derivatives
+                    if derivative.uuid not in skipped_uuids
+                ]
                 for segment, segment_derivatives in segments_to_derivatives.items()
             }
         )
         t_segment_store = time.monotonic()
 
-        derivative_records = [
-            EventMemory._build_derivative_record(derivative, derivative_embedding)
-            for derivative, derivative_embedding in zip(
-                derivatives,
+        embeddings_by_derivative = dict(
+            zip(
+                (derivative.uuid for derivative in derivatives),
                 derivative_embeddings,
                 strict=True,
             )
+        )
+        derivative_records = [
+            EventMemory._build_derivative_record(
+                derivative, embeddings_by_derivative[derivative.uuid]
+            )
+            for derivative in derivatives
+            if derivative.uuid not in skipped_uuids
         ]
-
         if derivative_records:
             await self._vector_store_collection.upsert(records=derivative_records)
+        if displaced_uuids:
+            await self._vector_store_collection.delete(record_uuids=displaced_uuids)
+            await self._segment_store_partition.delete_derivatives(displaced_uuids)
         t_vector_store = time.monotonic()
 
         phase_durations = {
             "segmentation": t_segmentation - t_start,
             "derivation": t_derivation - t_segmentation,
             "embedding": t_embedding - t_derivation,
-            "segment_store": t_segment_store - t_embedding,
+            "eviction": t_eviction - t_embedding,
+            "segment_store": t_segment_store - t_eviction,
             "vector_store": t_vector_store - t_segment_store,
         }
 
@@ -313,20 +381,47 @@ class EventMemory:
                     duration, labels={"phase": phase}
                 )
 
-    @classmethod
+    async def _stored_derivative_timestamps(
+        self, derivative_uuids: Iterable[UUID]
+    ) -> dict[UUID, datetime.datetime]:
+        """The event timestamp of each stored derivative, read from its segment.
+
+        The vector store answers uuids and scores only; the segment store
+        owns the derivative's segment, and the segment its timestamp. A
+        derivative whose segment is gone is omitted.
+        """
+        segment_by_derivative = (
+            await self._segment_store_partition.get_segment_uuids_by_derivative_uuids(
+                derivative_uuids
+            )
+        )
+        if not segment_by_derivative:
+            return {}
+        segments_by_uuid = await self._segment_store_partition.get_segment_contexts(
+            seed_segment_uuids=set(segment_by_derivative.values())
+        )
+        return {
+            derivative_uuid: segments_by_uuid[segment_uuid][0].timestamp
+            for derivative_uuid, segment_uuid in segment_by_derivative.items()
+            if segment_uuid in segments_by_uuid
+        }
+
+    @staticmethod
     def _build_derivative_record(
-        cls,
         derivative: Derivative,
         derivative_embedding: Sequence[float],
     ) -> Record:
         """Build a vector record from a derivative and its embedding."""
-        properties: dict[str, PropertyValue] = {}
-
-        # System-defined metadata (underscore-prefixed).
-        properties[cls._TIMESTAMP_FIELD_NAME] = derivative.timestamp
-
-        # User-defined properties.
-        properties.update(derivative.properties)
+        # Caller properties first: a reserved key cannot reach here
+        # (encode_events validates), and building in this order makes the
+        # merge itself enforce that a system value always wins.
+        properties: dict[str, PropertyValue] = dict(derivative.properties)
+        properties[EVENT_TIMESTAMP_KEY] = derivative.timestamp
+        if derivative.session_id is not None:
+            properties[EVENT_SESSION_KEY] = derivative.session_id
+        if derivative.source_id is not None:
+            properties[EVENT_SOURCE_KEY] = derivative.source_id
+        properties[BLOCK_KIND_KEY] = derivative.block.kind
 
         return Record(
             uuid=derivative.uuid,
@@ -334,74 +429,207 @@ class EventMemory:
             properties=properties,
         )
 
-    @classmethod
-    def _to_vector_record_property(cls, field: str) -> str:
+    @staticmethod
+    def _compute_batch_predecessors(
+        derivative_embeddings: Iterable[Sequence[float]],
+        similarity_threshold: float,
+    ) -> list[set[int]]:
         """
-        Translates canonical filter field name to vector record property.
+        Compute batch predecessors for each derivative embedding.
 
-        Event memory base properties (`foo`) translate to `_foo`.
+        The ith entry holds the indices j < i whose cosine similarity to i
+        is at or above the threshold. Only earlier indices count, so a
+        batch evicts exactly what serial ingestion would.
+        """
+        embeddings = np.asarray(list(derivative_embeddings), dtype=np.float64)
+        num_embeddings = len(embeddings)
+        if num_embeddings == 0:
+            return []
+
+        norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        normalized = embeddings / norms
+        similarity_matrix = normalized @ normalized.T
+
+        # The diagonal and the upper triangle can never pass the threshold.
+        similarity_matrix[np.triu_indices(num_embeddings)] = -np.inf
+        mask = similarity_matrix >= similarity_threshold
+
+        return [set(np.where(mask[i])[0].tolist()) for i in range(num_embeddings)]
+
+    @staticmethod
+    def _select_eviction_targets(
+        derivatives: Iterable[Derivative],
+        query_results: Iterable[QueryResult],
+        batch_predecessors: list[set[int]],
+        stored_timestamps: Mapping[UUID, datetime.datetime],
+        target_size: int,
+    ) -> tuple[set[UUID], set[UUID]]:
+        """
+        Select eviction targets considering both stored and batch similarity.
+
+        The cluster of a derivative is its stored neighbors not already
+        displaced in this batch, its batch predecessors not already skipped,
+        and itself. Within `target_size` nothing happens; over it, the
+        cluster is sorted by event timestamp and the earliest
+        `target_size // 2` and the latest remainder are kept: the middle's
+        stored members are displaced, its batch members skipped. A stored
+        neighbor with no timestamp in `stored_timestamps` (its segment is
+        gone) is not a member.
+
+        Returns a tuple of:
+        - the stored derivative UUIDs to displace
+        - the batch derivative UUIDs to skip
+        """
+        derivatives = list(derivatives)
+        query_results = list(query_results)
+
+        displaced_uuids: set[UUID] = set()
+        skipped_uuids: set[UUID] = set()
+
+        for derivative, query_result, predecessor_indexes in zip(
+            derivatives, query_results, batch_predecessors, strict=True
+        ):
+            # Cluster members: (timestamp, uuid, is_stored).
+            members: list[tuple[datetime.datetime, UUID, bool]] = []
+
+            for match in query_result.matches:
+                if match.record_uuid in displaced_uuids:
+                    continue
+                timestamp = stored_timestamps.get(match.record_uuid)
+                if timestamp is None:
+                    continue
+                members.append((timestamp, match.record_uuid, True))
+
+            for index in predecessor_indexes:
+                neighbor = derivatives[index]
+                if neighbor.uuid not in skipped_uuids:
+                    members.append((neighbor.timestamp, neighbor.uuid, False))
+
+            members.append((derivative.timestamp, derivative.uuid, False))
+
+            total_size = len(members)
+            if total_size <= target_size:
+                continue
+
+            # Oversized: trim the temporal middle.
+            members.sort()
+            keep_early = target_size // 2
+            keep_late = target_size - keep_early
+
+            for _, uuid, is_stored in members[keep_early : total_size - keep_late]:
+                if is_stored:
+                    displaced_uuids.add(uuid)
+                else:
+                    skipped_uuids.add(uuid)
+
+        return displaced_uuids, skipped_uuids
+
+    @staticmethod
+    def _to_vector_record_property(field: str) -> str:
+        """
+        Translate a caller's filter field name to a vector record property.
+
         User-defined properties (`m.foo` / `metadata.foo`) translate to `foo`.
+        `timestamp` is the event timestamp, under its reserved key. Any
+        other bare name (`foo`) translates to `_foo`, the layout the server
+        writes its own fields in.
         """
         internal_name, is_user_metadata = normalize_filter_field(field)
         if is_user_metadata:
             return demangle_user_metadata_key(internal_name)
+        if field == "timestamp":
+            return EVENT_TIMESTAMP_KEY
         return f"_{field}"
 
     async def query(
         self,
         query: str,
         *,
-        vector_search_limit: int = 20,
+        limit: int = 20,
+        min_cosine_similarity: float | None = None,
         expand_context: int = 0,
+        since: datetime.datetime | None = None,
+        until: datetime.datetime | None = None,
+        session_ids: Iterable[str] | None = None,
+        source_ids: Iterable[str] | None = None,
+        block_kinds: Iterable[str] | None = None,
         property_filter: FilterExpr | None = None,
-        format_options: FormatOptions | None = None,
-    ) -> QueryResult:
+    ) -> list[SearchHit]:
         """
         Query event memory for segments relevant to the query.
+
+        The vector stage: `rerank` is the second stage, for a caller that
+        has a reranker.
 
         Args:
             query (str):
                 The search query.
-            vector_search_limit (int):
-                The maximum number of seed segments
-                to retrieve from the vector search
-                (default: 20).
+            limit (int):
+                The maximum number of hits (default: 20).
+            min_cosine_similarity (float | None):
+                Drop matches whose cosine similarity is below this
+                (default: None).
             expand_context (int):
                 The number of additional segments to include
                 around each matched segment for additional context
                 (default: 0).
+            since (datetime | None):
+                Inclusive lower bound on the event timestamp (default: None).
+            until (datetime | None):
+                Exclusive upper bound on the event timestamp (default: None).
+            session_ids (Iterable[str] | None):
+                Keep only events of these sessions (default: None).
+            source_ids (Iterable[str] | None):
+                Keep only events of these sources (default: None).
+            block_kinds (Iterable[str] | None):
+                Keep only segments whose block is of these kinds (default: None).
             property_filter (FilterExpr | None):
                 Property fields and values
                 to use for filtering segments
                 (default: None).
-            format_options (FormatOptions | None):
-                Options for formatting.
-                (default: None).
 
         Returns:
-            QueryResult:
-                The query result.
+            list[SearchHit]:
+                At most `limit` hits in descending similarity, each with
+                its context window and the index of the matched segment in
+                it. Windows of different hits may overlap; each hit is
+                returned whole. Every count is a maximum.
 
         """
         async with self._tracker("query"):
             return await self._query(
                 query,
-                vector_search_limit=vector_search_limit,
+                limit=limit,
+                min_cosine_similarity=min_cosine_similarity,
                 expand_context=expand_context,
+                since=since,
+                until=until,
+                session_ids=session_ids,
+                source_ids=source_ids,
+                block_kinds=block_kinds,
                 property_filter=property_filter,
-                format_options=format_options,
             )
 
     async def _query(
         self,
         query: str,
         *,
-        vector_search_limit: int,
+        limit: int,
+        min_cosine_similarity: float | None,
         expand_context: int,
+        since: datetime.datetime | None,
+        until: datetime.datetime | None,
+        session_ids: Iterable[str] | None,
+        source_ids: Iterable[str] | None,
+        block_kinds: Iterable[str] | None,
         property_filter: FilterExpr | None,
-        format_options: FormatOptions | None,
-    ) -> QueryResult:
+    ) -> list[SearchHit]:
         t_start = time.monotonic()
+        session_ids = list(session_ids) if session_ids is not None else None
+        source_ids = list(source_ids) if source_ids is not None else None
+        block_kinds = list(block_kinds) if block_kinds is not None else None
+
         query_embedding = (
             await self._embedder.search_embed(
                 [query],
@@ -410,16 +638,28 @@ class EventMemory:
         t_embedding = time.monotonic()
 
         # Translate filter fields for vector store.
-        collection_filter = (
-            map_filter_fields(property_filter, EventMemory._to_vector_record_property)
-            if property_filter is not None
-            else None
+        collection_filter = conjoin(
+            [
+                system_predicates(
+                    since=since,
+                    until=until,
+                    session_ids=session_ids,
+                    source_ids=source_ids,
+                    block_kinds=block_kinds,
+                ),
+                map_filter_fields(
+                    property_filter, EventMemory._to_vector_record_property
+                )
+                if property_filter is not None
+                else None,
+            ]
         )
 
         # Search derivative collection for matches.
         [query_result] = await self._vector_store_collection.query(
             query_vectors=[query_embedding],
-            limit=vector_search_limit,
+            limit=limit,
+            min_cosine_similarity=min_cosine_similarity,
             property_filter=collection_filter,
         )
         t_vector_query = time.monotonic()
@@ -441,69 +681,40 @@ class EventMemory:
             if segment_uuid not in seed_cosine_similarities:
                 seed_cosine_similarities[segment_uuid] = match.cosine_similarity
 
-        seed_segment_uuids = list(seed_cosine_similarities)
-
-        max_backward_segments = expand_context // 3
-        max_forward_segments = expand_context - max_backward_segments
+        before = expand_context // 3
+        after = expand_context - before
 
         segment_contexts_by_seed = (
             await self._segment_store_partition.get_segment_contexts(
-                seed_segment_uuids=seed_segment_uuids,
-                max_backward_segments=max_backward_segments,
-                max_forward_segments=max_forward_segments,
+                seed_segment_uuids=seed_cosine_similarities.keys(),
+                before=before,
+                after=after,
+                since=since,
+                until=until,
+                source_ids=source_ids,
+                block_kinds=block_kinds,
                 property_filter=property_filter,
             )
         )
         t_segment_query = time.monotonic()
 
-        # Filter to seeds with results, preserving similarity order.
-        kept_seed_segment_uuids = [
-            seed_segment_uuid
-            for seed_segment_uuid in seed_segment_uuids
-            if seed_segment_uuid in segment_contexts_by_seed
-        ]
-        segment_contexts: list[list[Segment]] = [
-            segment_contexts_by_seed[seed_segment_uuid]
-            for seed_segment_uuid in kept_seed_segment_uuids
-        ]
-
-        # Use embedding scores if reranker is not available.
-        if self._reranker is None:
-            scores = [
-                seed_cosine_similarities[seed_uuid]
-                for seed_uuid in kept_seed_segment_uuids
-            ]
-        else:
-            reranker_format_options = format_options or FormatOptions(
-                time_style="short"
+        # Seeds the store did not return are dropped; similarity order is kept.
+        hits: list[SearchHit] = []
+        for seed_uuid, score in seed_cosine_similarities.items():
+            segments = segment_contexts_by_seed.get(seed_uuid)
+            if segments is None:
+                continue
+            seed_index = next(
+                index
+                for index, segment in enumerate(segments)
+                if segment.uuid == seed_uuid
             )
-            scores = await self._score_segment_contexts(
-                query, segment_contexts, reranker_format_options
-            )
-        t_scoring = time.monotonic()
-
-        # Return scored contexts ordered by score.
-        scored_segment_contexts = [
-            ScoredSegmentContext(
-                score=score, seed_segment_uuid=seed_uuid, segments=context
-            )
-            for score, seed_uuid, context in sorted(
-                zip(
-                    scores,
-                    kept_seed_segment_uuids,
-                    segment_contexts,
-                    strict=True,
-                ),
-                key=lambda triple: triple[0],
-                reverse=True,
-            )
-        ]
+            hits.append(SearchHit(score=score, seed=seed_index, segments=segments))
 
         phase_durations = {
             "embedding": t_embedding - t_start,
             "vector_query": t_vector_query - t_embedding,
             "segment_query": t_segment_query - t_vector_query,
-            "scoring": t_scoring - t_segment_query,
         }
 
         logger.debug(
@@ -519,152 +730,193 @@ class EventMemory:
             for phase, duration in phase_durations.items():
                 self._query_phase_seconds.observe(duration, labels={"phase": phase})
 
-        return QueryResult(scored_segment_contexts=scored_segment_contexts)
+        return hits
 
-    async def _score_segment_contexts(
+    async def expand(
         self,
-        query: str,
-        segment_contexts: Iterable[Iterable[Segment]],
-        format_options: FormatOptions,
-    ) -> list[float]:
-        """Score segment contexts using the reranker. Requires reranker."""
-        assert self._reranker is not None
-        context_strings = [
-            EventMemory.string_from_segment_context(
-                segment_context, format_options=format_options
+        anchor: UUID,
+        *,
+        before: int = 0,
+        after: int = 0,
+        since: datetime.datetime | None = None,
+        until: datetime.datetime | None = None,
+        source_ids: Iterable[str] | None = None,
+        block_kinds: Iterable[str] | None = None,
+        property_filter: FilterExpr | None = None,
+    ) -> Neighborhood:
+        """
+        Get the neighborhood of an anchor in its session's order.
+
+        The anchor is a segment uuid (from a hit) or an event uuid (its
+        first segment). The filters apply to the neighbors only, and the
+        anchor is never returned: its place is between the two lists. A
+        caller walks further by calling again from the first of `before`
+        or the last of `after` with one side zero.
+
+        Args:
+            anchor (UUID):
+                A segment or event uuid.
+            before (int):
+                The maximum number of segments before the anchor (default: 0).
+            after (int):
+                The maximum number of segments after the anchor (default: 0).
+            since (datetime | None):
+                Inclusive lower bound on the neighbors' timestamp (default: None).
+            until (datetime | None):
+                Exclusive upper bound on the neighbors' timestamp (default: None).
+            source_ids (Iterable[str] | None):
+                Keep only neighbors of these sources (default: None).
+            block_kinds (Iterable[str] | None):
+                Keep only neighbors whose block is of these kinds (default: None).
+            property_filter (FilterExpr | None):
+                Property fields and values to filter the neighbors by
+                (default: None).
+
+        Returns:
+            Neighborhood:
+                The neighbors before and after the anchor, in the store's order.
+
+        Raises:
+            LookupError: If the anchor is neither a segment nor an event of this memory.
+        """
+        async with self._tracker("expand"):
+            segment_uuids_by_event = (
+                await self._segment_store_partition.get_segment_uuids_by_event_uuids(
+                    event_uuids=[anchor],
+                )
             )
-            for segment_context in segment_contexts
-        ]
-        return await self._reranker.score(query, context_strings)
+            event_segment_uuids = segment_uuids_by_event.get(anchor)
+            seed = event_segment_uuids[0] if event_segment_uuids else anchor
+
+            neighborhoods = await self._segment_store_partition.get_neighbourhoods(
+                seed_segment_uuids=[seed],
+                before=before,
+                after=after,
+                since=since,
+                until=until,
+                source_ids=source_ids,
+                block_kinds=block_kinds,
+                property_filter=property_filter,
+            )
+            neighborhood = neighborhoods.get(seed)
+            if neighborhood is None:
+                raise LookupError(
+                    f"Anchor {anchor} is neither a segment nor an event of this memory"
+                )
+            return neighborhood
 
     @staticmethod
-    def string_from_segment_context(
-        segment_context: Iterable[Segment],
+    async def rerank(
+        query: str,
+        hits: Sequence[SearchHit],
         *,
-        format_options: FormatOptions | None = None,
+        reranker: Reranker,
+        limit: int,
+        min_score: float | None = None,
+        format_options: FormatOptions,
+    ) -> list[SearchHit]:
+        """
+        Rerank hits by a reranker's score of their rendered windows.
+
+        The second stage after `query`, for a caller that has a reranker:
+        each hit's window is rendered with `format_options` and scored
+        against the query; hits below `min_score` are dropped and at most
+        `limit` are returned in descending score, each with its score
+        replaced by the reranker's.
+        """
+        hits = list(hits)
+        if not hits:
+            return []
+        scores = await reranker.score(
+            query,
+            [
+                EventMemory.render(hit.segments, format_options=format_options)
+                for hit in hits
+            ],
+        )
+        reranked = [
+            SearchHit(score=score, seed=hit.seed, segments=hit.segments)
+            for hit, score in zip(hits, scores, strict=True)
+            if min_score is None or score >= min_score
+        ]
+        reranked.sort(key=lambda hit: hit.score, reverse=True)
+        return reranked[:limit]
+
+    @staticmethod
+    def _immediately_follows(previous: Segment, segment: Segment) -> bool:
+        """Whether `segment` is the very next piece of the same event as `previous`.
+
+        Two pieces are adjacent either within a block (the next chunk of it)
+        or across blocks (the first chunk of the next one). Anything else
+        means something between them is not being shown. A block's chunk
+        count is not known here, so the end of one block is recognized by
+        the next block starting at its own beginning rather than by
+        counting up to it.
+        """
+        if segment.event_uuid != previous.event_uuid:
+            return False
+        if segment.index == previous.index:
+            return segment.offset == previous.offset + 1
+        if segment.index == previous.index + 1:
+            return segment.offset == 0
+        return False
+
+    @staticmethod
+    def render(
+        segments: Iterable[Segment],
+        *,
+        format_options: FormatOptions,
     ) -> str:
-        """Format segment context as a string."""
-        if format_options is None:
-            format_options = FormatOptions(time_style="short")
+        """
+        The reader's text for a run of segments, in their order.
 
+        A header (the timestamp formatted by `format_options`, then the
+        context parts' contributions) starts each run of adjacent pieces
+        of one event; the pieces' block renderings are joined under it.
+        """
         context_string = ""
-        last_segment: Segment | None = None
+        previous: Segment | None = None
         accumulated_text = ""
-        first = True
 
-        for segment in segment_context:
-            is_continuation = (
-                last_segment is not None
-                and segment.event_uuid == last_segment.event_uuid
-                and segment.index == last_segment.index
+        for segment in segments:
+            is_continuation = previous is not None and EventMemory._immediately_follows(
+                previous, segment
             )
 
             if not is_continuation:
-                if not first:
+                if previous is not None:
                     context_string += (
                         json.dumps(accumulated_text, ensure_ascii=False) + "\n"
                     )
-                first = False
                 accumulated_text = ""
                 context_string += EventMemory._segment_header(segment, format_options)
 
-            text = EventMemory._extract_text(segment.block)
+            text = segment.block.render(format_options)
             if text is not None:
                 accumulated_text += text
             elif not is_continuation:
-                context_string += f"[{segment.block.block_type}]\n"
+                context_string += f"[{segment.block.kind}]\n"
 
-            last_segment = segment
+            previous = segment
 
-        if not first:
+        if previous is not None:
             context_string += json.dumps(accumulated_text, ensure_ascii=False) + "\n"
 
         return context_string.strip()
 
     @staticmethod
-    def string_from_segment_contexts(
-        segment_contexts: Iterable[Iterable[Segment]],
-        *,
-        format_options: FormatOptions | None = None,
-    ) -> str:
-        """Format multiple segment contexts as a string, separating disconnected components."""
-        segment_contexts = [list(context) for context in segment_contexts]
-
-        # Deduplicate segments and build union-find over their UUIDs in one pass.
-        segments_by_uuid: dict[UUID, Segment] = {}
-        component_parent: dict[UUID, UUID] = {}
-
-        def find(uuid: UUID) -> UUID:
-            component_parent.setdefault(uuid, uuid)
-            root = uuid
-            while component_parent[root] != root:
-                root = component_parent[root]
-            while component_parent[uuid] != root:
-                parent = component_parent[uuid]
-                component_parent[uuid] = root
-                uuid = parent
-            return root
-
-        for context in segment_contexts:
-            first_segment_root: UUID | None = None
-            for segment in context:
-                segments_by_uuid.setdefault(segment.uuid, segment)
-                if first_segment_root is None:
-                    first_segment_root = find(segment.uuid)
-                else:
-                    segment_root = find(segment.uuid)
-                    component_parent[segment_root] = first_segment_root
-
-        # Group unique segments by component root.
-        segments_by_root: dict[UUID, list[Segment]] = {}
-        for segment_uuid, segment in segments_by_uuid.items():
-            segments_by_root.setdefault(find(segment_uuid), []).append(segment)
-
-        # Sort segments within each component, then order components chronologically.
-        def segment_key(segment: Segment) -> tuple:
-            return (
-                segment.timestamp,
-                segment.event_uuid,
-                segment.index,
-                segment.offset,
-            )
-
-        components = list(segments_by_root.values())
-        for component in components:
-            component.sort(key=segment_key)
-        components.sort(key=lambda segments: segment_key(segments[0]))
-
-        return "\n\n".join(
-            EventMemory.string_from_segment_context(
-                segments, format_options=format_options
-            )
-            for segments in components
-        )
-
-    @staticmethod
     def _segment_header(segment: Segment, format_options: FormatOptions) -> str:
         """Build the header emitted before a segment."""
         formatted_timestamp = format_timestamp(segment.timestamp, format_options)
-        timestamp_prefix = f"[{formatted_timestamp}] " if formatted_timestamp else ""
-
-        match segment.context:
-            case ProducerContext(producer=producer):
-                return f"{timestamp_prefix}{producer}: "
-            case NullContext():
-                return timestamp_prefix
-            case _:
-                raise NotImplementedError(
-                    f"Unsupported context type: {type(segment.context).__name__}"
-                )
-
-    @staticmethod
-    def _extract_text(block: Block) -> str | None:
-        """Extract text from a block, if it contains text."""
-        match block:
-            case TextBlock(text=text):
-                return text
-            case _:
-                return None
+        header = f"[{formatted_timestamp}] " if formatted_timestamp else ""
+        for part_type in _RENDERED_PART_KINDS:
+            part = get_part(segment.context, part_type)
+            if part is None:
+                continue
+            contribution = part.render(format_options)
+            if contribution:
+                header += f"{contribution}: "
+        return header
 
     async def forget_events(self, event_uuids: Iterable[UUID]) -> None:
         """Forget events by their UUIDs."""
@@ -676,7 +928,6 @@ class EventMemory:
             await self._forget_events(event_uuids)
 
     async def _forget_events(self, event_uuids: set[UUID]) -> None:
-
         # Snapshot segment UUIDs for these events.
         segments_by_event = (
             await self._segment_store_partition.get_segment_uuids_by_event_uuids(
@@ -710,102 +961,3 @@ class EventMemory:
         await self._segment_store_partition.delete_segments(
             segment_uuids=segment_uuids,
         )
-
-    @staticmethod
-    def build_query_result_context(
-        query_result: QueryResult,
-        max_num_segments: int,
-    ) -> list[Segment]:
-        """
-        Build a single segment context from the query result within the limit.
-
-        Iterates contexts in score order, accumulating segments until the limit is reached.
-        When a context would exceed the limit, segments nearest the seed are prioritized.
-        Deduplicates across segment contexts in the query result.
-
-        Args:
-            query_result (QueryResult):
-                The query result with scored anchored segment contexts.
-            max_num_segments (int):
-                The maximum number of segments to return.
-
-        Returns:
-            list[Segment]:
-                Deduplicated segments ordered chronologically.
-        """
-        unified: set[Segment] = set()
-
-        for scored_context in query_result.scored_segment_contexts:
-            context = scored_context.segments
-
-            if len(unified) >= max_num_segments:
-                break
-            if (len(unified) + len(context)) <= max_num_segments:
-                unified.update(context)
-            else:
-                # Prioritize segments near the seed segment.
-                seed_index = next(
-                    index
-                    for index, segment in enumerate(context)
-                    if segment.uuid == scored_context.seed_segment_uuid
-                )
-
-                for segment in sorted(
-                    context,
-                    key=lambda s: EventMemory._seed_proximity(s, context, seed_index),
-                ):
-                    if len(unified) >= max_num_segments:
-                        break
-                    unified.add(segment)
-
-        return sorted(
-            unified,
-            key=lambda segment: (
-                segment.timestamp,
-                segment.event_uuid,
-                segment.index,
-                segment.offset,
-            ),
-        )
-
-    @staticmethod
-    def string_from_query_result(
-        query_result: QueryResult,
-        *,
-        max_num_segments: int | None = None,
-        format_options: FormatOptions | None = None,
-    ) -> str:
-        """Format a query result as a string with breaks between disconnected contexts."""
-        contexts: list[list[Segment]] = [
-            list(scored_context.segments)
-            for scored_context in query_result.scored_segment_contexts
-        ]
-
-        if max_num_segments is not None:
-            included = {
-                segment.uuid
-                for segment in EventMemory.build_query_result_context(
-                    query_result, max_num_segments
-                )
-            }
-            contexts = [
-                [segment for segment in context if segment.uuid in included]
-                for context in contexts
-            ]
-
-        return EventMemory.string_from_segment_contexts(
-            contexts, format_options=format_options
-        )
-
-    @staticmethod
-    def _seed_proximity(
-        segment: Segment,
-        context: list[Segment],
-        seed_index: int,
-    ) -> float:
-        """Score a segment by its proximity to the seed. Lower is closer."""
-        offset = context.index(segment) - seed_index
-        if offset >= 0:
-            # Forward context is more useful than backward.
-            return (offset - 0.5) / 2
-        return -offset

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/__init__.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/__init__.py
@@ -4,7 +4,6 @@ from .data_types import (
     SegmentStoreAttemptsExhaustedError,
     SegmentStorePartitionAlreadyExistsError,
     SegmentStorePartitionConfig,
-    SegmentStorePartitionConfigMismatchError,
     SegmentStorePartitionHandleStaleError,
 )
 from .segment_store import (
@@ -18,6 +17,5 @@ __all__ = [
     "SegmentStorePartition",
     "SegmentStorePartitionAlreadyExistsError",
     "SegmentStorePartitionConfig",
-    "SegmentStorePartitionConfigMismatchError",
     "SegmentStorePartitionHandleStaleError",
 ]

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/data_types.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/data_types.py
@@ -46,26 +46,6 @@ class SegmentStorePartitionConfig(BaseModel):
         return value
 
 
-class SegmentStorePartitionConfigMismatchError(Exception):
-    """Raised when opening a partition with a different configuration than it was created with."""
-
-    def __init__(
-        self,
-        partition_key: str,
-        existing_config: SegmentStorePartitionConfig,
-        requested_config: SegmentStorePartitionConfig,
-    ) -> None:
-        """Initialize with the partition key and configurations."""
-        self.partition_key = partition_key
-        self.existing_config = existing_config
-        self.requested_config = requested_config
-        super().__init__(
-            f"Partition {partition_key!r} already exists with a different configuration. "
-            f"Existing config: {existing_config.model_dump_json()}, "
-            f"requested config: {requested_config.model_dump_json()}."
-        )
-
-
 class SegmentStoreAttemptsExhaustedError(Exception):
     """The store exhausted its internal attempts; diagnose the cause.
 

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
@@ -296,9 +296,13 @@ class SegmentStore(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def open_partition(self, partition_key: str) -> SegmentStorePartition | None:
+    async def get_partition(self, partition_key: str) -> SegmentStorePartition | None:
         """
-        Open a partition-scoped handle for an existing partition.
+        Get a handle bound to an existing partition.
+
+        The handle owns nothing: a caller builds one here, drops it, and
+        builds another at will. Staleness is a property of a handle already
+        held, raised by its operations, never of this lookup.
 
         Args:
             partition_key (str):
@@ -306,49 +310,8 @@ class SegmentStore(ABC):
 
         Returns:
             SegmentStorePartition | None:
-                A partition-scoped handle, or None if the partition does not exist.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    async def open_or_create_partition(
-        self,
-        partition_key: str,
-        config: SegmentStorePartitionConfig,
-    ) -> SegmentStorePartition:
-        """
-        Open the partition if it exists, or create it if it does not.
-
-        Args:
-            partition_key (str):
-                The key of the partition.
-            config (SegmentStorePartitionConfig):
-                Configuration for the partition.
-
-        Returns:
-            SegmentStorePartition:
-                A partition-scoped handle.
-
-        Raises:
-            SegmentStorePartitionConfigMismatchError:
-                If the partition already exists with a different configuration.
-            SegmentStoreAttemptsExhaustedError:
-                If creation exhausted its internal attempts on a
-                failure that should not recur; an immediate retry is
-                unlikely to succeed -- diagnose the chained cause.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    async def close_partition(
-        self, segment_store_partition: SegmentStorePartition
-    ) -> None:
-        """
-        Close a partition-scoped handle.
-
-        Args:
-            segment_store_partition (SegmentStorePartition):
-                The partition-scoped handle to close.
+                A handle bound to the partition, or None if the partition
+                does not exist.
         """
         raise NotImplementedError
 
@@ -357,8 +320,8 @@ class SegmentStore(ABC):
         """
         Delete a partition.
 
-        The partition becomes unreachable immediately: it can no longer be
-        opened, and handles opened on it raise from then on.
+        The partition becomes unreachable immediately: `get_partition`
+        returns None for it, and handles bound to it raise from then on.
         Implementations may defer physically reclaiming its rows to
         `purge_deleted_partitions`. Idempotent.
 

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Mapping
 from datetime import datetime
 from uuid import UUID
 
-from memmachine_server.common.filter.filter_parser import FilterExpr
+from memmachine_server.common.filter import FilterExpr
 from memmachine_server.episodic_memory.event_memory.data_types import (
     Neighborhood,
     Segment,

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/segment_store.py
@@ -6,10 +6,12 @@ Defines an interface for adding, retrieving, and deleting segments of events.
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
+from datetime import datetime
 from uuid import UUID
 
 from memmachine_server.common.filter.filter_parser import FilterExpr
 from memmachine_server.episodic_memory.event_memory.data_types import (
+    Neighborhood,
     Segment,
 )
 from memmachine_server.episodic_memory.event_memory.segment_store.data_types import (
@@ -26,6 +28,20 @@ class SegmentStorePartition(ABC):
     then on, even if a partition is later created under the same key.
     A call with empty input may do no work and return without checking
     the handle.
+
+    Segments within a partition are in one total order,
+    `(session_id, timestamp, event_uuid, index, offset)`: a null session
+    id compares equal to a null session id and to nothing else, so the
+    ungrouped stream is one stream. Context windows and neighborhoods
+    walk this order and are confined to their seed's session, so they
+    never cross into another conversation interleaved in time.
+
+    The two reads, `get_segment_contexts` and `get_neighbourhoods`, take
+    the same parameters and differ in what they return. `before` and
+    `after` count segments on each side of a seed; `since` (inclusive)
+    and `until` (exclusive) bound the segment timestamp, so ranges meet
+    without overlap; `source_ids`, `block_kinds` and `property_filter`
+    select rows, and an empty id or kind list admits nothing.
     """
 
     @property
@@ -42,6 +58,9 @@ class SegmentStorePartition(ABC):
         """
         Add segments and their associated derivative UUIDs to the partition.
 
+        A segment's `session_id`, `source_id` and its block's `kind` are
+        stored beside the encoded block, so the store can filter on them.
+
         Args:
             segments_to_derivative_uuids (Mapping[Segment, Iterable[UUID]]):
                 A mapping from each segment to the UUIDs of its derivatives.
@@ -53,26 +72,92 @@ class SegmentStorePartition(ABC):
         self,
         seed_segment_uuids: Iterable[UUID],
         *,
-        max_backward_segments: int = 0,
-        max_forward_segments: int = 0,
+        before: int = 0,
+        after: int = 0,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        source_ids: Iterable[str] | None = None,
+        block_kinds: Iterable[str] | None = None,
         property_filter: FilterExpr | None = None,
     ) -> dict[UUID, list[Segment]]:
         """
         Get a window of segments around each of the seed segments.
 
+        The search window: the seed is a result, so every filter applies
+        to the seed as to the window rows, and a seed that fails a filter
+        or is unknown has no entry.
+
         Args:
             seed_segment_uuids (Iterable[UUID]):
                 The UUIDs of the seed segments for which to retrieve contexts.
-            max_backward_segments (int):
+            before (int):
                 The maximum number of segments to include before each seed segment (default: 0).
-            max_forward_segments (int):
+            after (int):
                 The maximum number of segments to include after each seed segment (default: 0).
+            since (datetime | None):
+                Inclusive lower bound on the segment timestamp (default: None).
+            until (datetime | None):
+                Exclusive upper bound on the segment timestamp (default: None).
+            source_ids (Iterable[str] | None):
+                Keep only segments whose source id is one of these (default: None).
+            block_kinds (Iterable[str] | None):
+                Keep only segments whose block is of one of these kinds (default: None).
             property_filter (FilterExpr | None):
-                An optional filter expression to apply to the segments (default: None).
+                An optional filter expression over segment properties (default: None).
 
         Returns:
             dict[UUID, list[Segment]]:
-                A mapping from each seed segment UUID to its context segments.
+                A mapping from each seed segment UUID to its context segments,
+                in the store's order, the seed among them.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_neighbourhoods(
+        self,
+        seed_segment_uuids: Iterable[UUID],
+        *,
+        before: int = 0,
+        after: int = 0,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        source_ids: Iterable[str] | None = None,
+        block_kinds: Iterable[str] | None = None,
+        property_filter: FilterExpr | None = None,
+    ) -> dict[UUID, Neighborhood]:
+        """
+        Get the segments around each seed segment, never the seed itself.
+
+        Expansion: the seed is an address the caller named and holds. It
+        is located whether or not it passes any filter, the filters apply
+        to the neighbors only, and it is never in the result. Other
+        segments of the seed's own event are ordinary neighbors.
+
+        Args:
+            seed_segment_uuids (Iterable[UUID]):
+                The UUIDs of the segments to gather neighbors around.
+            before (int):
+                The maximum number of segments to include before each seed (default: 0).
+            after (int):
+                The maximum number of segments to include after each seed (default: 0).
+            since (datetime | None):
+                Inclusive lower bound on the neighbors' timestamp (default: None).
+            until (datetime | None):
+                Exclusive upper bound on the neighbors' timestamp (default: None).
+            source_ids (Iterable[str] | None):
+                Keep only neighbors whose source id is one of these (default: None).
+            block_kinds (Iterable[str] | None):
+                Keep only neighbors whose block is of one of these kinds (default: None).
+            property_filter (FilterExpr | None):
+                An optional filter expression over the neighbors' properties
+                (default: None).
+
+        Returns:
+            dict[UUID, Neighborhood]:
+                A mapping from each known seed to its neighbors: `before`
+                in order ending just before the seed, `after` in order
+                starting just after it. A seed with no neighbors to show
+                maps to two empty lists; an unknown seed is absent.
         """
         raise NotImplementedError
 
@@ -90,7 +175,9 @@ class SegmentStorePartition(ABC):
 
         Returns:
             dict[UUID, list[UUID]]:
-                A mapping from each event UUID to the UUIDs of its associated segments.
+                A mapping from each event UUID to the UUIDs of its
+                associated segments, in the event's own order (by index,
+                then offset).
         """
         raise NotImplementedError
 
@@ -145,6 +232,20 @@ class SegmentStorePartition(ABC):
         Args:
             segment_uuids (Iterable[UUID]):
                 The UUIDs of the segments to delete.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def delete_derivatives(
+        self,
+        derivative_uuids: Iterable[UUID],
+    ) -> None:
+        """
+        Delete derivative links by derivative UUID, leaving their segments.
+
+        Args:
+            derivative_uuids (Iterable[UUID]):
+                The UUIDs of the derivatives to unlink.
         """
         raise NotImplementedError
 

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
@@ -93,7 +93,6 @@ from memmachine_server.episodic_memory.event_memory.segment_store.data_types imp
     SegmentStoreAttemptsExhaustedError,
     SegmentStorePartitionAlreadyExistsError,
     SegmentStorePartitionConfig,
-    SegmentStorePartitionConfigMismatchError,
     SegmentStorePartitionHandleStaleError,
 )
 from memmachine_server.episodic_memory.event_memory.segment_store.segment_store import (
@@ -1284,11 +1283,11 @@ class SQLAlchemySegmentStore(SegmentStore):
             raise _RegistryInsertRejectedError(str(incarnation)) from err
 
     @override
-    async def open_partition(
+    async def get_partition(
         self, partition_key: str
     ) -> SQLAlchemySegmentStorePartition | None:
         validate_partition_key(partition_key)
-        async with self._tracker("open_partition"):
+        async with self._tracker("get_partition"):
             async with self._create_session() as session:
                 partition_row = await SQLAlchemySegmentStore._get_partition_row(
                     session, partition_key
@@ -1297,79 +1296,6 @@ class SQLAlchemySegmentStore(SegmentStore):
                 return None
 
             return await self._partition_from_partition_row(partition_row)
-
-    @override
-    async def open_or_create_partition(
-        self,
-        partition_key: str,
-        config: SegmentStorePartitionConfig,
-    ) -> SQLAlchemySegmentStorePartition:
-        validate_partition_key(partition_key)
-        async with self._tracker("open_or_create_partition"):
-            return await self._open_or_create_partition(partition_key, config)
-
-    async def _open_or_create_partition(
-        self,
-        partition_key: str,
-        config: SegmentStorePartitionConfig,
-    ) -> SQLAlchemySegmentStorePartition:
-        attempts = 0
-        # Read-then-insert, retried: losing the insert race means a
-        # concurrent creator won (reopen its row), and finding no row
-        # after losing means a concurrent delete removed the winner --
-        # every retry requires another actor to have changed the state
-        # (or, vanishingly, a minted incarnation to have collided).
-        while True:
-            async with self._create_session() as session:
-                partition_row = await SQLAlchemySegmentStore._get_partition_row(
-                    session, partition_key
-                )
-
-            if partition_row is not None:
-                SQLAlchemySegmentStore._raise_if_partition_config_mismatch(
-                    partition_row, config
-                )
-                return await self._partition_from_partition_row(partition_row)
-
-            # Materialized before the insert so an unloadable codec
-            # config fails without committing a registry row for a
-            # partition that could never be opened; the open path above
-            # loads its codec from the committed row instead.
-            payload_codec = await self._load_payload_codec(config)
-            incarnation = uuid4()
-            try:
-                await self._insert_partition_row(partition_key, incarnation, config)
-            except (
-                SegmentStorePartitionAlreadyExistsError,
-                _RegistryInsertRejectedError,
-            ) as err:
-                attempts += 1
-                if attempts >= _MAX_MINT_ATTEMPTS:
-                    raise SegmentStoreAttemptsExhaustedError(
-                        f"Opening or creating partition {partition_key!r} "
-                        f"made no progress after {_MAX_MINT_ATTEMPTS} "
-                        f"attempts"
-                    ) from err
-                # Lost the creation race (reopen the winner's row next
-                # iteration) or minted a colliding incarnation (mint a
-                # fresh one).
-                continue
-
-            return SQLAlchemySegmentStorePartition(
-                partition_key=partition_key,
-                incarnation=incarnation,
-                create_session=self._create_session,
-                is_sqlite=self._is_sqlite,
-                config=config,
-                payload_codec=payload_codec,
-                tracker=self._tracker,
-            )
-
-    @override
-    async def close_partition(
-        self, segment_store_partition: SegmentStorePartition
-    ) -> None:
-        pass
 
     @override
     async def delete_partition(self, partition_key: str) -> None:
@@ -1582,21 +1508,3 @@ class SQLAlchemySegmentStore(SegmentStore):
                 select(PartitionRow).where(PartitionRow.partition_key == partition_key)
             )
         ).scalar_one_or_none()
-
-    @staticmethod
-    def _raise_if_partition_config_mismatch(
-        partition_row: PartitionRow,
-        config: SegmentStorePartitionConfig,
-    ) -> None:
-        """Raise if an existing partition row does not match the requested config."""
-        existing_config = SegmentStorePartitionConfig(
-            payload_codec_config=decode_payload_codec_config(
-                partition_row.payload_codec_config
-            )
-        )
-        if existing_config != config:
-            raise SegmentStorePartitionConfigMismatchError(
-                partition_row.partition_key,
-                existing_config,
-                config,
-            )

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
@@ -4,7 +4,7 @@ import json
 import logging
 import sqlite3
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import UTC, datetime, timedelta, timezone
 from typing import override
 from uuid import UUID, uuid4
@@ -25,8 +25,10 @@ from sqlalchemy import (
     LargeBinary,
     Select,
     String,
+    Text,
     Uuid,
     delete,
+    false,
     func,
     insert,
     literal,
@@ -50,6 +52,7 @@ from sqlalchemy.orm import (
 )
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql.elements import ColumnElement
+from sqlalchemy.sql.selectable import Subquery
 
 from memmachine_server.common.filter.filter_parser import (
     FilterExpr,
@@ -79,7 +82,7 @@ from memmachine_server.common.properties_json import (
 )
 from memmachine_server.common.utils import ensure_tz_aware, utc_offset_seconds
 from memmachine_server.episodic_memory.event_memory.data_types import (
-    NullContext,
+    Neighborhood,
     Segment,
     decode_block,
     decode_context,
@@ -151,7 +154,14 @@ class PartitionRow(BaseSegmentStore):
 
 
 class SegmentRow(BaseSegmentStore):
-    """Persisted segment."""
+    """Persisted segment.
+
+    `session_id`, `source_id` and `block_kind` are projections of the
+    segment the row already holds in its encoded block and fields: the
+    codec-encoded block is opaque to SQL, so what the store filters on is
+    copied out beside it at insert. `block_kind` is derived from the block
+    and never accepted as a separate input, so it cannot disagree with it.
+    """
 
     __tablename__ = "segment_store_sg"
 
@@ -167,7 +177,10 @@ class SegmentRow(BaseSegmentStore):
     timestamp_timezone_offset: MappedColumn[int] = mapped_column(
         Integer, nullable=False, default=0
     )
+    session_id: MappedColumn[str | None] = mapped_column(Text, nullable=True)
+    source_id: MappedColumn[str | None] = mapped_column(Text, nullable=True)
     context: MappedColumn[bytes] = mapped_column(LargeBinary, nullable=False)
+    block_kind: MappedColumn[str] = mapped_column(Text, nullable=False)
     block: MappedColumn[bytes] = mapped_column(LargeBinary, nullable=False)
     properties: MappedColumn[dict[str, JsonValue]] = mapped_column(
         _JSON_AUTO, nullable=False, default=dict
@@ -177,18 +190,29 @@ class SegmentRow(BaseSegmentStore):
     # deliberately decoupled so that partition deletion is a registry write
     # (O(1)) and the purge queue reclaims data rows asynchronously.
     __table_args__ = (
+        # Lookup by event, in the event's own order.
         Index(
-            "segment_store_sg__in_ev",
+            "segment_store_sg__in_event",
             "incarnation",
             "event_uuid",
+            "index",
+            "offset",
         ),
+        # The one total order the store exposes: context windows,
+        # neighborhoods and the timestamp bounds walk it.
         Index(
-            "segment_store_sg__in_ts_ev_ix_of",
+            "segment_store_sg__in_order",
             "incarnation",
+            "session_id",
             "timestamp",
             "event_uuid",
             "index",
             "offset",
+        ),
+        Index(
+            "segment_store_sg__in_source",
+            "incarnation",
+            "source_id",
         ),
     )
 
@@ -364,9 +388,12 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
                 # original offset is recorded separately and reapplied on read.
                 "timestamp": ensure_tz_aware(segment.timestamp).astimezone(UTC),
                 "timestamp_timezone_offset": utc_offset_seconds(segment.timestamp),
+                "session_id": segment.session_id,
+                "source_id": segment.source_id,
                 "context": self._payload_codec.encode(
                     json.dumps(encode_context(segment.context)).encode("utf-8")
                 ),
+                "block_kind": segment.block.kind,
                 "block": self._payload_codec.encode(
                     json.dumps(encode_block(segment.block)).encode("utf-8")
                 ),
@@ -402,83 +429,41 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
         self,
         seed_segment_uuids: Iterable[UUID],
         *,
-        max_backward_segments: int = 0,
-        max_forward_segments: int = 0,
+        before: int = 0,
+        after: int = 0,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        source_ids: Iterable[str] | None = None,
+        block_kinds: Iterable[str] | None = None,
         property_filter: FilterExpr | None = None,
     ) -> dict[UUID, list[Segment]]:
         seed_segment_uuids = set(seed_segment_uuids)
         if not seed_segment_uuids:
             return {}
+        conditions = SQLAlchemySegmentStorePartition._row_conditions(
+            since, until, source_ids, block_kinds, property_filter
+        )
 
         async with (
             self._tracker("get_segment_contexts"),
             self._create_session() as session,
         ):
-            seed_segments_query = select(SegmentRow).where(
-                SegmentRow.uuid.in_(seed_segment_uuids),
-                SegmentRow.incarnation == self._incarnation,
-                self._registry_row_query().exists(),
+            # The seed is a result: it must pass every filter itself.
+            seed_rows_by_uuid = await self._seed_rows(
+                session, seed_segment_uuids, conditions
             )
-            if property_filter is not None:
-                seed_segments_query = seed_segments_query.where(
-                    compile_sql_filter(
-                        property_filter,
-                        SQLAlchemySegmentStorePartition._resolve_segment_field,
-                    )
-                )
-            seed_segment_rows = (
-                (await session.execute(seed_segments_query)).scalars().all()
-            )
-
-            seed_segment_rows_by_uuid: dict[UUID, SegmentRow] = {
-                row.uuid: row for row in seed_segment_rows
-            }
-            if not seed_segment_rows_by_uuid:
+            if not seed_rows_by_uuid:
                 await self._ensure_partition_live(session)
                 return {}
 
-            # Short-circuit: no context needed.
-            if max_backward_segments <= 0 and max_forward_segments <= 0:
-                return {
-                    seed_segment_uuid: [
-                        self._segment_from_segment_row(
-                            seed_segment_row,
-                        )
-                    ]
-                    for seed_segment_uuid, seed_segment_row in seed_segment_rows_by_uuid.items()
-                }
-
-            # Get backward/forward context rows.
-            if not self._is_sqlite:
-                context_rows_by_seed = await self._get_context_rows_lateral(
-                    session,
-                    seed_segment_rows_by_uuid,
-                    max_backward_segments,
-                    max_forward_segments,
-                    property_filter,
-                )
-            else:
-                context_rows_by_seed = await self._get_context_rows_loop(
-                    session,
-                    seed_segment_rows_by_uuid,
-                    max_backward_segments,
-                    max_forward_segments,
-                    property_filter,
-                )
-
-            # Each statement above took its own snapshot (READ COMMITTED):
-            # a deletion committing between the seeds statement and the
-            # context statements would leave the seeds with silently
-            # empty context. One registry read after the last statement
-            # turns that window into the contractual stale-handle error.
-            await self._ensure_partition_live(session)
+            context_rows_by_seed = await self._context_rows(
+                session, seed_rows_by_uuid, before, after, conditions
+            )
 
             # Assemble results: [backward (reversed) + seed + forward].
             segments_by_seed: dict[UUID, list[Segment]] = {}
-            for seed_uuid, seed_row in seed_segment_rows_by_uuid.items():
-                backward_rows, forward_rows = context_rows_by_seed.get(
-                    seed_uuid, ([], [])
-                )
+            for seed_uuid, seed_row in seed_rows_by_uuid.items():
+                backward_rows, forward_rows = context_rows_by_seed[seed_uuid]
                 segments_by_seed[seed_uuid] = [
                     self._segment_from_segment_row(row)
                     for row in [*reversed(backward_rows), seed_row, *forward_rows]
@@ -486,103 +471,171 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
 
             return segments_by_seed
 
+    @override
+    async def get_neighbourhoods(
+        self,
+        seed_segment_uuids: Iterable[UUID],
+        *,
+        before: int = 0,
+        after: int = 0,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        source_ids: Iterable[str] | None = None,
+        block_kinds: Iterable[str] | None = None,
+        property_filter: FilterExpr | None = None,
+    ) -> dict[UUID, Neighborhood]:
+        seed_segment_uuids = set(seed_segment_uuids)
+        if not seed_segment_uuids:
+            return {}
+        conditions = SQLAlchemySegmentStorePartition._row_conditions(
+            since, until, source_ids, block_kinds, property_filter
+        )
+
+        async with (
+            self._tracker("get_neighbourhoods"),
+            self._create_session() as session,
+        ):
+            # The seed is an address, never part of the answer, so no
+            # filter has anything to say about it.
+            seed_rows_by_uuid = await self._seed_rows(session, seed_segment_uuids, [])
+            if not seed_rows_by_uuid:
+                await self._ensure_partition_live(session)
+                return {}
+
+            context_rows_by_seed = await self._context_rows(
+                session, seed_rows_by_uuid, before, after, conditions
+            )
+
+            neighborhoods: dict[UUID, Neighborhood] = {}
+            for seed_uuid in seed_rows_by_uuid:
+                backward_rows, forward_rows = context_rows_by_seed[seed_uuid]
+                neighborhoods[seed_uuid] = Neighborhood(
+                    before=[
+                        self._segment_from_segment_row(row)
+                        for row in reversed(backward_rows)
+                    ],
+                    after=[self._segment_from_segment_row(row) for row in forward_rows],
+                )
+            return neighborhoods
+
+    async def _seed_rows(
+        self,
+        session: AsyncSession,
+        seed_segment_uuids: set[UUID],
+        conditions: Sequence[ColumnElement[bool]],
+    ) -> dict[UUID, SegmentRow]:
+        """The seed rows of this partition that satisfy `conditions`."""
+        query = select(SegmentRow).where(
+            SegmentRow.uuid.in_(seed_segment_uuids),
+            SegmentRow.incarnation == self._incarnation,
+            self._registry_row_query().exists(),
+            *conditions,
+        )
+        rows = (await session.execute(query)).scalars().all()
+        return {row.uuid: row for row in rows}
+
+    async def _context_rows(
+        self,
+        session: AsyncSession,
+        seed_rows_by_uuid: Mapping[UUID, SegmentRow],
+        before: int,
+        after: int,
+        conditions: Sequence[ColumnElement[bool]],
+    ) -> dict[UUID, tuple[list[SegmentRow], list[SegmentRow]]]:
+        """The rows before and after each seed in the store's order.
+
+        Confined to the seed's session and filtered by `conditions`;
+        strictly before and strictly after, so the seed is in neither list.
+        """
+        if before <= 0 and after <= 0:
+            return {seed_uuid: ([], []) for seed_uuid in seed_rows_by_uuid}
+
+        if not self._is_sqlite:
+            context_rows_by_seed = await self._get_context_rows_lateral(
+                session, seed_rows_by_uuid, before, after, conditions
+            )
+        else:
+            context_rows_by_seed = await self._get_context_rows_loop(
+                session, seed_rows_by_uuid, before, after, conditions
+            )
+
+        # Each statement above took its own snapshot (READ COMMITTED):
+        # a deletion committing between the seeds statement and the
+        # context statements would leave the seeds with silently
+        # empty context. One registry read after the last statement
+        # turns that window into the contractual stale-handle error.
+        await self._ensure_partition_live(session)
+        return context_rows_by_seed
+
+    @staticmethod
+    def _row_conditions(
+        since: datetime | None,
+        until: datetime | None,
+        source_ids: Iterable[str] | None,
+        block_kinds: Iterable[str] | None,
+        property_filter: FilterExpr | None,
+    ) -> list[ColumnElement[bool]]:
+        """The row predicates of a read, on the typed system fields and the properties.
+
+        Timestamp bounds are put in UTC before they are bound: the column
+        holds the UTC instant, and SQLite compares the wall clock it is
+        given, so a bound in another zone would be compared on its digits.
+        An empty id or kind list admits nothing.
+        """
+        conditions: list[ColumnElement[bool]] = []
+        if since is not None:
+            conditions.append(
+                SegmentRow.timestamp >= ensure_tz_aware(since).astimezone(UTC)
+            )
+        if until is not None:
+            conditions.append(
+                SegmentRow.timestamp < ensure_tz_aware(until).astimezone(UTC)
+            )
+        if source_ids is not None:
+            conditions.append(_in_values(SegmentRow.source_id, source_ids))
+        if block_kinds is not None:
+            conditions.append(_in_values(SegmentRow.block_kind, block_kinds))
+        if property_filter is not None:
+            conditions.append(
+                compile_sql_filter(
+                    property_filter,
+                    SQLAlchemySegmentStorePartition._resolve_segment_field,
+                )
+            )
+        return conditions
+
+    @staticmethod
+    def _session_condition(session_id: str | None) -> ColumnElement[bool]:
+        """Rows of one session: a null session id matches null and nothing else.
+
+        Spelled as `=` or `IS NULL` on a value known before the statement
+        is built, rather than `IS NOT DISTINCT FROM`, which PostgreSQL
+        cannot serve from the ordering index.
+        """
+        if session_id is None:
+            return SegmentRow.session_id.is_(None)
+        return SegmentRow.session_id == session_id
+
     async def _get_context_rows_lateral(
         self,
         session: AsyncSession,
         seed_rows_by_uuid: Mapping[UUID, SegmentRow],
-        max_backward_segments: int,
-        max_forward_segments: int,
-        property_filter: FilterExpr | None,
+        before: int,
+        after: int,
+        conditions: Sequence[ColumnElement[bool]],
     ) -> dict[UUID, tuple[list[SegmentRow], list[SegmentRow]]]:
-        """Get backward/forward context using LATERAL joins (non-SQLite)."""
-        seeds_subquery = (
-            select(
-                SegmentRow.uuid.label("seed_uuid"),
-                SegmentRow.timestamp.label("seed_timestamp"),
-                SegmentRow.event_uuid.label("seed_event_uuid"),
-                SegmentRow.index.label("seed_index"),
-                SegmentRow.offset.label("seed_offset"),
-            )
-            .where(
-                SegmentRow.incarnation == self._incarnation,
-                SegmentRow.uuid.in_(seed_rows_by_uuid.keys()),
-                self._registry_row_query().exists(),
-            )
-            .subquery("seeds")
-        )
+        """Get backward/forward context using LATERAL joins (non-SQLite).
 
-        segment_ordering_columns = tuple_(
-            SegmentRow.timestamp,
-            SegmentRow.event_uuid,
-            SegmentRow.index,
-            SegmentRow.offset,
-        )
-        seed_ordering_columns = tuple_(
-            seeds_subquery.c.seed_timestamp,
-            seeds_subquery.c.seed_event_uuid,
-            seeds_subquery.c.seed_index,
-            seeds_subquery.c.seed_offset,
-        )
+        One pair of statements per distinct seed session, so the session
+        predicate is a literal the ordering index serves.
+        """
+        rows_by_seed: dict[UUID, tuple[list[SegmentRow], list[SegmentRow]]] = {
+            seed_uuid: ([], []) for seed_uuid in seed_rows_by_uuid
+        }
 
-        incarnation = self._incarnation
-
-        async def get_context_rows_directional(
-            range_condition: ColumnElement[bool],
-            ordering: Iterable[ColumnElement | InstrumentedAttribute],
-            limit: int,
-        ) -> dict[UUID, list[SegmentRow]]:
-            """Get context rows per seed in the specified direction."""
-            # Build a LATERAL subquery that gets context rows for each seed.
-            context_rows_query = (
-                select(SegmentRow)
-                .where(SegmentRow.incarnation == incarnation, range_condition)
-                .order_by(*ordering)
-                .limit(limit)
-                .correlate(seeds_subquery)
-            )
-            if property_filter is not None:
-                context_rows_query = context_rows_query.where(
-                    compile_sql_filter(
-                        property_filter,
-                        SQLAlchemySegmentStorePartition._resolve_segment_field,
-                    )
-                )
-            lateral_subquery = context_rows_query.subquery().lateral("context")
-
-            # Join each seed to its context rows via the LATERAL subquery.
-            seed_context_join_query = select(
-                seeds_subquery.c.seed_uuid,
-                lateral_subquery.c.uuid,
-                lateral_subquery.c.event_uuid,
-                lateral_subquery.c.index,
-                lateral_subquery.c.offset,
-                lateral_subquery.c.timestamp,
-                lateral_subquery.c.timestamp_timezone_offset,
-                lateral_subquery.c.context,
-                lateral_subquery.c.block,
-                lateral_subquery.c.properties,
-            ).select_from(seeds_subquery.join(lateral_subquery, true()))
-
-            # Group result rows by seed UUID.
-            rows_by_seed: dict[UUID, list[SegmentRow]] = {
-                seed_uuid: [] for seed_uuid in seed_rows_by_uuid
-            }
-            for row in (await session.execute(seed_context_join_query)).all():
-                rows_by_seed[row.seed_uuid].append(
-                    SegmentRow(
-                        uuid=row.uuid,
-                        incarnation=incarnation,
-                        event_uuid=row.event_uuid,
-                        index=row.index,
-                        offset=row.offset,
-                        timestamp=row.timestamp,
-                        timestamp_timezone_offset=row.timestamp_timezone_offset,
-                        context=row.context,
-                        block=row.block,
-                        properties=row.properties,
-                    )
-                )
-            return rows_by_seed
+        seeds_by_session: defaultdict[str | None, list[UUID]] = defaultdict(list)
+        for seed_uuid, seed_row in seed_rows_by_uuid.items():
+            seeds_by_session[seed_row.session_id].append(seed_uuid)
 
         chronological_order = [
             SegmentRow.timestamp,
@@ -592,41 +645,139 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
         ]
         reverse_chronological_order = [col.desc() for col in chronological_order]
 
-        backward_rows_by_seed = (
-            await get_context_rows_directional(
-                segment_ordering_columns < seed_ordering_columns,
-                reverse_chronological_order,
-                max_backward_segments,
+        for session_id, seed_uuids in seeds_by_session.items():
+            seeds_subquery = (
+                select(
+                    SegmentRow.uuid.label("seed_uuid"),
+                    SegmentRow.timestamp.label("seed_timestamp"),
+                    SegmentRow.event_uuid.label("seed_event_uuid"),
+                    SegmentRow.index.label("seed_index"),
+                    SegmentRow.offset.label("seed_offset"),
+                )
+                .where(
+                    SegmentRow.incarnation == self._incarnation,
+                    SegmentRow.uuid.in_(seed_uuids),
+                    self._registry_row_query().exists(),
+                )
+                .subquery("seeds")
             )
-            if max_backward_segments > 0
-            else {seed_uuid: [] for seed_uuid in seed_rows_by_uuid}
-        )
+            segment_ordering_columns = tuple_(
+                SegmentRow.timestamp,
+                SegmentRow.event_uuid,
+                SegmentRow.index,
+                SegmentRow.offset,
+            )
+            seed_ordering_columns = tuple_(
+                seeds_subquery.c.seed_timestamp,
+                seeds_subquery.c.seed_event_uuid,
+                seeds_subquery.c.seed_index,
+                seeds_subquery.c.seed_offset,
+            )
+            row_conditions = [
+                SQLAlchemySegmentStorePartition._session_condition(session_id),
+                *conditions,
+            ]
 
-        forward_rows_by_seed = (
-            await get_context_rows_directional(
-                segment_ordering_columns > seed_ordering_columns,
-                chronological_order,
-                max_forward_segments,
-            )
-            if max_forward_segments > 0
-            else {seed_uuid: [] for seed_uuid in seed_rows_by_uuid}
-        )
+            if before > 0:
+                backward_rows_by_seed = await self._lateral_context_rows(
+                    session,
+                    seeds_subquery,
+                    seed_uuids,
+                    [
+                        segment_ordering_columns < seed_ordering_columns,
+                        *row_conditions,
+                    ],
+                    reverse_chronological_order,
+                    before,
+                )
+                for seed_uuid, backward_rows in backward_rows_by_seed.items():
+                    rows_by_seed[seed_uuid][0].extend(backward_rows)
 
-        return {
-            seed_uuid: (
-                backward_rows_by_seed[seed_uuid],
-                forward_rows_by_seed[seed_uuid],
-            )
-            for seed_uuid in seed_rows_by_uuid
+            if after > 0:
+                forward_rows_by_seed = await self._lateral_context_rows(
+                    session,
+                    seeds_subquery,
+                    seed_uuids,
+                    [
+                        segment_ordering_columns > seed_ordering_columns,
+                        *row_conditions,
+                    ],
+                    chronological_order,
+                    after,
+                )
+                for seed_uuid, forward_rows in forward_rows_by_seed.items():
+                    rows_by_seed[seed_uuid][1].extend(forward_rows)
+
+        return rows_by_seed
+
+    async def _lateral_context_rows(
+        self,
+        session: AsyncSession,
+        seeds_subquery: Subquery,
+        seed_uuids: Iterable[UUID],
+        conditions: Sequence[ColumnElement[bool]],
+        ordering: Iterable[ColumnElement | InstrumentedAttribute],
+        limit: int,
+    ) -> dict[UUID, list[SegmentRow]]:
+        """Get context rows per seed in one direction."""
+        # Build a LATERAL subquery that gets context rows for each seed.
+        context_rows_query = (
+            select(SegmentRow)
+            .where(SegmentRow.incarnation == self._incarnation, *conditions)
+            .order_by(*ordering)
+            .limit(limit)
+            .correlate(seeds_subquery)
+        )
+        lateral_subquery = context_rows_query.subquery().lateral("context")
+
+        # Join each seed to its context rows via the LATERAL subquery.
+        seed_context_join_query = select(
+            seeds_subquery.c.seed_uuid,
+            lateral_subquery.c.uuid,
+            lateral_subquery.c.event_uuid,
+            lateral_subquery.c.index,
+            lateral_subquery.c.offset,
+            lateral_subquery.c.timestamp,
+            lateral_subquery.c.timestamp_timezone_offset,
+            lateral_subquery.c.session_id,
+            lateral_subquery.c.source_id,
+            lateral_subquery.c.context,
+            lateral_subquery.c.block_kind,
+            lateral_subquery.c.block,
+            lateral_subquery.c.properties,
+        ).select_from(seeds_subquery.join(lateral_subquery, true()))
+
+        # Group result rows by seed UUID.
+        rows_by_seed: dict[UUID, list[SegmentRow]] = {
+            seed_uuid: [] for seed_uuid in seed_uuids
         }
+        for row in (await session.execute(seed_context_join_query)).all():
+            rows_by_seed[row.seed_uuid].append(
+                SegmentRow(
+                    uuid=row.uuid,
+                    incarnation=self._incarnation,
+                    event_uuid=row.event_uuid,
+                    index=row.index,
+                    offset=row.offset,
+                    timestamp=row.timestamp,
+                    timestamp_timezone_offset=row.timestamp_timezone_offset,
+                    session_id=row.session_id,
+                    source_id=row.source_id,
+                    context=row.context,
+                    block_kind=row.block_kind,
+                    block=row.block,
+                    properties=row.properties,
+                )
+            )
+        return rows_by_seed
 
     async def _get_context_rows_loop(
         self,
         session: AsyncSession,
         seed_rows_by_uuid: Mapping[UUID, SegmentRow],
-        max_backward_segments: int,
-        max_forward_segments: int,
-        property_filter: FilterExpr | None,
+        before: int,
+        after: int,
+        conditions: Sequence[ColumnElement[bool]],
     ) -> dict[UUID, tuple[list[SegmentRow], list[SegmentRow]]]:
         """Get backward/forward context per seed (SQLite fallback)."""
         context_rows_by_seed: dict[UUID, tuple[list[SegmentRow], list[SegmentRow]]] = {}
@@ -638,15 +789,6 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
             SegmentRow.offset,
         )
 
-        compiled_property_filter = (
-            compile_sql_filter(
-                property_filter,
-                SQLAlchemySegmentStorePartition._resolve_segment_field,
-            )
-            if property_filter is not None
-            else None
-        )
-
         for seed_uuid, seed_row in seed_rows_by_uuid.items():
             seed_ordering_values = tuple_(
                 literal(seed_row.timestamp),
@@ -654,15 +796,20 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
                 literal(seed_row.index),
                 literal(seed_row.offset),
             )
+            session_condition = SQLAlchemySegmentStorePartition._session_condition(
+                seed_row.session_id
+            )
 
             backward_rows: list[SegmentRow] = []
-            if max_backward_segments > 0:
+            if before > 0:
                 backward_rows_query = (
                     select(SegmentRow)
                     .where(
                         SegmentRow.incarnation == self._incarnation,
+                        session_condition,
                         segment_ordering_columns < seed_ordering_values,
                         self._registry_row_query().exists(),
+                        *conditions,
                     )
                     .order_by(
                         SegmentRow.timestamp.desc(),
@@ -670,24 +817,22 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
                         SegmentRow.index.desc(),
                         SegmentRow.offset.desc(),
                     )
-                    .limit(max_backward_segments)
+                    .limit(before)
                 )
-                if compiled_property_filter is not None:
-                    backward_rows_query = backward_rows_query.where(
-                        compiled_property_filter
-                    )
                 backward_rows = list(
                     (await session.execute(backward_rows_query)).scalars().all()
                 )
 
             forward_rows: list[SegmentRow] = []
-            if max_forward_segments > 0:
+            if after > 0:
                 forward_rows_query = (
                     select(SegmentRow)
                     .where(
                         SegmentRow.incarnation == self._incarnation,
+                        session_condition,
                         segment_ordering_columns > seed_ordering_values,
                         self._registry_row_query().exists(),
+                        *conditions,
                     )
                     .order_by(
                         SegmentRow.timestamp,
@@ -695,12 +840,8 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
                         SegmentRow.index,
                         SegmentRow.offset,
                     )
-                    .limit(max_forward_segments)
+                    .limit(after)
                 )
-                if compiled_property_filter is not None:
-                    forward_rows_query = forward_rows_query.where(
-                        compiled_property_filter
-                    )
                 forward_rows = list(
                     (await session.execute(forward_rows_query)).scalars().all()
                 )
@@ -722,10 +863,14 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
             self._tracker("get_segment_uuids_by_event_uuids"),
             self._create_session() as session,
         ):
-            query = select(SegmentRow.event_uuid, SegmentRow.uuid).where(
-                SegmentRow.incarnation == self._incarnation,
-                SegmentRow.event_uuid.in_(event_uuids),
-                self._registry_row_query().exists(),
+            query = (
+                select(SegmentRow.event_uuid, SegmentRow.uuid)
+                .where(
+                    SegmentRow.incarnation == self._incarnation,
+                    SegmentRow.event_uuid.in_(event_uuids),
+                    self._registry_row_query().exists(),
+                )
+                .order_by(SegmentRow.event_uuid, SegmentRow.index, SegmentRow.offset)
             )
             rows = (await session.execute(query)).all()
             if not rows:
@@ -832,6 +977,40 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
                 )
             )
 
+    @override
+    async def delete_derivatives(
+        self,
+        derivative_uuids: Iterable[UUID],
+    ) -> None:
+        derivative_uuids = set(derivative_uuids)
+        if not derivative_uuids:
+            return
+
+        async with (
+            self._tracker("delete_derivatives"),
+            self._create_session() as session,
+            session.begin(),
+        ):
+            await self._lock_partition_for_write(session)
+            if not self._is_sqlite:
+                # Same deterministic lock order as delete_segments.
+                await session.execute(
+                    select(DerivativeLinkRow.uuid)
+                    .where(
+                        DerivativeLinkRow.incarnation == self._incarnation,
+                        DerivativeLinkRow.uuid.in_(derivative_uuids),
+                    )
+                    .order_by(DerivativeLinkRow.uuid)
+                    .with_for_update()
+                )
+
+            await session.execute(
+                delete(DerivativeLinkRow).where(
+                    DerivativeLinkRow.incarnation == self._incarnation,
+                    DerivativeLinkRow.uuid.in_(derivative_uuids),
+                )
+            )
+
     # Helpers
 
     @staticmethod
@@ -850,8 +1029,6 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
     def _segment_from_segment_row(self, row: SegmentRow) -> Segment:
         """Convert a SegmentRow into a Segment."""
         context = decode_context(json.loads(self._payload_codec.decode(row.context)))
-        if context is None:
-            context = NullContext()
         block = decode_block(json.loads(self._payload_codec.decode(row.block)))
         properties = decode_properties(row.properties)
         original_timezone = timezone(timedelta(seconds=row.timestamp_timezone_offset))
@@ -862,10 +1039,23 @@ class SQLAlchemySegmentStorePartition(SegmentStorePartition):
             index=row.index,
             offset=row.offset,
             timestamp=timestamp,
+            session_id=row.session_id,
+            source_id=row.source_id,
             context=context,
             block=block,
             properties=properties,
         )
+
+
+def _in_values(
+    column: InstrumentedAttribute[str] | InstrumentedAttribute[str | None],
+    values: Iterable[str],
+) -> ColumnElement[bool]:
+    """`column IN values`; an empty list admits nothing."""
+    values = list(values)
+    if not values:
+        return false()
+    return column.in_(values)
 
 
 class SQLAlchemySegmentStoreParams(BaseModel):

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segment_store/sqlalchemy_segment_store.py
@@ -54,8 +54,8 @@ from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.sql.selectable import Subquery
 
+from memmachine_server.common.filter import FilterExpr
 from memmachine_server.common.filter.filter_parser import (
-    FilterExpr,
     demangle_user_metadata_key,
     normalize_filter_field,
 )

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segmenter/passthrough_segmenter.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segmenter/passthrough_segmenter.py
@@ -30,6 +30,8 @@ class PassthroughSegmenter(Segmenter):
                 index=index,
                 offset=0,
                 timestamp=event.timestamp,
+                session_id=event.session_id,
+                source_id=event.source_id,
                 block=block,
                 context=event.context,
                 properties=event.properties,

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/segmenter/text_segmenter.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/segmenter/text_segmenter.py
@@ -85,6 +85,8 @@ class TextSegmenter(Segmenter):
                             index=index,
                             offset=offset,
                             timestamp=event.timestamp,
+                            session_id=event.session_id,
+                            source_id=event.source_id,
                             block=TextBlock(text=chunk),
                             context=event.context,
                             properties=event.properties,
@@ -92,7 +94,5 @@ class TextSegmenter(Segmenter):
                         for offset, chunk in enumerate(chunks)
                     )
                 case _:
-                    raise NotImplementedError(
-                        f"Unsupported block type: {type(block).__name__}"
-                    )
+                    raise NotImplementedError(f"Unsupported block kind: {block.kind!r}")
         return segments

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/system_filters.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/system_filters.py
@@ -1,0 +1,201 @@
+"""
+System fields of EventMemory as filters.
+
+EventMemory writes its system fields into every vector record under reserved
+property keys, and a search bounds them with typed parameters (`since`,
+`until`, `session_ids`, `source_ids`, `block_kinds`) beside the caller's
+property filter. This module owns the translation between the two forms:
+`system_predicates` builds the tree a vector store gets from the typed values,
+and `split_system` recovers the typed values from a tree that names the
+reserved keys. Nothing else in EventMemory knows the keys' spelling.
+"""
+
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Final
+
+from pydantic import BaseModel
+
+from memmachine_server.common.filter.filter_parser import (
+    And,
+    Comparison,
+    FilterExpr,
+    In,
+    IsNull,
+    Not,
+    Or,
+)
+from memmachine_server.common.property_keys import (
+    is_reserved_property_key,
+    reserved_property_key,
+)
+
+# Built rather than written out so the alphabet and length budget of the
+# vector store's naming contract are checked at import time.
+EVENT_TIMESTAMP_KEY: Final[str] = reserved_property_key("event", "timestamp")
+EVENT_SESSION_KEY: Final[str] = reserved_property_key("event", "session")
+EVENT_SOURCE_KEY: Final[str] = reserved_property_key("event", "source")
+BLOCK_KIND_KEY: Final[str] = reserved_property_key("block", "kind")
+
+
+class SystemFilters(BaseModel):
+    """The typed system filters of a search or an expansion."""
+
+    since: datetime | None = None
+    """Inclusive lower bound on the event timestamp."""
+    until: datetime | None = None
+    """Exclusive upper bound on the event timestamp."""
+    session_ids: list[str] | None = None
+    source_ids: list[str] | None = None
+    block_kinds: list[str] | None = None
+
+
+def conjoin(clauses: Iterable[FilterExpr | None]) -> FilterExpr | None:
+    """The conjunction of the given clauses; None when there are none."""
+    combined: FilterExpr | None = None
+    for clause in clauses:
+        if clause is None:
+            continue
+        combined = clause if combined is None else And(left=combined, right=clause)
+    return combined
+
+
+def system_predicates(
+    *,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    session_ids: Iterable[str] | None = None,
+    source_ids: Iterable[str] | None = None,
+    block_kinds: Iterable[str] | None = None,
+) -> FilterExpr | None:
+    """The predicates on reserved keys that a vector store evaluates.
+
+    `since` is inclusive and `until` exclusive, so ranges meet without
+    overlap. An empty id or kind list admits nothing; None admits everything.
+    """
+    clauses: list[FilterExpr | None] = [
+        Comparison(field=EVENT_TIMESTAMP_KEY, op=">=", value=since)
+        if since is not None
+        else None,
+        Comparison(field=EVENT_TIMESTAMP_KEY, op="<", value=until)
+        if until is not None
+        else None,
+        In(field=EVENT_SESSION_KEY, values=list(session_ids))
+        if session_ids is not None
+        else None,
+        In(field=EVENT_SOURCE_KEY, values=list(source_ids))
+        if source_ids is not None
+        else None,
+        In(field=BLOCK_KIND_KEY, values=list(block_kinds))
+        if block_kinds is not None
+        else None,
+    ]
+    return conjoin(clauses)
+
+
+def split_system(expr: FilterExpr | None) -> tuple[SystemFilters, FilterExpr | None]:
+    """Pull the conjuncts naming reserved keys out of a tree into typed values.
+
+    The inverse of `system_predicates`, for an API boundary that lets a
+    caller write a system field inside a filter: the returned tree names no
+    reserved key and is what the caller's `property_filter` becomes. A
+    reserved key is accepted only as a top-level conjunct in the shape
+    `system_predicates` builds (a `>=` or `<` on the timestamp, an `=` or an
+    `In` on the session, source or block kind); repeated conjuncts on one
+    field intersect. Anywhere else, or on any other reserved key, it raises
+    ValueError, since no typed value could carry it.
+    """
+    filters = SystemFilters()
+    rest: list[FilterExpr] = []
+    for conjunct in _conjuncts(expr):
+        if not _names_reserved_key(conjunct):
+            rest.append(conjunct)
+            continue
+        _absorb(filters, conjunct)
+    return filters, conjoin(rest)
+
+
+def _conjuncts(expr: FilterExpr | None) -> list[FilterExpr]:
+    if expr is None:
+        return []
+    if isinstance(expr, And):
+        return [*_conjuncts(expr.left), *_conjuncts(expr.right)]
+    return [expr]
+
+
+def _names_reserved_key(expr: FilterExpr) -> bool:
+    if isinstance(expr, Comparison | In | IsNull):
+        return is_reserved_property_key(expr.field)
+    if isinstance(expr, And | Or):
+        return _names_reserved_key(expr.left) or _names_reserved_key(expr.right)
+    if isinstance(expr, Not):
+        return _names_reserved_key(expr.expr)
+    raise TypeError(f"Unsupported filter expression type: {type(expr)!r}")
+
+
+def _absorb(filters: SystemFilters, conjunct: FilterExpr) -> None:
+    if isinstance(conjunct, Comparison) and conjunct.field == EVENT_TIMESTAMP_KEY:
+        _absorb_timestamp(filters, conjunct)
+    elif isinstance(conjunct, Comparison | In):
+        _absorb_ids(filters, conjunct)
+    else:
+        raise ValueError(
+            f"A reserved key is accepted only as a top-level = or In conjunct "
+            f"over strings, or >= and < on {EVENT_TIMESTAMP_KEY}; got {conjunct!r}"
+        )
+
+
+def _absorb_timestamp(filters: SystemFilters, conjunct: Comparison) -> None:
+    if not isinstance(conjunct.value, datetime):
+        raise TypeError(f"{EVENT_TIMESTAMP_KEY} compares with a datetime")
+    if conjunct.op == ">=":
+        filters.since = _later(filters.since, conjunct.value)
+    elif conjunct.op == "<":
+        filters.until = _earlier(filters.until, conjunct.value)
+    else:
+        raise ValueError(
+            f"{EVENT_TIMESTAMP_KEY} takes only >= (since) and < (until), "
+            f"got {conjunct.op!r}"
+        )
+
+
+def _absorb_ids(filters: SystemFilters, conjunct: Comparison | In) -> None:
+    ids = _string_ids(conjunct)
+    if ids is None:
+        raise ValueError(
+            f"A reserved key is accepted only as a top-level = or In conjunct "
+            f"over strings, or >= and < on {EVENT_TIMESTAMP_KEY}; got {conjunct!r}"
+        )
+    if conjunct.field == EVENT_SESSION_KEY:
+        filters.session_ids = _intersect(filters.session_ids, ids)
+    elif conjunct.field == EVENT_SOURCE_KEY:
+        filters.source_ids = _intersect(filters.source_ids, ids)
+    elif conjunct.field == BLOCK_KIND_KEY:
+        filters.block_kinds = _intersect(filters.block_kinds, ids)
+    else:
+        raise ValueError(f"{conjunct.field!r} is not a filterable system field")
+
+
+def _string_ids(conjunct: Comparison | In) -> list[str] | None:
+    """The string values an `=` or `In` leaf names; None for any other leaf."""
+    if isinstance(conjunct, Comparison):
+        if conjunct.op == "=" and isinstance(conjunct.value, str):
+            return [conjunct.value]
+        return None
+    if all(isinstance(value, str) for value in conjunct.values):
+        return [str(value) for value in conjunct.values]
+    return None
+
+
+def _later(current: datetime | None, bound: datetime) -> datetime:
+    return bound if current is None else max(current, bound)
+
+
+def _earlier(current: datetime | None, bound: datetime) -> datetime:
+    return bound if current is None else min(current, bound)
+
+
+def _intersect(current: list[str] | None, ids: list[str]) -> list[str]:
+    if current is None:
+        return ids
+    return [value for value in current if value in ids]

--- a/packages/server/src/memmachine_server/episodic_memory/event_memory/system_filters.py
+++ b/packages/server/src/memmachine_server/episodic_memory/event_memory/system_filters.py
@@ -16,14 +16,14 @@ from typing import Final
 
 from pydantic import BaseModel
 
-from memmachine_server.common.filter.filter_parser import (
-    And,
-    Comparison,
+from memmachine_server.common.filter import (
+    Equals,
     FilterExpr,
     In,
-    IsNull,
-    Not,
-    Or,
+    Ordering,
+    conjoin,
+    conjuncts,
+    filter_fields,
 )
 from memmachine_server.common.property_keys import (
     is_reserved_property_key,
@@ -50,16 +50,6 @@ class SystemFilters(BaseModel):
     block_kinds: list[str] | None = None
 
 
-def conjoin(clauses: Iterable[FilterExpr | None]) -> FilterExpr | None:
-    """The conjunction of the given clauses; None when there are none."""
-    combined: FilterExpr | None = None
-    for clause in clauses:
-        if clause is None:
-            continue
-        combined = clause if combined is None else And(left=combined, right=clause)
-    return combined
-
-
 def system_predicates(
     *,
     since: datetime | None = None,
@@ -71,26 +61,27 @@ def system_predicates(
     """The predicates on reserved keys that a vector store evaluates.
 
     `since` is inclusive and `until` exclusive, so ranges meet without
-    overlap. An empty id or kind list admits nothing; None admits everything.
+    overlap. None admits everything. An empty id or kind list admits
+    nothing, which is not a predicate: the caller answers that without a
+    query, and passing one here raises ValueError.
     """
     clauses: list[FilterExpr | None] = [
-        Comparison(field=EVENT_TIMESTAMP_KEY, op=">=", value=since)
-        if since is not None
-        else None,
-        Comparison(field=EVENT_TIMESTAMP_KEY, op="<", value=until)
-        if until is not None
-        else None,
-        In(field=EVENT_SESSION_KEY, values=list(session_ids))
-        if session_ids is not None
-        else None,
-        In(field=EVENT_SOURCE_KEY, values=list(source_ids))
-        if source_ids is not None
-        else None,
-        In(field=BLOCK_KIND_KEY, values=list(block_kinds))
-        if block_kinds is not None
-        else None,
+        Ordering(EVENT_TIMESTAMP_KEY, ">=", since) if since is not None else None,
+        Ordering(EVENT_TIMESTAMP_KEY, "<", until) if until is not None else None,
+        _in_ids(EVENT_SESSION_KEY, session_ids),
+        _in_ids(EVENT_SOURCE_KEY, source_ids),
+        _in_ids(BLOCK_KIND_KEY, block_kinds),
     ]
     return conjoin(clauses)
+
+
+def _in_ids(key: str, ids: Iterable[str] | None) -> In | None:
+    if ids is None:
+        return None
+    values = tuple(ids)
+    if not values:
+        raise ValueError(f"An empty {key} list admits nothing and is not a predicate")
+    return In(key, values)
 
 
 def split_system(expr: FilterExpr | None) -> tuple[SystemFilters, FilterExpr | None]:
@@ -100,91 +91,56 @@ def split_system(expr: FilterExpr | None) -> tuple[SystemFilters, FilterExpr | N
     caller write a system field inside a filter: the returned tree names no
     reserved key and is what the caller's `property_filter` becomes. A
     reserved key is accepted only as a top-level conjunct in the shape
-    `system_predicates` builds (a `>=` or `<` on the timestamp, an `=` or an
-    `In` on the session, source or block kind); repeated conjuncts on one
-    field intersect. Anywhere else, or on any other reserved key, it raises
-    ValueError, since no typed value could carry it.
+    `system_predicates` builds (a `>=` or `<` on the timestamp, an `Equals`
+    or an `In` on the session, source or block kind); repeated conjuncts on
+    one field intersect. Anywhere else, or on any other reserved key, it
+    raises ValueError, since no typed value could carry it.
     """
     filters = SystemFilters()
     rest: list[FilterExpr] = []
-    for conjunct in _conjuncts(expr):
-        if not _names_reserved_key(conjunct):
+    for conjunct in conjuncts(expr):
+        if not any(is_reserved_property_key(f) for f in filter_fields(conjunct)):
             rest.append(conjunct)
             continue
         _absorb(filters, conjunct)
     return filters, conjoin(rest)
 
 
-def _conjuncts(expr: FilterExpr | None) -> list[FilterExpr]:
-    if expr is None:
-        return []
-    if isinstance(expr, And):
-        return [*_conjuncts(expr.left), *_conjuncts(expr.right)]
-    return [expr]
-
-
-def _names_reserved_key(expr: FilterExpr) -> bool:
-    if isinstance(expr, Comparison | In | IsNull):
-        return is_reserved_property_key(expr.field)
-    if isinstance(expr, And | Or):
-        return _names_reserved_key(expr.left) or _names_reserved_key(expr.right)
-    if isinstance(expr, Not):
-        return _names_reserved_key(expr.expr)
-    raise TypeError(f"Unsupported filter expression type: {type(expr)!r}")
-
-
 def _absorb(filters: SystemFilters, conjunct: FilterExpr) -> None:
-    if isinstance(conjunct, Comparison) and conjunct.field == EVENT_TIMESTAMP_KEY:
-        _absorb_timestamp(filters, conjunct)
-    elif isinstance(conjunct, Comparison | In):
-        _absorb_ids(filters, conjunct)
-    else:
-        raise ValueError(
-            f"A reserved key is accepted only as a top-level = or In conjunct "
-            f"over strings, or >= and < on {EVENT_TIMESTAMP_KEY}; got {conjunct!r}"
-        )
+    match conjunct:
+        case Ordering(field, op, value) if field == EVENT_TIMESTAMP_KEY:
+            if not isinstance(value, datetime):
+                raise TypeError(f"{EVENT_TIMESTAMP_KEY} compares with a datetime")
+            if op == ">=":
+                filters.since = _later(filters.since, value)
+            elif op == "<":
+                filters.until = _earlier(filters.until, value)
+            else:
+                raise ValueError(
+                    f"{EVENT_TIMESTAMP_KEY} takes only >= (since) and < (until), "
+                    f"got {op!r}"
+                )
+        case Equals(field, value) if isinstance(value, str):
+            _absorb_ids(filters, field, [value])
+        case In(field, values) if all(isinstance(value, str) for value in values):
+            _absorb_ids(filters, field, [str(value) for value in values])
+        case _:
+            raise ValueError(
+                f"A reserved key is accepted only as a top-level Equals or In "
+                f"conjunct over strings, or >= and < on {EVENT_TIMESTAMP_KEY}; "
+                f"got {conjunct!r}"
+            )
 
 
-def _absorb_timestamp(filters: SystemFilters, conjunct: Comparison) -> None:
-    if not isinstance(conjunct.value, datetime):
-        raise TypeError(f"{EVENT_TIMESTAMP_KEY} compares with a datetime")
-    if conjunct.op == ">=":
-        filters.since = _later(filters.since, conjunct.value)
-    elif conjunct.op == "<":
-        filters.until = _earlier(filters.until, conjunct.value)
-    else:
-        raise ValueError(
-            f"{EVENT_TIMESTAMP_KEY} takes only >= (since) and < (until), "
-            f"got {conjunct.op!r}"
-        )
-
-
-def _absorb_ids(filters: SystemFilters, conjunct: Comparison | In) -> None:
-    ids = _string_ids(conjunct)
-    if ids is None:
-        raise ValueError(
-            f"A reserved key is accepted only as a top-level = or In conjunct "
-            f"over strings, or >= and < on {EVENT_TIMESTAMP_KEY}; got {conjunct!r}"
-        )
-    if conjunct.field == EVENT_SESSION_KEY:
+def _absorb_ids(filters: SystemFilters, field: str, ids: list[str]) -> None:
+    if field == EVENT_SESSION_KEY:
         filters.session_ids = _intersect(filters.session_ids, ids)
-    elif conjunct.field == EVENT_SOURCE_KEY:
+    elif field == EVENT_SOURCE_KEY:
         filters.source_ids = _intersect(filters.source_ids, ids)
-    elif conjunct.field == BLOCK_KIND_KEY:
+    elif field == BLOCK_KIND_KEY:
         filters.block_kinds = _intersect(filters.block_kinds, ids)
     else:
-        raise ValueError(f"{conjunct.field!r} is not a filterable system field")
-
-
-def _string_ids(conjunct: Comparison | In) -> list[str] | None:
-    """The string values an `=` or `In` leaf names; None for any other leaf."""
-    if isinstance(conjunct, Comparison):
-        if conjunct.op == "=" and isinstance(conjunct.value, str):
-            return [conjunct.value]
-        return None
-    if all(isinstance(value, str) for value in conjunct.values):
-        return [str(value) for value in conjunct.values]
-    return None
+        raise ValueError(f"{field!r} is not a filterable system field")
 
 
 def _later(current: datetime | None, bound: datetime) -> datetime:

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -41,9 +41,8 @@ from memmachine_server.episodic_memory.declarative_memory.data_types import (
 )
 from memmachine_server.episodic_memory.event_memory.data_types import (
     Event,
-    NullContext,
-    ProducerContext,
-    QueryResult,
+    FormatOptions,
+    SearchHit,
     TextBlock,
 )
 from memmachine_server.episodic_memory.event_memory.deriver import Deriver
@@ -198,6 +197,9 @@ class LongTermMemory:
         # ValueError at the LongTermMemory layer.
         self._user_property_keys: frozenset[str] = frozenset()
         self._session_id: str = params.session_id
+        # Event backend only: reranking is a stage LongTermMemory runs on
+        # top of EventMemory's vector search.
+        self._reranker: Reranker | None = None
 
         match params:
             case DeclarativeBackendParams():
@@ -218,10 +220,10 @@ class LongTermMemory:
                         segmenter=params.segmenter,
                         deriver=params.deriver,
                         embedder=params.embedder,
-                        reranker=params.reranker,
                         metrics_factory=params.metrics_factory,
                     ),
                 )
+                self._reranker = params.reranker
                 self._vector_store = params.vector_store
                 self._vector_store_namespace = params.vector_store_collection_namespace
                 self._segment_store = params.segment_store
@@ -327,12 +329,20 @@ class LongTermMemory:
             num_episodes_limit * _EVENT_BACKEND_DEDUP_OVERFETCH,
             num_episodes_limit,
         )
-        result = await event_memory.query(
+        hits = await event_memory.query(
             query,
-            vector_search_limit=vector_search_limit,
+            limit=vector_search_limit,
             expand_context=expand_context,
             property_filter=property_filter,
         )
+        if self._reranker is not None:
+            hits = await EventMemory.rerank(
+                query,
+                hits,
+                reranker=self._reranker,
+                limit=vector_search_limit,
+                format_options=FormatOptions(time_style="short"),
+            )
 
         if expand_context > 0:
             # The expanded windows carry timeline-neighbor segments; fold
@@ -340,7 +350,7 @@ class LongTermMemory:
             # backend folds neighbor episodes around its matches: contexts
             # of the best matches first, filled until the limit is met.
             return await self._unified_scored_event_episodes(
-                result,
+                hits,
                 num_episodes_limit=num_episodes_limit,
                 score_threshold=score_threshold,
             )
@@ -352,13 +362,13 @@ class LongTermMemory:
         # so the threshold always drops scores below it.
         ordered_uids: list[str] = []
         scores_by_uid: dict[str, float] = {}
-        for scored_context in result.scored_segment_contexts:
-            if not self._score_passes_threshold(scored_context.score, score_threshold):
+        for hit in hits:
+            if not self._score_passes_threshold(hit.score, score_threshold):
                 continue
-            episode_uid = LongTermMemory._scored_context_episode_uid(scored_context)
+            episode_uid = LongTermMemory._hit_episode_uid(hit)
             if episode_uid is None or episode_uid in scores_by_uid:
                 continue
-            scores_by_uid[episode_uid] = scored_context.score
+            scores_by_uid[episode_uid] = hit.score
             ordered_uids.append(episode_uid)
             if len(ordered_uids) >= num_episodes_limit:
                 break
@@ -629,7 +639,7 @@ class LongTermMemory:
 
     async def _unified_scored_event_episodes(
         self,
-        result: QueryResult,
+        hits: Iterable[SearchHit],
         *,
         num_episodes_limit: int,
         score_threshold: float | None,
@@ -645,17 +655,13 @@ class LongTermMemory:
         """
         assert self._episode_storage is not None
         scored_uid_contexts: list[tuple[float, str, list[str]]] = []
-        for scored_context in result.scored_segment_contexts:
-            if not self._score_passes_threshold(scored_context.score, score_threshold):
+        for hit in hits:
+            if not self._score_passes_threshold(hit.score, score_threshold):
                 continue
-            nuclear_uid, context_uids = LongTermMemory._episode_uid_context(
-                scored_context
-            )
+            nuclear_uid, context_uids = LongTermMemory._episode_uid_context(hit)
             if nuclear_uid is None:
                 continue
-            scored_uid_contexts.append(
-                (scored_context.score, nuclear_uid, context_uids)
-            )
+            scored_uid_contexts.append((hit.score, nuclear_uid, context_uids))
 
         episode_scores = LongTermMemory._unify_scored_uid_contexts(
             scored_uid_contexts,
@@ -687,19 +693,17 @@ class LongTermMemory:
         )
 
     @staticmethod
-    def _episode_uid_context(scored_context: object) -> tuple[str | None, list[str]]:
+    def _episode_uid_context(hit: SearchHit) -> tuple[str | None, list[str]]:
         """Episode uids covered by one segment window.
 
         Returns the seed segment's episode uid (the nucleus) and the deduped
         episode uids of every segment in the window, in the window's
         chronological order.
         """
-        segments = getattr(scored_context, "segments", [])
-        seed_uuid = getattr(scored_context, "seed_segment_uuid", None)
         nuclear_uid: str | None = None
         context_uids: list[str] = []
         seen: set[str] = set()
-        for segment in segments:
+        for index, segment in enumerate(hit.segments):
             episode_uid = segment.properties.get(_EPISODE_UID_FIELD)
             if episode_uid is None:
                 continue
@@ -707,7 +711,7 @@ class LongTermMemory:
             if episode_uid not in seen:
                 seen.add(episode_uid)
                 context_uids.append(episode_uid)
-            if segment.uuid == seed_uuid:
+            if index == hit.seed:
                 nuclear_uid = episode_uid
         return nuclear_uid, context_uids
 
@@ -751,15 +755,9 @@ class LongTermMemory:
         return episode_scores
 
     @staticmethod
-    def _scored_context_episode_uid(scored_context: object) -> str | None:
-        """Pull `_episode_uid` from the seed segment of a ScoredSegmentContext."""
-        # We don't import ScoredSegmentContext here just for typing; the runtime
-        # shape (`segments`, `seed_segment_uuid`) is what matters.
-        segments = getattr(scored_context, "segments", [])
-        seed_uuid = getattr(scored_context, "seed_segment_uuid", None)
-        seed = next((s for s in segments if s.uuid == seed_uuid), None)
-        if seed is None:
-            return None
+    def _hit_episode_uid(hit: SearchHit) -> str | None:
+        """Pull `_episode_uid` from the seed segment of a hit."""
+        seed = hit.segments[hit.seed]
         return cast(str | None, seed.properties.get(_EPISODE_UID_FIELD))
 
     @staticmethod
@@ -768,7 +766,10 @@ class LongTermMemory:
 
         - Event.uuid = uuid5(NAMESPACE, episode.uid) so the mapping is
           deterministic and reversible (`_episode_uid` carries the original).
-        - Context: ProducerContext for messages; NullContext otherwise.
+        - Event.source_id = producer_id, the one identity an episode has;
+          it has no conversation identity, so `session_id` keeps its
+          default and the events form the ungrouped stream. No context:
+          the server holds no readable name to render.
         - One TextBlock per event (Episode.content is a string today).
         - Properties: system fields stored with `_` prefix, user filterable
           metadata stored bare. Matches EventMemory's `_to_vector_record_property`
@@ -811,15 +812,10 @@ class LongTermMemory:
                 )
             properties.update(episode.filterable_metadata)
 
-        if episode.episode_type == EpisodeType.MESSAGE:
-            context = ProducerContext(producer=episode.producer_id)
-        else:
-            context = NullContext()
-
         return Event(
             uuid=uuid5(_EVENT_UUID_NAMESPACE, episode.uid),
             timestamp=episode.created_at,
-            context=context,
+            source_id=episode.producer_id,
             blocks=[TextBlock(text=episode.content)],
             properties=properties,
         )

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -26,7 +26,7 @@ from memmachine_server.common.reranker import Reranker
 from memmachine_server.common.vector_graph_store import VectorGraphStore
 from memmachine_server.common.vector_store import (
     VectorStore,
-    VectorStoreCollection,
+    VectorStorePartition,
 )
 from memmachine_server.episodic_memory.declarative_memory import (
     DeclarativeMemory,
@@ -126,11 +126,10 @@ class EventBackendParams(BaseModel):
         ...,
         description="Parent VectorStore (for partition lifecycle)",
     )
-    vector_store_collection: InstanceOf[VectorStoreCollection] = Field(
+    vector_store_partition: InstanceOf[VectorStorePartition] = Field(
         ...,
-        description="Already-opened VectorStore collection",
+        description="The session's VectorStore partition",
     )
-    vector_store_collection_namespace: str = Field(...)
     segment_store: InstanceOf[SegmentStore] = Field(
         ...,
         description="Parent SegmentStore (for partition lifecycle)",
@@ -186,7 +185,6 @@ class LongTermMemory:
         self._declarative_memory: DeclarativeMemory | None = None
         self._event_memory: EventMemory | None = None
         self._vector_store: VectorStore | None = None
-        self._vector_store_namespace: str | None = None
         self._segment_store: SegmentStore | None = None
         self._partition_key: str | None = None
         self._episode_storage: EpisodeStorage | None = None
@@ -215,7 +213,7 @@ class LongTermMemory:
                 self._event_memory = EventMemory(
                     EventMemoryParams(
                         segment_store_partition=params.segment_store_partition,
-                        vector_store_collection=params.vector_store_collection,
+                        vector_store_partition=params.vector_store_partition,
                         segmenter=params.segmenter,
                         deriver=params.deriver,
                         embedder=params.embedder,
@@ -224,7 +222,6 @@ class LongTermMemory:
                 )
                 self._reranker = params.reranker
                 self._vector_store = params.vector_store
-                self._vector_store_namespace = params.vector_store_collection_namespace
                 self._segment_store = params.segment_store
                 self._partition_key = params.partition_key
                 self._episode_storage = params.episode_storage
@@ -412,14 +409,13 @@ class LongTermMemory:
     async def drop_session_partition(self) -> None:
         """Delete all data for this session/partition.
 
-        On the event backend, this drops the underlying VectorStore collection
-        and SegmentStore partition. After this returns the instance is no
+        On the event backend, this drops the session's VectorStore and
+        SegmentStore partitions. After this returns the instance is no
         longer usable — `EventMemory` still holds handles to the deleted
-        collection and partition, and any reuse would talk to deleted
-        resources. We null those handles so subsequent calls fail loudly
-        rather than silently corrupt state. If the caller needs the same
-        session_id again, build a fresh LongTermMemory (which will open or
-        create a new collection/partition).
+        partitions, and any reuse would talk to deleted resources. We null
+        those handles so subsequent calls fail loudly rather than silently
+        corrupt state. If the caller needs the same session_id again, build
+        a fresh LongTermMemory (which will create new partitions).
         """
         if self._backend == "declarative":
             assert self._declarative_memory is not None
@@ -430,13 +426,9 @@ class LongTermMemory:
             return
 
         assert self._vector_store is not None
-        assert self._vector_store_namespace is not None
         assert self._segment_store is not None
         assert self._partition_key is not None
-        await self._vector_store.delete_collection(
-            namespace=self._vector_store_namespace,
-            name=self._partition_key,
-        )
+        await self._vector_store.delete_partition(self._partition_key)
         await self._segment_store.delete_partition(self._partition_key)
         # Drop references to the now-deleted resources so any further
         # add_episodes / search_scored / delete_episodes calls raise

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/long_term_memory.py
@@ -16,10 +16,9 @@ from memmachine_server.common.episode_store import (
     EpisodeStorage,
     EpisodeType,
 )
+from memmachine_server.common.filter import FilterExpr, map_filter_fields
 from memmachine_server.common.filter.filter_parser import (
-    FilterExpr,
     demangle_user_metadata_key,
-    map_filter_fields,
     normalize_filter_field,
 )
 from memmachine_server.common.metrics_factory import MetricsFactory

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
@@ -18,6 +18,7 @@ from memmachine_server.common.configuration.episodic_config import (
 )
 from memmachine_server.common.data_types import (
     PROPERTY_TYPE_NAME_TO_PROPERTY_TYPE,
+    PropertyType,
     PropertyValue,
 )
 from memmachine_server.common.resource_manager import CommonResourceManager
@@ -93,7 +94,9 @@ async def _event_params(
     config: EventLongTermMemoryConf,
     resource_manager: InstanceOf[CommonResourceManager],
 ) -> EventBackendParams:
-    vector_store = await resource_manager.get_vector_store(config.vector_store)
+    vector_store = await resource_manager.get_vector_store(
+        config.vector_store, indexed_properties=event_backend_indexed_properties()
+    )
     segment_store = await resource_manager.get_segment_store(config.segment_store)
     embedder = await resource_manager.get_embedder(config.embedder, validate=True)
     reranker = (
@@ -105,36 +108,14 @@ async def _event_params(
 
     partition_key = partition_key_for_session(config.session_id)
 
-    # Open the existing collection if any (preserves the original schema). Only
-    # create with our merged schema if the partition does not yet exist.
-    collection = await vector_store.open_collection(
+    # The keys a filter may name are validated below; which of them the
+    # store indexes is the store's own declaration.
+    _resolve_user_properties_schema(config.properties_schema)
+    collection = await vector_store.open_or_create_collection(
         namespace=_EVENT_BACKEND_NAMESPACE,
         name=partition_key,
+        config=VectorStoreCollectionConfig(vector_dimensions=embedder.dimensions),
     )
-    if collection is None:
-        user_schema = _resolve_user_properties_schema(config.properties_schema)
-        collection_config = VectorStoreCollectionConfig(
-            vector_dimensions=embedder.dimensions,
-            indexed_properties_schema={
-                **EventMemory.expected_vector_store_collection_schema(),
-                **EVENT_BACKEND_SYSTEM_FIELDS,
-                **user_schema,
-            },
-        )
-        await vector_store.create_collection(
-            namespace=_EVENT_BACKEND_NAMESPACE,
-            name=partition_key,
-            config=collection_config,
-        )
-        collection = await vector_store.open_collection(
-            namespace=_EVENT_BACKEND_NAMESPACE,
-            name=partition_key,
-        )
-        if collection is None:
-            raise RuntimeError(
-                f"Failed to open vector store collection after creation for "
-                f"partition {partition_key!r}"
-            )
 
     partition = await segment_store.open_or_create_partition(
         partition_key,
@@ -160,6 +141,18 @@ async def _event_params(
         user_property_keys=frozenset(config.properties_schema),
         metrics_factory=await resource_manager.get_metrics_factory("prometheus"),
     )
+
+
+def event_backend_indexed_properties() -> dict[str, PropertyType]:
+    """The system keys the event backend writes into every vector record.
+
+    EventMemory's reserved keys and the adapter's own event fields; the
+    vector store is built with these plus its configured user keys.
+    """
+    return {
+        **EventMemory.expected_vector_store_collection_schema(),
+        **EVENT_BACKEND_SYSTEM_FIELDS,
+    }
 
 
 def partition_key_for_session(session_id: str) -> str:

--- a/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
+++ b/packages/server/src/memmachine_server/episodic_memory/long_term_memory/service_locator.py
@@ -1,5 +1,6 @@
 """Helpers for building long-term memory from configuration."""
 
+import contextlib
 import hashlib
 import logging
 
@@ -22,7 +23,11 @@ from memmachine_server.common.data_types import (
     PropertyValue,
 )
 from memmachine_server.common.resource_manager import CommonResourceManager
-from memmachine_server.common.vector_store import VectorStoreCollectionConfig
+from memmachine_server.common.vector_store import (
+    VectorStore,
+    get_or_create_partition,
+    validate_collection_name,
+)
 from memmachine_server.episodic_memory.event_memory.deriver import Deriver
 from memmachine_server.episodic_memory.event_memory.deriver.text_deriver import (
     SentenceTextDeriver,
@@ -30,6 +35,9 @@ from memmachine_server.episodic_memory.event_memory.deriver.text_deriver import 
 )
 from memmachine_server.episodic_memory.event_memory.event_memory import EventMemory
 from memmachine_server.episodic_memory.event_memory.segment_store import (
+    SegmentStore,
+    SegmentStorePartition,
+    SegmentStorePartitionAlreadyExistsError,
     SegmentStorePartitionConfig,
 )
 from memmachine_server.episodic_memory.event_memory.segment_store.utils import (
@@ -53,7 +61,7 @@ from .long_term_memory import (
 
 logger = logging.getLogger(__name__)
 
-_EVENT_BACKEND_NAMESPACE = "long_term_memory"
+_EVENT_BACKEND_PURPOSE = "long_term_memory"
 
 
 async def long_term_memory_params_from_config(
@@ -94,11 +102,9 @@ async def _event_params(
     config: EventLongTermMemoryConf,
     resource_manager: InstanceOf[CommonResourceManager],
 ) -> EventBackendParams:
-    vector_store = await resource_manager.get_vector_store(
-        config.vector_store, indexed_properties=event_backend_indexed_properties()
-    )
     segment_store = await resource_manager.get_segment_store(config.segment_store)
     embedder = await resource_manager.get_embedder(config.embedder, validate=True)
+    vector_store = await event_backend_vector_store(config, resource_manager)
     reranker = (
         await resource_manager.get_reranker(config.reranker, validate=True)
         if config.reranker is not None
@@ -111,15 +117,9 @@ async def _event_params(
     # The keys a filter may name are validated below; which of them the
     # store indexes is the store's own declaration.
     _resolve_user_properties_schema(config.properties_schema)
-    collection = await vector_store.open_or_create_collection(
-        namespace=_EVENT_BACKEND_NAMESPACE,
-        name=partition_key,
-        config=VectorStoreCollectionConfig(vector_dimensions=embedder.dimensions),
-    )
-
-    partition = await segment_store.open_or_create_partition(
-        partition_key,
-        SegmentStorePartitionConfig(),
+    vector_store_partition = await get_or_create_partition(vector_store, partition_key)
+    partition = await _get_or_create_segment_partition(
+        segment_store, partition_key, SegmentStorePartitionConfig()
     )
 
     segmenter = _build_segmenter(config.segmenter)
@@ -128,8 +128,7 @@ async def _event_params(
     return EventBackendParams(
         session_id=config.session_id,
         vector_store=vector_store,
-        vector_store_collection=collection,
-        vector_store_collection_namespace=_EVENT_BACKEND_NAMESPACE,
+        vector_store_partition=vector_store_partition,
         segment_store=segment_store,
         segment_store_partition=partition,
         partition_key=partition_key,
@@ -141,6 +140,58 @@ async def _event_params(
         user_property_keys=frozenset(config.properties_schema),
         metrics_factory=await resource_manager.get_metrics_factory("prometheus"),
     )
+
+
+async def event_backend_vector_store(
+    config: EventLongTermMemoryConf,
+    resource_manager: InstanceOf[CommonResourceManager],
+) -> VectorStore:
+    """The event backend's vector store: the collection of its embedder, built for it."""
+    embedder = await resource_manager.get_embedder(config.embedder, validate=True)
+    return await resource_manager.get_vector_store(
+        config.vector_store,
+        collection=event_backend_collection(config.embedder),
+        vector_dimensions=embedder.dimensions,
+        indexed_properties=event_backend_indexed_properties(),
+    )
+
+
+def event_backend_collection(embedder_id: str) -> str:
+    """The collection the event backend keeps for one embedder.
+
+    One cell of the purpose-by-embedder matrix, named so that one backend
+    can hold the collections of several embedders side by side.
+    """
+    collection = f"{_EVENT_BACKEND_PURPOSE}__{embedder_id}"
+    try:
+        validate_collection_name(collection)
+    except ValueError as error:
+        raise ValueError(
+            f"Embedder id {embedder_id!r} cannot name a vector store collection: "
+            f"{error} Rename the embedder in the configuration."
+        ) from error
+    return collection
+
+
+async def _get_or_create_segment_partition(
+    segment_store: SegmentStore,
+    partition_key: str,
+    config: SegmentStorePartitionConfig,
+) -> SegmentStorePartition:
+    # Losing a creation race to a concurrent creator is fine: the winner's
+    # partition is the one returned.
+    partition = await segment_store.get_partition(partition_key)
+    if partition is not None:
+        return partition
+    with contextlib.suppress(SegmentStorePartitionAlreadyExistsError):
+        await segment_store.create_partition(partition_key, config)
+    partition = await segment_store.get_partition(partition_key)
+    if partition is None:
+        raise RuntimeError(
+            f"Segment store partition {partition_key!r} was deleted between its "
+            "creation and this lookup"
+        )
+    return partition
 
 
 def event_backend_indexed_properties() -> dict[str, PropertyType]:

--- a/packages/server/src/memmachine_server/episodic_memory/short_term_memory/short_term_memory.py
+++ b/packages/server/src/memmachine_server/episodic_memory/short_term_memory/short_term_memory.py
@@ -26,14 +26,18 @@ from memmachine_server.common.data_types import (
 from memmachine_server.common.episode_store import Episode
 from memmachine_server.common.episode_store.episode_model import episodes_to_string
 from memmachine_server.common.errors import ShortTermMemoryClosedError
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
     And,
-    Comparison,
+    Equals,
     FilterExpr,
     In,
-    IsNull,
+    IsMissing,
     Not,
+    NotEquals,
     Or,
+    Ordering,
+)
+from memmachine_server.common.filter.filter_parser import (
     demangle_user_metadata_key,
     normalize_filter_field,
 )
@@ -319,26 +323,24 @@ class ShortTermMemory:
         """Check if an episode matches the given filter expression."""
         if expr is None:
             return True
-        if isinstance(expr, Comparison):
-            value = self._resolve_field(episode, expr.field)
-            return self._compare(value, expr.op, expr.value)
-        if isinstance(expr, In):
-            value = self._resolve_field(episode, expr.field)
-            return value in expr.values
-        if isinstance(expr, IsNull):
-            value = self._resolve_field(episode, expr.field)
-            return value is None
-        if isinstance(expr, And):
-            return self._check_filter(episode, expr.left) and self._check_filter(
-                episode, expr.right
-            )
-        if isinstance(expr, Or):
-            return self._check_filter(episode, expr.left) or self._check_filter(
-                episode, expr.right
-            )
-        if isinstance(expr, Not):
-            return not self._check_filter(episode, expr.expr)
-        raise TypeError(f"Unsupported filter type: {type(expr)!r}")
+        match expr:
+            case Equals(field, value):
+                return self._compare(self._resolve_field(episode, field), "=", value)
+            case NotEquals(field, value):
+                resolved = self._resolve_field(episode, field)
+                return resolved is not None and self._compare(resolved, "!=", value)
+            case Ordering(field, op, value):
+                return self._compare(self._resolve_field(episode, field), op, value)
+            case In(field, values):
+                return self._resolve_field(episode, field) in values
+            case IsMissing(field):
+                return self._resolve_field(episode, field) is None
+            case And(operands):
+                return all(self._check_filter(episode, o) for o in operands)
+            case Or(operands):
+                return any(self._check_filter(episode, o) for o in operands)
+            case Not(operand):
+                return not self._check_filter(episode, operand)
 
     def _resolve_field(self, episode: Episode, field: str) -> PropertyValue | None:
         """Resolve a field name to its value from an episode."""

--- a/packages/server/src/memmachine_server/installation/configuration_wizard.py
+++ b/packages/server/src/memmachine_server/installation/configuration_wizard.py
@@ -78,6 +78,9 @@ class ConfigurationWizard:
     SQLITE_VEC_VECTOR_STORE_ID = "sqlite_vec_vector_store"
     QDRANT_VECTOR_STORE_ID = "qdrant_vector_store"
     MILVUS_VECTOR_STORE_ID = "milvus_vector_store"
+    # Seconds a request to a remote vector store may take; the config field
+    # itself has no default, so the wizard supplies the starting point.
+    VECTOR_STORE_REQUEST_TIMEOUT = 30.0
     LANGUAGE_MODEL_NAME = "llm_model"
     EMBEDDER_NAME = "my_embedder"
     RERANKER_NAME = "my_reranker"
@@ -494,13 +497,18 @@ class ConfigurationWizard:
             case self.QDRANT_VECTOR_STORE_ID:
                 # Localhost defaults assume `docker run -p 6333:6333 qdrant/qdrant`
                 # or similar; user can edit cfg.yml to point at a remote Qdrant.
-                databases.qdrant_confs = {self.QDRANT_VECTOR_STORE_ID: QdrantConf()}
+                databases.qdrant_confs = {
+                    self.QDRANT_VECTOR_STORE_ID: QdrantConf(
+                        request_timeout=self.VECTOR_STORE_REQUEST_TIMEOUT
+                    )
+                }
             case self.MILVUS_VECTOR_STORE_ID:
                 # Local file defaults use Milvus Lite. Users can edit cfg.yml
                 # to point at a Milvus server or Zilliz Cloud URI/token.
                 databases.milvus_confs = {
                     self.MILVUS_VECTOR_STORE_ID: MilvusConf(
                         uri="memmachine_milvus.db",
+                        request_timeout=self.VECTOR_STORE_REQUEST_TIMEOUT,
                     )
                 }
             case self.SQLITE_VECTOR_STORE_ID:

--- a/packages/server/src/memmachine_server/main/memmachine.py
+++ b/packages/server/src/memmachine_server/main/memmachine.py
@@ -30,14 +30,8 @@ from memmachine_server.common.errors import (
     ResourceNotReadyError,
     SessionNotFoundError,
 )
+from memmachine_server.common.filter import And, Equals, FilterExpr
 from memmachine_server.common.filter.filter_parser import (
-    And as FilterAnd,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Comparison as FilterComparison,
-)
-from memmachine_server.common.filter.filter_parser import (
-    FilterExpr,
     parse_filter,
     to_property_filter,
 )
@@ -48,6 +42,9 @@ from memmachine_server.common.session_manager.session_data_manager import (
     SessionDataManager,
 )
 from memmachine_server.episodic_memory import EpisodicMemory
+from memmachine_server.episodic_memory.long_term_memory.service_locator import (
+    event_backend_indexed_properties,
+)
 from memmachine_server.retrieval_agent import create_retrieval_agent
 from memmachine_server.retrieval_agent.common.agent_api import (
     AgentToolBase,
@@ -369,11 +366,7 @@ class MemMachine:
 
     async def _delete_session_episode_store(self, session_key: str) -> None:
         episode_store = await self._resources.get_episode_storage()
-        session_filter = FilterComparison(
-            field="session_key",
-            op="=",
-            value=session_key,
-        )
+        session_filter = Equals(field="session_key", value=session_key)
         while True:
             episode_ids = await episode_store.get_episode_ids(
                 filter_expr=session_filter,
@@ -452,7 +445,10 @@ class MemMachine:
             ("reranker", self._resources.get_reranker, getattr(ltm, "reranker", None)),
             (
                 "vector store",
-                self._resources.get_vector_store,
+                partial(
+                    self._resources.get_vector_store,
+                    indexed_properties=event_backend_indexed_properties(),
+                ),
                 getattr(ltm, "vector_store", None),
             ),
             (
@@ -730,7 +726,7 @@ class MemMachine:
             return right
         if right is None:
             return left
-        return FilterAnd(left=left, right=right)
+        return And((left, right))
 
     async def add_episodes(
         self,
@@ -1109,11 +1105,7 @@ class MemMachine:
 
         if MemoryType.Episodic in target_memories:
             episode_storage = await self._resources.get_episode_storage()
-            session_filter = FilterComparison(
-                field="session_key",
-                op="=",
-                value=session_data.session_key,
-            )
+            session_filter = Equals(field="session_key", value=session_data.session_key)
             combined_filter = self._merge_filter_exprs(
                 session_filter,
                 search_filter_expr,
@@ -1170,11 +1162,7 @@ class MemMachine:
         """
         episode_storage = await self._resources.get_episode_storage()
 
-        session_filter = FilterComparison(
-            field="session_key",
-            op="=",
-            value=session_data.session_key,
-        )
+        session_filter = Equals(field="session_key", value=session_data.session_key)
 
         search_filter_expr = parse_filter(search_filter) if search_filter else None
         combined_filter = self._merge_filter_exprs(session_filter, search_filter_expr)

--- a/packages/server/src/memmachine_server/main/memmachine.py
+++ b/packages/server/src/memmachine_server/main/memmachine.py
@@ -15,6 +15,7 @@ from memmachine_server.common.configuration import Configuration
 from memmachine_server.common.configuration.episodic_config import (
     EpisodicMemoryConf,
     EpisodicMemoryConfPartial,
+    EventLongTermMemoryConf,
     LongTermMemoryConfPartial,
     ShortTermMemoryConfPartial,
 )
@@ -43,7 +44,7 @@ from memmachine_server.common.session_manager.session_data_manager import (
 )
 from memmachine_server.episodic_memory import EpisodicMemory
 from memmachine_server.episodic_memory.long_term_memory.service_locator import (
-    event_backend_indexed_properties,
+    event_backend_vector_store,
 )
 from memmachine_server.retrieval_agent import create_retrieval_agent
 from memmachine_server.retrieval_agent.common.agent_api import (
@@ -444,14 +445,6 @@ class MemMachine:
             ("embedder", self._resources.get_embedder, getattr(ltm, "embedder", None)),
             ("reranker", self._resources.get_reranker, getattr(ltm, "reranker", None)),
             (
-                "vector store",
-                partial(
-                    self._resources.get_vector_store,
-                    indexed_properties=event_backend_indexed_properties(),
-                ),
-                getattr(ltm, "vector_store", None),
-            ),
-            (
                 "segment store",
                 self._resources.get_segment_store,
                 getattr(ltm, "segment_store", None),
@@ -459,6 +452,15 @@ class MemMachine:
         ):
             if name:
                 warmers.append((label, partial(getter, name)))
+        if isinstance(ltm, EventLongTermMemoryConf):
+            # The store is one collection per embedder, so building it needs
+            # the embedder's dimensions first.
+            warmers.append(
+                (
+                    "vector store",
+                    partial(event_backend_vector_store, ltm, self._resources),
+                )
+            )
 
         for label, warm in warmers:
             try:

--- a/packages/server/src/memmachine_server/retrieval_agent/common/agent_api.py
+++ b/packages/server/src/memmachine_server/retrieval_agent/common/agent_api.py
@@ -11,9 +11,7 @@ from pydantic import BaseModel, ConfigDict, InstanceOf
 
 from memmachine_server.common.episode_store import Episode
 from memmachine_server.common.episode_store.episode_model import episodes_to_string
-from memmachine_server.common.filter.filter_parser import (
-    FilterExpr,
-)
+from memmachine_server.common.filter import FilterExpr
 from memmachine_server.common.language_model.language_model import LanguageModel
 from memmachine_server.common.reranker.reranker import Reranker
 from memmachine_server.episodic_memory import EpisodicMemory

--- a/packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py
+++ b/packages/server/src/memmachine_server/semantic_memory/semantic_ingestion.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field, InstanceOf, TypeAdapter
 
 from memmachine_server.common.embedder import Embedder
 from memmachine_server.common.episode_store import Episode, EpisodeIdT, EpisodeStorage
-from memmachine_server.common.filter.filter_parser import And, Comparison
+from memmachine_server.common.filter import And, Equals
 from memmachine_server.common.language_model import LanguageModel
 from memmachine_server.semantic_memory.semantic_llm import (
     LLMReducedFeature,
@@ -197,10 +197,10 @@ class IngestionService:
                     )
 
                 filter_expr = And(
-                    left=Comparison(field="set_id", op="=", value=set_id),
-                    right=Comparison(
-                        field="category", op="=", value=semantic_category.name
-                    ),
+                    (
+                        Equals(field="set_id", value=set_id),
+                        Equals(field="category", value=semantic_category.name),
+                    )
                 )
 
                 features = [
@@ -305,18 +305,12 @@ class IngestionService:
 
                 case SemanticCommandType.DELETE:
                     filter_expr = And(
-                        left=And(
-                            left=Comparison(field="set_id", op="=", value=set_id),
-                            right=Comparison(
-                                field="category_name", op="=", value=category_name
-                            ),
-                        ),
-                        right=And(
-                            left=Comparison(
-                                field="feature", op="=", value=command.feature
-                            ),
-                            right=Comparison(field="tag", op="=", value=command.tag),
-                        ),
+                        (
+                            Equals(field="set_id", value=set_id),
+                            Equals(field="category_name", value=category_name),
+                            Equals(field="feature", value=command.feature),
+                            Equals(field="tag", value=command.tag),
+                        )
                     )
 
                     await self._semantic_storage.delete_feature_set(
@@ -335,13 +329,11 @@ class IngestionService:
         async def _consolidate_type(
             semantic_category: InstanceOf[SemanticCategory],
         ) -> None:
-            from memmachine_server.common.filter.filter_parser import And, Comparison
-
             filter_expr = And(
-                left=Comparison(field="set_id", op="=", value=set_id),
-                right=Comparison(
-                    field="category_name", op="=", value=semantic_category.name
-                ),
+                (
+                    Equals(field="set_id", value=set_id),
+                    Equals(field="category_name", value=semantic_category.name),
+                )
             )
 
             features = [

--- a/packages/server/src/memmachine_server/semantic_memory/semantic_memory.py
+++ b/packages/server/src/memmachine_server/semantic_memory/semantic_memory.py
@@ -24,12 +24,7 @@ from memmachine_server.common.errors import (
     CategoryNotFoundError,
     InvalidSetIdConfigurationError,
 )
-from memmachine_server.common.filter.filter_parser import (
-    And,
-    Comparison,
-    FilterExpr,
-    In,
-)
+from memmachine_server.common.filter import And, Equals, FilterExpr, In
 from memmachine_server.common.language_model import LanguageModel
 from memmachine_server.common.utils import merge_async_iterators
 
@@ -70,18 +65,18 @@ class ResourceManager(Protocol):
 def _with_has_set_ids(
     set_ids: Sequence[SetIdT],
     filter_expr: FilterExpr | None,
-) -> FilterExpr:
+) -> FilterExpr | None:
     if len(set_ids) == 0:
         return filter_expr
 
     set_expr = In(
         field="set_id",
-        values=list(set_ids),
+        values=tuple(set_ids),
     )
 
     if filter_expr is None:
         return set_expr
-    return And(left=set_expr, right=filter_expr)
+    return And((set_expr, filter_expr))
 
 
 class SemanticService:
@@ -720,9 +715,8 @@ class SemanticService:
 
             await self.delete_feature_set(
                 set_ids=set_ids,
-                filter_expr=Comparison(
+                filter_expr=Equals(
                     field="category_name",
-                    op="=",
                     value=category.name,
                 ),
             )

--- a/packages/server/src/memmachine_server/semantic_memory/semantic_session_manager.py
+++ b/packages/server/src/memmachine_server/semantic_memory/semantic_session_manager.py
@@ -18,7 +18,7 @@ from typing import Protocol, runtime_checkable
 from pydantic import BaseModel, JsonValue
 
 from memmachine_server.common.episode_store import Episode, EpisodeIdT
-from memmachine_server.common.filter.filter_parser import FilterExpr
+from memmachine_server.common.filter import FilterExpr
 from memmachine_server.semantic_memory.config_store.config_store import (
     SemanticConfigStorage as ESemanticConfigStorage,
 )

--- a/packages/server/src/memmachine_server/semantic_memory/storage/neo4j_semantic_storage.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/neo4j_semantic_storage.py
@@ -26,26 +26,16 @@ from pydantic import InstanceOf
 from memmachine_server.common.data_types import FilterValue, PropertyValue
 from memmachine_server.common.episode_store import EpisodeIdT
 from memmachine_server.common.errors import InvalidArgumentError
-from memmachine_server.common.filter.filter_parser import (
-    And as FilterAnd,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Comparison as FilterComparison,
-)
-from memmachine_server.common.filter.filter_parser import (
+from memmachine_server.common.filter import (
+    And,
+    Equals,
     FilterExpr,
-)
-from memmachine_server.common.filter.filter_parser import (
-    In as FilterIn,
-)
-from memmachine_server.common.filter.filter_parser import (
-    IsNull as FilterIsNull,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Not as FilterNot,
-)
-from memmachine_server.common.filter.filter_parser import (
-    Or as FilterOr,
+    In,
+    IsMissing,
+    Not,
+    NotEquals,
+    Or,
+    Ordering,
 )
 from memmachine_server.common.neo4j_utils import coerce_datetime_to_timestamp
 from memmachine_server.semantic_memory.semantic_model import SemanticFeature, SetIdT
@@ -1085,81 +1075,77 @@ class Neo4jSemanticStorage(SemanticStorage):
         *,
         target_field: str,
     ) -> set[str] | None:
-        if isinstance(expr, FilterComparison):
-            if expr.field != target_field or expr.op != "=":
+        match expr:
+            case Equals(field, value):
+                return {str(value)} if field == target_field else None
+            case In(field, values):
+                return {str(v) for v in values} if field == target_field else None
+            case And(operands):
+                definite = [
+                    values
+                    for operand in operands
+                    if (
+                        values := self._collect_field_values(
+                            operand, target_field=target_field
+                        )
+                    )
+                    is not None
+                ]
+                return set.intersection(*definite) if definite else None
+            case NotEquals() | Ordering() | IsMissing() | Or() | Not():
+                # None of these names a definite set of values.
                 return None
-            return {str(expr.value)}
-        if isinstance(expr, FilterIn):
-            if expr.field != target_field:
-                return None
-            return {str(v) for v in expr.values}
-        if isinstance(expr, FilterAnd):
-            return self._merge_and_values(expr, target_field)
-        # Or, IsNull, Not cannot provide definite values
-        return None
-
-    def _merge_and_values(self, expr: FilterAnd, target_field: str) -> set[str] | None:
-        left_vals = self._collect_field_values(expr.left, target_field=target_field)
-        right_vals = self._collect_field_values(expr.right, target_field=target_field)
-        if left_vals is None:
-            return right_vals
-        if right_vals is None:
-            return left_vals
-        return left_vals & right_vals
 
     def _render_filter_expr(
         self,
         alias: str,
         expr: FilterExpr,
     ) -> tuple[str, dict[str, Any]]:
-        if isinstance(expr, FilterIsNull):
-            field_ref, _ = self._resolve_field_reference(alias, expr.field)
-            return f"{field_ref} IS NULL", {}
-
-        if isinstance(expr, FilterIn):
-            field_ref, value_adapter = self._resolve_field_reference(
-                alias,
-                expr.field,
-            )
-            param = self._next_filter_param()
-            adapted_values = (
-                [self._adapt_filter_value(v, value_adapter) for v in expr.values]
-                if value_adapter is not None
-                else list(expr.values)
-            )
-            return f"{field_ref} IN ${param}", {param: adapted_values}
-
-        if isinstance(expr, FilterComparison):
-            field_ref, value_adapter = self._resolve_field_reference(
-                alias,
-                expr.field,
-            )
-            param = self._next_filter_param()
-            adapted_value = (
-                self._adapt_filter_value(expr.value, value_adapter)
-                if value_adapter is not None
-                else expr.value
-            )
-            cypher_op = "<>" if expr.op == "!=" else expr.op
-            return f"{field_ref} {cypher_op} ${param}", {param: adapted_value}
-
-        if isinstance(expr, FilterAnd):
-            left_cond, left_params = self._render_filter_expr(alias, expr.left)
-            right_cond, right_params = self._render_filter_expr(alias, expr.right)
-            condition = f"({left_cond}) AND ({right_cond})"
-            left_params.update(right_params)
-            return condition, left_params
-        if isinstance(expr, FilterOr):
-            left_cond, left_params = self._render_filter_expr(alias, expr.left)
-            right_cond, right_params = self._render_filter_expr(alias, expr.right)
-            condition = f"({left_cond}) OR ({right_cond})"
-            left_params.update(right_params)
-            return condition, left_params
-        if isinstance(expr, FilterNot):
-            inner_cond, inner_params = self._render_filter_expr(alias, expr.expr)
-            condition = f"NOT ({inner_cond})"
-            return condition, inner_params
-        raise TypeError(f"Unsupported filter expression type: {type(expr)!r}")
+        match expr:
+            case IsMissing(field):
+                field_ref, _ = self._resolve_field_reference(alias, field)
+                return f"{field_ref} IS NULL", {}
+            case In(field, values):
+                field_ref, value_adapter = self._resolve_field_reference(alias, field)
+                param = self._next_filter_param()
+                adapted_values = (
+                    [self._adapt_filter_value(v, value_adapter) for v in values]
+                    if value_adapter is not None
+                    else list(values)
+                )
+                return f"{field_ref} IN ${param}", {param: adapted_values}
+            case (
+                Equals(field, value)
+                | NotEquals(field, value)
+                | Ordering(field, _, value)
+            ):
+                field_ref, value_adapter = self._resolve_field_reference(alias, field)
+                param = self._next_filter_param()
+                adapted_value = (
+                    self._adapt_filter_value(value, value_adapter)
+                    if value_adapter is not None
+                    else value
+                )
+                match expr:
+                    case Equals():
+                        cypher_op = "="
+                    case NotEquals():
+                        cypher_op = "<>"
+                    case Ordering(op=op):
+                        cypher_op = op
+                return f"{field_ref} {cypher_op} ${param}", {param: adapted_value}
+            case And(operands) | Or(operands):
+                joiner = " AND " if isinstance(expr, And) else " OR "
+                conditions: list[str] = []
+                params: dict[str, Any] = {}
+                for operand in operands:
+                    condition, operand_params = self._render_filter_expr(alias, operand)
+                    conditions.append(f"({condition})")
+                    params.update(operand_params)
+                return joiner.join(conditions), params
+            case Not(operand):
+                inner_cond, inner_params = self._render_filter_expr(alias, operand)
+                return f"NOT ({inner_cond})", inner_params
 
     _KNOWN_FIELDS: frozenset[str] = frozenset(
         {

--- a/packages/server/src/memmachine_server/semantic_memory/storage/sqlalchemy_pgvector_semantic.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/sqlalchemy_pgvector_semantic.py
@@ -39,8 +39,8 @@ from sqlalchemy.sql import Delete, Select, func
 
 from memmachine_server.common.episode_store.episode_model import EpisodeIdT
 from memmachine_server.common.errors import InvalidArgumentError, ResourceNotFoundError
+from memmachine_server.common.filter import FilterExpr
 from memmachine_server.common.filter.filter_parser import (
-    FilterExpr,
     demangle_user_metadata_key,
     normalize_filter_field,
 )

--- a/packages/server/src/memmachine_server/semantic_memory/storage/storage_base.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/storage_base.py
@@ -10,7 +10,7 @@ import numpy as np
 from pydantic import InstanceOf
 
 from memmachine_server.common.episode_store.episode_model import EpisodeIdT
-from memmachine_server.common.filter.filter_parser import FilterExpr
+from memmachine_server.common.filter import FilterExpr
 from memmachine_server.semantic_memory.semantic_model import (
     FeatureIdT,
     SemanticFeature,

--- a/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
@@ -34,8 +34,8 @@ from sqlalchemy.sql import Delete, Select, func
 
 from memmachine_server.common.episode_store.episode_model import EpisodeIdT
 from memmachine_server.common.errors import InvalidArgumentError, ResourceNotFoundError
+from memmachine_server.common.filter import FilterExpr
 from memmachine_server.common.filter.filter_parser import (
-    FilterExpr,
     demangle_user_metadata_key,
     normalize_filter_field,
 )

--- a/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
+++ b/packages/server/src/memmachine_server/semantic_memory/storage/vector_store_semantic_storage.py
@@ -44,7 +44,7 @@ from memmachine_server.common.filter.sql_filter_util import (
     compile_sql_filter,
 )
 from memmachine_server.common.utils import ensure_tz_aware
-from memmachine_server.common.vector_store import Record, VectorStoreCollection
+from memmachine_server.common.vector_store import Record, VectorStorePartition
 from memmachine_server.semantic_memory.semantic_model import SemanticFeature, SetIdT
 from memmachine_server.semantic_memory.storage.storage_base import (
     FeatureIdT,
@@ -184,11 +184,11 @@ class VectorStoreSemanticStorage(SemanticStorage):
     def __init__(
         self,
         sqlalchemy_engine: AsyncEngine,
-        vector_collection: VectorStoreCollection,
+        vector_partition: VectorStorePartition,
     ) -> None:
-        """Initialize storage with an async SQLAlchemy engine and vector collection."""
+        """Initialize storage with an async SQLAlchemy engine and a vector store partition."""
         self._engine = sqlalchemy_engine
-        self._vector_collection = vector_collection
+        self._vector_partition = vector_partition
         self._session_factory = async_sessionmaker(
             bind=self._engine,
             expire_on_commit=False,
@@ -212,7 +212,7 @@ class VectorStoreSemanticStorage(SemanticStorage):
             await session.execute(delete(VectorSemanticSetIngestedHistory))
             await session.execute(delete(VectorSemanticFeature))
             await session.commit()
-        await self._vector_collection.delete(record_uuids=vector_uuids)
+        await self._vector_partition.delete(record_uuids=vector_uuids)
 
     async def reset_set_ids(self, set_ids: Sequence[SetIdT]) -> None:
         del set_ids
@@ -248,7 +248,7 @@ class VectorStoreSemanticStorage(SemanticStorage):
             await session.commit()
             feature_id = FeatureIdT(str(result.scalar_one()))
 
-        await self._vector_collection.upsert(
+        await self._vector_partition.upsert(
             records=[Record(uuid=vector_uuid, vector=embedding.tolist())]
         )
         return feature_id
@@ -298,7 +298,7 @@ class VectorStoreSemanticStorage(SemanticStorage):
         # Only an embedding reaches the vector store; everything else this
         # method can change lives on the row above.
         if embedding is not None:
-            await self._vector_collection.upsert(
+            await self._vector_partition.upsert(
                 records=[Record(uuid=row.vector_uuid, vector=embedding.tolist())]
             )
 
@@ -377,7 +377,7 @@ class VectorStoreSemanticStorage(SemanticStorage):
             )
             await session.commit()
 
-        await self._vector_collection.delete(record_uuids=vector_uuids)
+        await self._vector_partition.delete(record_uuids=vector_uuids)
 
     async def delete_feature_set(
         self,
@@ -391,7 +391,7 @@ class VectorStoreSemanticStorage(SemanticStorage):
         async with self._create_session() as session:
             await session.execute(stmt)
             await session.commit()
-        await self._vector_collection.delete(record_uuids=vector_uuids)
+        await self._vector_partition.delete(record_uuids=vector_uuids)
 
     async def add_citations(
         self,
@@ -615,7 +615,7 @@ class VectorStoreSemanticStorage(SemanticStorage):
             _DEFAULT_VECTOR_QUERY_LIMIT,
             offset + page_size if page_size is not None else 0,
         )
-        [query_result] = await self._vector_collection.query(
+        [query_result] = await self._vector_partition.query(
             query_vectors=[vector_search_opts.query_embedding.tolist()],
             limit=limit,
             min_cosine_similarity=vector_search_opts.min_distance,

--- a/sample_configs/episodic_memory_config.cpu.sample
+++ b/sample_configs/episodic_memory_config.cpu.sample
@@ -101,7 +101,13 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        request_timeout: 30              # seconds; required, bounds every request
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
+        # Property keys every collection indexes and filters on, with their
+        # types (str, int, float, bool, datetime). The service's own system
+        # keys are added; any other key is rejected by the store.
+        # indexed_properties:
+        #   category: str
     # VectorStore for vector-backed semantic memory.
     # Wire it via `semantic_memory.vector_collection`.
     semantic_vector_store:
@@ -112,7 +118,13 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        request_timeout: 30              # seconds; required, bounds every request
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
+        # Property keys every collection indexes and filters on, with their
+        # types (str, int, float, bool, datetime). The service's own system
+        # keys are added; any other key is rejected by the store.
+        # indexed_properties:
+        #   category: str
     #
     # Alternative: Milvus. The local .db URI uses Milvus Lite; replace it with
     # http(s)://... plus token/db_name for Milvus server or Zilliz Cloud.
@@ -123,6 +135,9 @@ resources:
     #     # token: $MILVUS_TOKEN
     #     # db_name: default
     #     consistency_level: Session       # Strong, Session, Bounded, Eventually
+    #     request_timeout: 30              # seconds; required
+    #     # indexed_properties:
+    #     #   category: str
     # semantic_vector_store:
     #   provider: milvus
     #   config:
@@ -130,6 +145,7 @@ resources:
     #     # token: $MILVUS_TOKEN
     #     # db_name: default
     #     consistency_level: Session
+    #     request_timeout: 30              # seconds; required
     #
     # Alternative: a local file-backed SQLite vector store. Single-writer; OK
     # for embedded/dev use, not recommended for multi-process server deploys.
@@ -143,6 +159,8 @@ resources:
     #     # table on every restart — fine for tests, not for production.
     #     index_directory: event_vector_indexes
     #     save_threshold: 1000             # ops before auto-saving
+    #     # indexed_properties:
+    #     #   category: str
   embedders:
     openai_embedder:
       provider: openai

--- a/sample_configs/episodic_memory_config.gpu.sample
+++ b/sample_configs/episodic_memory_config.gpu.sample
@@ -100,7 +100,13 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        request_timeout: 30              # seconds; required, bounds every request
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
+        # Property keys every collection indexes and filters on, with their
+        # types (str, int, float, bool, datetime). The service's own system
+        # keys are added; any other key is rejected by the store.
+        # indexed_properties:
+        #   category: str
     # VectorStore for vector-backed semantic memory.
     # Wire it via `semantic_memory.vector_collection`.
     semantic_vector_store:
@@ -111,7 +117,13 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        request_timeout: 30              # seconds; required, bounds every request
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
+        # Property keys every collection indexes and filters on, with their
+        # types (str, int, float, bool, datetime). The service's own system
+        # keys are added; any other key is rejected by the store.
+        # indexed_properties:
+        #   category: str
     #
     # Alternative: Milvus. The local .db URI uses Milvus Lite; replace it with
     # http(s)://... plus token/db_name for Milvus server or Zilliz Cloud.
@@ -122,6 +134,9 @@ resources:
     #     # token: $MILVUS_TOKEN
     #     # db_name: default
     #     consistency_level: Session       # Strong, Session, Bounded, Eventually
+    #     request_timeout: 30              # seconds; required
+    #     # indexed_properties:
+    #     #   category: str
     # semantic_vector_store:
     #   provider: milvus
     #   config:
@@ -129,6 +144,7 @@ resources:
     #     # token: $MILVUS_TOKEN
     #     # db_name: default
     #     consistency_level: Session
+    #     request_timeout: 30              # seconds; required
     #
     # Alternative: a local file-backed SQLite vector store. Single-writer; OK
     # for embedded/dev use, not recommended for multi-process server deploys.
@@ -142,6 +158,8 @@ resources:
     #     # table on every restart — fine for tests, not for production.
     #     index_directory: event_vector_indexes
     #     save_threshold: 1000             # ops before auto-saving
+    #     # indexed_properties:
+    #     #   category: str
   embedders:
     openai_embedder:
       provider: openai

--- a/sample_configs/episodic_memory_config.nebula.sample
+++ b/sample_configs/episodic_memory_config.nebula.sample
@@ -118,7 +118,13 @@ resources:
         grpc_port: 6334
         prefer_grpc: false
         https: false
+        request_timeout: 30              # seconds; required, bounds every request
         # api_key: <YOUR_QDRANT_API_KEY>   # required for Qdrant Cloud
+        # Property keys every collection indexes and filters on, with their
+        # types (str, int, float, bool, datetime). The service's own system
+        # keys are added; any other key is rejected by the store.
+        # indexed_properties:
+        #   category: str
     #
     # Alternative: Milvus. The local .db URI uses Milvus Lite; replace it with
     # http(s)://... plus token/db_name for Milvus server or Zilliz Cloud.
@@ -129,6 +135,9 @@ resources:
     #     # token: $MILVUS_TOKEN
     #     # db_name: default
     #     consistency_level: Session       # Strong, Session, Bounded, Eventually
+    #     request_timeout: 30              # seconds; required
+    #     # indexed_properties:
+    #     #   category: str
     #
     # Alternative: a local file-backed SQLite vector store. Single-writer; OK
     # for embedded/dev use, not recommended for multi-process server deploys.
@@ -142,6 +151,8 @@ resources:
     #     # table on every restart — fine for tests, not for production.
     #     index_directory: event_vector_indexes
     #     save_threshold: 1000             # ops before auto-saving
+    #     # indexed_properties:
+    #     #   category: str
 
   embedders:
     openai_embedder:


### PR DESCRIPTION
### Purpose of the change

Lands the store-as-collection decisions on both storage components without pulling in the tenant lifecycle. Stacked on #1606 (its commit shows in this diff until it merges); stacked on #1597 through it.

- **One store is one collection.** A `VectorStore` is built for one collection, named at construction with its vector dimensions and its declared `indexed_properties`. The composition root builds one store per cell of the purpose-by-embedder matrix (`long_term_memory__<embedder>`, `semantic_memory__<embedder>`), and the collection name is what keeps two stores over one engine or client apart: it names the native Qdrant and Milvus collections, the SQLite table prefixes, and each store's registry. `namespace`, `VectorStoreCollectionConfig`, the content-addressed native names and the config-mismatch error go.
- **Handles are partitions, and the verb is `get_partition` on both stores.**

  ```
  provision()                                        # idempotent DDL
  create_partition(partition_key)                    # strict
  get_partition(partition_key) -> Partition | None   # None when absent
  delete_partition(partition_key)                    # idempotent
  ```

  `get_partition` reads the registry row and binds; a lookup that does I/O is fine as long as nothing has to be closed, and staleness stays a property of a handle already held, raised by its operations. The segment store's `open_partition` becomes `get_partition`; `open_or_create_partition` and `close_partition` go from both stores, and create-if-absent is the composition root's (`get_or_create_partition` beside the vector store ABC, and its counterpart in the service locator).
- **Each partition records what it was created under** (dimensions and declared schema, in the SQLite registry rows and the Qdrant and Milvus registry points), and `get_partition` raises `VectorStorePartitionSchemaMismatchError` when a store built with others opens it. The SQLite registries are shared tables keyed by collection and partition, so stores of different collections share one engine.
- **`DatabaseManager.get_vector_store(backend, collection=, vector_dimensions=, indexed_properties=)`** builds and caches one store per (backend, collection), provisions and starts it, and refuses the same collection asked for with other dimensions or keys. The "second service refused" guard from #1606 is gone, since a cell is a store by construction.

### What stays with the lifecycle work

- Keys stay `str` under today's identifier contract. The decided `partition(key: UUID)` needs keys minted once and never reused, which the tenant service's tombstone provides; a UUID derived from the session id would be reused across delete and recreate.
- Logical delete, purge and the per-operation registry read. `delete_partition` deletes synchronously as `delete_collection` did.
- The schema command. The composition root calls `provision()` when it builds a store until then.
- Shared tables for the SQLite stores' records; records tables and index files stay per partition, named by collection and key.

### Tests

The four store modules, the segment store module, the resource manager and wiring tests are rewritten to the shape: fixtures build a store per collection and provision it; `create_collection(namespace, name, config)` calls become `create_partition(name)`, and so on. Tests of removed paths go: open-or-create idempotency and config mismatch on both stores, the segment store's lost-race retry arm (that loop lived in the removed method; the composition root's create-if-absent makes one attempt), and the namespace tests. Added: two stores of different collections over one engine are isolated; provisioning creates the payload indexes on a Qdrant collection that already exists and survives two concurrent provisioners (integration); the same collection asked for with other dimensions or keys is refused; collections on one backend share its engine.

`uv run pytest packages/server/server_tests`: 2016 passed, 2 skipped. `ruff check` and `ruff format --check` clean. `ty check packages` reports only the diagnostics already on the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtbsPQafKpBUn7ksnDU2UY
